### PR TITLE
feat(crud): filter by relation, Closes #127

### DIFF
--- a/packages/core/manifest/e2e/tests/crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/crud.e2e-spec.ts
@@ -12,20 +12,50 @@ describe('CRUD (e2e)', () => {
     expect(response.status).toBe(201)
   })
 
-  it('GET /dynamic/:entity', async () => {
-    const response = await global.request.get('/dynamic/dogs')
+  describe('GET /dynamic/:entity', () => {
+    it('should return all items', async () => {
+      const response = await global.request.get('/dynamic/dogs')
 
-    expect(response.status).toBe(200)
-    expect(response.body).toMatchObject<Paginator<any>>({
-      data: expect.any(Array),
-      currentPage: expect.any(Number),
-      lastPage: expect.any(Number),
-      from: expect.any(Number),
-      to: expect.any(Number),
-      total: expect.any(Number),
-      perPage: expect.any(Number)
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject<Paginator<any>>({
+        data: expect.any(Array),
+        currentPage: expect.any(Number),
+        lastPage: expect.any(Number),
+        from: expect.any(Number),
+        to: expect.any(Number),
+        total: expect.any(Number),
+        perPage: expect.any(Number)
+      })
+      expect(response.body.data.length).toBe(1)
     })
-    expect(response.body.data.length).toBe(1)
+
+    it('should filter items by field', async () => {
+      const response = await global.request.get(
+        `/dynamic/dogs?name_eq=${dummyDog.name}`
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.body.data.length).toBe(1)
+    })
+
+    it('should filter items by relationship', async () => {
+      const bigNumber: number = 999
+
+      const response = await global.request.get(
+        `/dynamic/dogs?relations=owner&owner.id_eq=${bigNumber}`
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.body.data.length).toBe(0)
+    })
+
+    it('should return a 400 error if the filter field does not exist', async () => {
+      const response = await global.request.get(
+        `/dynamic/dogs?invalidField_eq=${dummyDog.name}`
+      )
+
+      expect(response.status).toBe(400)
+    })
   })
 
   it('GET /dynamic/:entity/select-options', async () => {

--- a/packages/core/manifest/src/crud/tests/crud.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/crud.service.spec.ts
@@ -1,0 +1,41 @@
+import { CrudService } from '../services/crud.service'
+import { Test, TestingModule } from '@nestjs/testing'
+import { ManifestService } from '../../manifest/services/manifest/manifest.service'
+import { PaginationService } from '../services/pagination.service'
+import { EntityService } from '../../entity/services/entity/entity.service'
+
+describe('CrudService', () => {
+  let service: CrudService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CrudService,
+        {
+          provide: ManifestService,
+          useValue: {
+            getEntityRepository: jest.fn()
+          }
+        },
+        {
+          provide: PaginationService,
+          useValue: {
+            paginate: jest.fn()
+          }
+        },
+        {
+          provide: EntityService,
+          useValue: {
+            findOne: jest.fn()
+          }
+        }
+      ]
+    }).compile()
+
+    service = module.get<CrudService>(CrudService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Description

This PR adds the possibility to filter by relations.

Related PR in docs: https://github.com/mnfst/docs/pull/7

## Related Issues

Closes:
- #127 

## How can it be tested?

Run Manifest backend:

```
cd packages/core/manifest
npm run start:dev
```

And then with an API client like Postman run queries like:
```
GET http://localhost:1111/api/dynamic/cats?relations=owner&owner.id_eq=1
GET http://localhost:1111/api/dynamic/cats?relations=owner&owner.name_eq=InvalidName
```

## Check list before submitting

- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I updated the documentation if necessary
- [x] This PR is wrote in a clear language and correctly labeled
