### PR TITLE
Fixed Duplicate code for issue #170

### DIFF
--- a/packages/core/manifest/src/open-api/services/open-api-manifest.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-manifest.service.ts
@@ -1,7 +1,7 @@
 import { AppManifest, EntityManifest } from '@repo/types'
 import { Injectable } from '@nestjs/common'
 import { PathItemObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface'
-
+import { getForbiddenResponse } from '../utils/common-response.utils'
 @Injectable()
 export class OpenApiManifestService {
   /**
@@ -36,32 +36,7 @@ export class OpenApiManifestService {
                 }
               }
             },
-            '403': {
-              description: 'Forbidden',
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      message: {
-                        type: 'string'
-                      },
-                      error: {
-                        type: 'string'
-                      },
-                      statusCode: {
-                        type: 'number'
-                      }
-                    }
-                  },
-                  example: {
-                    message: 'Forbidden resource',
-                    error: 'Forbidden',
-                    statusCode: 403
-                  }
-                }
-              }
-            }
+            '403': getForbiddenResponse()
           }
         }
       }
@@ -106,32 +81,7 @@ export class OpenApiManifestService {
               }
             }
           },
-          '403': {
-            description: 'Forbidden',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    message: {
-                      type: 'string'
-                    },
-                    error: {
-                      type: 'string'
-                    },
-                    statusCode: {
-                      type: 'number'
-                    }
-                  }
-                },
-                example: {
-                  message: 'Forbidden resource',
-                  error: 'Forbidden',
-                  statusCode: 403
-                }
-              }
-            }
-          }
+          '403': getForbiddenResponse()
         }
       }
     }

--- a/packages/core/manifest/src/open-api/utils/common-response.utils.ts
+++ b/packages/core/manifest/src/open-api/utils/common-response.utils.ts
@@ -1,0 +1,35 @@
+
+/**
+ * Generates the forbidden response object.
+ *
+ * @returns The forbidden response object.
+ */
+
+export function getForbiddenResponse() {
+    return {
+        description: 'Forbidden',
+        content: {
+            'application/json': {
+                schema: {
+                    type: 'object',
+                    properties: {
+                        message: {
+                            type: 'string'
+                        },
+                        error: {
+                            type: 'string'
+                        },
+                        statusCode: {
+                            type: 'number'
+                        }
+                    }
+                },
+                example: {
+                    message: 'Forbidden resource',
+                    error: 'Forbidden',
+                    statusCode: 403
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue Number
#170 

## Description
This PR refactors the code by eliminating the duplication of the 403 Forbidden response in the OpenAPI manifest generation. A reusable utility function getForbiddenResponse has been created and moved to a separate file (common-response.utils.ts). This function is now used across multiple files where the 403 Forbidden response is required, ensuring DRY principles and improving maintainability.

## Related Issues
N/A 

## How can it be tested?
1. You can just run the existing unit and integration tests to ensure no breaking changes.
2. Test the API endpoints that require a 403 Forbidden response to confirm that the response format remains consistent after refactoring.
3. Optionally, manually invoke any API endpoints related to manifest or entity manifest to make sure it's proper.

## Checklist before submitting
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] This PR is wrote in a clear language and correctly labeled
