### PR TITLE
🐛 fix(entityManifest): admin props not displayed in manifest

### DIFF
--- a/.changeset/lucky-bikes-cover.md
+++ b/.changeset/lucky-bikes-cover.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+fixed admins cannot be managed in admin panel

--- a/packages/core/manifest/src/constants.ts
+++ b/packages/core/manifest/src/constants.ts
@@ -29,30 +29,6 @@ export const DEFAULT_IMAGE_SIZES: ImageSizesObject = {
   }
 }
 
-// Admin entity.
-export const DEFAULT_ADMIN_CREDENTIALS = {
-  email: 'admin@manifest.build',
-  password: 'admin'
-}
-export const ADMIN_ENTITY_MANIFEST: EntityManifest = {
-  className: 'Admin',
-  mainProp: 'email',
-  slug: 'admins',
-  authenticable: true,
-  nameSingular: 'admin',
-  namePlural: 'admins',
-  properties: [],
-  relationships: [],
-  belongsToMany: [],
-  policies: {
-    create: [{ access: 'admin' }],
-    read: [{ access: 'admin' }],
-    update: [{ access: 'admin' }],
-    delete: [{ access: 'admin' }],
-    signup: [{ access: 'forbidden' }]
-  }
-}
-
 export const AUTHENTICABLE_PROPS: PropertyManifest[] = [
   {
     name: 'email',
@@ -67,6 +43,30 @@ export const AUTHENTICABLE_PROPS: PropertyManifest[] = [
     validation: { isNotEmpty: true }
   }
 ]
+
+// Admin entity.
+export const DEFAULT_ADMIN_CREDENTIALS = {
+  email: 'admin@manifest.build',
+  password: 'admin'
+}
+export const ADMIN_ENTITY_MANIFEST: EntityManifest = {
+  className: 'Admin',
+  mainProp: 'email',
+  slug: 'admins',
+  authenticable: true,
+  nameSingular: 'admin',
+  namePlural: 'admins',
+  properties: AUTHENTICABLE_PROPS,
+  relationships: [],
+  belongsToMany: [],
+  policies: {
+    create: [{ access: 'admin' }],
+    read: [{ access: 'admin' }],
+    update: [{ access: 'admin' }],
+    delete: [{ access: 'admin' }],
+    signup: [{ access: 'forbidden' }]
+  }
+}
 
 // Reserved words that are not considered as filters.
 export const QUERY_PARAMS_RESERVED_WORDS = [


### PR DESCRIPTION
## Description

Bugfix

## Related Issues

- Closes #269

## How can it be tested?

Launch admin panel and edit admins (CRUD). Everything should work

## Impacted packages

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [ ] [add-manifest](https://www.npmjs.com/package/add-manifest)
- [ ] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [x] This PR is wrote in a clear language and correctly labeled
