### PR TITLE
Strict policies

### DIFF
--- a/.changeset/yellow-deers-rule.md
+++ b/.changeset/yellow-deers-rule.md
@@ -1,0 +1,6 @@
+---
+'manifest': patch
+'add-manifest': patch
+---
+
+Removed public access by default for CRUD operations, thanks @lexicality

--- a/package-lock.json
+++ b/package-lock.json
@@ -4487,11 +4487,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -4847,7 +4850,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4855,7 +4860,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4884,101 +4891,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.6",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.6",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -6207,13 +6140,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6259,13 +6194,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6273,6 +6209,8 @@
     },
     "node_modules/@balena/dockerignore": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -6962,6 +6900,39 @@
       "version": "1.1.3",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.2.tgz",
+      "integrity": "sha512-nnR5nmL6lxF8YBqb6gWvEgLdLh/Fn+kvAdX5hUOnt48sNSb0riz/93ASd2E5gvanPA41X6Yp25bIfGRp1SMb2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -8080,6 +8051,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "license": "MIT"
@@ -8585,11 +8567,13 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "10.4.8",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.15.tgz",
+      "integrity": "sha512-vaLg1ZgwhG29BuLDxPA9OAcIlgqzp9/N8iG0wGapyUNTf4IY4O6zAHgN6QalwLhFxq7nOI021vdRojR1oF3bqg==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.7.0",
+        "tslib": "2.8.1",
         "uid": "2.0.2"
       },
       "funding": {
@@ -8625,7 +8609,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "10.4.8",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.15.tgz",
+      "integrity": "sha512-UBejmdiYwaH6fTsz2QFBlC1cJHM+3UDeLZN+CiP9I1fRv2KlBZsmozGLbV5eS1JAVWJB4T5N5yQ0gjN8ZvcS2w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8633,7 +8619,7 @@
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
         "path-to-regexp": "3.3.0",
-        "tslib": "2.7.0",
+        "tslib": "2.8.1",
         "uid": "2.0.2"
       },
       "funding": {
@@ -8696,10 +8682,6 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0"
       }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
     },
     "node_modules/@nestjs/schematics": {
       "version": "10.2.3",
@@ -8898,11 +8880,13 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "10.4.8",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.15.tgz",
+      "integrity": "sha512-eGlWESkACMKti+iZk1hs6FUY/UqObmMaa8HAN9JLnaYkoLf1Jeh+EuHlGnfqo/Rq77oznNLIyaA3PFjrFDlNUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tslib": "2.7.0"
+        "tslib": "2.8.1"
       },
       "funding": {
         "type": "opencollective",
@@ -9666,6 +9650,80 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@repo/admin": {
       "resolved": "packages/core/admin",
@@ -10918,6 +10976,8 @@
     },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10926,7 +10986,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.34",
+      "version": "3.3.37",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.37.tgz",
+      "integrity": "sha512-r+IoKpE5MLKaeD8CvoEh39ckWMLHR/+WBMoRQxrkL+apJqEWLMhBHh+93KIfyPWGd6gK7Q21jpoULKgNoRI0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11160,7 +11222,9 @@
       }
     },
     "node_modules/@types/ssh2": {
-      "version": "1.15.4",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11176,7 +11240,9 @@
       }
     },
     "node_modules/@types/ssh2/node_modules/@types/node": {
-      "version": "18.19.75",
+      "version": "18.19.86",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
+      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11185,6 +11251,8 @@
     },
     "node_modules/@types/ssh2/node_modules/undici-types": {
       "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },
@@ -14439,14 +14507,16 @@
       }
     },
     "node_modules/docker-modem": {
-      "version": "3.0.8",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
+      "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
         "split-ca": "^1.0.1",
-        "ssh2": "^1.11.0"
+        "ssh2": "^1.15.0"
       },
       "engines": {
         "node": ">= 8.0"
@@ -14454,6 +14524,8 @@
     },
     "node_modules/docker-modem/node_modules/readable-stream": {
       "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14466,32 +14538,36 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "3.3.5",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.5.tgz",
+      "integrity": "sha512-ZPmKSr1k1571Mrh7oIBS/j0AqAccoecY2yH420ni5j1KyNMgnoTh4Nu4FWunh0HZIJmRSmSysJjBIpa/zyWUEA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "docker-modem": "^3.0.0",
-        "tar-fs": "~2.0.1"
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.6",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "~2.1.2",
+        "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">= 8.0"
       }
     },
