### PR TITLE
:sparkles: PATCH items (CRUD)

### DIFF
--- a/.changeset/stale-carrots-push.md
+++ b/.changeset/stale-carrots-push.md
@@ -1,0 +1,6 @@
+---
+'manifest': minor
+'@mnfst/sdk': minor
+---
+
+Added PATCH requests for item update

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - enhancement
+  - title: '🐛 Bug Fixes'
+    labels:
+      - bug
+  - title: '🛠 Maintenance'
+    labels:
+      - chore
+      - refactor
+      - tests
+      - dependencies
+change-template: '- $TITLE (#$NUMBER)'
+no-changes-template: '- No changes'
+
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish
 
 on:
   push:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,30 @@
+name: Release Drafter
+
+on:
+  push:
+    tags:
+      - 'manifest@*.*.*' # Match tags for "manifest"
+      - '@mnfst/sdk@*.*.*' # Match tags for "@mnfst/sdk"
+      - 'add-manifest@*.*.*' # Match tags for "add-manifest"
+  workflow_dispatch: # Allow manual triggering of the workflow
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Step 2: Run Release Drafter to draft and publish the release
+      - name: Draft and Publish Release
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,5 +9,12 @@ export default [
   },
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   pluginJs.configs.recommended,
-  ...tseslint.configs.recommended
+  ...tseslint.configs.recommended,
+  {
+    // Allow "any" in test files.
+    files: ['**/*.spec.ts', '**/*.e2e-spec.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off'
+    }
+  }
 ]

