### PR TITLE
fix(seeder): cannot seed if entity name is reserved word, Closes #257

### DIFF
--- a/.changeset/kind-badgers-share.md
+++ b/.changeset/kind-badgers-share.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix seed failing if entity name is a reserved word on SQLite

--- a/packages/core/manifest/src/seed/services/seeder.service.ts
+++ b/packages/core/manifest/src/seed/services/seeder.service.ts
@@ -60,11 +60,12 @@ export class SeederService {
 
     // Truncate all tables.
     const queryRunner: QueryRunner = this.dataSource.createQueryRunner()
+
     await queryRunner.query('PRAGMA foreign_keys = OFF')
     await Promise.all(
       entityMetadatas.map(async (entity: EntityMetadata) =>
         queryRunner
-          .query(`DELETE FROM ${entity.tableName}`)
+          .query(`DELETE FROM [${entity.tableName}]`)
           .then(() =>
             queryRunner.query(
               `DELETE FROM sqlite_sequence WHERE name = '${entity.tableName}'`

--- a/packages/core/manifest/src/validation/tests/custom-validators.spec.ts
+++ b/packages/core/manifest/src/validation/tests/custom-validators.spec.ts
@@ -33,8 +33,6 @@ describe('Custom validators', () => {
       })
     )
 
-    console.log(goodValidations, badValidations)
-
     expect(goodValidations.every((validation) => validation.length === 0)).toBe(
       true
     )


### PR DESCRIPTION
## Description

fix(seeder): cannot seed if entity name is reserved word, Closes #257

## Related Issues

- #257 

## How can it be tested?

## Impacted packages

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [ ] [add-manifest](https://www.npmjs.com/package/add-manifest)
- [ ] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [x] This PR is wrote in a clear language and correctly labeled
