### PR TITLE
Timestamp property type

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,12 +8,10 @@
 
 Check the packages that require a new publication or release:
 
-| Task            | Impacted | Comments |
-| --------------- | -------- | -------- |
-| @mnfst/manifest | [ ]      |          |
-| @mnfst/admin    | [ ]      |          |
-| @mnfst/types    | [ ]      |          |
-| doc             | [ ]      |          |
+- [ ] @mnfst/manifest
+- [ ] @mnfst/types
+- [ ] @mnfst/admin
+- [ ] doc
 
 ## Check list before submitting
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,17 @@
 
 ## How can it be tested?
 
+## Impacted packages
+
+Check the packages that require a new publication or release:
+
+| Task            | Impacted | Comments |
+| --------------- | -------- | -------- |
+| @mnfst/manifest | [ ]      |          |
+| @mnfst/admin    | [ ]      |          |
+| @mnfst/types    | [ ]      |          |
+| doc             | [ ]      |          |
+
 ## Check list before submitting
 
 - [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: ./packages/core/manifest
+      # Enure that we are using the latest version of the types package (even if it is not published yet).
+      - name: Link local types
+        run: npm run link-local-types
       - name: Build App
         run: npm run build
         working-directory: ./packages/core/manifest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,6 +23,7 @@ jobs:
       # Enure that we are using the latest version of the types package (even if it is not published yet).
       - name: Link local types
         run: npm run link-local-types
+        working-directory: ./packages/core/manifest
       - name: Build App
         run: npm run build
         working-directory: ./packages/core/manifest

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -28,7 +28,8 @@
     "start": "ng serve",
     "build": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "link-local-types": "cd ../types && npm install && npm run build && npm link && cd ../manifest && npm link @mnfst/types"
   },
   "private": false,
   "license": "MIT",

--- a/packages/core/admin/src/app/modules/shared/inputs/input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/input.component.ts
@@ -21,6 +21,7 @@ import { SelectInputComponent } from './select-input/select-input.component'
 import { TextInputComponent } from './text-input/text-input.component'
 import { TextareaInputComponent } from './textarea-input/textarea-input.component'
 import { UrlInputComponent } from './url-input/url-input.component'