-    "node_modules/dockerode/node_modules/chownr": {
-      "version": "1.1.4",
+    "node_modules/dockerode/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/dockerode/node_modules/tar-fs": {
-      "version": "2.0.1",
-      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/doctrine": {
@@ -16108,11 +16184,13 @@
       }
     },
     "node_modules/get-port": {
-      "version": "5.1.1",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -18329,6 +18407,8 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -19201,6 +19281,13 @@
       "version": "4.17.21",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -24458,6 +24545,31 @@
         "url": "https://github.com/steveukx/properties?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
@@ -26159,6 +26271,8 @@
     },
     "node_modules/split-ca": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -26880,7 +26994,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -27126,23 +27242,25 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "10.18.0",
+      "version": "10.24.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.24.0.tgz",
+      "integrity": "sha512-akkNb3LO2IhxnJzl5kj6dDt2c5q0bWHSTUSLSsqqLuZkaJTYCyWCE76uSzJLGpCkASV7Bw4XOOKvn4Tu0GHeFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^3.3.29",
+        "@types/dockerode": "^3.3.35",
         "archiver": "^7.0.1",
         "async-lock": "^1.4.1",
         "byline": "^5.0.0",
         "debug": "^4.3.5",
         "docker-compose": "^0.24.8",
-        "dockerode": "^3.3.5",
-        "get-port": "^5.1.1",
+        "dockerode": "^4.0.4",
+        "get-port": "^7.1.0",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^2.3.0",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.0.6",
+        "tar-fs": "^3.0.7",
         "tmp": "^0.2.3",
         "undici": "^5.28.5"
       }
@@ -27247,14 +27365,6 @@
       "version": "1.0.5",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -27559,7 +27669,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tuf-js": {
@@ -29213,7 +29325,7 @@
       }
     },
     "packages/core/manifest": {
-      "version": "4.11.0",
+      "version": "4.11.3",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.744.0",

--- a/packages/core/manifest/manifest/backend.yml
+++ b/packages/core/manifest/manifest/backend.yml
@@ -1,54 +1,37 @@
-name: My pet app
-
+name: Personal portfolio
 entities:
-  Cat 😺:
+  Project:
     properties:
-      - name
-      - { name: age, type: number, default: 30 }
-      - { name: birthdate, type: date }
-      - { name: acquiredAt, type: timestamp }
-      - { name: hiddenProp, type: boolean, default: true }
-      - { name: certificate, type: file }
-      - { name: photo, type: image }
-      - { name: description, type: richText, validation: { required: true } }
+      - { name: title, validation: { required: true } }
+      - { name: excerpt, validation: { required: true } }
+      - role
+      - { name: date, type: date }
+      - { name: url, type: link }
+      - {
+          name: photo,
+          type: image,
+          options:
+            {
+              sizes:
+                {
+                  small: { height: 403, width: 805 },
+                  social: { height: 630, width: 1200 },
+                  large: { height: 806, width: 1610 }
+                }
+            }
+        }
+      - { name: description, type: richText }
+      - seoTitle
+      - seoDescription
+    policies:
+      read:
+        - access: public
 
-    belongsTo:
-      - { name: owner, entity: User }
-
+  Contacts:
+    properties:
+      - { name: name, type: string, validation: { required: true } }
+      - { name: email, type: email, validation: { required: true } }
+      - { name: message, type: text, validation: { required: true } }
     policies:
       create:
         - access: public
-      update:
-        - { access: public }
-      delete:
-        - { access: 🔒, allow: [User] }
-
-  Food:
-    single: false
-    properties:
-      - name
-      - { name: expirationDate, type: date }
-    belongsToMany:
-      - { name: cats, entity: Cat }
-
-  User:
-    authenticable: true
-    properties:
-      - name
-
-  ContactPage:
-    single: true
-    nameSingular: Contact
-    slug: contact
-    properties:
-      - { name: title, type: string }
-      - { name: content, type: text }
-      - { name: image, type: image }
-    validation:
-      title: { required: true }
-
-endpoints:
-  createCat:
-    path: /cats
-    method: GET
-    handler: createCat

--- a/packages/core/manifest/src/crud/controllers/collection.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/collection.controller.ts
@@ -24,6 +24,7 @@ import { IsCollectionGuard } from '../guards/is-collection.guard'
 import { HookInterceptor } from '../../hook/hook.interceptor'
 import { COLLECTIONS_PATH } from '../../constants'
 import { MiddlewareInterceptor } from '../../middleware/middleware.interceptor'
+import { IsAdminGuard } from '../../auth/guards/is-admin.guard'
 
 @Controller(COLLECTIONS_PATH)
 @UseGuards(PolicyGuard, IsCollectionGuard)
@@ -50,8 +51,17 @@ export class CollectionController {
     })
   }
 
