### PR TITLE
fix issue 186

### DIFF
--- a/.changeset/lazy-parents-tickle.md
+++ b/.changeset/lazy-parents-tickle.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fixed error 400 'The value must be a valid' when a field of type timestamp is added or edited. Furthermore added unit tests to TimestampInputComponent

--- a/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.spec.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TimestampInputComponent } from './timestamp-input.component';
+import { PropType } from '../../../../../../../types/src/crud';
 
 describe('TimestampInputComponent', () => {
   let component: TimestampInputComponent;
@@ -14,10 +15,49 @@ describe('TimestampInputComponent', () => {
     
     fixture = TestBed.createComponent(TimestampInputComponent);
     component = fixture.componentInstance;
+    component.prop = {
+      name: 'test',
+      type: PropType.Timestamp
+    }
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should emit valueChanged event with timestamp when input changes', () => {
+    const numericTimestamp = 1696161600;
+    const mockTimestamp = new Date(numericTimestamp).getTime();
+
+    spyOn(component.valueChanged, 'emit');
+
+    component.onChange({ target: { value: numericTimestamp } });
+
+    expect(component.valueChanged.emit).toHaveBeenCalledWith(mockTimestamp);
+  });
+
+  it('should emit null if input value is empty', () => {
+    spyOn(component.valueChanged, 'emit');
+
+    component.onChange({ target: { value: '' } });
+
+    expect(component.valueChanged.emit).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should apply "is-danger" class when isError is true', () => {
+    component.isError = true;
+    fixture.detectChanges();
+
+    const inputElement = fixture.nativeElement.querySelector('input');
+    expect(inputElement.classList.contains('is-danger')).toBe(true);
+  });
+
+  it('should not apply "is-danger" class when isError is false', () => {
+    component.isError = false;
+    fixture.detectChanges();
+
+    const inputElement = fixture.nativeElement.querySelector('input');
+    expect(inputElement.classList.contains('is-danger')).toBe(false);
   });
 });

--- a/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/timestamp-input/timestamp-input.component.ts
@@ -25,7 +25,7 @@ import { PropertyManifest } from '@repo/types'
 })
 export class TimestampInputComponent {
   @Input() prop: PropertyManifest
-  @Input() value: string
+  @Input() value: number
   @Input() isError: boolean
 
   @Output() valueChanged: EventEmitter<number> = new EventEmitter()
@@ -39,6 +39,7 @@ export class TimestampInputComponent {
   }
 
   onChange(event: any) {
-    this.valueChanged.emit(event.target.value)
+    const valueDate = event.target.value ? new Date(event.target.value) : null
+    this.valueChanged.emit(valueDate?.getTime())
   }
 }

--- a/packages/core/manifest/src/validation/records/type-validators.ts
+++ b/packages/core/manifest/src/validation/records/type-validators.ts
@@ -52,7 +52,6 @@ export const typeValidators: Record<
   [PropType.Timestamp]: (value: number) =>
     typeof value === 'number' &&
     Number.isInteger(value) &&
-    value > 0 &&
     isFinite(value)
       ? null
       : 'The value must be a valid timestamp',


### PR DESCRIPTION
## Description
Fixed error 400 'The value must be a valid' when a field of type timestamp is added or edited. Furthermore added unit tests to TimestampInputComponent

## Related Issues
#186
## How can it be tested?

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
