### PR TITLE
Refactor SCSS files to remove redundant values

### DIFF
--- a/packages/core/admin/src/app/modules/layout/side-menu/side-menu.component.scss
+++ b/packages/core/admin/src/app/modules/layout/side-menu/side-menu.component.scss
@@ -36,7 +36,7 @@
     padding: 1px math.div(all.$column-gap, 2);
 
     ul {
-      margin: 5px 0 0 0;
+      margin: 5px 0 0;
       border-left: 0;
       padding-left: 0;
 

--- a/packages/core/admin/src/app/modules/layout/touch-menu/touch-menu.component.scss
+++ b/packages/core/admin/src/app/modules/layout/touch-menu/touch-menu.component.scss
@@ -81,7 +81,7 @@ nav.navbar {
     height: 0;
     border-style: solid;
     border-width: 0 6px 6px;
-    border-color: transparent transparent rgba($sidenav-item-color, 0.1) transparent;
+    border-color: rgba($sidenav-item-color, 0.1) transparent;
   }
 
   &:before {
@@ -93,7 +93,7 @@ nav.navbar {
     height: 0;
     border-style: solid;
     border-width: 0 6px 6px;
-    border-color: transparent transparent rgba($sidenav-item-color, 0.1) transparent;
+    border-color: rgba($sidenav-item-color, 0.1) transparent;
   }
 }
 

--- a/packages/core/admin/src/styles/components/_colorpicker.scss
+++ b/packages/core/admin/src/styles/components/_colorpicker.scss
@@ -60,11 +60,11 @@
 
   &:after {
     top: -5px;
-    border-color: transparent transparent $light transparent;
+    border-color: transparent $light;
   }
 
   &:before {
     top: -6px;
-    border-color: transparent transparent $grey-lighter transparent;
+    border-color: transparent $grey-lighter;
   }
 }


### PR DESCRIPTION
## Description
Removed unnecessary transparent values in border-color properties in the following files:

- touch-menu.component.scss

- side-menu.component.scss

- components_colorpicker.scss

Simplified margin property in side-menu.component.scss to remove redundant 0 value.
## Related Issues
Fixes #150

## How can it be tested?
Review the updated SCSS files.

## Impacted packages
No packages impacted

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [x] [add-manifest](https://www.npmjs.com/package/add-manifest)
- [x] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [x] This PR is wrote in a clear language and correctly labeled