--- a/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
@@ -15,12 +15,14 @@ describe('Collection CRUD (e2e)', () => {
     location: { lat: 12, lng: 13 }
   }
 
-  it('POST /collections/:entity', async () => {
-    const response = await global.request
-      .post('/collections/dogs')
-      .send(dummyDog)
+  describe('POST /collections/:entity', () => {
+    it('should create an item', async () => {
+      const response = await global.request
+        .post('/collections/dogs')
+        .send(dummyDog)
 
-    expect(response.status).toBe(201)
+      expect(response.status).toBe(201)
+    })
   })
 
   describe('GET /collections/:entity', () => {
@@ -69,77 +71,115 @@ describe('Collection CRUD (e2e)', () => {
     })
   })
 
-  it('GET /collections/:entity/select-options', async () => {
-    const response = await global.request.get(
-      '/collections/dogs/select-options'
-    )
+  describe('GET /collections/:entity/select-options', () => {
+    it('should get select options', async () => {
+      const response = await global.request.get(
+        '/collections/dogs/select-options'
+      )
 
-    expect(response.status).toBe(200)
-    expect(response.body).toMatchObject<SelectOption[]>([
-      {
-        label: dummyDog.name,
-        id: 1
-      }
-    ])
-  })
-
-  it('GET /collections/:entity/:id', async () => {
-    const response = await global.request.get('/collections/dogs/1')
-
-    expect(response.status).toBe(200)
-    expect(response.body).toMatchObject(dummyDog)
-  })
-
-  it('PUT /collections/:entity/:id', async () => {
-    const newName = 'Rex'
-
-    const response = await global.request.put('/collections/dogs/1').send({
-      name: newName
-    })
-
-    expect(response.status).toBe(200)
-
-    const updatedResponse = await global.request.get('/collections/dogs/1')
-
-    expect(updatedResponse.status).toBe(200)
-    expect(updatedResponse.body).toMatchObject({
-      name: newName
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject<SelectOption[]>([
+        {
+          label: dummyDog.name,
+          id: 1
+        }
+      ])
     })
   })
 
-  it('PATCH /collections/:entity/:id', async () => {
-    const postResponse = await global.request
-      .post('/collections/dogs')
-      .send(dummyDog)
+  describe('GET /collections/:entity/:id', () => {
+    it('should return an item', async () => {
+      const response = await global.request.get('/collections/dogs/1')
 
-    const newAge = 6
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject(dummyDog)
+    })
+  })
 
-    const response = await global.request
-      .patch(`/collections/dogs/${postResponse.body.id}`)
-      .send({
-        age: newAge
+  describe('PUT /collections/:entity/:id', () => {
+    it('should fully update an item', async () => {
+      const newName = 'Rex'
+
+      const response = await global.request.put('/collections/dogs/1').send({
+        name: newName
       })
 
-    expect(response.status).toBe(200)
+      expect(response.status).toBe(200)
 
-    const updatedResponse = await global.request.get(
-      `/collections/dogs/${postResponse.body.id}`
-    )
+      const updatedResponse = await global.request.get('/collections/dogs/1')
 
-    expect(updatedResponse.status).toBe(200)
-    expect(updatedResponse.body).toMatchObject({
-      ...dummyDog,
-      age: newAge
+      expect(updatedResponse.status).toBe(200)
+      expect(updatedResponse.body).toMatchObject({
+        name: newName
+      })
     })
   })
 
-  it('DELETE /collections/:entity/:id', async () => {
-    const response = await global.request.delete('/collections/dogs/1')
+  describe('PATCH /collections/:entity/:id', () => {
+    it('should patch an item', async () => {
+      const postResponse = await global.request
+        .post('/collections/dogs')
+        .send(dummyDog)
 
-    expect(response.status).toBe(200)
+      const newAge = 6
 
-    const updatedResponse = await global.request.get('/collections/dogs/1')
+      const response = await global.request
+        .patch(`/collections/dogs/${postResponse.body.id}`)
+        .send({
+          age: newAge
+        })
 
-    expect(updatedResponse.status).toBe(404)
+      expect(response.status).toBe(200)
+
+      const updatedResponse = await global.request.get(
+        `/collections/dogs/${postResponse.body.id}`
+      )
+
+      expect(updatedResponse.status).toBe(200)
+      expect(updatedResponse.body).toMatchObject({
+        ...dummyDog,
+        age: newAge
+      })
+    })
+
+    it('should keep relations if not provided', async () => {
+      const dogWithOwner = {
+        name: 'Charlie',
+        ownerId: 1
+      }
+
+      const createResponse = await global.request
+        .post('/collections/dogs')
+        .send(dogWithOwner)
+
+      expect(createResponse.status).toBe(201)
+
+      const updateResponse = await global.request
+        .patch(`/collections/dogs/${createResponse.body.id}`)
+        .send({
+          name: 'Charlie 2'
+        })
+
+      expect(updateResponse.status).toBe(200)
+
+      const fetchResponse = await global.request.get(
+        `/collections/dogs/${createResponse.body.id}?relations=owner`
+      )
+
+      expect(fetchResponse.status).toBe(200)
+      expect(fetchResponse.body?.owner?.id).toEqual(1)
+    })
+  })
+
+  describe('DELETE /collections/:entity/:id', () => {
+    it('should delete an item', async () => {
+      const response = await global.request.delete('/collections/dogs/1')
+
+      expect(response.status).toBe(200)
+
+      const updatedResponse = await global.request.get('/collections/dogs/1')
+
+      expect(updatedResponse.status).toBe(404)
+    })
   })
 })

--- a/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
@@ -103,8 +103,33 @@ describe('Collection CRUD (e2e)', () => {
 
     expect(updatedResponse.status).toBe(200)
     expect(updatedResponse.body).toMatchObject({
-      ...dummyDog,
       name: newName
+    })
+  })
+
+  it('PATCH /collections/:entity/:id', async () => {
+    const postResponse = await global.request
+      .post('/collections/dogs')
+      .send(dummyDog)
+
+    const newAge = 6
+
+    const response = await global.request
+      .patch(`/collections/dogs/${postResponse.body.id}`)
+      .send({
+        age: newAge
+      })
+
+    expect(response.status).toBe(200)
+
+    const updatedResponse = await global.request.get(
+      `/collections/dogs/${postResponse.body.id}`
+    )
+
+    expect(updatedResponse.status).toBe(200)
+    expect(updatedResponse.body).toMatchObject({
+      ...dummyDog,
+      age: newAge
     })
   })
 

--- a/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
@@ -143,9 +143,15 @@ describe('Collection CRUD (e2e)', () => {
     })
 
     it('should keep relations if not provided', async () => {
+      const createOwnerResponse = await global.request
+        .post('/collections/owners')
+        .send({
+          name: 'John Doe'
+        })
+
       const dogWithOwner = {
         name: 'Charlie',
-        ownerId: 1
+        ownerId: createOwnerResponse.body.id
       }
 
       const createResponse = await global.request

--- a/packages/core/manifest/e2e/tests/single-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/single-crud.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('Single CRUD (e2e)', () => {
     })
   })
 
-  describe('PUT /collections/:entity', () => {
+  describe('PUT /singles/:entity', () => {
     it('can update a single entity', async () => {
       const newTitle: string = 'Contact Us'
 

--- a/packages/core/manifest/e2e/tests/validation.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/validation.e2e-spec.ts
@@ -164,7 +164,7 @@ describe('Validation (e2e)', () => {
 
       const updateResponse = await global.request
         .put('/collections/super-users/1')
-        .send({ name: 'new name' })
+        .send({ name: 'new name', email: 'example2@manifest.build' })
 
       expect(badCreateResponse.status).toBe(400)
       expect(

--- a/packages/core/manifest/src/crud/controllers/collection.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/collection.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Put,
   Query,
@@ -86,12 +87,27 @@ export class CollectionController {
 
   @Put(':entity/:id')
   @Rule('update')
-  update(
-    @Param('entity') entity: string,
+  put(
+    @Param('entity') entitySlug: string,
     @Param('id', ParseIntPipe) id: number,
-    @Body() entityDto: Partial<BaseEntity>
+    @Body() itemDto: Partial<BaseEntity>
   ): Promise<BaseEntity> {
-    return this.crudService.update(entity, id, entityDto)
+    return this.crudService.update({ entitySlug, id, itemDto })
+  }
+
+  @Patch(':entity/:id')
+  @Rule('update')
+  patch(
+    @Param('entity') entitySlug: string,
+    @Param('id', ParseIntPipe) id: number,
+    @Body() itemDto: Partial<BaseEntity>
+  ): Promise<BaseEntity> {
+    return this.crudService.update({
+      entitySlug,
+      id,
+      itemDto,
+      partialReplacement: true
+    })
   }
 
   @Delete(':entity/:id')

--- a/packages/core/manifest/src/crud/controllers/single.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/single.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   NotFoundException,
   Param,
+  Patch,
   Put,
   Req,
   UseGuards
@@ -55,10 +56,24 @@ export class SingleController {
 
   @Put(':entity')
   @Rule('update')
-  update(
-    @Param('entity') entity: string,
-    @Body() entityDto: Partial<BaseEntity>
+  put(
+    @Param('entity') entitySlug: string,
+    @Body() itemDto: Partial<BaseEntity>
   ): Promise<BaseEntity> {
-    return this.crudService.update(entity, 1, entityDto)
+    return this.crudService.update({ entitySlug, id: 1, itemDto })
+  }
+
+  @Patch(':entity')
+  @Rule('update')
+  patch(
+    @Param('entity') entitySlug: string,
+    @Body() itemDto: Partial<BaseEntity>
+  ): Promise<BaseEntity> {
+    return this.crudService.update({
+      entitySlug,
+      id: 1,
+      itemDto,
+      partialReplacement: true
+    })
   }
 }

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -237,12 +237,12 @@ export class CrudService {
 
     const newItem: BaseEntity = entityRepository.create(itemDto)
     const relationItems: { [key: string]: BaseEntity | BaseEntity[] } =
-      await this.relationshipService.fetchRelationItemsFromDto(
+      await this.relationshipService.fetchRelationItemsFromDto({
         itemDto,
-        entityManifest.relationships
+        relationships: entityManifest.relationships
           .filter((r) => r.type !== 'one-to-many')
           .filter((r) => r.type !== 'many-to-many' || r.owningSide)
-      )
+      })
 
     if (entityManifest.authenticable && itemDto.password) {
       newItem.password = SHA3(newItem.password).toString()
@@ -311,12 +311,13 @@ export class CrudService {
     }
 
     const relationItems: { [key: string]: BaseEntity | BaseEntity[] } =
-      await this.relationshipService.fetchRelationItemsFromDto(
+      await this.relationshipService.fetchRelationItemsFromDto({
         itemDto,
-        entityManifest.relationships
+        relationships: entityManifest.relationships
           .filter((r) => r.type !== 'one-to-many')
-          .filter((r) => r.type !== 'many-to-many' || r.owningSide)
-      )
+          .filter((r) => r.type !== 'many-to-many' || r.owningSide),
+        emptyMissing: !partialReplacement
+      })
 
     // On partial replacement, only update the provided props.
     if (partialReplacement) {
@@ -324,7 +325,10 @@ export class CrudService {
 
       // Remove undefined values to keep the existing values.
       Object.keys(relationItems).forEach((key: string) => {
-        if (relationItems[key] === undefined) {
+        if (
+          relationItems[key] === undefined ||
+          relationItems[key]?.length === 0
+        ) {
           delete relationItems[key]
         }
       })

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -330,7 +330,7 @@ export class CrudService {
       })
     }
 
-    const updatedItem: BaseEntity = entityRepository.create(itemDto)
+    const updatedItem: BaseEntity = entityRepository.create({ id, ...itemDto })
 
     // Hash password if it exists.
     if (entityManifest.authenticable && itemDto.password) {

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -274,6 +274,15 @@ export class CrudService {
     return entityRepository.save({})
   }
 
+  /*
+   * Updates an item doing a FULL REPLACEMENT of the item.
+   *
+   * @param entitySlug the entity slug.
+   * @param id the item id.
+   * @param itemDto the item dto.
+   *
+   * @returns the updated item.
+   */
   async update(
     entitySlug: string,
     id: number,
@@ -290,6 +299,10 @@ export class CrudService {
 
     const item: BaseEntity = await entityRepository.findOne({ where: { id } })
 
+    if (!item) {
+      throw new NotFoundException('Item not found')
+    }
+
     const relationItems: { [key: string]: BaseEntity | BaseEntity[] } =
       await this.relationshipService.fetchRelationItemsFromDto(
         itemDto,
@@ -298,14 +311,7 @@ export class CrudService {
           .filter((r) => r.type !== 'many-to-many' || r.owningSide)
       )
 
-    if (!item) {
-      throw new NotFoundException('Item not found')
-    }
-
-    const updatedItem: BaseEntity = entityRepository.create({
-      ...item,
-      ...itemDto
-    } as BaseEntity)
+    const updatedItem: BaseEntity = entityRepository.create(itemDto)
 
     // Hash password if it exists.
     if (entityManifest.authenticable && itemDto.password) {

--- a/packages/core/manifest/src/crud/tests/collection.controller.spec.ts
+++ b/packages/core/manifest/src/crud/tests/collection.controller.spec.ts
@@ -8,6 +8,7 @@ import { EntityManifestService } from '../../manifest/services/entity-manifest.s
 
 describe('CollectionController', () => {
   let controller: CollectionController
+  let crudService: CrudService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -16,14 +17,18 @@ describe('CollectionController', () => {
         {
           provide: AuthService,
           useValue: {
-            isReqUserAdmin: jest.fn()
+            isReqUserAdmin: jest.fn(() => Promise.resolve(false))
           }
         },
         {
           provide: CrudService,
           useValue: {
             findOne: jest.fn(),
-            update: jest.fn()
+            findAll: jest.fn(),
+            findSelectOptions: jest.fn(),
+            store: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn()
           }
         },
         {
@@ -48,9 +53,99 @@ describe('CollectionController', () => {
     }).compile()
 
     controller = module.get<CollectionController>(CollectionController)
+    crudService = module.get<CrudService>(CrudService)
   })
 
   it('should be defined', () => {
     expect(controller).toBeDefined()
+  })
+
+  it('should call crudService.findAll', async () => {
+    const entitySlug = 'cats'
+    const queryParams = {}
+    const req = {} as any
+
+    await controller.findAll(entitySlug, queryParams, req)
+
+    expect(crudService.findAll).toHaveBeenCalledWith({
+      entitySlug,
+      queryParams,
+      fullVersion: false
+    })
+  })
+
+  it('should call crudService.findSelectOptions', async () => {
+    const entitySlug = 'cats'
+    const queryParams = {}
+
+    await controller.findSelectOptions(entitySlug, queryParams)
+
+    expect(crudService.findSelectOptions).toHaveBeenCalledWith({
+      entitySlug,
+      queryParams
+    })
+  })
+
+  it('should call crudService.findOne', async () => {
+    const entitySlug = 'cats'
+    const id = 1
+    const queryParams = {}
+    const req = {} as any
+
+    await controller.findOne(entitySlug, id, queryParams, req)
+
+    expect(crudService.findOne).toHaveBeenCalledWith({
+      entitySlug,
+      id,
+      queryParams,
+      fullVersion: false
+    })
+  })
+
+  it('should call crudService.store', async () => {
+    const entity = 'cats'
+    const itemDto = {}
+
+    await controller.store(entity, itemDto)
+
+    expect(crudService.store).toHaveBeenCalledWith(entity, itemDto)
+  })
+
+  it('should call crudService.update', async () => {
+    const entitySlug = 'cats'
+    const id = 1
+    const itemDto = {}
+
+    await controller.put(entitySlug, id, itemDto)
+
+    expect(crudService.update).toHaveBeenCalledWith({
+      entitySlug,
+      id,
+      itemDto: itemDto
+    })
+  })
+
+  it('should call crudService.update with partialReplacement', async () => {
+    const entitySlug = 'cats'
+    const id = 1
+    const itemDto = {}
+
+    await controller.patch(entitySlug, id, itemDto)
+
+    expect(crudService.update).toHaveBeenCalledWith({
+      entitySlug,
+      id,
+      itemDto: itemDto,
+      partialReplacement: true
+    })
+  })
+
+  it('should call crudService.delete', async () => {
+    const entitySlug = 'cats'
+    const id = 1
+
+    await controller.delete(entitySlug, id)
+
+    expect(crudService.delete).toHaveBeenCalledWith(entitySlug, id)
   })
 })

--- a/packages/core/manifest/src/crud/tests/crud.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/crud.service.spec.ts
@@ -7,6 +7,19 @@ import { ValidationService } from '../../validation/services/validation.service'
 import { RelationshipService } from '../../entity/services/relationship.service'
 describe('CrudService', () => {
   let service: CrudService
+  let entityService: EntityService
+  let validationService: ValidationService
+
+  const dummyItem = {
+    name: 'Superman',
+    age: 30,
+    color: 'blue',
+    mentor: {
+      name: 'Batman',
+      age: 40,
+      color: 'black'
+    }
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -15,7 +28,9 @@ describe('CrudService', () => {
         {
           provide: EntityManifestService,
           useValue: {
-            getEntityRepository: jest.fn()
+            getEntityManifest: jest.fn(() => ({
+              relationships: []
+            }))
           }
         },
         {
@@ -27,28 +42,138 @@ describe('CrudService', () => {
         {
           provide: EntityService,
           useValue: {
-            findOne: jest.fn()
+            findOne: jest.fn(),
+            getEntityRepository: jest.fn(() => ({
+              findOne: jest.fn(() => Promise.resolve(dummyItem)),
+              create: jest.fn((item) => item),
+              save: jest.fn((item) => item)
+            }))
           }
         },
         {
           provide: ValidationService,
           useValue: {
-            validate: jest.fn()
+            validate: jest.fn(() => [])
           }
         },
         {
           provide: RelationshipService,
           useValue: {
-            fetchRelationItemsFromDto: jest.fn()
+            fetchRelationItemsFromDto: jest.fn((itemDto) => ({
+              mentor: itemDto.mentor
+            }))
           }
         }
       ]
     }).compile()
 
     service = module.get<CrudService>(CrudService)
+    entityService = module.get<EntityService>(EntityService)
+    validationService = module.get<ValidationService>(ValidationService)
   })
 
   it('should be defined', () => {
     expect(service).toBeDefined()
+  })
+
+  describe('update', () => {
+    it('should update an entity', async () => {
+      const entitySlug = 'test'
+      const id = 1
+      const data = { name: 'test' }
+
+      const result = await service.update(entitySlug, id, data)
+
+      expect(result).toEqual(data)
+    })
+
+    it('should throw an error if the entity is not found', async () => {
+      const entitySlug = 'test'
+      const id = 1
+      const data = { name: 'test' }
+
+      jest.spyOn(entityService, 'getEntityRepository').mockReturnValue({
+        findOne: jest.fn(() => Promise.resolve(null)),
+        create: jest.fn((item) => item),
+        save: jest.fn((item) => item)
+      } as any)
+
+      await expect(service.update(entitySlug, id, data)).rejects.toThrow()
+    })
+
+    it('should update relationships', async () => {
+      const entitySlug = 'test'
+      const id = 1
+      const data = { mentor: { id: 2 } }
+
+      const result = await service.update(entitySlug, id, data)
+
+      expect(result.mentor).toEqual(data.mentor)
+    })
+
+    it('should do a full replacement of properties', async () => {
+      const entitySlug = 'test'
+      const id = 1
+      const data = { name: 'test' }
+
+      const result = await service.update(entitySlug, id, data)
+
+      expect(result.name).toEqual(data.name)
+      expect(result.age).toBeUndefined()
+    })
+
+    it('should do a full replacement of relationships', async () => {
+      const entitySlug = 'test'
+      const id = 1
+      const itemWithoutRelation = {}
+      const itemWithNewRelation = { mentor: { id: 2 } }
+
+      const resultWithoutRelation = await service.update(
+        entitySlug,
+        id,
+        itemWithoutRelation
+      )
+      const resultWithNewRelation = await service.update(
+        entitySlug,
+        id,
+        itemWithNewRelation
+      )
+
+      expect(resultWithoutRelation.mentor).toEqual(
+        itemWithoutRelation['mentor']
+      )
+      expect(resultWithNewRelation.mentor).toEqual(itemWithNewRelation.mentor)
+    })
+
+    it('should throw an error if validation fails', async () => {
+      jest.spyOn(validationService, 'validate').mockReturnValue([
+        {
+          property: 'name',
+          constraints: {
+            isNotEmpty: 'name should not be empty'
+          }
+        }
+      ])
+
+      const entitySlug = 'test'
+      const id = 1
+      const data = { name: '' }
+
+      expect(service.update(entitySlug, id, data)).rejects.toThrow()
+    })
+  })
+
+  describe('patch', () => {
+    it('should patch an entity', async () => {})
+
+    it('should throw an error if the entity is not found', async () => {})
+
+    it('should patch relationships', async () => {})
+
+    it('should do a partial replacement of properties', async () => {})
+
+    it('should do a partial replacement of relationships', async () => {})
+
+    it('should throw an error if validation fails', async () => {})
   })
 })

--- a/packages/core/manifest/src/crud/tests/crud.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/crud.service.spec.ts
@@ -80,17 +80,17 @@ describe('CrudService', () => {
     it('should update an entity', async () => {
       const entitySlug = 'test'
       const id = 1
-      const data = { name: 'test' }
+      const itemDto = { name: 'test' }
 
-      const result = await service.update(entitySlug, id, data)
+      const result = await service.update({ entitySlug, id, itemDto })
 
-      expect(result).toEqual(data)
+      expect(result).toEqual(itemDto)
     })
 
     it('should throw an error if the entity is not found', async () => {
       const entitySlug = 'test'
       const id = 1
-      const data = { name: 'test' }
+      const itemDto = { name: 'test' }
 
       jest.spyOn(entityService, 'getEntityRepository').mockReturnValue({
         findOne: jest.fn(() => Promise.resolve(null)),
@@ -98,27 +98,29 @@ describe('CrudService', () => {
         save: jest.fn((item) => item)
       } as any)
 
-      await expect(service.update(entitySlug, id, data)).rejects.toThrow()
+      await expect(
+        service.update({ entitySlug, id, itemDto })
+      ).rejects.toThrow()
     })
 
     it('should update relationships', async () => {
       const entitySlug = 'test'
       const id = 1
-      const data = { mentor: { id: 2 } }
+      const itemDto = { mentor: { id: 2 } }
 
-      const result = await service.update(entitySlug, id, data)
+      const result = await service.update({ entitySlug, id, itemDto })
 
-      expect(result.mentor).toEqual(data.mentor)
+      expect(result.mentor).toEqual(itemDto.mentor)
     })
 
     it('should do a full replacement of properties', async () => {
       const entitySlug = 'test'
       const id = 1
-      const data = { name: 'test' }
+      const itemDto = { name: 'test' }
 
-      const result = await service.update(entitySlug, id, data)
+      const result = await service.update({ entitySlug, id, itemDto })
 
-      expect(result.name).toEqual(data.name)
+      expect(result.name).toEqual(itemDto.name)
       expect(result.age).toBeUndefined()
     })
 
@@ -128,16 +130,16 @@ describe('CrudService', () => {
       const itemWithoutRelation = {}
       const itemWithNewRelation = { mentor: { id: 2 } }
 
-      const resultWithoutRelation = await service.update(
+      const resultWithoutRelation = await service.update({
         entitySlug,
         id,
-        itemWithoutRelation
-      )
-      const resultWithNewRelation = await service.update(
+        itemDto: itemWithoutRelation
+      })
+      const resultWithNewRelation = await service.update({
         entitySlug,
         id,
-        itemWithNewRelation
-      )
+        itemDto: itemWithNewRelation
+      })
 
       expect(resultWithoutRelation.mentor).toEqual(
         itemWithoutRelation['mentor']
@@ -157,23 +159,54 @@ describe('CrudService', () => {
 
       const entitySlug = 'test'
       const id = 1
-      const data = { name: '' }
+      const itemDto = { name: '' }
 
-      expect(service.update(entitySlug, id, data)).rejects.toThrow()
+      expect(service.update({ entitySlug, id, itemDto })).rejects.toThrow()
     })
-  })
 
-  describe('patch', () => {
-    it('should patch an entity', async () => {})
+    describe('update (partial replacement)', () => {
+      it('should do a partial replacement of properties', async () => {
+        const entitySlug = 'test'
+        const id = 1
+        const itemDto = { name: 'test' }
 
-    it('should throw an error if the entity is not found', async () => {})
+        const result = await service.update({
+          entitySlug,
+          id,
+          itemDto,
+          partialReplacement: true
+        })
 
-    it('should patch relationships', async () => {})
+        expect(result.name).toEqual(itemDto.name)
+        expect(result.age).toEqual(dummyItem.age)
+      })
 
-    it('should do a partial replacement of properties', async () => {})
+      it('should replace relations only if specified', async () => {
+        const entitySlug = 'test'
+        const id = 1
+        const itemDto = { mentor: { id: 2 } }
+        const itemWithoutRelation = { name: 'test' }
 
-    it('should do a partial replacement of relationships', async () => {})
+        const result = await service.update({
+          entitySlug,
+          id,
+          itemDto,
+          partialReplacement: true
+        })
 
-    it('should throw an error if validation fails', async () => {})
+        const resultWithoutRelation = await service.update({
+          entitySlug,
+          id,
+          itemDto: itemWithoutRelation,
+          partialReplacement: true
+        })
+
+        expect(result.mentor).toEqual(itemDto.mentor)
+        expect(result.name).toEqual(dummyItem.name)
+
+        expect(resultWithoutRelation.mentor).toEqual(dummyItem.mentor)
+        expect(resultWithoutRelation.name).toEqual(itemWithoutRelation.name)
+      })
+    })
   })
 })

--- a/packages/core/manifest/src/crud/tests/crud.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/crud.service.spec.ts
@@ -84,7 +84,7 @@ describe('CrudService', () => {
 
       const result = await service.update({ entitySlug, id, itemDto })
 
-      expect(result).toEqual(itemDto)
+      expect(result.name).toEqual(itemDto.name)
     })
 
     it('should throw an error if the entity is not found', async () => {

--- a/packages/core/manifest/src/crud/tests/database.controller.spec.ts
+++ b/packages/core/manifest/src/crud/tests/database.controller.spec.ts
@@ -24,4 +24,9 @@ describe('DatabaseController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined()
   })
+
+  it('should return true if the database is empty', async () => {
+    const res = await controller.isDbEmpty()
+    expect(res).toEqual({ empty: true })
+  })
 })

--- a/packages/core/manifest/src/crud/tests/single.controller.spec.ts
+++ b/packages/core/manifest/src/crud/tests/single.controller.spec.ts
@@ -94,4 +94,35 @@ describe('SingleController', () => {
       expect(res).toEqual(emptyRecord)
     })
   })
+
+  describe('PUT :entity', () => {
+    it('should call crudService.update with ID 1', async () => {
+      const entitySlug = 'test'
+      const itemDto = { name: 'test' }
+
+      await controller.put(entitySlug, itemDto as any)
+
+      expect(crudService.update).toHaveBeenCalledWith({
+        entitySlug,
+        id: 1,
+        itemDto
+      })
+    })
+  })
+
+  describe('PATCH :entity', () => {
+    it('should call crudService.update with ID 1 and partialReplacement true', async () => {
+      const entitySlug = 'test'
+      const itemDto = { name: 'test' }
+
+      await controller.patch(entitySlug, itemDto as any)
+
+      expect(crudService.update).toHaveBeenCalledWith({
+        entitySlug,
+        id: 1,
+        itemDto,
+        partialReplacement: true
+      })
+    })
+  })
 })

--- a/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
+++ b/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
@@ -14,6 +14,7 @@ describe('RelationshipService', () => {
     entity: 'User',
     type: 'many-to-one'
   }
+  const dummyUserIds: number[] = [1, 2, 3]
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -30,7 +31,11 @@ describe('RelationshipService', () => {
         {
           provide: EntityService,
           useValue: {
-            getEntityRepository: jest.fn()
+            getEntityRepository: jest.fn(() => ({
+              findOneBy: jest.fn(({ id }) => Promise.resolve({ id })),
+              findBy: jest.fn(() => dummyUserIds.map((id) => ({ id })))
+            })),
+            getEntityMetadata: jest.fn(() => ({ target: 'Owner' }))
           }
         }
       ]
@@ -72,5 +77,70 @@ describe('RelationshipService', () => {
         expect(relation.id).toBeLessThanOrEqual(mockSeedCount)
       })
     })
+  })
+
+  describe('fetchRelationItemsFromDto', () => {
+    it('should return an object with the relation items', async () => {
+      const itemDto = {
+        ownerId: 1
+      }
+
+      const relationItems = await service.fetchRelationItemsFromDto({
+        itemDto,
+        relationships: [dummyRelationManifest]
+      })
+
+      console.log(relationItems)
+
+      expect(relationItems.owner['id']).toBe(itemDto.ownerId)
+    })
+
+    it('should retrun an object with the relation items for many-to-many relationships', async () => {
+      const manyToManyRelationManifest: RelationshipManifest = {
+        name: 'users',
+        entity: 'User',
+        type: 'many-to-many',
+        owningSide: true
+      }
+
+      const itemDto = {
+        userIds: dummyUserIds
+      }
+
+      const relationItems = (await service.fetchRelationItemsFromDto({
+        itemDto,
+        relationships: [manyToManyRelationManifest]
+      })) as any
+      console.log(relationItems)
+
+      expect(relationItems.users.length).toBe(3)
+
+      relationItems.users.forEach((user, index) => {
+        expect(user['id']).toBe(itemDto.userIds[index])
+      })
+    })
+  })
+
+  it('should empty missing relationships if emptyMissing is true', async () => {
+    const itemDto = {}
+
+    const relationItems = await service.fetchRelationItemsFromDto({
+      itemDto,
+      relationships: [dummyRelationManifest],
+      emptyMissing: true
+    })
+
+    expect(relationItems.owner).toBeNull()
+  })
+
+  it('should not empty missing relationships by default', async () => {
+    const itemDto = {}
+
+    const relationItems = await service.fetchRelationItemsFromDto({
+      itemDto,
+      relationships: [dummyRelationManifest]
+    })
+
+    expect(relationItems.owner).toBeUndefined()
   })
 })

--- a/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
+++ b/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
@@ -90,8 +90,6 @@ describe('RelationshipService', () => {
         relationships: [dummyRelationManifest]
       })
 
-      console.log(relationItems)
-
       expect(relationItems.owner['id']).toBe(itemDto.ownerId)
     })
 

--- a/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
@@ -137,7 +137,9 @@ export class EntityManifestService {
           entitySchema.slug ||
           slugify(
             dasherize(
-              pluralize.plural(entitySchema.className || className)
+              entitySchema.single
+                ? entitySchema.className || className
+                : pluralize.plural(entitySchema.className || className)
             ).toLowerCase()
           ),
         single: entitySchema.single || false,

--- a/packages/core/manifest/src/manifest/services/relationship-manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/relationship-manifest.service.ts
@@ -145,7 +145,8 @@ export class RelationshipManifestService {
           otherEntityManifest.relationships.find(
             (relationship: RelationshipManifest) =>
               relationship.entity === currentEntityManifest.className &&
-              relationship.type === 'many-to-many'
+              relationship.type === 'many-to-many' &&
+              relationship.owningSide === true
           )
 
         if (oppositeRelationship) {

--- a/packages/core/manifest/src/manifest/tests/relationship-manifest.service.spec.ts
+++ b/packages/core/manifest/src/manifest/tests/relationship-manifest.service.spec.ts
@@ -33,7 +33,8 @@ describe('RelationshipManifestService', () => {
           {
             name: 'friends',
             entity: 'Dog',
-            type: 'many-to-many'
+            type: 'many-to-many',
+            owningSide: true
           }
         ],
         policies: {

--- a/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
@@ -41,12 +41,13 @@ describe('OpenApiCrudService', () => {
     expect(service).toBeDefined()
   })
 
-  it('should generate all 6 entity paths', () => {
+  it('should generate all 7 entity paths', () => {
     jest.spyOn(service, 'generateListPath').mockReturnValue({})
     jest.spyOn(service, 'generateListSelectOptionsPath').mockReturnValue({})
     jest.spyOn(service, 'generateCreatePath').mockReturnValue({})
     jest.spyOn(service, 'generateDetailPath').mockReturnValue({})
     jest.spyOn(service, 'generateUpdatePath').mockReturnValue({})
+    jest.spyOn(service, 'generatePatchPath').mockReturnValue({})
     jest.spyOn(service, 'generateDeletePath').mockReturnValue({})
 
     const paths = service.generateEntityPaths([dummyEntityManifest])
@@ -59,6 +60,7 @@ describe('OpenApiCrudService', () => {
     expect(service.generateCreatePath).toHaveBeenCalled()
     expect(service.generateDetailPath).toHaveBeenCalled()
     expect(service.generateUpdatePath).toHaveBeenCalled()
+    expect(service.generatePatchPath).toHaveBeenCalled()
     expect(service.generateDeletePath).toHaveBeenCalled()
   })
 })

--- a/packages/core/manifest/src/validation/tests/custom-validators.spec.ts
+++ b/packages/core/manifest/src/validation/tests/custom-validators.spec.ts
@@ -61,8 +61,6 @@ describe('Custom validators', () => {
       })
     )
 
-    console.log(goodValidations, badValidations)
-
     expect(goodValidations.every((validation) => validation.length === 0)).toBe(
       true
     )
@@ -90,8 +88,6 @@ describe('Custom validators', () => {
         validation: { isEmpty: true }
       })
     )
-
-    console.log(goodValidations, badValidations)
 
     expect(goodValidations.every((validation) => validation.length === 0)).toBe(
       true

--- a/packages/js-sdk/src/Manifest.ts
+++ b/packages/js-sdk/src/Manifest.ts
@@ -149,7 +149,7 @@ export default class Manifest {
   }
 
   /**
-   * Update an item of the entity.
+   * Update an item of the entity doing a full replace. Leaving blank fields and relations will remove them. Use patch for partial updates.
    *
    * @param id The id of the item to update.
    * @param itemDto The DTO of the item to update.
@@ -161,6 +161,23 @@ export default class Manifest {
     return this.fetch({
       path: `/collections/${this.slug}/${id}`,
       method: 'PUT',
+      body: itemDto
+    }) as Promise<T>
+  }
+
+  /**
+   * Partially update an item of the entity. Leaving blank fields and relations will not remove them. Use update for full replaces.
+   *
+   * @param id The id of the item to update.
+   * @param itemDto The DTO of the item to update.
+   *
+   * @returns The updated item.
+   * @example client.from('cats').update(1, { name: 'updated name' });
+   */
+  async patch<T>(id: number, itemDto: unknown): Promise<T> {
+    return this.fetch({
+      path: `/collections/${this.slug}/${id}`,
+      method: 'PATCH',
       body: itemDto
     }) as Promise<T>
   }
@@ -337,14 +354,14 @@ export default class Manifest {
     }) as Promise<{ email: string }>
   }
 
-  private fetch({
+  private async fetch({
     path,
     method,
     body,
     queryParams
   }: {
     path: string
-    method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
+    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
     body?: unknown
     queryParams?: Record<string, string | number | boolean>
   }): Promise<unknown> {

--- a/packages/js-sdk/tests/crud.spec.ts
+++ b/packages/js-sdk/tests/crud.spec.ts
@@ -164,6 +164,28 @@ describe('CRUD operations', () => {
       expect(item).toMatchObject(dummyItem)
     })
 
+    it('should patch an item', async () => {
+      const id: number = 1
+
+      fetchMock.mock(
+        {
+          url: `${collectionBaseUrl}/cats/${id}`,
+          method: 'PATCH',
+          body: {
+            name: 'Tom'
+          }
+        },
+        dummyItem
+      )
+
+      const manifest = new Manifest()
+      const item = await manifest.from('cats').patch(id, {
+        name: 'Tom'
+      })
+
+      expect(item).toMatchObject(dummyItem)
+    })
+
     it('should delete an item', async () => {
       const id: number = 1
 


### PR DESCRIPTION
## Description

This PRs removes an ambiguity updating items (see #265). Updating an item leaving props and relations blank/empty results in a strange behavior: 
- empty props are not deleted (original value is conserved)
- relations are deleted

This PRs distinguishes between both behaviors by proposing a PATCH method in addition to the PUT method:
- PUT method does a full replacement of props and relations (empty props/relations are considered deleted)
- PATCH method does a partial update touching only the props and relations present in the body

- [Related DOC PR](https://github.com/mnfst/docs/pull/15)

## Related Issues

- Closes #265 
- Closes #257 

## How can it be tested?

Get the related doc from the **website** repository replacing `docs/fetch-content.sh` by

```bash
#!/bin/bash
# Remove the existing directory if it exists
rm -rf content

# Clone the repository into the 'content' directory
git clone --depth 1 --branch patch https://github.com/mnfst/docs.git content
```

And then run `npm run fetch-content` and browse the documentation to play around.

I recommend using Postman to update existing items that have relations with both PUT and PATCH methods to see if it does as it says.

## Impacted packages

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [ ] [add-manifest](https://www.npmjs.com/package/add-manifest)
- [x] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [x] This PR is wrote in a clear language and correctly labeled
