### PR TITLE
chore: prevent uncontrolled data used in path

### DIFF
--- a/.changeset/dirty-spiders-wonder.md
+++ b/.changeset/dirty-spiders-wonder.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+prevent using uncontrolled data in path

--- a/packages/core/manifest/src/storage/tests/storage.service.spec.ts
+++ b/packages/core/manifest/src/storage/tests/storage.service.spec.ts
@@ -30,6 +30,7 @@ describe('StorageService', () => {
   }
 
   const baseUrl: string = 'http://localhost:3333'
+  const publicFolder: string = 'public'
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -41,6 +42,9 @@ describe('StorageService', () => {
             get: jest.fn((setting) => {
               if (setting === 'baseUrl') {
                 return baseUrl
+              }
+              if (setting === 'paths.publicFolder') {
+                return publicFolder
               }
               return null
             })


### PR DESCRIPTION
## Description

Security. Prevent uncontrolled data usage in path.

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
