### PR TITLE
Display API Documentation (Swagger UI)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
     "metas",
     "mnfst",
     "nestjs",
+    "openapi",
     "typeorm",
     "uniqid"
   ],

--- a/packages/core/manifest/e2e/jest.setup.ts
+++ b/packages/core/manifest/e2e/jest.setup.ts
@@ -5,6 +5,8 @@ import { INestApplication } from '@nestjs/common'
 import supertest from 'supertest'
 import { load } from 'js-yaml'
 import fs from 'fs'
+import { SwaggerModule } from '@nestjs/swagger'
+import { OpenApiService } from '../src/open-api/services/open-api.service'
 
 let app: INestApplication
 
@@ -34,6 +36,10 @@ beforeAll(async () => {
 
   // Store request object in global scope to use in tests.
   global.request = supertest(app.getHttpServer())
+
+  // Set the SwaggerModule to serve the OpenAPI doc.
+  const openApiService = app.get(OpenApiService)
+  SwaggerModule.setup('api', app, openApiService.generateOpenApiObject())
 
   await app.init()
 })

--- a/packages/core/manifest/e2e/tests/open-api.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/open-api.e2e-spec.ts
@@ -1,0 +1,8 @@
+describe('Open API (e2e)', () => {
+  it('GET /api', async () => {
+    const response = await global.request.get('/api')
+
+    expect(response.status).toBe(200)
+    expect(response.text).toContain('<html lang="en">')
+  })
+})

--- a/packages/core/manifest/package-lock.json
+++ b/packages/core/manifest/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/config": "^3.2.0",
         "@nestjs/core": "^10.3.3",
         "@nestjs/platform-express": "^10.3.3",
+        "@nestjs/swagger": "^7.3.1",
         "@nestjs/typeorm": "^10.0.2",
         "ajv": "^8.12.0",
         "better-sqlite3": "^9.6.0",