+import { TimestampInputComponent } from './timestamp-input/timestamp-input.component'
 
 @Component({
   selector: 'app-input',
@@ -30,6 +31,7 @@ import { UrlInputComponent } from './url-input/url-input.component'
     BooleanInputComponent,
     CurrencyInputComponent,
     DateInputComponent,
+    TimestampInputComponent,
     EmailInputComponent,
     UrlInputComponent,
     MultiSelectInputComponent,
@@ -111,6 +113,14 @@ import { UrlInputComponent } from './url-input/url-input.component'
       *ngIf="prop?.type === PropType.Date"
     >
     </app-date-input>
+    <app-timestamp-input
+      [prop]="prop"
+      [value]="value"
+      [isError]="isError"
+      (valueChanged)="onChange($event)"
+      *ngIf="prop?.type === PropType.Timestamp"
+    >
+    </app-timestamp-input>
     <app-password-input
       [prop]="prop"
       [value]="value"

--- a/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.spec.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TimestampInputComponent } from './timestamp-input.component';
+
+describe('TimestampInputComponent', () => {
+  let component: TimestampInputComponent;
+  let fixture: ComponentFixture<TimestampInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TimestampInputComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TimestampInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.ts
@@ -1,0 +1,44 @@
+import { NgClass } from '@angular/common'
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild
+} from '@angular/core'
+import { PropertyManifest } from '@mnfst/types'
+
+@Component({
+  selector: 'app-timestamp-input',
+  standalone: true,
+  imports: [NgClass],
+  template: `<label [for]="prop.name">{{ prop.name }}</label>
+    <input
+      class="input"
+      [ngClass]="{ 'is-danger': isError }"
+      type="datetime-local"
+      [value]="value"
+      (change)="onChange($event)"
+      #input
+    />`
+})
+export class TimestampInputComponent {
+  @Input() prop: PropertyManifest
+  @Input() value: string
+  @Input() isError: boolean
+
+  @Output() valueChanged: EventEmitter<number> = new EventEmitter()
+
+  @ViewChild('input', { static: true }) input: ElementRef
+
+  ngOnInit(): void {
+    if (this.value !== undefined) {
+      this.input.nativeElement.value = this.value
+    }
+  }
+
+  onChange(event: any) {
+    this.valueChanged.emit(event.target.value)
+  }
+}

--- a/packages/core/admin/src/app/modules/shared/yields/date-yield/date-yield.component.ts
+++ b/packages/core/admin/src/app/modules/shared/yields/date-yield/date-yield.component.ts
@@ -1,10 +1,10 @@
-import { CommonModule } from '@angular/common'
+import { DatePipe, NgIf } from '@angular/common'
 import { Component, Input } from '@angular/core'
 
 @Component({
   selector: 'app-date-yield',
   standalone: true,
-  imports: [CommonModule],
+  imports: [DatePipe, NgIf],
   template: `<span class="is-nowrap">{{ value | date : 'MM/dd/yy' }}</span>
     <span class="is-nowrap" *ngIf="!value"> - </span> `,
   styleUrls: ['./date-yield.component.scss']

--- a/packages/core/admin/src/app/modules/shared/yields/timestamp-yield/timestamp-yield.component.spec.ts
+++ b/packages/core/admin/src/app/modules/shared/yields/timestamp-yield/timestamp-yield.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TimestampYieldComponent } from './timestamp-yield.component';
+
+describe('TimestampYieldComponent', () => {
+  let component: TimestampYieldComponent;
+  let fixture: ComponentFixture<TimestampYieldComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TimestampYieldComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TimestampYieldComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/core/admin/src/app/modules/shared/yields/timestamp-yield/timestamp-yield.component.ts
+++ b/packages/core/admin/src/app/modules/shared/yields/timestamp-yield/timestamp-yield.component.ts
@@ -1,0 +1,14 @@
+import { DatePipe } from '@angular/common'
+import { Component, Input } from '@angular/core'
+
+@Component({
+  selector: 'app-timestamp-yield',
+  standalone: true,
+  imports: [DatePipe],
+  template: `<span class="is-nowrap">{{
+    value | date : 'yyyy-MM-dd HH:mm:ss'
+  }}</span>`
+})
+export class TimestampYieldComponent {
+  @Input() value: string
+}

--- a/packages/core/admin/src/app/modules/shared/yields/yield.component.ts
+++ b/packages/core/admin/src/app/modules/shared/yields/yield.component.ts
@@ -13,6 +13,7 @@ import { LocationYieldComponent } from './location-yield/location-yield.componen
 import { NumberYieldComponent } from './number-yield/number-yield.component'
 import { ProgressBarYieldComponent } from './progress-bar-yield/progress-bar-yield.component'
 import { TextYieldComponent } from './text-yield/text-yield.component'
+import { TimestampYieldComponent } from './timestamp-yield/timestamp-yield.component'
 
 @Component({
   selector: 'app-yield',
@@ -22,6 +23,7 @@ import { TextYieldComponent } from './text-yield/text-yield.component'
     BooleanYieldComponent,
     CurrencyYieldComponent,
     DateYieldComponent,
+    TimestampYieldComponent,
     EmailYieldComponent,
     NumberYieldComponent,
     LinkYieldComponent,
@@ -45,22 +47,23 @@ import { TextYieldComponent } from './text-yield/text-yield.component'
       [value]="value"
       [compact]="compact"
     ></app-link-yield>
-
     <app-boolean-yield
       *ngIf="prop.type === PropType.Boolean"
       [value]="value"
     ></app-boolean-yield>
-
     <app-currency-yield
       *ngIf="prop.type === PropType.Money"
       [currency]="prop.options?.['currency']"
       [value]="value"
     ></app-currency-yield>
-
     <app-date-yield
       *ngIf="prop.type === PropType.Date"
       [value]="value"
     ></app-date-yield>
+    <app-timestamp-yield
+      *ngIf="prop.type === PropType.Timestamp"
+      [value]="value"
+    ></app-timestamp-yield>
     <app-email-yield
       *ngIf="prop.type === PropType.Email"
       [value]="value"

--- a/packages/core/admin/src/styles/components/_forms.scss
+++ b/packages/core/admin/src/styles/components/_forms.scss
@@ -19,6 +19,11 @@
   color: $input-placeholder-color !important;
 }
 
+input[type="datetime-local"] {
+  display: block;
+  padding-right: 12px;
+}
+
 label:not(.file-label):not(.checkbox):not(.image-label):not(.is-boxed) {
   font-size: $size-6;
   font-weight: $weight-bold;

--- a/packages/core/manifest/e2e/assets/mock-backend.yml
+++ b/packages/core/manifest/e2e/assets/mock-backend.yml
@@ -6,9 +6,22 @@ entities:
       - { name: email, type: email }
 
   Dog:
+    # Testing all property types.
     properties:
       - name
+      - { name: description, type: text }
       - { name: age, type: number }
+      - { name: website, type: link }
+      - { name: price, type: money, options: { currency: EUR } }
       - { name: birthdate, type: date }
+      - { name: isGoodBoy, type: boolean }
+      - { name: acquiredAt, type: timestamp }
+      - { name: password, type: password }
+      - { name: email, type: email }
+      - {
+          name: favoriteToy,
+          type: choice,
+          options: { values: [ball, bone, frisbee] }
+        }
     belongsTo:
       - Owner

--- a/packages/core/manifest/e2e/tests/crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/crud.e2e-spec.ts
@@ -3,7 +3,16 @@ import { Paginator, SelectOption } from '@mnfst/types'
 describe('CRUD (e2e)', () => {
   const dummyDog = {
     name: 'Fido',
-    age: 5
+    age: 5,
+    website: 'https://example.com',
+    description: 'lorem ipsum',
+    birthdate: new Date().toISOString(),
+    password: 'password',
+    price: 100,
+    isGoodBoy: true,
+    acquiredAt: new Date().toISOString(),
+    email: 'test@example.com',
+    favoriteToy: 'ball'
   }
 
   it('POST /dynamic/:entity', async () => {

--- a/packages/core/manifest/package.json
+++ b/packages/core/manifest/package.json
@@ -37,6 +37,7 @@
     "test:e2e": "jest --config ./e2e/jest-e2e.json",
     "test:e2e:ci": "jest --config ./e2e/jest-e2e.json --ci",
     "generate-types": "ts-node src/manifest/json-schema/GenerateTypes.ts",
+    "link-local-types": "cd ../types && npm install && npm run build && npm link && cd ../manifest && npm link @mnfst/types",
     "prebuild": "npm run generate-types"
   },
   "files": [

--- a/packages/core/manifest/src/entity/records/prop-type-column-types.ts
+++ b/packages/core/manifest/src/entity/records/prop-type-column-types.ts
@@ -9,6 +9,7 @@ export const propTypeColumnTypes: Record<PropType, ColumnType> = {
   [PropType.Text]: 'text',
   [PropType.Money]: 'decimal',
   [PropType.Date]: 'date',
+  [PropType.Timestamp]: 'text',
   [PropType.Email]: 'varchar',
   [PropType.Boolean]: 'boolean',
   [PropType.Password]: 'varchar',

--- a/packages/core/manifest/src/entity/records/prop-type-seed-functions.ts
+++ b/packages/core/manifest/src/entity/records/prop-type-seed-functions.ts
@@ -16,6 +16,7 @@ export const propTypeSeedFunctions: Record<PropType, (options?: any) => any> = {
       dec: 2
     }),
   [PropType.Date]: () => faker.date.past(),
+  [PropType.Timestamp]: () => faker.date.recent(),
   [PropType.Email]: () => faker.internet.email(),
   [PropType.Boolean]: () => faker.datatype.boolean(),
   [PropType.Password]: () => SHA3('manifest').toString(),

--- a/packages/core/manifest/src/entity/services/entity/entity.service.spec.ts
+++ b/packages/core/manifest/src/entity/services/entity/entity.service.spec.ts
@@ -5,6 +5,7 @@ import { DataSource } from 'typeorm'
 
 describe('EntityService', () => {
   let service: EntityService
+  let dataSource: DataSource
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -27,9 +28,30 @@ describe('EntityService', () => {
     }).compile()
 
     service = module.get<EntityService>(EntityService)
+    dataSource = module.get<DataSource>(DataSource)
   })
 
   it('should be defined', () => {
     expect(service).toBeDefined()
+  })
+
+  describe('getEntityRepository', () => {
+    it('should fail if no entity metadata or entity slug is provided', () => {
+      expect(() => {
+        service.getEntityRepository({})
+      }).toThrow()
+    })
+
+    it('should return a repository', () => {
+      const entityMetadata = {
+        target: 'Entity'
+      } as any
+
+      const result = service.getEntityRepository({
+        entityMetadata
+      })
+
+      expect(dataSource.getRepository).toHaveBeenCalledWith('Entity')
+    })
   })
 })

--- a/packages/core/manifest/src/manifest/json-schema/definitions/property-schema.json
+++ b/packages/core/manifest/src/manifest/json-schema/definitions/property-schema.json
@@ -21,6 +21,7 @@
             "link",
             "money",
             "date",
+            "timestamp",
             "email",
             "boolean",
             "relation",

--- a/packages/core/manifest/src/manifest/json-schema/schema.json
+++ b/packages/core/manifest/src/manifest/json-schema/schema.json
@@ -1,12 +1,16 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://schema.manifest.build/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "App Manifest Schema",
-  "description": "A complete backend in a single file.",
+  "description": "A complete backend in a single file",
   "type": "object",
   "properties": {
     "name": {
       "description": "The name of your app",
+      "type": "string"
+    },
+    "version": {
+      "description": "The version of your app",
       "type": "string"
     },
     "entities": {

--- a/packages/core/manifest/src/manifest/services/manifest/manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/manifest/manifest.service.ts
@@ -126,12 +126,16 @@ export class ManifestService {
   }
 
   /**
-   * Transform an AppManifestSchema into an AppManifest.
+   * Transform an AppManifestSchema into an AppManifest ensuring that undefined properties are filled in with defaults.
    *
    * @param manifestSchema the manifest schema to transform.
    * @returns the manifest with defaults filled in and short form properties transformed into long form.
    */
   transformAppManifest(manifestSchema: AppManifestSchema): AppManifest {
+    if (!manifestSchema.version) {
+      manifestSchema.version = '0.0.1'
+    }
+
     if (!manifestSchema.entities) {
       manifestSchema.entities = {}
     }

--- a/packages/core/types/README.md
+++ b/packages/core/types/README.md
@@ -2,6 +2,16 @@
 
 Utility types used by Manifest.
 
+## Development
+
+When updating this library, you may need to fetch your local copy of it instead of the published packages from other projects.
+
+The `packages/core/admin` and `packages/core/manifest` projects in this repository have a command to do that it their package.json file. Simply run:
+
+```bash
+npm run link-local-types
+```
+
 ## Build
 
 ```

--- a/packages/core/types/src/crud/PropType.ts
+++ b/packages/core/types/src/crud/PropType.ts
@@ -8,6 +8,7 @@ export enum PropType {
   Link = 'link',
   Money = 'money',
   Date = 'date',
+  Timestamp = 'timestamp',
   Email = 'email',
   Boolean = 'boolean',
   Password = 'password',

--- a/packages/core/types/src/manifests/AppManifest.ts
+++ b/packages/core/types/src/manifests/AppManifest.ts
@@ -8,6 +8,11 @@ export interface AppManifest extends AppManifestSchema {
   name: string
 
   /**
+   * The version of the app.
+   */
+  version?: string
+
+  /**
    * The entities of the app.
    */
   entities?: {

--- a/packages/core/types/src/manifests/ManifestSchema.ts
+++ b/packages/core/types/src/manifests/ManifestSchema.ts
@@ -24,6 +24,7 @@ export type PropertyManifestSchema =
         | 'link'
         | 'money'
         | 'date'
+        | 'timestamp'
         | 'email'
         | 'boolean'
         | 'relation'
@@ -67,13 +68,17 @@ export type RelationshipManifestSchema =
   | string
 
 /**
- * A complete backend in a single file.
+ * A complete backend in a single file
  */
 export interface AppManifestSchema {
   /**
    * The name of your app
    */
   name: string
+  /**
+   * The version of your app
+   */
+  version?: string
   /**
    * The entities in your app. Doc: https://manifest.build/docs/entities
    */


### PR DESCRIPTION
## Description

This PR adds the **Timestamp** type to properties.

## Related Issues

- Closes #122

## How can it be tested?

### Setup

First of all we need to use the local @mnfst/types because it has been updated
```bash
cd packages/core/types
npm run build
npm link # May require sudo
```

Launch the latest admin panel:
```bash
cd packages/core/admin
npm install
npm link @mnfst/types # May require sudo
npm run start
```

Launch the Manifest backend
```bash
cd packages/core/manifest
npm install
npm link @mnfst/types # May require sudo
npm run start:dev
```

### Run

- In your `packages/core/manifest/backend.yml` file, create a new prop with the "timestamp" type
- run `npm run seed`
- Go to your admin panel **at localhost:4200 (NOT localhost:1111)** and play around with the new prop on list, create-edit and detail views
- Use the API to see if it works correctly

### Tests

```bash
cd packages/core/manifest
npm run test
npm run test:e2e
```

## Impacted packages

Check the packages that require a new publication or release:

- [x] @mnfst/manifest
- [x] @mnfst/types
- [x] @mnfst/admin
- [x] doc (PR: https://github.com/mnfst/docs/pull/5)

## Check list before submitting

- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I updated the documentation if necessary
- [ ] This PR is wrote in a clear language and correctly labeled
