### PR TITLE
feat: prevent admin users from deleting their own accounts

### DIFF
--- a/packages/core/admin/src/app/modules/crud/views/list/list.component.html
+++ b/packages/core/admin/src/app/modules/crud/views/list/list.component.html
@@ -137,7 +137,10 @@
                 ></a>
                 <a
                   class="button is-light is-small is-circle"
-                  (click)="toggleDeleteModal(item)"
+                  [class.is-disabled]="entityManifest.slug === 'admins' && item['id'] === currentAdminId"
+                  [attr.aria-disabled]="entityManifest.slug === 'admins' && item['id'] === currentAdminId ? true : null"
+                  [attr.title]="entityManifest.slug === 'admins' && item['id'] === currentAdminId ? 'You cannot delete your own admin account' : null"
+                  (click)="entityManifest.slug === 'admins' && item['id'] === currentAdminId ? null : toggleDeleteModal(item)"
                   ><i class="icon icon-trash-2"></i
                 ></a>
               </div>
@@ -198,10 +201,18 @@
         <button class="button is-white" (click)="toggleDeleteModal()">
           Cancel
         </button>
-        <button class="button is-danger" (click)="delete(itemToDelete['id'])">
+        <button
+          class="button is-danger"
+          [disabled]="entityManifest.slug === 'admins' && itemToDelete && itemToDelete['id'] === currentAdminId"
+          [attr.title]="entityManifest.slug === 'admins' && itemToDelete && itemToDelete['id'] === currentAdminId ? 'You cannot delete your own admin account' : null"
+          (click)="delete(itemToDelete['id'])"
+        >
           Delete
         </button>
       </div>
+      <p class="help is-danger mt-2" *ngIf="entityManifest.slug === 'admins' && itemToDelete && itemToDelete['id'] === currentAdminId">
+        You cannot delete your own admin account.
+      </p>
       <button
         class="modal-close is-large"
         aria-label="close"

--- a/packages/core/admin/src/app/modules/crud/views/list/list.component.ts
+++ b/packages/core/admin/src/app/modules/crud/views/list/list.component.ts
@@ -14,6 +14,7 @@ import { ManifestService } from '../../../shared/services/manifest.service'
 import { CrudService } from '../../services/crud.service'
 import { MetaService } from '../../../shared/services/meta.service'
 import { CapitalizeFirstLetterPipe } from '../../../shared/pipes/capitalize-first-letter.pipe'
+import { AuthService } from '../../../auth/auth.service'
 
 @Component({
   selector: 'app-list',
@@ -28,6 +29,9 @@ export class ListComponent implements OnInit {
   entityManifest: EntityManifest
   properties: PropertyManifest[]
 
+  // Current admin ID used to prevent self-deletion in admin listing
+  currentAdminId: string | null = null
+
   queryParams: Params
   PropType = PropType
 
@@ -38,10 +42,17 @@ export class ListComponent implements OnInit {
     private activatedRoute: ActivatedRoute,
     private metaService: MetaService,
     private flashMessageService: FlashMessageService,
-    private renderer: Renderer2
+    private renderer: Renderer2,
+    private authService: AuthService
   ) {}
 
   ngOnInit(): void {
+    // Ensure current admin is loaded and keep ID in sync
+    this.authService.currentUser$.subscribe((admin) => {
+      this.currentAdminId = admin?.id || null
+    })
+    this.authService.loadCurrentUser().subscribe()
+
     combineLatest([
       this.activatedRoute.queryParams,
       this.activatedRoute.params


### PR DESCRIPTION
## Description
This PR prevents an admin from deleting their own account while logged in. Previously, the admin could remove themselves from the app (from settings > admin) which resulted in a strange behavior. Now, a error is thrown if an admin tries to. I also updated the tests to correctly test the deletion (with a new mock and a new test case).
## Related Issues
* [Admin should not be able to delete itself #318 ](https://github.com/mnfst/manifest/issues/318)
## How can it be tested?
Try to delete yourself as an admin and an error shoul be thrown.
<img width="993" alt="image" src="https://github.com/user-attachments/assets/ae8b9056-3ce8-497b-95c0-3d1cb1be832d" />


## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
