### PR TITLE
Fixed Missing Radix Parameter Issue

### DIFF
--- a/packages/core/helpers/src/index.ts
+++ b/packages/core/helpers/src/index.ts
@@ -135,12 +135,12 @@ export function forceNumberArray(
   if (typeof value === 'number') {
     return [value]
   } else if (typeof value === 'string') {
-    return [parseInt(value)]
+    return [parseInt(value, 10)]
   } else if (typeof value === 'undefined' || value === null) {
     return []
   }
 
-  return value.map((v) => (typeof v === 'string' ? parseInt(v) : v))
+  return value.map((v) => (typeof v === 'string' ? parseInt(v, 10) : v))
 }
 
 /**


### PR DESCRIPTION
Fixes issue #173 

## Description
This issue was caused when 'forceNumberArray()' method from packages/core/helpers/src/index.ts was imported to packages/core/admin/src/app/modules/shared/inputs/multi-select-input/multi-select-input.component.ts. 

This method was using the in-built 'parseInt()' method without providing the radix parameter. I added the radix value of '10' in the method, as it was expected to be parsed into a decimal value. This fixed the issue.

## Related Issues
None

## How can it be tested?
Using codefactor

## Impacted packages
packages/core/helpers/src/index.ts
packages/core/admin/src/app/modules/shared/inputs/multi-select-input/multi-select-input.component.ts

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [ ] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [x] This PR is wrote in a clear language and correctly labeled
