### PR TITLE
fix: route to /404 if item not found

### DIFF
--- a/.changeset/tasty-goats-rush.md
+++ b/.changeset/tasty-goats-rush.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add route to 404 page if item not found in detail page or edit page

--- a/packages/core/admin/src/app/modules/crud/views/create-edit/create-edit.component.ts
+++ b/packages/core/admin/src/app/modules/crud/views/create-edit/create-edit.component.ts
@@ -63,21 +63,25 @@ export class CreateEditComponent {
       this.singleMode = this.activatedRoute.snapshot.data['mode'] === 'single'
 
       if (this.edit) {
-        if (this.singleMode) {
-          this.item = await this.crudService.showSingle(
-            this.entityManifest.slug
-          )
-        } else {
-          this.item = await this.crudService.show(
-            this.entityManifest.slug,
-            params['id'],
-            {
-              relations: this.entityManifest.relationships
-                .filter((r) => r.type !== 'one-to-many')
-                .filter((r) => r.type !== 'many-to-many' || r.owningSide)
-                .map((r) => r.name)
-            }
-          )
+        try {
+          if (this.singleMode) {
+            this.item = await this.crudService.showSingle(
+              this.entityManifest.slug
+            )
+          } else {
+            this.item = await this.crudService.show(
+              this.entityManifest.slug,
+              params['id'],
+              {
+                relations: this.entityManifest.relationships
+                  .filter((r) => r.type !== 'one-to-many')
+                  .filter((r) => r.type !== 'many-to-many' || r.owningSide)
+                  .map((r) => r.name)
+              }
+            )
+          }
+        } catch (err) {
+          this.router.navigate(['/404'])
         }
 
         this.breadcrumbService.breadcrumbLinks.next([

--- a/packages/core/admin/src/app/modules/crud/views/detail/detail.component.ts
+++ b/packages/core/admin/src/app/modules/crud/views/detail/detail.component.ts
@@ -38,19 +38,23 @@ export class DetailComponent {
       this.singleMode = this.activatedRoute.snapshot.data['mode'] === 'single'
 
       // Get the item.
-      if (this.singleMode) {
-        this.item = await this.crudService.showSingle(this.entityManifest.slug)
-      } else {
-        this.item = await this.crudService.show(
-          this.entityManifest.slug,
-          params['id'],
-          {
-            relations: this.entityManifest.relationships
-              ?.filter((r) => r.type !== 'one-to-many')
-              .filter((r) => r.type !== 'many-to-many' || r.owningSide)
-              .map((relationship: RelationshipManifest) => relationship.name)
-          }
-        )
+      try {
+        if (this.singleMode) {
+          this.item = await this.crudService.showSingle(this.entityManifest.slug)
+        } else {
+          this.item = await this.crudService.show(
+            this.entityManifest.slug,
+            params['id'],
+            {
+              relations: this.entityManifest.relationships
+                ?.filter((r) => r.type !== 'one-to-many')
+                .filter((r) => r.type !== 'many-to-many' || r.owningSide)
+                .map((relationship: RelationshipManifest) => relationship.name)
+            }
+          )
+        }
+      } catch (err) {
+        this.router.navigate(['/404'])
       }
 
       // Set the breadcrumbs.


### PR DESCRIPTION
## Description
this PR add a route to 404 page if item not found in detail page or edit page
## Related Issues
#286 
## How can it be tested?

## Impacted packages

Check the NPM packages that require a new publication or release:

- [x] [manifest](https://www.npmjs.com/package/manifest)
- [ ] [add-manifest](https://www.npmjs.com/package/add-manifest)
- [ ] [@mnfst/sdk](https://www.npmjs.com/package/@mnfst/sdk)

## Check list before submitting

- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
- [ ] This PR is wrote in a clear language and correctly labeled