@@ -1819,6 +1820,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
+    },
     "node_modules/@mnfst/admin": {
       "version": "0.1.0-alpha.4",
       "resolved": "https://registry.npmjs.org/@mnfst/admin/-/admin-0.1.0-alpha.4.tgz",
@@ -2040,6 +2046,25 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.3.8",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.8.tgz",
@@ -2081,6 +2106,38 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
       "dev": true
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.3.1.tgz",
+      "integrity": "sha512-LUC4mr+5oAleEC/a2j8pNRh1S5xhKXJ1Gal5ZdRjt9XebQgbngXCdW7JTA9WOEcwGtFZN9EnKYdquzH971LZfw==",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.14.2",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.11.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.3.3",
@@ -10061,6 +10118,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.2.tgz",
+      "integrity": "sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A=="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/packages/core/manifest/package.json
+++ b/packages/core/manifest/package.json
@@ -52,6 +52,7 @@
     "@nestjs/config": "^3.2.0",
     "@nestjs/core": "^10.3.3",
     "@nestjs/platform-express": "^10.3.3",
+    "@nestjs/swagger": "^7.3.1",
     "@nestjs/typeorm": "^10.0.2",
     "ajv": "^8.12.0",
     "better-sqlite3": "^9.6.0",

--- a/packages/core/manifest/src/app.module.ts
+++ b/packages/core/manifest/src/app.module.ts
@@ -16,6 +16,7 @@ import { ManifestModule } from './manifest/manifest.module'
 import { SeedModule } from './seed/seed.module'
 import { HealthModule } from './health/health.module'
 import { BetterSqlite3ConnectionOptions } from 'typeorm/driver/better-sqlite3/BetterSqlite3ConnectionOptions'
+import { OpenApiModule } from './open-api/open-api.module'
 
 @Module({
   imports: [
@@ -44,7 +45,8 @@ import { BetterSqlite3ConnectionOptions } from 'typeorm/driver/better-sqlite3/Be
     CrudModule,
     AuthModule,
     LoggerModule,
-    HealthModule
+    HealthModule,
+    OpenApiModule
   ]
 })
 export class AppModule {
@@ -57,8 +59,9 @@ export class AppModule {
   private async init() {
     const isSeed: boolean = process.argv[1].includes('seed')
     const isTest: boolean = process.env.NODE_ENV === 'test'
+    const isProduction: boolean = process.env.NODE_ENV === 'production'
 
-    if (!isSeed && !isTest) {
+    if (!isSeed && !isTest && !isProduction) {
       this.loggerService.initMessage()
     }
   }

--- a/packages/core/manifest/src/auth/auth.controller.ts
+++ b/packages/core/manifest/src/auth/auth.controller.ts
@@ -4,7 +4,9 @@ import { AuthenticableEntity } from '@mnfst/types'
 import { Request } from 'express'
 import { AuthService } from './auth.service'
 import { SignupAuthenticableEntityDto } from './dtos/signup-authenticable-entity.dto'
+import { ApiTags } from '@nestjs/swagger'
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}

--- a/packages/core/manifest/src/auth/dtos/signup-authenticable-entity.dto.ts
+++ b/packages/core/manifest/src/auth/dtos/signup-authenticable-entity.dto.ts
@@ -1,10 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger'
 import { IsEmail, IsNotEmpty } from 'class-validator'
 
 export class SignupAuthenticableEntityDto {
+  @ApiProperty({
+    description: 'The email of the user',
+    example: 'admin@manifest.build'
+  })
   @IsNotEmpty()
   @IsEmail()
   public email: string
 
+  @ApiProperty({
+    description: 'The password of the user',
+    example: 'admin'
+  })
   @IsNotEmpty()
   public password: string
 }

--- a/packages/core/manifest/src/config/paths.ts
+++ b/packages/core/manifest/src/config/paths.ts
@@ -1,7 +1,8 @@
-export default (): { paths: { admin: string } } => {
+export default (): { paths: { admin: string; database: string } } => {
   return {
     paths: {
-      admin: `${process.cwd()}/node_modules/@mnfst/admin/dist`
+      admin: `${process.cwd()}/node_modules/@mnfst/admin/dist`,
+      database: `${process.cwd()}/manifest/backend.yml`
     }
   }
 }

--- a/packages/core/manifest/src/constants.ts
+++ b/packages/core/manifest/src/constants.ts
@@ -1,7 +1,3 @@
-// Manifest.
-export const MANIFEST_FOLDER_NAME = 'manifest'
-export const MANIFEST_FILE_NAME = 'backend.yml'
-
 // Default values.
 export const DEFAULT_PORT = 1111
 export const DEFAULT_RESULTS_PER_PAGE = 20

--- a/packages/core/manifest/src/logger/logger.service.ts
+++ b/packages/core/manifest/src/logger/logger.service.ts
@@ -17,13 +17,21 @@ export class LoggerService {
 
     console.log()
 
+    console.log(chalk.blue('Manifest backend successfully started! '))
+    console.log()
+
     console.log(
       chalk.blue(
-        '🎉 Manifest successfully started! See your admin panel: ',
+        '🖥️  Admin Panel: ',
         chalk.underline.blue(`http://localhost:${port}`)
       )
     )
-
+    console.log(
+      chalk.blue(
+        '📚 API Doc: ',
+        chalk.underline.blue(`http://localhost:${port}/api`)
+      )
+    )
     console.log()
   }
 }

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -57,8 +57,7 @@ async function bootstrap() {
       customfavIcon: 'assets/images/favicon.png',
       customSiteTitle: 'Manifest API Doc',
       customCss: `
-        .topbar-wrapper img {content:url(\'assets/images/logo.svg\'); width:300px; height:auto;}
-        .swagger-ui .topbar { background-color: white; }`
+        .swagger-ui .topbar { background-color: blue; }`
     })
   }
 

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -57,7 +57,1678 @@ async function bootstrap() {
       customfavIcon: 'assets/images/favicon.png',
       customSiteTitle: 'Manifest API Doc',
       customCss: `
-        .swagger-ui .topbar { background-color: blue; }`
+        
+.swagger-ui html {
+  box-sizing: border-box
+}
+
+.swagger-ui *, .swagger-ui :after, .swagger-ui :before {
+  box-sizing: inherit
+}
+
+.swagger-ui body {
+  margin: 0;
+  background: #F6F7F9
+}
+
+.swagger-ui .wrapper {
+  width: 100%;
+  max-width: 1460px;
+  margin: 0 auto;
+  padding: 0 20px
+}
+
+.swagger-ui .opblock-tag-section {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column
+}
+
+.swagger-ui .opblock-tag {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 20px 10px 10px;
+  cursor: pointer;
+  -webkit-transition: all .2s;
+  transition: all .2s;
+  border-bottom: 1px solid #EAEAEF;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui .opblock-tag:hover {
+  background: rgba(57, 57, 60, .02)
+}
+
+.swagger-ui .opblock-tag {
+  font-size: 24px;
+  margin: 0 0 5px;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .opblock-tag.no-desc span {
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.swagger-ui .opblock-tag svg {
+  -webkit-transition: all .4s;
+  transition: all .4s
+}
+
+.swagger-ui .opblock-tag small {
+  font-size: 14px;
+  font-weight: 400;
+  padding: 0 10px;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .parаmeter__type {
+  font-size: 12px;
+  padding: 5px 0;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui .view-line-link {
+  position: relative;
+  top: 3px;
+  width: 20px;
+  margin: 0 5px;
+  cursor: pointer;
+  -webkit-transition: all .5s;
+  transition: all .5s
+}
+
+.swagger-ui .opblock {
+  margin: 0 0 15px;
+  border: 1px solid #000;
+  border-radius: 4px;
+  box-shadow: none;
+}
+
+.swagger-ui .opblock.is-open .opblock-summary {
+  border-bottom: 1px solid #000
+}
+
+.swagger-ui .opblock .opblock-section-header {
+  padding: 8px 20px;
+  background: hsla(0, 0%, 100%, .8);
+  box-shadow: none;
+}
+
+.swagger-ui .opblock .opblock-section-header, .swagger-ui .opblock .opblock-section-header label {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui .opblock .opblock-section-header label {
+  font-size: 12px;
+  font-weight: 700;
+  margin: 0;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .opblock .opblock-section-header label span {
+  padding: 0 10px 0 0
+}
+
+.swagger-ui .opblock .opblock-section-header h4 {
+  font-size: 14px;
+  margin: 0;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .opblock .opblock-summary-method {
+  font-size: 14px;
+  font-weight: 700;
+  min-width: 80px;
+  padding: 6px 15px;
+  text-align: center;
+  border-radius: 3px;
+  background: #000;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, .1);
+  font-family: Titillium Web, sans-serif;
+  color: #fff
+}
+
+.swagger-ui .opblock .opblock-summary-path, .swagger-ui .opblock .opblock-summary-path__deprecated {
+  font-size: 16px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 10px;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui .opblock .opblock-summary-path .view-line-link, .swagger-ui .opblock .opblock-summary-path__deprecated .view-line-link {
+  position: relative;
+  top: 2px;
+  width: 0;
+  margin: 0;
+  cursor: pointer;
+  -webkit-transition: all .5s;
+  transition: all .5s
+}
+
+.swagger-ui .opblock .opblock-summary-path:hover .view-line-link, .swagger-ui .opblock .opblock-summary-path__deprecated:hover .view-line-link {
+  width: 18px;
+  margin: 0 5px
+}
+
+.swagger-ui .opblock .opblock-summary-path__deprecated {
+  text-decoration: line-through
+}
+
+.swagger-ui .opblock .opblock-summary-description {
+  font-size: 13px;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .opblock .opblock-summary {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 5px;
+  cursor: pointer;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui .opblock.opblock-post {
+  border-color: #49cc90;
+  background: rgba(73, 204, 144, .1)
+}
+
+.swagger-ui .opblock.opblock-post .opblock-summary-method {
+  background: #49cc90
+}
+
+.swagger-ui .opblock.opblock-post .opblock-summary {
+  border-color: #49cc90
+}
+
+.swagger-ui .opblock.opblock-put {
+  border-color: #fca130;
+  background: rgba(252, 161, 48, .1)
+}
+
+.swagger-ui .opblock.opblock-put .opblock-summary-method {
+  background: #fca130
+}
+
+.swagger-ui .opblock.opblock-put .opblock-summary {
+  border-color: #fca130
+}
+
+.swagger-ui .opblock.opblock-delete {
+  border-color: #f93e3e;
+  background: rgba(249, 62, 62, .1)
+}
+
+.swagger-ui .opblock.opblock-delete .opblock-summary-method {
+  background: #f93e3e
+}
+
+.swagger-ui .opblock.opblock-delete .opblock-summary {
+  border-color: #f93e3e
+}
+
+.swagger-ui .opblock.opblock-get {
+  border-color: #61affe;
+  background: #F5F7F9
+}
+
+.swagger-ui .opblock.opblock-get .opblock-summary-method {
+  background: #61affe
+}
+
+.swagger-ui .opblock.opblock-get .opblock-summary {
+  border-color: #61affe
+}
+
+.swagger-ui .opblock.opblock-patch {
+  border-color: #50e3c2;
+  background: rgba(80, 227, 194, .1)
+}
+
+.swagger-ui .opblock.opblock-patch .opblock-summary-method {
+  background: #50e3c2
+}
+
+.swagger-ui .opblock.opblock-patch .opblock-summary {
+  border-color: #50e3c2
+}
+
+.swagger-ui .opblock.opblock-head {
+  border-color: #9012fe;
+  background: rgba(144, 18, 254, .1)
+}
+
+.swagger-ui .opblock.opblock-head .opblock-summary-method {
+  background: #9012fe
+}
+
+.swagger-ui .opblock.opblock-head .opblock-summary {
+  border-color: #9012fe
+}
+
+.swagger-ui .opblock.opblock-options {
+  border-color: #0d5aa7;
+  background: rgba(13, 90, 167, .1)
+}
+
+.swagger-ui .opblock.opblock-options .opblock-summary-method {
+  background: #0d5aa7
+}
+
+.swagger-ui .opblock.opblock-options .opblock-summary {
+  border-color: #0d5aa7
+}
+
+.swagger-ui .opblock.opblock-deprecated {
+  opacity: .6;
+  border-color: #ebebeb;
+  background: hsla(0, 0%, 92%, .1)
+}
+
+.swagger-ui .opblock.opblock-deprecated .opblock-summary-method {
+  background: #ebebeb
+}
+
+.swagger-ui .opblock.opblock-deprecated .opblock-summary {
+  border-color: #ebebeb
+}
+
+.swagger-ui .tab {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 20px 0 10px;
+  padding: 0;
+  list-style: none
+}
+
+.swagger-ui .tab li {
+  font-size: 12px;
+  min-width: 100px;
+  min-width: 90px;
+  padding: 0;
+  cursor: pointer;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .tab li:first-of-type {
+  position: relative;
+  padding-left: 0
+}
+
+.swagger-ui .tab li:first-of-type:after {
+  position: absolute;
+  top: 0;
+  right: 6px;
+  width: 1px;
+  height: 100%;
+  content: "";
+  background: rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .tab li.active {
+  font-weight: 700
+}
+
+.swagger-ui .opblock-description-wrapper, .swagger-ui .opblock-title_normal {
+  padding: 15px 20px
+}
+
+.swagger-ui .opblock-description-wrapper, .swagger-ui .opblock-description-wrapper h4, .swagger-ui .opblock-title_normal, .swagger-ui .opblock-title_normal h4 {
+  font-size: 12px;
+  margin: 0 0 5px;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .opblock-description-wrapper p, .swagger-ui .opblock-title_normal p {
+  font-size: 14px;
+  margin: 0;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .execute-wrapper {
+  padding: 20px;
+  text-align: right
+}
+
+.swagger-ui .execute-wrapper .btn {
+  width: 100%;
+  padding: 8px 40px
+}
+
+.swagger-ui .body-param-options {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column
+}
+
+.swagger-ui .body-param-options .body-param-edit {
+  padding: 10px 0
+}
+
+.swagger-ui .body-param-options label {
+  padding: 8px 0
+}
+
+.swagger-ui .body-param-options label select {
+  margin: 3px 0 0
+}
+
+.swagger-ui .responses-inner {
+  padding: 20px
+}
+
+.swagger-ui .responses-inner h4, .swagger-ui .responses-inner h5 {
+  font-size: 12px;
+  margin: 10px 0 5px;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .response-col_status {
+  font-size: 14px;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .response-col_status .response-undocumented {
+  font-size: 11px;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #999
+}
+
+.swagger-ui .response-col_description__inner span {
+  font-size: 12px;
+  font-style: italic;
+  display: block;
+  margin: 10px 0;
+  padding: 10px;
+  border-radius: 4px;
+  background: #41444e;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #fff
+}
+
+.swagger-ui .response-col_description__inner span p {
+  margin: 0
+}
+
+.swagger-ui .opblock-body pre {
+  font-size: 12px;
+  margin: 0;
+  padding: 10px;
+  white-space: pre-wrap;
+  border-radius: 4px;
+  background: #41444e;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #fff
+}
+
+.swagger-ui .opblock-body pre span {
+  color: #fff!important
+}
+
+.swagger-ui .scheme-container {
+  margin: 0 0 20px;
+  padding: 30px 0;
+  background: #fff;
+  box-shadow: none;
+}
+
+.swagger-ui .scheme-container .schemes {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui .scheme-container .schemes>label {
+  font-size: 12px;
+  font-weight: 700;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: -20px 15px 0 0;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .scheme-container .schemes>label select {
+  min-width: 130px;
+  text-transform: uppercase
+}
+
+.swagger-ui .loading-container {
+  padding: 40px 0 60px
+}
+
+.swagger-ui .loading-container .loading {
+  position: relative
+}
+
+.swagger-ui .loading-container .loading:after {
+  font-size: 10px;
+  font-weight: 700;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  content: "loading";
+  -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  text-transform: uppercase;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .loading-container .loading:before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: block;
+  width: 60px;
+  height: 60px;
+  margin: -30px;
+  content: "";
+  -webkit-animation: rotation 1s infinite linear, opacity .5s;
+  animation: rotation 1s infinite linear, opacity .5s;
+  opacity: 1;
+  border: 2px solid rgba(85, 85, 85, .1);
+  border-top-color: rgba(0, 0, 0, .6);
+  border-radius: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden
+}
+
+@-webkit-keyframes rotation {
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn)
+  }
+}
+
+@keyframes rotation {
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn)
+  }
+}
+
+@-webkit-keyframes blinker {
+  50% {
+    opacity: 0
+  }
+}
+
+@keyframes blinker {
+  50% {
+    opacity: 0
+  }
+}
+
+.swagger-ui .btn {
+  font-size: 14px;
+  font-weight: 700;
+  padding: 5px 23px;
+  -webkit-transition: all .3s;
+  transition: all .3s;
+  border: 2px solid #888;
+  border-radius: 4px;
+  background: transparent;
+  box-shadow: none;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .btn[disabled] {
+  cursor: not-allowed;
+  opacity: .3
+}
+
+.swagger-ui .btn:hover {
+  box-shadow: none;
+}
+
+.swagger-ui .btn.cancel {
+  border-color: #ff6060;
+  font-family: Titillium Web, sans-serif;
+  color: #ff6060
+}
+
+.swagger-ui .btn.authorize {
+  line-height: 1;
+  display: inline;
+  color: #49cc90;
+  border-color: #49cc90
+}
+
+.swagger-ui .btn.authorize span {
+  float: left;
+  padding: 4px 20px 0 0
+}
+
+.swagger-ui .btn.authorize svg {
+  fill: #49cc90
+}
+
+.swagger-ui .btn.execute {
+  -webkit-animation: pulse 2s infinite;
+  animation: pulse 2s infinite;
+  color: #fff;
+  border-color: #4990e2
+}
+
+@-webkit-keyframes pulse {
+  0% {
+    color: #fff;
+    background: #4990e2;
+    box-shadow: none;
+  }
+  70% {
+    box-shadow: none;
+  }
+  to {
+    color: #fff;
+    background: #4990e2;
+    box-shadow: none;
+  }
+}
+
+@keyframes pulse {
+  0% {
+    color: #fff;
+    background: #4990e2;
+    box-shadow: none;
+  }
+  70% {
+    box-shadow: none;
+  }
+  to {
+    color: #fff;
+    background: #4990e2;
+    box-shadow: none;
+  }
+}
+
+.swagger-ui .btn-group {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 30px
+}
+
+.swagger-ui .btn-group .btn {
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.swagger-ui .btn-group .btn:first-child {
+  border-radius: 4px 0 0 4px
+}
+
+.swagger-ui .btn-group .btn:last-child {
+  border-radius: 0 4px 4px 0
+}
+
+.swagger-ui .authorization__btn {
+  padding: 0 10px;
+  border: none;
+  background: none
+}
+
+.swagger-ui .authorization__btn.locked {
+  opacity: 1
+}
+
+.swagger-ui .authorization__btn.unlocked {
+  opacity: .4
+}
+
+.swagger-ui .expand-methods, .swagger-ui .expand-operation {
+  border: none;
+  background: none
+}
+
+.swagger-ui .expand-methods svg, .swagger-ui .expand-operation svg {
+  width: 20px;
+  height: 20px
+}
+
+.swagger-ui .expand-methods {
+  padding: 0 10px
+}
+
+.swagger-ui .expand-methods:hover svg {
+  fill: #444
+}
+
+.swagger-ui .expand-methods svg {
+  -webkit-transition: all .3s;
+  transition: all .3s;
+  fill: #777
+}
+
+.swagger-ui button {
+  cursor: pointer;
+  outline: none
+}
+
+.swagger-ui select {
+  font-size: 14px;
+  font-weight: 700;
+  padding: 5px 40px 5px 10px;
+  border: 2px solid #41444e;
+  border-radius: 4px;
+  background: #f7f7f7 url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCI+ICAgIDxwYXRoIGQ9Ik0xMy40MTggNy44NTljLjI3MS0uMjY4LjcwOS0uMjY4Ljk3OCAwIC4yNy4yNjguMjcyLjcwMSAwIC45NjlsLTMuOTA4IDMuODNjLS4yNy4yNjgtLjcwNy4yNjgtLjk3OSAwbC0zLjkwOC0zLjgzYy0uMjctLjI2Ny0uMjctLjcwMSAwLS45NjkuMjcxLS4yNjguNzA5LS4yNjguOTc4IDBMMTAgMTFsMy40MTgtMy4xNDF6Ii8+PC9zdmc+) right 10px center no-repeat;
+  background-size: 20px;
+  box-shadow: none;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none
+}
+
+.swagger-ui select[multiple] {
+  margin: 5px 0;
+  padding: 5px;
+  background: #f7f7f7
+}
+
+.swagger-ui .opblock-body select {
+  min-width: 230px
+}
+
+.swagger-ui label {
+  font-size: 12px;
+  font-weight: 700;
+  margin: 0 0 5px;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui input[type=email], .swagger-ui input[type=password], .swagger-ui input[type=search], .swagger-ui input[type=text] {
+  min-width: 100px;
+  margin: 5px 0;
+  padding: 8px 10px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  background: #fff
+}
+
+.swagger-ui input[type=email].invalid, .swagger-ui input[type=password].invalid, .swagger-ui input[type=search].invalid, .swagger-ui input[type=text].invalid {
+  -webkit-animation: shake .4s 1;
+  animation: shake .4s 1;
+  border-color: #f93e3e;
+  background: #feebeb
+}
+
+@-webkit-keyframes shake {
+  10%, 90% {
+    -webkit-transform: translate3d(-1px, 0, 0);
+    transform: translate3d(-1px, 0, 0)
+  }
+  20%, 80% {
+    -webkit-transform: translate3d(2px, 0, 0);
+    transform: translate3d(2px, 0, 0)
+  }
+  30%, 50%, 70% {
+    -webkit-transform: translate3d(-4px, 0, 0);
+    transform: translate3d(-4px, 0, 0)
+  }
+  40%, 60% {
+    -webkit-transform: translate3d(4px, 0, 0);
+    transform: translate3d(4px, 0, 0)
+  }
+}
+
+@keyframes shake {
+  10%, 90% {
+    -webkit-transform: translate3d(-1px, 0, 0);
+    transform: translate3d(-1px, 0, 0)
+  }
+  20%, 80% {
+    -webkit-transform: translate3d(2px, 0, 0);
+    transform: translate3d(2px, 0, 0)
+  }
+  30%, 50%, 70% {
+    -webkit-transform: translate3d(-4px, 0, 0);
+    transform: translate3d(-4px, 0, 0)
+  }
+  40%, 60% {
+    -webkit-transform: translate3d(4px, 0, 0);
+    transform: translate3d(4px, 0, 0)
+  }
+}
+
+.swagger-ui textarea {
+  font-size: 12px;
+  width: 100%;
+  min-height: 280px;
+  padding: 10px;
+  border: none;
+  border-radius: 4px;
+  outline: none;
+  background: hsla(0, 0%, 100%, .8);
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui textarea:focus {
+  border: 2px solid #61affe
+}
+
+.swagger-ui textarea.curl {
+  font-size: 12px;
+  min-height: 100px;
+  margin: 0;
+  padding: 10px;
+  resize: none;
+  border-radius: 4px;
+  background: #41444e;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #fff
+}
+
+.swagger-ui .checkbox {
+  padding: 5px 0 10px;
+  -webkit-transition: opacity .5s;
+  transition: opacity .5s;
+  color: #333
+}
+
+.swagger-ui .checkbox label {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex
+}
+
+.swagger-ui .checkbox p {
+  font-weight: 400!important;
+  font-style: italic;
+  margin: 0!important;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui .checkbox input[type=checkbox] {
+  display: none
+}
+
+.swagger-ui .checkbox input[type=checkbox]+label>.item {
+  position: relative;
+  top: 3px;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin: 0 8px 0 0;
+  padding: 5px;
+  cursor: pointer;
+  border-radius: 1px;
+  background: #e8e8e8;
+  box-shadow: none;
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none
+}
+
+.swagger-ui .checkbox input[type=checkbox]+label>.item:active {
+  -webkit-transform: scale(.9);
+  transform: scale(.9)
+}
+
+.swagger-ui .checkbox input[type=checkbox]:checked+label>.item {
+  background: #e8e8e8 url("data:image/svg+xml;charset=utf-8,%3Csvg width='10' height='8' viewBox='3 7 10 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%2341474E' fill-rule='evenodd' d='M6.333 15L3 11.667l1.333-1.334 2 2L11.667 7 13 8.333z'/%3E%3C/svg%3E") 50% no-repeat
+}
+
+.swagger-ui .dialog-ux {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0
+}
+
+.swagger-ui .dialog-ux .backdrop-ux {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0, 0, 0, .8)
+}
+
+.swagger-ui .dialog-ux .modal-ux {
+  position: absolute;
+  z-index: 9999;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  min-width: 300px;
+  max-width: 650px;
+  -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  border: 1px solid #ebebeb;
+  border-radius: 4px;
+  background: #fff;
+  box-shadow: none;
+}
+
+.swagger-ui .dialog-ux .modal-ux-content {
+  overflow-y: auto;
+  max-height: 540px;
+  padding: 20px
+}
+
+.swagger-ui .dialog-ux .modal-ux-content p {
+  font-size: 12px;
+  margin: 0 0 5px;
+  color: #41444e;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .dialog-ux .modal-ux-content h4 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 15px 0 0;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .dialog-ux .modal-ux-header {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 12px 0;
+  border-bottom: 1px solid #ebebeb;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui .dialog-ux .modal-ux-header .close-modal {
+  padding: 0 10px;
+  border: none;
+  background: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none
+}
+
+.swagger-ui .dialog-ux .modal-ux-header h3 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+  padding: 0 20px;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .model {
+  font-size: 12px;
+  font-weight: 300;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui .model-toggle {
+  font-size: 10px;
+  position: relative;
+  top: 6px;
+  display: inline-block;
+  margin: auto .3em;
+  cursor: pointer;
+  -webkit-transition: -webkit-transform .15s ease-in;
+  transition: -webkit-transform .15s ease-in;
+  transition: transform .15s ease-in;
+  transition: transform .15s ease-in, -webkit-transform .15s ease-in;
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+  -webkit-transform-origin: 50% 50%;
+  transform-origin: 50% 50%
+}
+
+.swagger-ui .model-toggle.collapsed {
+  -webkit-transform: rotate(0deg);
+  transform: rotate(0deg)
+}
+
+.swagger-ui .model-toggle:after {
+  display: block;
+  width: 20px;
+  height: 20px;
+  content: "";
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z'/%3E%3C/svg%3E") 50% no-repeat;
+  background-size: 100%
+}
+
+.swagger-ui .model-jump-to-path {
+  position: relative;
+  cursor: pointer
+}
+
+.swagger-ui .model-jump-to-path .view-line-link {
+  position: absolute;
+  top: -.4em;
+  cursor: pointer
+}
+
+.swagger-ui .model-title {
+  position: relative
+}
+
+.swagger-ui .model-title:hover .model-hint {
+  visibility: visible
+}
+
+.swagger-ui .model-hint {
+  position: absolute;
+  top: -1.8em;
+  visibility: hidden;
+  padding: .1em .5em;
+  white-space: nowrap;
+  color: #ebebeb;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, .7)
+}
+
+.swagger-ui section.models {
+  margin: 30px 0;
+  border: 1px solid #EAEAEF;
+  border-radius: 4px
+}
+
+.swagger-ui section.models.is-open {
+  padding: 0 0 20px
+}
+
+.swagger-ui section.models.is-open h4 {
+  margin: 0 0 5px;
+  border-bottom: 1px solid #EAEAEF
+}
+
+.swagger-ui section.models.is-open h4 svg {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg)
+}
+
+.swagger-ui section.models h4 {
+  font-size: 16px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0;
+  padding: 10px 20px 10px 10px;
+  cursor: pointer;
+  -webkit-transition: all .2s;
+  transition: all .2s;
+  font-family: Titillium Web, sans-serif;
+  color: #777;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui section.models h4 svg {
+  -webkit-transition: all .4s;
+  transition: all .4s
+}
+
+.swagger-ui section.models h4 span {
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.swagger-ui section.models h4:hover {
+  57rg57a(60, 0, 0, .02)
+}
+
+.swagger-ui section.models h5 {
+  font-size: 16px;
+  margin: 0 0 10px;
+  font-family: Titillium Web, sans-serif;
+  color: #777
+}
+
+.swagger-ui section.models .model-jump-to-path {
+  position: relative;
+  top: 5px
+}
+
+.swagger-ui section.models .model-container {
+  margin: 0 20px 15px;
+  -webkit-transition: all .5s;
+  transition: all .5s;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, .05)
+}
+
+.swagger-ui section.models .model-container:hover {
+  background: rgba(0, 0, 0, .07)
+}
+
+.swagger-ui section.models .model-container:first-of-type {
+  margin: 20px
+}
+
+.swagger-ui section.models .model-container:last-of-type {
+  margin: 0 20px
+}
+
+.swagger-ui section.models .model-box {
+  background: none
+}
+
+.swagger-ui .model-box {
+  padding: 10px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .model-box .model-jump-to-path {
+  position: relative;
+  top: 4px
+}
+
+.swagger-ui .model-title {
+  font-size: 16px;
+  font-family: Titillium Web, sans-serif;
+  color: #555
+}
+
+.swagger-ui span>span.model, .swagger-ui span>span.model .brace-close {
+  padding: 0 0 0 10px
+}
+
+.swagger-ui .prop-type {
+  color: #55a
+}
+
+.swagger-ui .prop-enum {
+  display: block
+}
+
+.swagger-ui .prop-format {
+  color: #999
+}
+
+.swagger-ui table {
+  width: 100%;
+  padding: 0 10px;
+  border-collapse: collapse
+}
+
+.swagger-ui table.model tbody tr td {
+  padding: 0;
+  vertical-align: top
+}
+
+.swagger-ui table.model tbody tr td:first-of-type {
+  width: 100px;
+  padding: 0
+}
+
+.swagger-ui table.headers td {
+  font-size: 12px;
+  font-weight: 300;
+  vertical-align: middle;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui table tbody tr td {
+  padding: 10px 0 0;
+  vertical-align: top
+}
+
+.swagger-ui table tbody tr td:first-of-type {
+  width: 20%;
+  padding: 10px 0
+}
+
+.swagger-ui table thead tr td, .swagger-ui table thead tr th {
+  font-size: 12px;
+  font-weight: 700;
+  padding: 12px 0;
+  text-align: left;
+  border-bottom: 1px solid rgba(59, 65, 81, .2);
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .parameters-col_description p {
+  font-size: 14px;
+  margin: 0;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .parameters-col_description input[type=text] {
+  width: 100%;
+  max-width: 340px
+}
+
+.swagger-ui .parameter__name {
+  font-size: 16px;
+  font-weight: 400;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .parameter__name.required {
+  font-weight: 700
+}
+
+.swagger-ui .parameter__name.required:after {
+  font-size: 10px;
+  position: relative;
+  top: -6px;
+  padding: 5px;
+  content: "required";
+  color: rgba(255, 0, 0, .6)
+}
+
+.swagger-ui .parameter__in {
+  font-size: 12px;
+  font-style: italic;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #888
+}
+
+.swagger-ui .table-container {
+  padding: 20px
+}
+
+.swagger-ui .topbar {
+  padding: 8px 30px;
+  background-color: #2430F0
+}
+
+.swagger-ui .topbar .topbar-wrapper {
+  -ms-flex-align: center
+}
+
+.swagger-ui .topbar .topbar-wrapper, .swagger-ui .topbar a {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  align-items: center
+}
+
+.swagger-ui .topbar a {
+  font-size: 1.5em;
+  font-weight: 700;
+  text-decoration: none;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -ms-flex-align: center;
+  font-family: Titillium Web, sans-serif;
+  color: #fff
+}
+
+.swagger-ui .topbar a span {
+  margin: 0;
+  padding: 0 10px
+}
+
+.swagger-ui .topbar .download-url-wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex
+}
+
+.swagger-ui .topbar .download-url-wrapper input[type=text] {
+  min-width: 350px;
+  margin: 0;
+  border: 2px solid #547f00;
+  border-radius: 4px 0 0 4px;
+  outline: none
+}
+
+.swagger-ui .topbar .download-url-wrapper .download-url-button {
+  font-size: 16px;
+  font-weight: 700;
+  padding: 4px 40px;
+  border: none;
+  border-radius: 0 4px 4px 0;
+  background: #547f00;
+  font-family: Titillium Web, sans-serif;
+  color: #fff
+}
+
+.swagger-ui .info {
+  margin: 50px 0
+}
+
+.swagger-ui .info hgroup.main {
+  margin: 0 0 20px
+}
+
+.swagger-ui .info hgroup.main a {
+  font-size: 12px
+}
+
+.swagger-ui .info p {
+  font-size: 14px;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .info code {
+  padding: 3px 5px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, .05);
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #9012fe
+}
+
+.swagger-ui .info a {
+  font-size: 14px;
+  -webkit-transition: all .4s;
+  transition: all .4s;
+  font-family: Open Sans, sans-serif;
+  color: #4990e2
+}
+
+.swagger-ui .info a:hover {
+  color: #1f69c0
+}
+
+.swagger-ui .info>div {
+  margin: 0 0 5px
+}
+
+.swagger-ui .info .base-url {
+  font-size: 12px;
+  font-weight: 300!important;
+  margin: 0;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui .info .title {
+  font-size: 36px;
+  margin: 0;
+  font-family: Open Sans, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .info .title small {
+  font-size: 10px;
+  position: relative;
+  top: -5px;
+  display: inline-block;
+  margin: 0 0 0 5px;
+  padding: 2px 4px;
+  vertical-align: super;
+  border-radius: 57px;
+  background: #7d8492
+}
+
+.swagger-ui .info .title small pre {
+  margin: 0;
+  font-family: Titillium Web, sans-serif;
+  color: #fff
+}
+
+.swagger-ui .auth-btn-wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 0;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center
+}
+
+.swagger-ui .auth-wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end
+}
+
+.swagger-ui .auth-wrapper .authorize {
+  padding-right: 20px
+}
+
+.swagger-ui .auth-container {
+  margin: 0 0 10px;
+  padding: 10px 20px;
+  border-bottom: 1px solid #ebebeb
+}
+
+.swagger-ui .auth-container:last-of-type {
+  margin: 0;
+  padding: 10px 20px;
+  border: 0
+}
+
+.swagger-ui .auth-container h4 {
+  margin: 5px 0 15px!important
+}
+
+.swagger-ui .auth-container .wrapper {
+  margin: 0;
+  padding: 0
+}
+
+.swagger-ui .auth-container input[type=password], .swagger-ui .auth-container input[type=text] {
+  min-width: 230px
+}
+
+.swagger-ui .auth-container .errors {
+  font-size: 12px;
+  padding: 10px;
+  border-radius: 4px;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui .scopes h2 {
+  font-size: 14px;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+.swagger-ui .scope-def {
+  padding: 0 0 20px
+}
+
+.swagger-ui .errors-wrapper {
+  margin: 20px;
+  padding: 10px 20px;
+  -webkit-animation: scaleUp .5s;
+  animation: scaleUp .5s;
+  border: 2px solid #f93e3e;
+  border-radius: 4px;
+  background: rgba(249, 62, 62, .1)
+}
+
+.swagger-ui .errors-wrapper .error-wrapper {
+  margin: 0 0 10px
+}
+
+.swagger-ui .errors-wrapper .errors h4 {
+  font-size: 14px;
+  margin: 0;
+  font-family: Source Code Pro, monospace;
+  font-weight: 600;
+  color: #3b4151
+}
+
+.swagger-ui .errors-wrapper hgroup {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center
+}
+
+.swagger-ui .errors-wrapper hgroup h4 {
+  font-size: 20px;
+  margin: 0;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  font-family: Titillium Web, sans-serif;
+  color: #3b4151
+}
+
+@-webkit-keyframes scaleUp {
+  0% {
+    -webkit-transform: scale(.8);
+    transform: scale(.8);
+    opacity: 0
+  }
+  to {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    opacity: 1
+  }
+}
+
+@keyframes scaleUp {
+  0% {
+    -webkit-transform: scale(.8);
+    transform: scale(.8);
+    opacity: 0
+  }
+  to {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    opacity: 1
+  }
+}
+
+.swagger-ui .Resizer.vertical.disabled {
+  display: none
+}
+
+/*# sourceMappingURL=swagger-ui.css.map*/
+
+/**
+ * Swagger UI Theme Overrides
+ *
+ * Theme: Newspaper
+ * Author: Mark Ostrander
+ * Github: https://github.com/ostranme/swagger-ui-themes
+ */
+
+ .swagger-ui .opblock.opblock-post {
+   border-color: #F2F2F6;
+   background: #F5F7F9;
+ }
+
+ .swagger-ui .opblock.opblock-post .opblock-summary-method {
+   background: #535356;
+ }
+
+ .swagger-ui .opblock.opblock-post .opblock-summary {
+   border-color: #F2F2F6;
+ }
+
+ .swagger-ui .opblock.opblock-put {
+   border-color: #F2F2F6;
+   background: #F5F7F9;
+ }
+
+ .swagger-ui .opblock.opblock-put .opblock-summary-method {
+   background: #535356;
+ }
+
+ .swagger-ui .opblock.opblock-put .opblock-summary {
+   border-color: #F2F2F6;
+ }
+
+ .swagger-ui .opblock.opblock-delete {
+   border-color: #F2F2F6;
+   background: #F5F7F9;
+ }
+
+ .swagger-ui .opblock.opblock-delete .opblock-summary-method {
+   background: #535356;
+ }
+
+ .swagger-ui .opblock.opblock-delete .opblock-summary {
+   border-color: #F2F2F6;
+ }
+
+ .swagger-ui .opblock.opblock-get {
+   border-color: #F2F2F6;
+   background: #F5F7F9;
+ }
+
+ .swagger-ui .opblock.opblock-get .opblock-summary-method {
+   background: #535356;
+ }
+
+ .swagger-ui .opblock.opblock-get .opblock-summary {
+   border-color: #F2F2F6;
+ }
+
+ .swagger-ui .opblock.opblock-patch {
+   border-color: #F2F2F6;
+   background: #F5F7F9;
+ }
+
+ .swagger-ui .opblock.opblock-patch .opblock-summary-method {
+   background: #535356;
+ }
+
+ .swagger-ui .opblock.opblock-patch .opblock-summary {
+   border-color: #F2F2F6;
+ }
+
+ .swagger-ui .opblock.opblock-head {
+   border-color: #F2F2F6;
+   background: #F5F7F9;
+ }
+
+ .swagger-ui .opblock.opblock-head .opblock-summary-method {
+   background: #535356;
+ }
+
+ .swagger-ui .opblock.opblock-head .opblock-summary {
+   border-color: #F2F2F6;
+ }
+
+ .swagger-ui .opblock.opblock-options {
+   border-color: #F2F2F6;
+   background: #F5F7F9;
+ }
+
+ .swagger-ui .opblock.opblock-options .opblock-summary-method {
+   background: #535356;
+ }
+
+ .swagger-ui .opblock.opblock-options .opblock-summary {
+   border-color: #F2F2F6;
+ }
+
+ .swagger-ui .topbar {
+   padding: 8px 30px;
+   background-color: #535356;
+ }
+ .swagger-ui .topbar .download-url-wrapper input[type=text] {
+   min-width: 350px;
+   margin: 0;
+   border: 2px solid #F2F2F6;
+   border-radius: 4px 0 0 4px;
+   outline: none;
+ }
+
+ .swagger-ui .topbar .download-url-wrapper .download-url-button {
+   font-size: 16px;
+   font-weight: 700;
+   padding: 4px 40px;
+   border: none;
+   border-radius: 0 4px 4px 0;
+   background: #F2F2F6;
+   font-family: Titillium Web, sans-serif;
+   color: #535356;
+ }
+
+ .swagger-ui .info a {
+   font-size: 14px;
+   -webkit-transition: all .4s;
+   transition: all .4s;
+   font-family: Open Sans, sans-serif;
+   color: #535356;
+ }
+
+ .swagger-ui .info a:hover {
+   color: #535356;
+ }
+
+ .swagger-ui .btn.authorize {
+   line-height: 1;
+   display: inline;
+   color: #535356;
+   border-color: #535356;
+ }
+ .swagger-ui .btn.authorize svg {
+   fill: #535356;
+ }
+`
     })
   }
 

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -1,6 +1,7 @@
 import { ValidationPipe } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { NestFactory } from '@nestjs/core'
+import { SwaggerModule, DocumentBuilder, OpenAPIObject } from '@nestjs/swagger'
 import connectLiveReload from 'connect-livereload'
 import * as express from 'express'
 import * as livereload from 'livereload'
@@ -46,6 +47,15 @@ async function bootstrap() {
       res.sendFile(join(adminPath, 'index.html'))
     }
   })
