### PR TITLE
Reduce bundle size

### DIFF
--- a/.changeset/large-horses-count.md
+++ b/.changeset/large-horses-count.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+reduced bundle size, thanks @nicholas-codecov

--- a/packages/core/admin/angular.json
+++ b/packages/core/admin/angular.json
@@ -32,6 +32,7 @@
           },
           "configurations": {
             "production": {
+              "extractLicenses": false,
               "budgets": [
                 {
                   "type": "initial",

--- a/packages/core/manifest/.npmignore
+++ b/packages/core/manifest/.npmignore
@@ -1,0 +1,1 @@
+tsconfig.build.tsbuildinfo

--- a/packages/core/manifest/.npmignore
+++ b/packages/core/manifest/.npmignore
@@ -1,1 +1,0 @@
-tsconfig.build.tsbuildinfo

--- a/packages/core/manifest/package.json
+++ b/packages/core/manifest/package.json
@@ -47,7 +47,7 @@
     "test:e2e:ci": "jest --config ./e2e/jest-e2e.config.json --ci",
     "test:unit": "jest --config ./jest.config.json",
     "test:unit:ci": "jest --config ./jest.config.json --ci --coverage",
-    "postbuild": "rm -fr ./dist/admin/dist",
+    "postbuild": "rm -fr ./dist/admin/dist && rm ./dist/tsconfig.build.tsbuildinfo",
     "postpublish": "node ../../../scripts/update-package.js"
   },
   "files": [

--- a/packages/core/manifest/src/auth/tests/policies.spec.ts
+++ b/packages/core/manifest/src/auth/tests/policies.spec.ts
@@ -1,0 +1,66 @@
+import { ADMIN_ENTITY_MANIFEST } from '../../constants'
+import { policies } from '../policies/policies'
+
+describe('Policies', () => {
+  const user = { email: 'admin@testfr' } as any
+
+  describe('admin', () => {
+    it('should return true if the user is an admin', () => {
+      expect(
+        policies.admin(user, { slug: ADMIN_ENTITY_MANIFEST.slug } as any)
+      ).toBe(true)
+    })
+
+    it('should return false if the user is not an admin', () => {
+      const user = { email: 'user@testfr' } as any
+
+      expect(policies.admin(user, { slug: 'contributors' } as any)).toBe(false)
+    })
+  })
+
+  describe('public', () => {
+    it('should return true', () => {
+      expect(policies.public(user, {} as any)).toBe(true)
+    })
+  })
+
+  describe('forbidden', () => {
+    it('should return false', () => {
+      expect(policies.forbidden(user, {} as any)).toBe(false)
+    })
+  })
+
+  describe('restricted', () => {
+    it('should return true if the user is an admin', () => {
+      expect(
+        policies.restricted(user, { slug: ADMIN_ENTITY_MANIFEST.slug } as any, {
+          allow: ['users']
+        })
+      ).toBe(true)
+    })
+
+    it('should return false if there is no user logged in', () => {
+      expect(
+        policies.restricted(null, { slug: 'contributors' } as any, {
+          allow: []
+        })
+      ).toBe(false)
+    })
+
+    it('should return true if the user is logged in and from entity list', () => {
+      expect(
+        policies.restricted(user, { className: 'contributors' } as any, {
+          allow: ['contributors', 'guests']
+        })
+      ).toBe(true)
+    })
+
+    it('should return false if the user is logged in but not in list', () => {
+      expect(
+        policies.restricted(user, { className: 'guests' } as any, {
+          allow: ['users']
+        })
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/core/manifest/tsconfig.build.json
+++ b/packages/core/manifest/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "e2e", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "e2e", "dist", "**/*spec.ts"],
+  "compilerOptions": {
+    "sourceMap": false,
+    "declaration": false
+  }
 }


### PR DESCRIPTION
## Description

This PR aims to reduce the [manifest](https://www.npmjs.com/package/manifest) package size

## Related Issues

None

## How can it be tested?

- Clone and play around

## Impacted packages

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)

## Check list before submitting

- [ ] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [ ] This PR is wrote in a clear language and correctly labeled