+  /**
+   * Get select options for a specific entity. This is used for select inputs in admin panel forms.
+   * This is why we use the `IsAdminGuard` here.
+   *
+   * @param entitySlug The slug of the entity.
+   * @param queryParams The query parameters to filter the select options.
+   *
+   * @returns The select options for the entity.
+   */
   @Get(':entity/select-options')
-  @Rule('read')
+  @UseGuards(IsAdminGuard)
   findSelectOptions(
     @Param('entity') entitySlug: string,
     @Query() queryParams: { [key: string]: string | string[] }

--- a/packages/core/manifest/src/crud/controllers/single.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/single.controller.ts
@@ -35,6 +35,15 @@ export class SingleController {
     private readonly crudService: CrudService
   ) {}
 
+  /**
+   * Get a single item of a specific single type entity.
+   * If the item does not exist, it will create a new one.
+   *
+   * @param entitySlug The slug of the entity.
+   * @param req The request object.
+   *
+   * @returns The single item of the entity.
+   */
   @Get(':entity')
   @Rule('read')
   async findOne(

--- a/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
@@ -30,8 +30,7 @@ import {
   AUTHENTICABLE_PROPS,
   DEFAULT_IMAGE_SIZES,
   DEFAULT_SEED_COUNT,
-  FORBIDDEN_ACCESS_POLICY,
-  PUBLIC_ACCESS_POLICY
+  FORBIDDEN_ACCESS_POLICY
 } from '../../constants'
 
 import { ManifestService } from './manifest.service'
@@ -257,24 +256,24 @@ export class EntityManifestService {
       policies: {
         create: this.policyService.transformPolicies(
           entitySchema.policies?.create,
-          PUBLIC_ACCESS_POLICY
+          ADMIN_ACCESS_POLICY
         ),
         read: this.policyService.transformPolicies(
           entitySchema.policies?.read,
-          PUBLIC_ACCESS_POLICY
+          ADMIN_ACCESS_POLICY
         ),
         update: this.policyService.transformPolicies(
           entitySchema.policies?.update,
-          PUBLIC_ACCESS_POLICY
+          ADMIN_ACCESS_POLICY
         ),
         delete: this.policyService.transformPolicies(
           entitySchema.policies?.delete,
-          PUBLIC_ACCESS_POLICY
+          ADMIN_ACCESS_POLICY
         ),
         signup: entitySchema.authenticable
           ? this.policyService.transformPolicies(
               entitySchema.policies?.signup,
-              PUBLIC_ACCESS_POLICY
+              ADMIN_ACCESS_POLICY
             )
           : [FORBIDDEN_ACCESS_POLICY]
       }
@@ -305,7 +304,7 @@ export class EntityManifestService {
         create: [FORBIDDEN_ACCESS_POLICY],
         read: this.policyService.transformPolicies(
           entitySchema.policies?.read,
-          PUBLIC_ACCESS_POLICY
+          ADMIN_ACCESS_POLICY
         ),
         update: this.policyService.transformPolicies(
           entitySchema.policies?.update,

--- a/packages/core/manifest/src/open-api/open-api.module.ts
+++ b/packages/core/manifest/src/open-api/open-api.module.ts
@@ -5,6 +5,7 @@ import { ManifestModule } from '../manifest/manifest.module'
 import { OpenApiManifestService } from './services/open-api-manifest.service'
 import { OpenApiAuthService } from './services/open-api-auth.service'
 import { OpenApiEndpointService } from './services/open-api.endpoint.service'
+import { OpenApiUtilsService } from './services/open-api-utils.service'
 
 @Module({
   imports: [ManifestModule],
@@ -13,7 +14,8 @@ import { OpenApiEndpointService } from './services/open-api.endpoint.service'
     OpenApiCrudService,
     OpenApiManifestService,
     OpenApiAuthService,
-    OpenApiEndpointService
+    OpenApiEndpointService,
+    OpenApiUtilsService
   ]
 })
 export class OpenApiModule {}

--- a/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
@@ -117,6 +117,9 @@ export class OpenApiCrudService {
         summary: `List ${entityManifest.namePlural}`,
         description: `Retrieves a paginated list of ${entityManifest.namePlural}. In addition to the general parameters below, each property of the ${entityManifest.nameSingular} can be used as a filter: https://manifest.build/docs/rest-api#filters`,
         tags: [upperCaseFirstLetter(entityManifest.namePlural)],
+        security: this.openApiUtilsService.getSecurityRequirements(
+          entityManifest.policies.read
+        ),
         parameters: [
           {
             name: 'page',
@@ -200,6 +203,9 @@ export class OpenApiCrudService {
         summary: `List ${entityManifest.namePlural} for select options`,
         description: `Retrieves a list of ${entityManifest.namePlural} for select options. The response is an array of objects with the properties 'id' and 'label'.`,
         tags: [upperCaseFirstLetter(entityManifest.namePlural)],
+        security: this.openApiUtilsService.getSecurityRequirements(
+          entityManifest.policies.read
+        ),
         responses: {
           '200': {
             description: `List of ${entityManifest.namePlural} for select options`,

--- a/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
@@ -201,11 +201,13 @@ export class OpenApiCrudService {
     return {
       get: {
         summary: `List ${entityManifest.namePlural} for select options`,
-        description: `Retrieves a list of ${entityManifest.namePlural} for select options. The response is an array of objects with the properties 'id' and 'label'.`,
+        description: `Retrieves a list of ${entityManifest.namePlural} for select options. The response is an array of objects with the properties 'id' and 'label'. Used in the admin panel to fill select dropdowns.`,
         tags: [upperCaseFirstLetter(entityManifest.namePlural)],
-        security: this.openApiUtilsService.getSecurityRequirements(
-          entityManifest.policies.read
-        ),
+        security: [
+          {
+            Admin: []
+          }
+        ],
         responses: {
           '200': {
             description: `List of ${entityManifest.namePlural} for select options`,

--- a/packages/core/manifest/src/open-api/services/open-api-utils.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-utils.service.ts
@@ -5,7 +5,7 @@ import { SecurityRequirementObject } from '@nestjs/swagger/dist/interfaces/open-
 @Injectable()
 export class OpenApiUtilsService {
   /**
-   * Retrieves the security requirements from the policies.
+   * Retrieves the security requirements from the policies (auth).
    *
    * @param policies
    * @returns
@@ -27,8 +27,6 @@ export class OpenApiUtilsService {
           [policy.access.charAt(0).toUpperCase() + policy.access.slice(1)]: []
         }
       })
-
-    console.log('Security requirements:', security)
 
     return security
   }

--- a/packages/core/manifest/src/open-api/services/open-api-utils.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-utils.service.ts
@@ -17,10 +17,15 @@ export class OpenApiUtilsService {
       .filter((policy) => policy.access !== 'public')
       .map((policy) => {
         if (policy.access === 'restricted') {
-          return policy.allow?.reduce((acc, entity) => {
-            acc[entity] = []
-            return acc
-          }, {})
+          return policy.allow?.reduce(
+            (acc, entity) => {
+              acc[entity] = []
+              return acc
+            },
+            {
+              Admin: []
+            }
+          )
         }
 
         return {

--- a/packages/core/manifest/src/open-api/services/open-api-utils.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-utils.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common'
+import { PolicyManifest } from '../../../../types/src'
+import { SecurityRequirementObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface'
+
+@Injectable()
+export class OpenApiUtilsService {
+  /**
+   * Retrieves the security requirements from the policies.
+   *
+   * @param policies
+   * @returns
+   */
+  getSecurityRequirements(
+    policies: PolicyManifest[]
+  ): SecurityRequirementObject[] {
+    const security = policies
+      .filter((policy) => policy.access !== 'public')
+      .map((policy) => {
+        if (policy.access === 'restricted') {
+          return policy.allow?.reduce((acc, entity) => {
+            acc[entity] = []
+            return acc
+          }, {})
+        }
+
+        return {
+          [policy.access.charAt(0).toUpperCase() + policy.access.slice(1)]: []
+        }
+      })
+
+    console.log('Security requirements:', security)
+
+    return security
+  }
+}

--- a/packages/core/manifest/src/open-api/services/open-api.endpoint.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api.endpoint.service.ts
@@ -2,9 +2,12 @@ import { Injectable } from '@nestjs/common'
 import { EndpointManifest } from '../../../../types/src'
 import { PathItemObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface'
 import { API_PATH, ENDPOINTS_PATH } from '../../constants'
+import { OpenApiUtilsService } from './open-api-utils.service'
 
 @Injectable()
 export class OpenApiEndpointService {
+  constructor(private readonly openApiUtilsService: OpenApiUtilsService) {}
+
   /**
    * Generates the dynamic endpoint paths for the OpenAPI document from an Endpoint Manifest.
    *
@@ -27,6 +30,9 @@ export class OpenApiEndpointService {
           summary: endpoint.name,
           description: endpoint.description,
           tags: ['Dynamic endpoints'],
+          security: this.openApiUtilsService.getSecurityRequirements(
+            endpoint.policies
+          ),
           parameters: Object.keys(
             this.extractRouteParams(endpoint.path) || {}
           ).map((paramName) => ({
@@ -59,7 +65,7 @@ export class OpenApiEndpointService {
   private extractRouteParams(route: string): Record<string, string> {
     const params: Record<string, string> = {}
     const regex = /:(\w+)/g
-    let match
+    let match: RegExpExecArray | null
 
     while ((match = regex.exec(route)) !== null) {
       params[match[1]] = 'string'

--- a/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-crud.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { OpenApiCrudService } from '../services/open-api-crud.service'
-import { EntityManifest, PropType } from '@repo/types'
+import { EntityManifest, PolicyManifest, PropType } from '@repo/types'
+import { OpenApiUtilsService } from '../services/open-api-utils.service'
 
 describe('OpenApiCrudService', () => {
   let service: OpenApiCrudService
@@ -30,7 +31,15 @@ describe('OpenApiCrudService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OpenApiCrudService]
+      providers: [
+        OpenApiCrudService,
+        {
+          provide: OpenApiUtilsService,
+          useValue: {
+            getSecurityRequirements: jest.fn(() => [])
+          }
+        }
+      ]
     }).compile()
 
     service = module.get<OpenApiCrudService>(OpenApiCrudService)
@@ -40,146 +49,276 @@ describe('OpenApiCrudService', () => {
     expect(service).toBeDefined()
   })
 
-  it('should generate all 7 entity paths', () => {
-    jest.spyOn(service, 'generateListPath').mockReturnValue({})
-    jest.spyOn(service, 'generateListSelectOptionsPath').mockReturnValue({})
-    jest.spyOn(service, 'generateCreatePath').mockReturnValue({})
-    jest.spyOn(service, 'generateDetailPath').mockReturnValue({})
-    jest.spyOn(service, 'generateUpdatePath').mockReturnValue({})
-    jest.spyOn(service, 'generatePatchPath').mockReturnValue({})
-    jest.spyOn(service, 'generateDeletePath').mockReturnValue({})
+  describe('generateEntityPaths', () => {
+    it('should generate all 7 entity paths', () => {
+      jest.spyOn(service, 'generateListPath').mockReturnValue({})
+      jest.spyOn(service, 'generateListSelectOptionsPath').mockReturnValue({})
+      jest.spyOn(service, 'generateCreatePath').mockReturnValue({})
+      jest.spyOn(service, 'generateDetailPath').mockReturnValue({})
+      jest.spyOn(service, 'generateUpdatePath').mockReturnValue({})
+      jest.spyOn(service, 'generatePatchPath').mockReturnValue({})
+      jest.spyOn(service, 'generateDeletePath').mockReturnValue({})
 
-    const paths = service.generateEntityPaths([dummyEntityManifest])
+      const paths = service.generateEntityPaths([dummyEntityManifest])
 
-    expect(paths).toBeDefined()
-    expect(Object.keys(paths).length).toBe(3)
+      expect(paths).toBeDefined()
+      expect(Object.keys(paths).length).toBe(3)
 
-    expect(service.generateListPath).toHaveBeenCalled()
-    expect(service.generateListSelectOptionsPath).toHaveBeenCalled()
-    expect(service.generateCreatePath).toHaveBeenCalled()
-    expect(service.generateDetailPath).toHaveBeenCalled()
-    expect(service.generateUpdatePath).toHaveBeenCalled()
-    expect(service.generatePatchPath).toHaveBeenCalled()
-    expect(service.generateDeletePath).toHaveBeenCalled()
-  })
+      expect(service.generateListPath).toHaveBeenCalled()
+      expect(service.generateListSelectOptionsPath).toHaveBeenCalled()
+      expect(service.generateCreatePath).toHaveBeenCalled()
+      expect(service.generateDetailPath).toHaveBeenCalled()
+      expect(service.generateUpdatePath).toHaveBeenCalled()
+      expect(service.generatePatchPath).toHaveBeenCalled()
+      expect(service.generateDeletePath).toHaveBeenCalled()
+    })
 
-  it('should generate list path with a success response', () => {
-    const path = service.generateListPath(dummyEntityManifest)
-
-    expect(path).toBeDefined()
-    expect(path).toMatchObject({
-      get: {
-        summary: expect.any(String),
-        description: expect.any(String),
-        tags: [expect.any(String)],
-        parameters: expect.any(Array),
-        responses: {
-          '200': expect.any(Object)
+    it('should not generate create path if create policy is forbidden', () => {
+      jest.spyOn(service, 'generateCreatePath').mockReturnValue({})
+      const forbiddenEntityManifest = {
+        ...dummyEntityManifest,
+        policies: {
+          create: [{ access: 'forbidden' }],
+          read: [],
+          update: [],
+          delete: [],
+          signup: []
         }
-      }
+      } as EntityManifest
+      const paths = service.generateEntityPaths([forbiddenEntityManifest])
+
+      expect(paths).toBeDefined()
+      expect(service.generateCreatePath).not.toHaveBeenCalled()
+    })
+
+    it('should not generate list, list select options and detail path if read policy is forbidden', () => {
+      jest.spyOn(service, 'generateListPath').mockReturnValue({})
+      jest.spyOn(service, 'generateListSelectOptionsPath').mockReturnValue({})
+      jest.spyOn(service, 'generateDetailPath').mockReturnValue({})
+
+      const forbiddenEntityManifest = {
+        ...dummyEntityManifest,
+        policies: {
+          create: [],
+          read: [{ access: 'forbidden' }],
+          update: [],
+          delete: [],
+          signup: []
+        }
+      } as EntityManifest
+      const paths = service.generateEntityPaths([forbiddenEntityManifest])
+
+      expect(paths).toBeDefined()
+      expect(service.generateListPath).not.toHaveBeenCalled()
+      expect(service.generateListSelectOptionsPath).not.toHaveBeenCalled()
+      expect(service.generateDetailPath).not.toHaveBeenCalled()
+    })
+
+    it('should not generate update and patch paths if update policy is forbidden', () => {
+      jest.spyOn(service, 'generateUpdatePath').mockReturnValue({})
+      jest.spyOn(service, 'generatePatchPath').mockReturnValue({})
+
+      const forbiddenEntityManifest = {
+        ...dummyEntityManifest,
+        policies: {
+          create: [],
+          read: [],
+          update: [{ access: 'forbidden' }],
+          delete: [],
+          signup: []
+        }
+      } as EntityManifest
+      const paths = service.generateEntityPaths([forbiddenEntityManifest])
+
+      expect(paths).toBeDefined()
+      expect(service.generateUpdatePath).not.toHaveBeenCalled()
+      expect(service.generatePatchPath).not.toHaveBeenCalled()
+    })
+
+    it('should not generate delete path if delete policy is forbidden', () => {
+      jest.spyOn(service, 'generateDeletePath').mockReturnValue({})
+
+      const forbiddenEntityManifest = {
+        ...dummyEntityManifest,
+        policies: {
+          create: [],
+          read: [],
+          update: [],
+          delete: [{ access: 'forbidden' }],
+          signup: []
+        }
+      } as EntityManifest
+      const paths = service.generateEntityPaths([forbiddenEntityManifest])
+
+      expect(paths).toBeDefined()
+      expect(service.generateDeletePath).not.toHaveBeenCalled()
     })
   })
 
-  it('should generate list select options path with a success response', () => {
-    const path = service.generateListSelectOptionsPath(dummyEntityManifest)
+  describe('generateListPath', () => {
+    it('should generate list path with a success response', () => {
+      const path = service.generateListPath(dummyEntityManifest)
 
-    expect(path).toBeDefined()
-    expect(path).toMatchObject({
-      get: {
-        summary: expect.any(String),
-        description: expect.any(String),
-        tags: [expect.any(String)],
-        responses: {
-          '200': expect.any(Object)
+      expect(path).toBeDefined()
+      expect(path).toMatchObject({
+        get: {
+          summary: expect.any(String),
+          description: expect.any(String),
+          tags: [expect.any(String)],
+          parameters: expect.any(Array),
+          security: expect.any(Array),
+          responses: {
+            '200': expect.any(Object)
+          }
         }
-      }
+      })
     })
   })
 
-  it('should generate create path with a success response', () => {
-    const path = service.generateCreatePath(dummyEntityManifest)
+  describe('generateListSelectOptionsPath', () => {
+    it('should generate list select options path with a success response', () => {
+      const path = service.generateListSelectOptionsPath(dummyEntityManifest)
 
-    expect(path).toBeDefined()
-    expect(path).toMatchObject({
-      post: {
-        summary: expect.any(String),
-        description: expect.any(String),
-        tags: [expect.any(String)],
-        requestBody: expect.any(Object),
-        responses: {
-          '201': expect.any(Object)
+      expect(path).toBeDefined()
+      expect(path).toMatchObject({
+        get: {
+          summary: expect.any(String),
+          description: expect.any(String),
+          tags: [expect.any(String)],
+          security: expect.any(Array),
+          responses: {
+            '200': expect.any(Object)
+          }
         }
-      }
+      })
     })
   })
 
-  it('should generate detail path with a success response', () => {
-    const path = service.generateDetailPath(dummyEntityManifest)
+  describe('generateCreatePath', () => {
+    it('should generate create path with a success response', () => {
+      const path = service.generateCreatePath(dummyEntityManifest)
 
-    expect(path).toBeDefined()
-    expect(path).toMatchObject({
-      get: {
-        summary: expect.any(String),
-        description: expect.any(String),
-        tags: [expect.any(String)],
-        parameters: expect.any(Array),
-        responses: {
-          '200': expect.any(Object)
+      expect(path).toBeDefined()
+      expect(path).toMatchObject({
+        post: {
+          summary: expect.any(String),
+          description: expect.any(String),
+          tags: [expect.any(String)],
+          requestBody: expect.any(Object),
+          security: expect.any(Array),
+          responses: {
+            '201': expect.any(Object)
+          }
         }
-      }
+      })
     })
   })
 
-  it('should generate update path with a success response', () => {
-    const path = service.generateUpdatePath(dummyEntityManifest)
+  describe('generateDetailPath', () => {
+    it('should generate detail path with a success response', () => {
+      const path = service.generateDetailPath(dummyEntityManifest)
 
-    expect(path).toBeDefined()
-    expect(path).toMatchObject({
-      put: {
-        summary: expect.any(String),
-        description: expect.any(String),
-        tags: [expect.any(String)],
-        parameters: expect.any(Array),
-        requestBody: expect.any(Object),
-        responses: {
-          '200': expect.any(Object)
+      expect(path).toBeDefined()
+      expect(path).toMatchObject({
+        get: {
+          summary: expect.any(String),
+          description: expect.any(String),
+          tags: [expect.any(String)],
+          parameters: expect.any(Array),
+          security: expect.any(Array),
+          responses: {
+            '200': expect.any(Object)
+          }
         }
-      }
+      })
     })
   })
 
-  it('should generate patch path with a success response', () => {
-    const path = service.generatePatchPath(dummyEntityManifest)
+  describe('generateUpdatePath', () => {
+    it('should generate update path with a success response', () => {
+      const path = service.generateUpdatePath(dummyEntityManifest)
 
-    expect(path).toBeDefined()
-    expect(path).toMatchObject({
-      patch: {
-        summary: expect.any(String),
-        description: expect.any(String),
-        tags: [expect.any(String)],
-        parameters: expect.any(Array),
-        requestBody: expect.any(Object),
-        responses: {
-          '200': expect.any(Object)
+      expect(path).toBeDefined()
+      expect(path).toMatchObject({
+        put: {
+          summary: expect.any(String),
+          description: expect.any(String),
+          tags: [expect.any(String)],
+          parameters: expect.any(Array),
+          requestBody: expect.any(Object),
+          security: expect.any(Array),
+          responses: {
+            '200': expect.any(Object)
+          }
         }
-      }
+      })
     })
   })
 
-  it('should generate delete path with a success response', () => {
-    const path = service.generateDeletePath(dummyEntityManifest)
+  describe('generatePatchPath', () => {
+    it('should generate patch path with a success response', () => {
+      const path = service.generatePatchPath(dummyEntityManifest)
 
-    expect(path).toBeDefined()
-    expect(path).toMatchObject({
-      delete: {
-        summary: expect.any(String),
-        description: expect.any(String),
-        tags: [expect.any(String)],
-        parameters: expect.any(Array),
-        responses: {
-          '200': expect.any(Object)
+      expect(path).toBeDefined()
+      expect(path).toMatchObject({
+        patch: {
+          summary: expect.any(String),
+          description: expect.any(String),
+          tags: [expect.any(String)],
+          parameters: expect.any(Array),
+          requestBody: expect.any(Object),
+          security: expect.any(Array),
+          responses: {
+            '200': expect.any(Object)
+          }
         }
-      }
+      })
+    })
+  })
+
+  describe('generateDeletePath', () => {
+    it('should generate delete path with a success response', () => {
+      const path = service.generateDeletePath(dummyEntityManifest)
+
+      expect(path).toBeDefined()
+      expect(path).toMatchObject({
+        delete: {
+          summary: expect.any(String),
+          description: expect.any(String),
+          tags: [expect.any(String)],
+          parameters: expect.any(Array),
+          security: expect.any(Array),
+          responses: {
+            '200': expect.any(Object)
+          }
+        }
+      })
+    })
+  })
+
+  describe('isNotForbidden', () => {
+    it('should return true if all policies are not forbidden', () => {
+      const policies: PolicyManifest[] = [
+        { access: 'public' },
+        { access: 'restricted', allow: ['User'] }
+      ]
+      const result = service.isNotForbidden(policies)
+      expect(result).toBe(true)
+    })
+
+    it('should return false if any policy is forbidden', () => {
+      const policies: PolicyManifest[] = [
+        { access: 'public' },
+        { access: 'forbidden' }
+      ]
+      const result = service.isNotForbidden(policies)
+      expect(result).toBe(false)
+    })
+
+    it('should return true if no policies are present', () => {
+      const policies: PolicyManifest[] = []
+      const result = service.isNotForbidden(policies)
+      expect(result).toBe(true)
     })
   })
 })

--- a/packages/core/manifest/src/open-api/tests/open-api-utils.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api-utils.service.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { OpenApiUtilsService } from '../services/open-api-utils.service'
+import { PolicyManifest } from '../../../../types/src'
+
+describe('OpenApiUtilsService', () => {
+  let service: OpenApiUtilsService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OpenApiUtilsService]
+    }).compile()
+
+    service = module.get<OpenApiUtilsService>(OpenApiUtilsService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  describe('getSecurityRequirements', () => {
+    it('should return security requirements for restricted policies', () => {
+      const policies: PolicyManifest[] = [
+        { access: 'restricted', allow: ['User', 'Admin'] }
+      ]
+      const result = service.getSecurityRequirements(policies)
+      expect(result).toEqual([{ Admin: [], User: [] }])
+    })
+
+    it('should return security requirements for public policies', () => {
+      const policies: PolicyManifest[] = [{ access: 'public' }]
+      const result = service.getSecurityRequirements(policies)
+      expect(result).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Description

This PR changes default Manifest behaviors regarding access to CRUD actions.

By default we had everything public when policies were not defined. This way of doing can cause privacy errors if the developers are not aware of how it works. The PR changes this behavior by putting all CRUD action accessible to **admin** only by default ([doc here](https://manifest.build/docs/authentication#access-types)).

I also passed the "select-option" endpoint as admin only as can confuse users and only serves for the admin panel.

Doc PR: https://github.com/mnfst/docs/pull/29

## How can it be tested?

Replace the default `backend.yml` by:

```yaml

name: My pet app 🐾
entities:
  Owner:
    properties:
      - name
      - { name: birthdate, type: date }

  Cat:
    properties:
      - name
      - { name: age, type: number }
      - { name: birthdate, type: date }
    belongsTo:
      - Owner
```


- Go to the API doc and ensure every CRUD route should be "admin only" and have the lock displayed
- Test that the endpoints are actually locked for real and return a 403 error
- Work on the following project (porfolio template) and you should be able to make it functional easily adding public read policy for `Project` and public create Policy for `Contact`

```yaml
name: Personal portfolio
entities:
  Project:
    properties:
      - { name: title, validation: { required: true } }
      - { name: excerpt, validation: { required: true } }
      - role
      - { name: date, type: date }
      - { name: url, type: link }
      - {
          name: photo,
          type: image,
          options:
            {
              sizes:
                {
                  small: { height: 403, width: 805 },
                  social: { height: 630, width: 1200 },
                  large: { height: 806, width: 1610 }
                }
            }
        }
      - { name: description, type: richText }
      - seoTitle
      - seoDescription

  Contacts:
    properties:
      - { name: name, type: string, validation: { required: true } }
      - { name: email, type: email, validation: { required: true } }
      - { name: message, type: text, validation: { required: true } }
```

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
