### PR TITLE
feat(admin): prefill default admin credentials on login if exists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,6 @@ There are several ways to contribute to Manifest other than developing:
 
 Otherwise, you also can offer your help by talking to a team member on our [Discord](https://discord.com/invite/FepAked3W7) 🤗.
 
-
-
 ## Packages and repositories
 
 Before coding it is important to understand where the functionality you want to change is located.
@@ -30,8 +28,7 @@ Manifest is a set of several packages and [repositories](https://github.com/orgs
 | Manifest       | Manifest core                              | NestJS / Express / TypeORM | [manifest](https://github.com/mnfst/manifest) | [manifest](https://www.npmjs.com/package/manifest)         |
 | Manifest Admin | Official Admin Panel                       | Angular                    | [manifest](https://github.com/mnfst/manifest) | -                                                          |
 | Add Manifest   | NPX install script                         | OCLIF                      | [manifest](https://github.com/mnfst/manifest) | [add-manifest](https://www.npmjs.com/package/add-manifest) |
-| JS SDK         | JavaScript SDK                             | TypeScript                 | [manifest](https://github.com/mnfst/manifest) | [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)     |
-| Manifest Types | Utility types                              | TypeScript                 | [manifest](https://github.com/mnfst/manifest) | -                                                          |
+| JS SDK         | Client JavaScript SDK                      | TypeScript                 | [manifest](https://github.com/mnfst/manifest) | [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)     |
 | Website        | Official website: https://manifest.build   | NextJS                     | [website](https://github.com/mnfst/website)   | -                                                          |
 | Docs           | Documentation: https://manifest.build/docs | Markdown / Docusaurus      | [docs](https://github.com/mnfst/docs)         | -                                                          |
 

--- a/packages/core/admin/src/app/modules/auth/auth.service.ts
+++ b/packages/core/admin/src/app/modules/auth/auth.service.ts
@@ -65,4 +65,15 @@ export class AuthService {
 
     return this.currentUserPromise
   }
+
+  /**
+   * Returns true if the default user admin is in the database, false otherwise
+   */
+  async isDefaultAdminExists(): Promise<boolean> {
+    return (
+      firstValueFrom(
+        this.http.get(`${environment.apiBaseUrl}/auth/admins/default-exists`)
+      ) as Promise<{ exists: boolean }>
+    ).then((res) => res.exists)
+  }
 }

--- a/packages/core/admin/src/app/modules/auth/views/login/login.component.html
+++ b/packages/core/admin/src/app/modules/auth/views/login/login.component.html
@@ -4,11 +4,16 @@
       <div class="columns">
         <div class="column col-login">
           <div>
-            <img src="/assets/images/logo.svg" alt="manifest logo" class="mb-3" width="264"/>
+            <img
+              src="/assets/images/logo.svg"
+              alt="manifest logo"
+              class="mb-3"
+              width="264"
+            />
 
             <h2 class="title is-4">Sign in</h2>
 
-            <div class="has-text-left">
+            <div class="has-text-left" *ngIf="form">
               <div class="field mb-5">
                 <div class="control">
                   <app-input
@@ -44,23 +49,8 @@
             </div>
           </div>
         </div>
-        <div class="column col-decoration">
-
-        </div>
+        <div class="column col-decoration"></div>
       </div>
     </div>
   </div>
 </section>
-
-<!-- <div
-  class="notification is-warning is-light is-size-5 has-text-centered"
-  *ngIf="appConfig?.production === false"
->
-  <p>You can use the following credentials to login:</p>
-  <p>
-    <span>Email: </span
-    ><strong class="mr-4 ml-1">{{ defaultUser.email }}</strong>
-    <span>password: </span
-    ><strong class="ml-1">{{ defaultUser.password }}</strong>
-  </p>
-</div> -->

--- a/packages/core/admin/src/app/modules/auth/views/login/login.component.ts
+++ b/packages/core/admin/src/app/modules/auth/views/login/login.component.ts
@@ -7,6 +7,7 @@ import { PropType } from '@repo/types'
 
 import { FlashMessageService } from '../../../shared/services/flash-message.service'
 import { AuthService } from '../../auth.service'
+import { DEFAULT_ADMIN_CREDENTIALS } from '../../../../../constants'
 
 @Component({
   selector: 'app-login',
@@ -19,10 +20,7 @@ export class LoginComponent implements OnInit {
 
   PropType = PropType
 
-  form: FormGroup = new FormGroup({
-    email: new FormControl('', [Validators.required, Validators.email]),
-    password: new FormControl('', [Validators.required])
-  })
+  form: FormGroup
 
   constructor(
     private readonly authService: AuthService,
@@ -32,19 +30,25 @@ export class LoginComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.activatedRoute.queryParams.subscribe((queryParams: Params) => {
-      if (queryParams['email']) {
+    this.activatedRoute.queryParams.subscribe(async (queryParams: Params) => {
+      if (queryParams['email'] && queryParams['password']) {
         this.suggestedEmail = queryParams['email']
-      }
-      if (queryParams['password']) {
         this.suggestedPassword = queryParams['password']
+      } else {
+        if (await this.authService.isDefaultAdminExists()) {
+          this.suggestedEmail = DEFAULT_ADMIN_CREDENTIALS.email
+          this.suggestedPassword = DEFAULT_ADMIN_CREDENTIALS.password
+        }
       }
-      if (this.suggestedEmail) {
-        this.patchValue('email', this.suggestedEmail)
-      }
-      if (this.suggestedPassword) {
-        this.patchValue('password', this.suggestedPassword)
-      }
+
+      this.form = new FormGroup({
+        email: new FormControl(this.suggestedEmail || '', [
+          Validators.required
+        ]),
+        password: new FormControl(this.suggestedPassword || '', [
+          Validators.required
+        ])
+      })
     })
   }
 

--- a/packages/core/admin/src/app/modules/shared/inputs/password-input/password-input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/password-input/password-input.component.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   EventEmitter,
   Input,
+  OnInit,
   Output,
   ViewChild
 } from '@angular/core'
@@ -24,7 +25,7 @@ import { PropertyManifest } from '@repo/types'
     />`,
   styleUrls: ['./password-input.component.scss']
 })
-export class PasswordInputComponent {
+export class PasswordInputComponent implements OnInit {
   @Input() prop: PropertyManifest
   @Input() value: string
   @Input() isError: boolean
@@ -32,6 +33,12 @@ export class PasswordInputComponent {
   @Output() valueChanged: EventEmitter<number> = new EventEmitter()
 
   @ViewChild('input', { static: true }) input: ElementRef
+
+  ngOnInit(): void {
+    if (this.value !== undefined) {
+      this.input.nativeElement.value = this.value
+    }
+  }
 
   onChange(event: any) {
     this.valueChanged.emit(event.target.value)

--- a/packages/core/admin/src/constants.ts
+++ b/packages/core/admin/src/constants.ts
@@ -1,2 +1,8 @@
 export const TOKEN_KEY = 'manifestToken'
 export const ADMIN_CLASS_NAME = 'Admin'
+
+// TODO: Create a shared package for these constants as they also exist in the core package.
+export const DEFAULT_ADMIN_CREDENTIALS = {
+  email: 'admin@manifest.build',
+  password: 'admin'
+}

--- a/packages/core/manifest/e2e/tests/authentication.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/authentication.e2e-spec.ts
@@ -50,6 +50,15 @@ describe('Authentication (e2e)', () => {
 
       expect(response.status).toBe(403)
     })
+
+    it('returns true if the default user admin is in the database', async () => {
+      const response = await global.request.get('/auth/admins/default-exists')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject({
+        exists: true
+      })
+    })
   })
 
   describe('Authenticable entity', () => {

--- a/packages/core/manifest/src/auth/auth.controller.ts
+++ b/packages/core/manifest/src/auth/auth.controller.ts
@@ -49,4 +49,11 @@ export class AuthController {
   ): Promise<AuthenticableEntity> {
     return (await this.authService.getUserFromRequest(req)).user
   }
+
+  @Get('admins/default-exists')
+  public async isDefaultAdminExists(): Promise<{
+    exists: boolean
+  }> {
+    return this.authService.isDefaultAdminExists()
+  }
 }

--- a/packages/core/manifest/src/auth/auth.service.ts
+++ b/packages/core/manifest/src/auth/auth.service.ts
@@ -7,11 +7,9 @@ import * as jwt from 'jsonwebtoken'
 import { Repository } from 'typeorm'
 import { EntityService } from '../entity/services/entity.service'
 import { SignupAuthenticableEntityDto } from './dtos/signup-authenticable-entity.dto'
-import { ADMIN_ENTITY_MANIFEST } from '../constants'
+import { ADMIN_ENTITY_MANIFEST, DEFAULT_ADMIN_CREDENTIALS } from '../constants'
 import { ManifestService } from '../manifest/services/manifest.service'
 import { validate } from 'class-validator'
-
-// import { EntityMetaService } from '../crud/services/entity-meta.service'
 
 @Injectable()
 export class AuthService {
@@ -196,5 +194,26 @@ export class AuthService {
       (res: { user: AuthenticableEntity; entitySlug: string }) =>
         !!res?.user && res?.entitySlug === ADMIN_ENTITY_MANIFEST.slug
     )
+  }
+
+  /**
+   * Returns whether the default admin exists.
+   *
+   * @returns A promise that resolves to an object with the key 'exists' that is true if the default admin exists, and false otherwise.
+   * */
+  async isDefaultAdminExists(): Promise<{ exists: boolean }> {
+    const entityRepository: Repository<AuthenticableEntity> =
+      this.entityService.getEntityRepository({
+        entitySlug: ADMIN_ENTITY_MANIFEST.slug
+      }) as Repository<AuthenticableEntity>
+
+    return {
+      exists: await entityRepository.exists({
+        where: {
+          email: DEFAULT_ADMIN_CREDENTIALS.email,
+          password: SHA3(DEFAULT_ADMIN_CREDENTIALS.password).toString()
+        }
+      })
+    }
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b36268e5-edcd-475b-89f2-fc3c83cf745a)


## Description

Onboarding: suggest default user credential on admin login if exists.

## Related Issues

- Closes #193 

## How can it be tested?

- Remove the database (`packages/core/manifest/manigest/backend.db`) to make sure that there is no data in it.
- Run `npm run dev` from the root and see the admin login page. The fields should be empty.
- Run `npm run seed` and then reload the admin panel login page. You should the pre-filled credentials. 

## Impacted packages

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [ ] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [x] This PR is wrote in a clear language and correctly labeled
