### PR TITLE
🔧 New environment variables: DB path / Public path / Show OPEN API

### DIFF
--- a/.changeset/ninety-cats-float.md
+++ b/.changeset/ninety-cats-float.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+added dynamic path for db and public folder

--- a/packages/core/manifest/src/config/database.ts
+++ b/packages/core/manifest/src/config/database.ts
@@ -4,7 +4,8 @@ export default (): { database: SqliteConnectionOptions } => {
   return {
     database: {
       type: 'sqlite',
-      database: `${process.cwd()}/manifest/backend.db`,
+      database:
+        process.env.DATABASE_PATH || `${process.cwd()}/manifest/backend.db`,
       dropSchema: process.env.DB_DROP_SCHEMA === 'true' || false,
       synchronize: true
     }

--- a/packages/core/manifest/src/config/paths.ts
+++ b/packages/core/manifest/src/config/paths.ts
@@ -3,6 +3,7 @@ import path from 'path'
 export default (): {
   paths: {
     adminPanelFolder: string
+    publicFolder: string
     manifestFile: string
     handlersFolder: string
   }
@@ -13,6 +14,7 @@ export default (): {
         process.env.NODE_ENV === 'contribution'
           ? path.join(process.cwd(), '..', 'admin', 'dist')
           : `${process.cwd()}/node_modules/manifest/dist/admin`,
+      publicFolder: process.env.PUBLIC_FOLDER || `${process.cwd()}/public`,
       manifestFile:
         process.env.MANIFEST_FILE_PATH ||
         `${process.cwd()}/manifest/backend.yml`,

--- a/packages/core/manifest/src/constants.ts
+++ b/packages/core/manifest/src/constants.ts
@@ -7,7 +7,7 @@ import {
 } from '@repo/types'
 
 // Paths.
-export const STORAGE_PATH: string = 'public/storage'
+export const STORAGE_PATH: string = 'storage'
 export const API_PATH: string = 'api'
 export const COLLECTIONS_PATH: string = 'collections'
 export const SINGLES_PATH: string = 'singles'

--- a/packages/core/manifest/src/storage/services/storage.service.ts
+++ b/packages/core/manifest/src/storage/services/storage.service.ts
@@ -33,7 +33,10 @@ export class StorageService {
 
     const filePath: string = `${folder}/${uniqid()}-${slugify(file.originalname)}`
 
-    fs.writeFileSync(`${STORAGE_PATH}/${filePath}`, file.buffer)
+    fs.writeFileSync(
+      `${this.configService.get('paths').publicFolder}/${STORAGE_PATH}/${filePath}`,
+      file.buffer
+    )
 
     return this.prependStorageUrl(filePath)
   }
@@ -70,9 +73,12 @@ export class StorageService {
           .resize(imageSizes[sizeName].width, imageSizes[sizeName].height, {
             fit: imageSizes[sizeName].fit
           })
-          .toFile(`${STORAGE_PATH}/${imagePath}`, () => {
-            return imagePath
-          })
+          .toFile(
+            `${this.configService.get('paths').publicFolder}/${STORAGE_PATH}/${imagePath}`,
+            () => {
+              return imagePath
+            }
+          )
 
         imagePaths[sizeName] = this.prependStorageUrl(imagePath)
       }
@@ -95,18 +101,20 @@ export class StorageService {
 
     const folder: string = `${kebabize(entity)}/${kebabize(property)}/${dateString}`
 
-    mkdirp.sync(`${STORAGE_PATH}/${folder}`)
+    mkdirp.sync(
+      `${this.configService.get('paths').publicFolder}/${STORAGE_PATH}/${folder}`
+    )
 
     return folder
   }
 
   /**
-   * Prepends the storage URL to the given value.
+   * Prepends the storage absolute URL to the given value.
    *
    * @param value The value to prepend the storage URL to.
    * @returns The value with the storage URL prepended.
    */
   prependStorageUrl(value: string): string {
-    return `${this.configService.get('baseUrl')}/storage/${value}`
+    return `${this.configService.get('baseUrl')}/${STORAGE_PATH}/${value}`
   }
 }

--- a/packages/core/manifest/src/storage/tests/storage.service.spec.ts
+++ b/packages/core/manifest/src/storage/tests/storage.service.spec.ts
@@ -86,6 +86,8 @@ describe('StorageService', () => {
     expect(filePaths).toBeDefined()
     expect(Object.keys(filePaths).length).toBe(2)
     expect(Object.keys(filePaths)).toMatchObject(Object.keys(imageSizes))
+    expect(sharp.prototype.resize).toHaveBeenCalledTimes(2)
+    expect(sharp.prototype.toFile).toHaveBeenCalledTimes(2)
   })
 
   it('should prepend the storage url before the path', () => {

--- a/packages/core/manifest/src/upload/tests/upload.controller.spec.ts
+++ b/packages/core/manifest/src/upload/tests/upload.controller.spec.ts
@@ -29,19 +29,49 @@ describe('UploadController', () => {
   })
 
   describe('uploadFile', () => {
-    it('should return the path of the uploaded file', () => {})
+    it('should return the path of the uploaded file', () => {
+      const file = {
+        buffer: Buffer.from('file content'),
+        originalname: 'file.txt'
+      }
 
-    it('creates unique file names', () => {})
+      const entity = 'entity'
+      const property = 'property'
+      const path = 'path'
 
-    it('should return a 400 error if entity name or property is not provided', () => {})
+      jest.spyOn(uploadService, 'storeFile').mockReturnValue(path)
 
-    it('expect the file to be passed as "file" in a multipart/form-data', () => {})
+      expect(controller.uploadFile(file, entity, property)).toEqual({ path })
+
+      expect(uploadService.storeFile).toHaveBeenCalledWith({
+        file,
+        entity,
+        property
+      })
+    })
   })
   describe('uploadImage', () => {
-    it('should upload an image', () => {})
+    it('should upload an image', () => {
+      const image = {
+        buffer: Buffer.from('image content'),
+        originalname: 'image.jpg'
+      }
 
-    it('should return a 400 error if entity name or property is not provided', () => {})
+      const entity = 'entity'
+      const property = 'property'
+      const imagePaths = { thumbnail: 'path', medium: 'path' }
 
-    it('expect the image to be passed as "image" in a multipart/form-data', () => {})
+      jest.spyOn(uploadService, 'storeImage').mockReturnValue(imagePaths)
+
+      expect(controller.uploadImage(image, entity, property)).toEqual(
+        imagePaths
+      )
+
+      expect(uploadService.storeImage).toHaveBeenCalledWith({
+        image,
+        entity,
+        property
+      })
+    })
   })
 })

--- a/packages/core/manifest/src/upload/tests/upload.service.spec.ts
+++ b/packages/core/manifest/src/upload/tests/upload.service.spec.ts
@@ -2,11 +2,22 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { UploadService } from '../services/upload.service'
 import { EntityManifestService } from '../../manifest/services/entity-manifest.service'
 import { StorageService } from '../../storage/services/storage.service'
+import { PropType, PropertyManifest } from '../../../../types/src'
+import { DEFAULT_IMAGE_SIZES } from '../../constants'
 
 describe('UploadService', () => {
   let service: UploadService
   let storageService: StorageService
   let entityManifestService: EntityManifestService
+
+  const dummyImageProp: PropertyManifest = {
+    name: 'avatar',
+    type: PropType.Image,
+    options: {
+      sizes: DEFAULT_IMAGE_SIZES
+    }
+  }
+  const imagePaths = { large: 'imagePaths' }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -15,13 +26,23 @@ describe('UploadService', () => {
         {
           provide: StorageService,
           useValue: {
-            store: jest.fn()
+            store: jest.fn(),
+            storeImage: jest.fn(() => imagePaths)
           }
         },
         {
           provide: EntityManifestService,
           useValue: {
-            getEntityManifest: jest.fn()
+            getEntityManifest: jest.fn(() => ({
+              properties: [
+                dummyImageProp,
+                {
+                  name: 'not-an-image',
+                  type: PropType.String,
+                  options: { required: true }
+                }
+              ]
+            }))
           }
         }
       ]
@@ -36,5 +57,67 @@ describe('UploadService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined()
+  })
+
+  describe('storeFile', () => {
+    it('should store a file', () => {
+      const file = {
+        buffer: Buffer.from('file content'),
+        originalname: 'file.txt'
+      }
+
+      const entity = 'entity'
+      const property = 'property'
+      const path = 'path'
+
+      jest.spyOn(storageService, 'store').mockReturnValue(path)
+
+      expect(service.storeFile({ file, entity, property })).toEqual(path)
+
+      expect(storageService.store).toHaveBeenCalledWith(entity, property, file)
+    })
+  })
+
+  describe('store image', () => {
+    it('should store an image', () => {
+      const image = {
+        buffer: Buffer.from('image content'),
+        originalname: 'image.jpg'
+      }
+
+      const entity = 'entity'
+
+      const result = service.storeImage({
+        image,
+        entity,
+        property: dummyImageProp.name
+      })
+
+      expect(result).toEqual(imagePaths)
+
+      expect(storageService.storeImage).toHaveBeenCalledWith(
+        entity,
+        dummyImageProp.name,
+        image,
+        dummyImageProp.options.sizes
+      )
+    })
+
+    it('should fail if property is not an image', () => {
+      const image = {
+        buffer: Buffer.from('image content'),
+        originalname: 'image.jpg'
+      }
+
+      const entity = 'entity'
+
+      expect(() =>
+        service.storeImage({
+          image,
+          entity,
+          property: 'not-an-image'
+        })
+      ).toThrow()
+    })
   })
 })


### PR DESCRIPTION
## Description

This PR adds 3 new environment variables to Manifest:

```env

DATABASE_PATH
PUBLIC_PATH
OPEN_API_DOCS
```

There is no doc PR yet as it will be created later depending on the experience deploying manifest to several hosting providers. 

The main goal is to be able to put files that need persistent data (db+ storage) in the same folder.

## Related Issues

-  #252 

## How can it be tested?

Create a new folder next to public and call it `disk` for example (targeting [Render Disks](https://render.com/docs/disks)) and add the following variables in your dotenv:

```env
DATABASE_PATH=./disk/db/new.db
PUBLIC_FOLDER=./disk/public
```

Restart and test to store data, files and images. Everything should work.

For the API DOC, set `OPEN_API_DOCS=false` in dotenv to disable it

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
