### PR TITLE
Fix Style API docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "yaml.schemas": {
-    "https://schema.manifest.build/schema.json": "**/manifest/**/*.yml"
+    "./packages/core/json-schema/src/schema/schema.json": "**/manifest/**/**backend.yml"
   },
   "workbench.colorCustomizations": {
     "activityBar.activeBackground": "#f8a94a",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
   "yaml.schemas": {
-    "./packages/core/manifest/src/manifest/json-schema/schema.json": "**/manifest/**/*.yml"
+    "https://schema.manifest.build/schema.json": "**/manifest/**/*.yml"
   },
-
   "workbench.colorCustomizations": {
     "activityBar.activeBackground": "#f8a94a",
     "activityBar.activeBorder": "#57b3a0",

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -507,6 +507,7 @@ background: #ce107c;
 
 .swagger-ui .responses-inner h4
 {
+  
   margin: 25px 0 5px;
   color: #1eb1e8;
   border-left: solid 3px #41444e2b;

--- a/packages/core/manifest/src/main.ts
+++ b/packages/core/manifest/src/main.ts
@@ -505,6 +505,14 @@ background: #ce107c;
   color: #3b4151
 }
 
+.swagger-ui .responses-inner h4
+{
+  margin: 25px 0 5px;
+  color: #1eb1e8;
+  border-left: solid 3px #41444e2b;
+  padding-left: 3px;
+}
+
 .swagger-ui .response-col_status {
   font-size: 14px;
   font-family: Open Sans, sans-serif;


### PR DESCRIPTION
## Issue Number
#133 

## Description
This PR Fix the API documentation, Now the titles of response are easy to read and noticeable by adding some space, change color and add border left
## Related Issues
N/A
## How can it be tested?

## Impacted packages

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [x] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [x] This PR is wrote in a clear language and correctly labeled