+
+  const apiDoc = new DocumentBuilder()
+    .setTitle('Cats example')
+    .setDescription('The cats API description')
+    .build()
+
+  const document: OpenAPIObject = SwaggerModule.createDocument(app, apiDoc)
+
+  SwaggerModule.setup('api', app, document)
 
   await app.listen(configService.get('PORT') || DEFAULT_PORT)
 }

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -268,55 +268,55 @@ async function bootstrap() {
 }
 
 .swagger-ui .opblock.opblock-post {
-  border-color: #49cc90;
+  border-color: #57b3a0;
   background: rgba(73, 204, 144, .1)
 }
 
 .swagger-ui .opblock.opblock-post .opblock-summary-method {
-  background: #49cc90
+  background: #57b3a0
 }
 
 .swagger-ui .opblock.opblock-post .opblock-summary {
-  border-color: #49cc90
+  border-color: #57b3a0
 }
 
 .swagger-ui .opblock.opblock-put {
-  border-color: #fca130;
+  border-color: #f8a94a;
   background: rgba(252, 161, 48, .1)
 }
 
 .swagger-ui .opblock.opblock-put .opblock-summary-method {
-  background: #fca130
+  background: #f8a94a
 }
 
 .swagger-ui .opblock.opblock-put .opblock-summary {
-  border-color: #fca130
+  border-color: #f8a94a
 }
 
 .swagger-ui .opblock.opblock-delete {
-  border-color: #f93e3e;
+  border-color: #f46470;
   background: rgba(249, 62, 62, .1)
 }
 
 .swagger-ui .opblock.opblock-delete .opblock-summary-method {
-  background: #f93e3e
+  background: #f46470
 }
 
 .swagger-ui .opblock.opblock-delete .opblock-summary {
-  border-color: #f93e3e
+  border-color: #f46470
 }
 
 .swagger-ui .opblock.opblock-get {
-  border-color: #61affe;
+  border-color: #2430F0;
   background: #F5F7F9
 }
 
 .swagger-ui .opblock.opblock-get .opblock-summary-method {
-  background: #61affe
+  background: #2430F0
 }
 
 .swagger-ui .opblock.opblock-get .opblock-summary {
-  border-color: #61affe
+  border-color: #2430F0
 }
 
 .swagger-ui .opblock.opblock-patch {
@@ -331,6 +331,18 @@ async function bootstrap() {
 .swagger-ui .opblock.opblock-patch .opblock-summary {
   border-color: #50e3c2
 }
+  .swagger-ui .opblock.opblock-put .tab-header .tab-item.active h4 span:after {
+  background: #f8a94a;
+  }
+
+  .swagger-ui .opblock.opblock-post .tab-header .tab-item.active h4 span:after {
+  background: #57b3a0;
+  }
+
+.swagger-ui .opblock.opblock-delete .tab-header .tab-item.active h4 span:after {
+background: #f46470;
+}
+
 
 .swagger-ui .opblock.opblock-head {
   border-color: #9012fe;
@@ -644,16 +656,16 @@ async function bootstrap() {
 }
 
 .swagger-ui .btn.cancel {
-  border-color: #ff6060;
+  border-color: #f46470;
   font-family: Titillium Web, sans-serif;
-  color: #ff6060
+  color: #f46470
 }
 
 .swagger-ui .btn.authorize {
   line-height: 1;
   display: inline;
-  color: #49cc90;
-  border-color: #49cc90
+  color: #57b3a0;
+  border-color: #57b3a0
 }
 
 .swagger-ui .btn.authorize span {
@@ -662,20 +674,20 @@ async function bootstrap() {
 }
 
 .swagger-ui .btn.authorize svg {
-  fill: #49cc90
+  fill: #57b3a0
 }
 
 .swagger-ui .btn.execute {
   -webkit-animation: pulse 2s infinite;
   animation: pulse 2s infinite;
   color: #fff;
-  border-color: #4990e2
+  border-color: #2430F0
 }
 
 @-webkit-keyframes pulse {
   0% {
     color: #fff;
-    background: #4990e2;
+    background: #2430F0;
     box-shadow: none;
   }
   70% {
@@ -683,7 +695,7 @@ async function bootstrap() {
   }
   to {
     color: #fff;
-    background: #4990e2;
+    background: #2430F0;
     box-shadow: none;
   }
 }
@@ -691,7 +703,7 @@ async function bootstrap() {
 @keyframes pulse {
   0% {
     color: #fff;
-    background: #4990e2;
+    background: #2430F0;
     box-shadow: none;
   }
   70% {
@@ -699,7 +711,7 @@ async function bootstrap() {
   }
   to {
     color: #fff;
-    background: #4990e2;
+    background: #2430F0;
     box-shadow: none;
   }
 }
@@ -814,7 +826,7 @@ async function bootstrap() {
 .swagger-ui input[type=email].invalid, .swagger-ui input[type=password].invalid, .swagger-ui input[type=search].invalid, .swagger-ui input[type=text].invalid {
   -webkit-animation: shake .4s 1;
   animation: shake .4s 1;
-  border-color: #f93e3e;
+  border-color: #f46470;
   background: #feebeb
 }
 
@@ -871,7 +883,7 @@ async function bootstrap() {
 }
 
 .swagger-ui textarea:focus {
-  border: 2px solid #61affe
+  border: 2px solid #2430F0
 }
 
 .swagger-ui textarea.curl {
@@ -886,8 +898,18 @@ async function bootstrap() {
   font-weight: 600;
   color: #fff
 }
+  .swagger-ui .opblock.opblock-get .tab-header .tab-item.active h4 span:after {
+    background: #2430F0;
+  }
+  
 
-.swagger-ui .checkbox {
+  .swagger-ui .response-control-media-type__accept-message {
+      color: #57b3a0
+  }
+      .swagger-ui .response-control-media-type--accept-controller select {
+      border-color: #57b3a0}
+
+  .swagger-ui .checkbox {
   padding: 5px 0 10px;
   -webkit-transition: opacity .5s;
   transition: opacity .5s;
@@ -1397,7 +1419,7 @@ async function bootstrap() {
   -webkit-transition: all .4s;
   transition: all .4s;
   font-family: Open Sans, sans-serif;
-  color: #4990e2
+  color: #2430F0
 }
 
 .swagger-ui .info a:hover {
@@ -1517,7 +1539,7 @@ async function bootstrap() {
   padding: 10px 20px;
   -webkit-animation: scaleUp .5s;
   animation: scaleUp .5s;
-  border: 2px solid #f93e3e;
+  border: 2px solid #f46470;
   border-radius: 4px;
   background: rgba(249, 62, 62, .1)
 }

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -53,7 +53,13 @@ async function bootstrap() {
   if (!isProduction && !isTest) {
     const openApiService: OpenApiService = app.get(OpenApiService)
 
-    SwaggerModule.setup('api', app, openApiService.generateOpenApiObject())
+    SwaggerModule.setup('api', app, openApiService.generateOpenApiObject(), {
+      customfavIcon: 'assets/images/favicon.png',
+      customSiteTitle: 'Manifest API Doc',
+      customCss: `
+        .topbar-wrapper img {content:url(\'assets/images/logo.svg\'); width:300px; height:auto;}
+        .swagger-ui .topbar { background-color: white; }`
+    })
   }
 
   await app.listen(configService.get('PORT') || DEFAULT_PORT)

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -50,7 +50,7 @@ async function bootstrap() {
     }
   })
 
-  if (!isProduction && !isTest) {
+  if (!isProduction) {
     const openApiService: OpenApiService = app.get(OpenApiService)
 
     SwaggerModule.setup('api', app, openApiService.generateOpenApiObject(), {

--- a/packages/core/manifest/src/manifest/controllers/manifest.controller.ts
+++ b/packages/core/manifest/src/manifest/controllers/manifest.controller.ts
@@ -3,7 +3,9 @@ import { Controller, Get, Param, Req } from '@nestjs/common'
 import { Request } from 'express'
 import { AuthService } from '../../auth/auth.service'
 import { ManifestService } from '../services/manifest/manifest.service'
+import { ApiTags } from '@nestjs/swagger'
 
+@ApiTags('Manifest')
 @Controller('manifest')
 export class ManifestController {
   constructor(

--- a/packages/core/manifest/src/manifest/services/yaml/yaml.service.spec.ts
+++ b/packages/core/manifest/src/manifest/services/yaml/yaml.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { YamlService } from './yaml.service'
 import * as fs from 'fs'
+import { ConfigService } from '@nestjs/config'
 
 jest.mock('fs')
 
@@ -15,7 +16,17 @@ describe('YamlService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [YamlService]
+      providers: [
+        YamlService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(() => ({
+              database: 'mocked database path'
+            }))
+          }
+        }
+      ]
     }).compile()
 
     service = module.get<YamlService>(YamlService)

--- a/packages/core/manifest/src/manifest/services/yaml/yaml.service.ts
+++ b/packages/core/manifest/src/manifest/services/yaml/yaml.service.ts
@@ -4,10 +4,12 @@ import * as fs from 'fs'
 import * as yaml from 'js-yaml'
 
 import { AppManifestSchema } from '@mnfst/types'
-import { MANIFEST_FILE_NAME, MANIFEST_FOLDER_NAME } from '../../../constants'
+import { ConfigService } from '@nestjs/config'
 
 @Injectable()
 export class YamlService {
+  constructor(private readonly configService: ConfigService) {}
+
   /**
    *
    * Load the manifest from the YML file and transform it into a AppManifest object.
@@ -17,7 +19,7 @@ export class YamlService {
    **/
   load(): AppManifestSchema {
     let fileContent: string = fs.readFileSync(
-      `${process.cwd()}/${MANIFEST_FOLDER_NAME}/${MANIFEST_FILE_NAME}`,
+      this.configService.get('paths').database,
       'utf8'
     )
 

--- a/packages/core/manifest/src/open-api/open-api.module.ts
+++ b/packages/core/manifest/src/open-api/open-api.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common'
 import { OpenApiService } from './services/open-api.service'
 import { OpenApiCrudService } from './services/open-api-crud.service'
+import { ManifestModule } from '../manifest/manifest.module'
 
 @Module({
+  imports: [ManifestModule],
   providers: [OpenApiService, OpenApiCrudService]
 })
 export class OpenApiModule {}

--- a/packages/core/manifest/src/open-api/open-api.module.ts
+++ b/packages/core/manifest/src/open-api/open-api.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { OpenApiService } from './services/open-api.service'
+import { OpenApiCrudService } from './services/open-api-crud.service'
+
+@Module({
+  providers: [OpenApiService, OpenApiCrudService]
+})
+export class OpenApiModule {}

--- a/packages/core/manifest/src/open-api/open-api.module.ts
+++ b/packages/core/manifest/src/open-api/open-api.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common'
 import { OpenApiService } from './services/open-api.service'
 import { OpenApiCrudService } from './services/open-api-crud.service'
 import { ManifestModule } from '../manifest/manifest.module'
+import { OpenApiManifestService } from './services/open-api-manifest.service'
 
 @Module({
   imports: [ManifestModule],
-  providers: [OpenApiService, OpenApiCrudService]
+  providers: [OpenApiService, OpenApiCrudService, OpenApiManifestService]
 })
 export class OpenApiModule {}

--- a/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
@@ -45,7 +45,7 @@ export class OpenApiCrudService {
       get: {
         summary: `List ${entityManifest.namePlural}`,
         description: `Retrieves a paginated list of ${entityManifest.namePlural}. In addition to the general parameters below, each property of the ${entityManifest.nameSingular} can be used as a filter: https://manifest.build/docs/rest-api#filters`,
-        tags: [entityManifest.namePlural],
+        tags: [this.capitalizeFirstLetter(entityManifest.namePlural)],
         parameters: [
           {
             name: 'page',
@@ -128,7 +128,7 @@ export class OpenApiCrudService {
       get: {
         summary: `List ${entityManifest.namePlural} for select options`,
         description: `Retrieves a list of ${entityManifest.namePlural} for select options. The response is an array of objects with the properties 'id' and 'label'.`,
-        tags: [entityManifest.namePlural],
+        tags: [this.capitalizeFirstLetter(entityManifest.namePlural)],
         responses: {
           '200': {
             description: `List of ${entityManifest.namePlural} for select options`,
@@ -161,7 +161,7 @@ export class OpenApiCrudService {
       post: {
         summary: `Create a new ${entityManifest.nameSingular}`,
         description: `Creates a new ${entityManifest.nameSingular} passing the properties in the request body as JSON.`,
-        tags: [entityManifest.namePlural],
+        tags: [this.capitalizeFirstLetter(entityManifest.namePlural)],
         requestBody: {
           content: {
             'application/json': {
@@ -195,7 +195,7 @@ export class OpenApiCrudService {
       get: {
         summary: `Get a single ${entityManifest.nameSingular}`,
         description: `Retrieves the details of a single ${entityManifest.nameSingular} by its ID.`,
-        tags: [entityManifest.namePlural],
+        tags: [this.capitalizeFirstLetter(entityManifest.namePlural)],
         parameters: [
           {
             name: 'id',
@@ -238,7 +238,7 @@ export class OpenApiCrudService {
       put: {
         summary: `Update an existing ${entityManifest.nameSingular}`,
         description: `Updates a single ${entityManifest.nameSingular} by its ID. The properties to update are passed in the request body as JSON.`,
-        tags: [entityManifest.namePlural],
+        tags: [this.capitalizeFirstLetter(entityManifest.namePlural)],
         requestBody: {
           content: {
             'application/json': {
@@ -290,7 +290,7 @@ export class OpenApiCrudService {
       delete: {
         summary: `Delete an existing ${entityManifest.nameSingular}`,
         description: `Deletes a single ${entityManifest.nameSingular} by its ID.`,
-        tags: [entityManifest.namePlural],
+        tags: [this.capitalizeFirstLetter(entityManifest.namePlural)],
         parameters: [
           {
             name: 'id',
@@ -312,5 +312,10 @@ export class OpenApiCrudService {
         }
       }
     }
+  }
+
+  private capitalizeFirstLetter(str: string) {
+    if (str.length === 0) return str // Handle empty string case
+    return str.charAt(0).toUpperCase() + str.slice(1)
   }
 }

--- a/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
@@ -1,0 +1,22 @@
+import { EntityManifest } from '@mnfst/types'
+import { Injectable } from '@nestjs/common'
+import { PathItemObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface'
+
+@Injectable()
+export class OpenApiCrudService {
+  generateEntityPaths(entityManifest: EntityManifest): PathItemObject[] {}
+
+  generateListPath(entityManifest: EntityManifest): PathItemObject {}
+
+  generateListSelectOptionsPath(
+    entityManifest: EntityManifest
+  ): PathItemObject {}
+
+  generateCreatePath(entityManifest: EntityManifest): PathItemObject {}
+
+  generateDetailPath(entityManifest: EntityManifest): PathItemObject {}
+
+  generateUpdatePath(entityManifest: EntityManifest): PathItemObject {}
+
+  generateDeletePath(entityManifest: EntityManifest): PathItemObject {}
+}

--- a/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
@@ -4,6 +4,13 @@ import { PathItemObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.in
 
 @Injectable()
 export class OpenApiCrudService {
+  /**
+   * Generates the paths for the entities. For each entity, it generates the paths for listing, creating, updating and deleting.
+   *
+   * @param entityManifests The entity manifests.
+   * @returns The paths object.
+   *
+   */
   generateEntityPaths(
     entityManifests: EntityManifest[]
   ): Record<string, PathItemObject> {
@@ -26,6 +33,13 @@ export class OpenApiCrudService {
     return paths
   }
 
+  /**
+   * Generates the path for listing entities.
+   *
+   * @param entityManifest The entity manifest.
+   * @returns The path item object.
+   *
+   */
   generateListPath(entityManifest: EntityManifest): PathItemObject {
     return {
       get: {
@@ -89,10 +103,7 @@ export class OpenApiCrudService {
             content: {
               'application/json': {
                 schema: {
-                  type: 'array',
-                  items: {
-                    $ref: '#/components/schemas/Paginator'
-                  }
+                  $ref: '#/components/schemas/Paginator'
                 }
               }
             }
@@ -102,12 +113,21 @@ export class OpenApiCrudService {
     }
   }
 
+  /**
+   * Generates the path for listing entities for select options.
+   * This is used to fill select dropdown options.
+   *
+   * @param entityManifest The entity manifest.
+   * @returns The path item object.
+   *
+   */
   generateListSelectOptionsPath(
     entityManifest: EntityManifest
   ): PathItemObject {
     return {
       get: {
         summary: `List ${entityManifest.namePlural} for select options`,
+        description: `Retrieves a list of ${entityManifest.namePlural} for select options. The response is an array of objects with the properties 'id' and 'label'.`,
         tags: [entityManifest.namePlural],
         responses: {
           '200': {
@@ -117,7 +137,7 @@ export class OpenApiCrudService {
                 schema: {
                   type: 'array',
                   items: {
-                    $ref: `#/components/schemas/${entityManifest.slug}`
+                    $ref: `#/components/schemas/SelectOption`
                   }
                 }
               }
@@ -128,81 +148,166 @@ export class OpenApiCrudService {
     }
   }
 
+  /**
+   * Generates the path for creating an entity.
+   * This is used to create a new entity.
+   *
+   * @param entityManifest The entity manifest.
+   * @returns The path item object.
+   *
+   */
   generateCreatePath(entityManifest: EntityManifest): PathItemObject {
     return {
       post: {
-        summary: `Create ${entityManifest.nameSingular}`,
+        summary: `Create a new ${entityManifest.nameSingular}`,
+        description: `Creates a new ${entityManifest.nameSingular} passing the properties in the request body as JSON.`,
         tags: [entityManifest.namePlural],
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${entityManifest.slug}`
+                type: 'object'
               }
             }
           }
         },
         responses: {
           '201': {
-            description: `The ${entityManifest.nameSingular} has been successfully created`
+            description: `OK`
+          },
+          '400': {
+            description: `Bad request`
           }
         }
       }
     }
   }
 
+  /**
+   * Generates the path for retrieving the details of an entity.
+   *
+   * @param entityManifest The entity manifest.
+   * @returns The path item object.
+   *
+   */
   generateDetailPath(entityManifest: EntityManifest): PathItemObject {
     return {
       get: {
-        summary: `Get ${entityManifest.nameSingular}`,
+        summary: `Get a single ${entityManifest.nameSingular}`,
+        description: `Retrieves the details of a single ${entityManifest.nameSingular} by its ID.`,
         tags: [entityManifest.namePlural],
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            description: `The ID of the ${entityManifest.nameSingular}`,
+            required: true,
+            schema: {
+              type: 'integer'
+            }
+          }
+        ],
         responses: {
           '200': {
-            description: `The ${entityManifest.nameSingular}`,
+            description: `OK`,
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${entityManifest.slug}`
+                  type: 'object'
                 }
               }
             }
+          },
+          '404': {
+            description: `The ${entityManifest.nameSingular} was not found`
           }
         }
       }
     }
   }
 
+  /**
+   * Generates the path for updating an entity.
+   *
+   * @param entityManifest The entity manifest.
+   * @returns The path item object.
+   *
+   */
   generateUpdatePath(entityManifest: EntityManifest): PathItemObject {
     return {
       put: {
-        summary: `Update ${entityManifest.nameSingular}`,
+        summary: `Update an existing ${entityManifest.nameSingular}`,
+        description: `Updates a single ${entityManifest.nameSingular} by its ID. The properties to update are passed in the request body as JSON.`,
         tags: [entityManifest.namePlural],
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${entityManifest.slug}`
+                type: 'object'
               }
             }
           }
         },
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            description: `The ID of the ${entityManifest.nameSingular}`,
+            required: true,
+            schema: {
+              type: 'integer'
+            }
+          }
+        ],
         responses: {
           '200': {
-            description: `The ${entityManifest.nameSingular} has been successfully updated`
+            description: `OK`,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object'
+                }
+              }
+            }
+          },
+          '404': {
+            description: `Not found`
           }
         }
       }
     }
   }
 
+  /**
+   * Generates the path for deleting an entity.
+   *
+   * @param entityManifest The entity manifest.
+   * @returns The path item object.
+   *
+   */
   generateDeletePath(entityManifest: EntityManifest): PathItemObject {
     return {
       delete: {
-        summary: `Delete ${entityManifest.nameSingular}`,
+        summary: `Delete an existing ${entityManifest.nameSingular}`,
+        description: `Deletes a single ${entityManifest.nameSingular} by its ID.`,
         tags: [entityManifest.namePlural],
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            description: `The ID of the ${entityManifest.nameSingular}`,
+            required: true,
+            schema: {
+              type: 'integer'
+            }
+          }
+        ],
         responses: {
           '200': {
-            description: `The ${entityManifest.nameSingular} has been successfully deleted`
+            description: `OK`
+          },
+          '404': {
+            description: `The ${entityManifest.nameSingular} was not found`
           }
         }
       }

--- a/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
@@ -4,19 +4,208 @@ import { PathItemObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.in
 
 @Injectable()
 export class OpenApiCrudService {
-  generateEntityPaths(entityManifest: EntityManifest): PathItemObject[] {}
+  generateEntityPaths(
+    entityManifests: EntityManifest[]
+  ): Record<string, PathItemObject> {
+    const paths: Record<string, PathItemObject> = {}
 
-  generateListPath(entityManifest: EntityManifest): PathItemObject {}
+    entityManifests.forEach((entityManifest: EntityManifest) => {
+      paths[`/api/dynamic/${entityManifest.slug}`] = {
+        ...this.generateListPath(entityManifest),
+        ...this.generateCreatePath(entityManifest)
+      }
+      paths[`/api/dynamic/${entityManifest.slug}/select-options`] =
+        this.generateListSelectOptionsPath(entityManifest)
+      paths[`/api/dynamic/${entityManifest.slug}/{id}`] = {
+        ...this.generateDetailPath(entityManifest),
+        ...this.generateUpdatePath(entityManifest),
+        ...this.generateDeletePath(entityManifest)
+      }
+    })
+
+    return paths
+  }
+
+  generateListPath(entityManifest: EntityManifest): PathItemObject {
+    return {
+      get: {
+        summary: `List ${entityManifest.namePlural}`,
+        description: `Retrieves a paginated list of ${entityManifest.namePlural}. In addition to the general parameters below, each property of the ${entityManifest.nameSingular} can be used as a filter: https://manifest.build/docs/rest-api#filters`,
+        tags: [entityManifest.namePlural],
+        parameters: [
+          {
+            name: 'page',
+            in: 'query',
+            description: 'The page number',
+            required: false,
+            schema: {
+              type: 'integer',
+              default: 1
+            }
+          },
+          {
+            name: 'perPage',
+            in: 'query',
+            description: 'The number of items per page',
+            required: false,
+            schema: {
+              type: 'integer',
+              default: 10
+            }
+          },
+          {
+            name: 'orderBy',
+            in: 'query',
+            description: 'The field to order by',
+            required: false,
+            schema: {
+              type: 'string'
+            }
+          },
+          {
+            name: 'order',
+            in: 'query',
+            description: 'The order direction',
+            required: false,
+            schema: {
+              type: 'string',
+              enum: ['ASC', 'DESC']
+            }
+          },
+          {
+            name: 'relations',
+            in: 'query',
+            description:
+              'The relations to include. For several relations, use a comma-separated list',
+            required: false,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/Paginator'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
   generateListSelectOptionsPath(
     entityManifest: EntityManifest
-  ): PathItemObject {}
+  ): PathItemObject {
+    return {
+      get: {
+        summary: `List ${entityManifest.namePlural} for select options`,
+        tags: [entityManifest.namePlural],
+        responses: {
+          '200': {
+            description: `List of ${entityManifest.namePlural} for select options`,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: `#/components/schemas/${entityManifest.slug}`
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
-  generateCreatePath(entityManifest: EntityManifest): PathItemObject {}
+  generateCreatePath(entityManifest: EntityManifest): PathItemObject {
+    return {
+      post: {
+        summary: `Create ${entityManifest.nameSingular}`,
+        tags: [entityManifest.namePlural],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: `#/components/schemas/${entityManifest.slug}`
+              }
+            }
+          }
+        },
+        responses: {
+          '201': {
+            description: `The ${entityManifest.nameSingular} has been successfully created`
+          }
+        }
+      }
+    }
+  }
 
-  generateDetailPath(entityManifest: EntityManifest): PathItemObject {}
+  generateDetailPath(entityManifest: EntityManifest): PathItemObject {
+    return {
+      get: {
+        summary: `Get ${entityManifest.nameSingular}`,
+        tags: [entityManifest.namePlural],
+        responses: {
+          '200': {
+            description: `The ${entityManifest.nameSingular}`,
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: `#/components/schemas/${entityManifest.slug}`
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
-  generateUpdatePath(entityManifest: EntityManifest): PathItemObject {}
+  generateUpdatePath(entityManifest: EntityManifest): PathItemObject {
+    return {
+      put: {
+        summary: `Update ${entityManifest.nameSingular}`,
+        tags: [entityManifest.namePlural],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: `#/components/schemas/${entityManifest.slug}`
+              }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: `The ${entityManifest.nameSingular} has been successfully updated`
+          }
+        }
+      }
+    }
+  }
 
-  generateDeletePath(entityManifest: EntityManifest): PathItemObject {}
+  generateDeletePath(entityManifest: EntityManifest): PathItemObject {
+    return {
+      delete: {
+        summary: `Delete ${entityManifest.nameSingular}`,
+        tags: [entityManifest.namePlural],
+        responses: {
+          '200': {
+            description: `The ${entityManifest.nameSingular} has been successfully deleted`
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/core/manifest/src/open-api/services/open-api-manifest.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-manifest.service.ts
@@ -4,6 +4,13 @@ import { PathItemObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.in
 
 @Injectable()
 export class OpenApiManifestService {
+  /**
+   * Generates the paths for the manifest endpoints.
+   *
+   * @param appManifest The manifest of the application.
+   * @returns The paths for the manifest endpoints.
+   *
+   */
   generateManifestPaths(
     appManifest: AppManifest
   ): Record<string, PathItemObject> {
@@ -39,6 +46,13 @@ export class OpenApiManifestService {
     return paths
   }
 
+  /**
+   * Generates the path for the entity manifest endpoint.
+   *
+   * @param entityManifest The manifest of the entity.
+   * @returns The path for the entity manifest endpoint.
+   *
+   */
   generateEntityManifestPath(entityManifest: EntityManifest): PathItemObject {
     return {
       get: {

--- a/packages/core/manifest/src/open-api/services/open-api-manifest.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-manifest.service.ts
@@ -1,0 +1,63 @@
+import { AppManifest, EntityManifest } from '@mnfst/types'
+import { Injectable } from '@nestjs/common'
+import { PathItemObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface'
+
+@Injectable()
+export class OpenApiManifestService {
+  generateManifestPaths(
+    appManifest: AppManifest
+  ): Record<string, PathItemObject> {
+    const paths: Record<string, PathItemObject> = {
+      '/api/manifest': {
+        get: {
+          summary: 'Get the manifest',
+          description: 'Retrieves the manifest of the application.',
+          tags: ['Manifest'],
+          responses: {
+            '200': {
+              description: 'The manifest of the application.',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/AppManifest'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    Object.values(appManifest.entities).forEach(
+      (entityManifest: EntityManifest) => {
+        paths[`/api/manifest/entities/${entityManifest.slug}`] =
+          this.generateEntityManifestPath(entityManifest)
+      }
+    )
+
+    return paths
+  }
+
+  generateEntityManifestPath(entityManifest: EntityManifest): PathItemObject {
+    return {
+      get: {
+        summary: `Get the ${entityManifest.nameSingular} manifest`,
+        description: `Retrieves the manifest of the ${entityManifest.nameSingular} entity with all its properties.`,
+        tags: ['Manifest'],
+        responses: {
+          '200': {
+            description: `The manifest of the ${entityManifest.nameSingular} entity.`,
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/EntityManifest'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/manifest/src/open-api/services/open-api.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api.service.ts
@@ -53,6 +53,17 @@ export class OpenApiService {
                 type: 'integer'
               }
             }
+          },
+          SelectOption: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'number'
+              },
+              label: {
+                type: 'string'
+              }
+            }
           }
         }
       }

--- a/packages/core/manifest/src/open-api/services/open-api.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common'
+import { OpenApiCrudService } from './open-api-crud.service'
+import { OpenAPIObject } from '@nestjs/swagger'
+import { ManifestService } from '../../manifest/services/manifest/manifest.service'
+
+@Injectable()
+export class OpenApiService {
+  constructor(
+    private readonly manifestService: ManifestService,
+    private readonly openApiCrudService: OpenApiCrudService
+  ) {}
+
+  generateOpenApiObject(): OpenAPIObject {}
+}

--- a/packages/core/manifest/src/open-api/services/open-api.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { OpenApiCrudService } from './open-api-crud.service'
 import { OpenAPIObject } from '@nestjs/swagger'
 import { ManifestService } from '../../manifest/services/manifest/manifest.service'
+import { AppManifest } from '@mnfst/types'
 
 @Injectable()
 export class OpenApiService {
@@ -10,5 +11,51 @@ export class OpenApiService {
     private readonly openApiCrudService: OpenApiCrudService
   ) {}
 
-  generateOpenApiObject(): OpenAPIObject {}
+  generateOpenApiObject(): OpenAPIObject {
+    const appManifest: AppManifest = this.manifestService.getAppManifest()
+
+    return {
+      openapi: '3.0.0',
+      info: {
+        title: appManifest.name,
+        version: '1.0.0'
+      },
+      paths: this.openApiCrudService.generateEntityPaths(
+        Object.values(appManifest.entities)
+      ),
+      components: {
+        schemas: {
+          Paginator: {
+            type: 'object',
+            properties: {
+              data: {
+                type: 'array',
+                items: {
+                  type: 'object'
+                }
+              },
+              currentPage: {
+                type: 'integer'
+              },
+              lastPage: {
+                type: 'integer'
+              },
+              from: {
+                type: 'integer'
+              },
+              to: {
+                type: 'integer'
+              },
+              total: {
+                type: 'integer'
+              },
+              perPage: {
+                type: 'integer'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/core/manifest/src/open-api/services/open-api.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api.service.ts
@@ -3,26 +3,37 @@ import { OpenApiCrudService } from './open-api-crud.service'
 import { OpenAPIObject } from '@nestjs/swagger'
 import { ManifestService } from '../../manifest/services/manifest/manifest.service'
 import { AppManifest } from '@mnfst/types'
+import { OpenApiManifestService } from './open-api-manifest.service'
 
 @Injectable()
 export class OpenApiService {
   constructor(
     private readonly manifestService: ManifestService,
-    private readonly openApiCrudService: OpenApiCrudService
+    private readonly openApiCrudService: OpenApiCrudService,
+    private readonly openApiManifestService: OpenApiManifestService
   ) {}
 
+  /**
+   * Generates the OpenAPI object for the application.
+   *
+   * @returns The OpenAPI object.
+   *
+   */
   generateOpenApiObject(): OpenAPIObject {
     const appManifest: AppManifest = this.manifestService.getAppManifest()
 
     return {
-      openapi: '3.0.0',
+      openapi: '3.1.0',
       info: {
         title: appManifest.name,
-        version: '1.0.0'
+        version: '' // Version is not supported yet.
       },
-      paths: this.openApiCrudService.generateEntityPaths(
-        Object.values(appManifest.entities)
-      ),
+      paths: {
+        ...this.openApiCrudService.generateEntityPaths(
+          Object.values(appManifest.entities)
+        ),
+        ...this.openApiManifestService.generateManifestPaths(appManifest)
+      },
       components: {
         schemas: {
           Paginator: {
@@ -61,6 +72,80 @@ export class OpenApiService {
                 type: 'number'
               },
               label: {
+                type: 'string'
+              }
+            }
+          },
+          AppManifest: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string'
+              },
+              entities: {
+                type: 'object',
+                additionalProperties: {
+                  $ref: '#/components/schemas/EntityManifest'
+                }
+              }
+            }
+          },
+          EntityManifest: {
+            type: 'object',
+            properties: {
+              className: {
+                type: 'string'
+              },
+              nameSingular: {
+                type: 'string'
+              },
+              namePlural: {
+                type: 'string'
+              },
+              slug: {
+                type: 'string'
+              },
+              mainProp: {
+                type: 'string'
+              },
+              seedCount: {
+                type: 'number'
+              },
+              belongsTo: {
+                type: 'array',
+                items: {
+                  $ref: '#/components/schemas/RelationshipManifest'
+                }
+              },
+              properties: {
+                type: 'array',
+                items: {
+                  $ref: '#/components/schemas/PropertyManifest'
+                }
+              }
+            }
+          },
+          RelationshipManifest: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string'
+              },
+              entity: {
+                type: 'string'
+              },
+              eager: {
+                type: 'boolean'
+              }
+            }
+          },
+          PropertyManifest: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string'
+              },
+              type: {
                 type: 'string'
               }
             }

--- a/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { OpenApiCrudService } from '../services/open-api-crud.service'
+import { EntityManifest, PropType } from '@mnfst/types'
+
+describe('OpenApiCrudService', () => {
+  let service: OpenApiCrudService
+
+  const dummyEntityManifest: EntityManifest = {
+    className: 'Cat',
+    nameSingular: 'cat',
+    namePlural: 'cats',
+    slug: 'cats',
+    mainProp: 'name',
+    seedCount: 50,
+    belongsTo: [],
+    properties: [
+      {
+        name: 'name',
+        type: PropType.String
+      }
+    ]
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OpenApiCrudService]
+    }).compile()
+
+    service = module.get<OpenApiCrudService>(OpenApiCrudService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  it('should generate all 6 entity paths', () => {
+    const paths = service.generateEntityPaths(dummyEntityManifest)
+
+    expect(paths).toBeDefined()
+    expect(paths.length).toBe(6)
+
+    expect(service.generateListPath).toHaveBeenCalled()
+    expect(service.generateListSelectOptionsPath).toHaveBeenCalled()
+    expect(service.generateCreatePath).toHaveBeenCalled()
+    expect(service.generateDetailPath).toHaveBeenCalled()
+    expect(service.generateUpdatePath).toHaveBeenCalled()
+    expect(service.generateDeletePath).toHaveBeenCalled()
+  })
+})

--- a/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
@@ -34,10 +34,17 @@ describe('OpenApiCrudService', () => {
   })
 
   it('should generate all 6 entity paths', () => {
-    const paths = service.generateEntityPaths(dummyEntityManifest)
+    jest.spyOn(service, 'generateListPath').mockReturnValue({})
+    jest.spyOn(service, 'generateListSelectOptionsPath').mockReturnValue({})
+    jest.spyOn(service, 'generateCreatePath').mockReturnValue({})
+    jest.spyOn(service, 'generateDetailPath').mockReturnValue({})
+    jest.spyOn(service, 'generateUpdatePath').mockReturnValue({})
+    jest.spyOn(service, 'generateDeletePath').mockReturnValue({})
+
+    const paths = service.generateEntityPaths([dummyEntityManifest])
 
     expect(paths).toBeDefined()
-    expect(paths.length).toBe(6)
+    expect(Object.keys(paths).length).toBe(3)
 
     expect(service.generateListPath).toHaveBeenCalled()
     expect(service.generateListSelectOptionsPath).toHaveBeenCalled()

--- a/packages/core/manifest/src/open-api/tests/open-api-manifest.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-manifest.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { OpenApiManifestService } from '../open-api-manifest.service'
+
+describe('OpenApiManifestService', () => {
+  let service: OpenApiManifestService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OpenApiManifestService]
+    }).compile()
+
+    service = module.get<OpenApiManifestService>(OpenApiManifestService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/packages/core/manifest/src/open-api/tests/open-api-manifest.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-manifest.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { OpenApiManifestService } from '../open-api-manifest.service'
+import { OpenApiManifestService } from '../services/open-api-manifest.service'
 
 describe('OpenApiManifestService', () => {
   let service: OpenApiManifestService

--- a/packages/core/manifest/src/open-api/tests/open-api.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { OpenApiService } from '../services/open-api.service'
+import { AppManifest, EntityManifest, PropType } from '@mnfst/types'
+import { OpenAPIObject } from '@nestjs/swagger'
+import { OpenApiCrudService } from '../services/open-api-crud.service'
+import { ManifestService } from '../../manifest/services/manifest/manifest.service'
+
+describe('OpenApiService', () => {
+  let service: OpenApiService
+  let openApiCrudService: OpenApiCrudService
+
+  const dummyAppManifest: AppManifest = {
+    name: 'Test App',
+    entities: {
+      Invoice: {
+        className: 'Invoice',
+        properties: [
+          {
+            name: 'name',
+            type: PropType.String
+          }
+        ],
+        belongsTo: []
+      }
+    }
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OpenApiService,
+        {
+          provide: OpenApiCrudService,
+          useValue: {
+            generateEntityPaths: jest.fn((entityManifest: EntityManifest) => {})
+          }
+        },
+        {
+          provide: ManifestService,
+          useValue: {
+            getAppManifest: jest.fn(() => dummyAppManifest)
+          }
+        }
+      ]
+    }).compile()
+
+    service = module.get<OpenApiService>(OpenApiService)
+    openApiCrudService = module.get<OpenApiCrudService>(OpenApiCrudService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  it('should return an OpenAPIObject', () => {
+    const openApiObject: OpenAPIObject = service.generateOpenApiObject()
+
+    expect(openApiObject.openapi).toBe('3.0.0')
+    expect(openApiObject.info.title).toBe('Test App')
+    expect(openApiObject.info.version).toBe('1.0.0')
+    expect(openApiObject.paths).toEqual([])
+  })
+
+  it('should generate paths for each entity', () => {
+    jest.spyOn(openApiCrudService, 'generateEntityPaths')
+
+    service.generateOpenApiObject()
+
+    expect(openApiCrudService.generateEntityPaths).toHaveBeenCalledTimes(
+      Object.keys(dummyAppManifest.entities).length
+    )
+  })
+})


### PR DESCRIPTION
![image](https://github.com/mnfst/manifest/assets/6626184/c70aa1ce-3740-4d5d-88ad-20c9deafa669)


## Description

This PR adds the API Documentation feature to Manifest.

## How can it be tested?

- Go to `packages/core/manifest`
- Run `npm run start:dev`
- You should see the link to the API doc in the console
- Click on the link to see it and play around with the different endpoints.


### run tests manually
```
npm run test
npm run test:e2e
```

:warning: @SebConejo to add style to the Api doc you can go edit `packages/core/manifest/src/main.ts` line 59 for custom css.

## Check list before submitting

The doc will be updated after publish

- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I updated the documentation if necessary
- [x] This PR is wrote in a clear language and correctly labeled
