### PR TITLE
Fix stackblitz seed

### DIFF
--- a/.changeset/heavy-toes-arrive.md
+++ b/.changeset/heavy-toes-arrive.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+fix manifest:seed cmd failing on stackblitz

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          fetch-tags: true
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -41,4 +40,6 @@ jobs:
           slug: mnfst/manifest
           directory: ./packages/core/manifest/coverage
       - name: Changeset
-        run: npx changeset status --since=master
+        run: |
+          git fetch origin master:refs/remotes/origin/master
+          npx changeset status --since=origin/master

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "18.x"
+          node-version: "20.x"
       - name: Install root dependencies
         run: npm install
       - name: Install dependencies (workspaces)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<div align="center">
-🚀 Featured on HackerNews – join the momentum & give us a ⭐ if you like it!
-</div>
-
-<br>
-
 <p align="center">
   <a href="https://manifest.build/#gh-light-mode-only">
     <img alt="manifest" src="https://manifest.build/assets/images/logo-transparent.svg" height="55px" alt="Manifest logo" title="Manifest - The 1-file micro-backend" />
@@ -116,7 +110,6 @@ Manifest is an MIT-licensed open-source project. If you find it useful and want 
 <h3 align="center">Sponsors</h3>
 
 [![Frame 1587](https://github.com/user-attachments/assets/5826d2d7-50d1-48e3-a32b-503569b90ebb)](https://opencollective.com/mnfst)
-
 
 <h3 align="center">Backed by</h3>
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "test": "turbo run test",
-    "test:ci": "turbo run test:ci",
+    "test:ci": "turbo run test:ci --no-cache",
     "lint": "turbo run lint",
     "seed": "cd packages/core/manifest && npm run seed",
     "prepare": "husky",

--- a/packages/core/manifest/e2e/assets/mock-backend.yml
+++ b/packages/core/manifest/e2e/assets/mock-backend.yml
@@ -34,6 +34,15 @@ entities:
 
     belongsTo:
       - Owner
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   # Testing all default property types with the Sheep entity.
   Sheep:
@@ -59,6 +68,15 @@ entities:
 
     belongsTo:
       - Owner
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   # Testing policies with the Bird entity.
   Bird:
@@ -128,6 +146,15 @@ entities:
       model: { contains: "turbo" }
       brand: { minLength: 3, maxLength: 20 }
       year: { min: 2023, max: 2024, isOptional: true }
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   SuperUser:
     authenticable: true
@@ -149,6 +176,15 @@ entities:
               isJSON: false
             }
         }
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   # Testing relationships with the Post, Author, and Tags entities.
   Post:
@@ -159,32 +195,86 @@ entities:
       - Author
     belongsToMany:
       - Tag
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   Note:
     properties:
       - title
     belongsTo:
       - { name: author, entity: Author, eager: true }
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   Tweet:
     properties:
       - text
     belongsToMany:
       - { name: customTagNames, entity: Tag, eager: true }
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   Author:
     properties:
       - name
     belongsTo:
       - University
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   University:
     properties:
       - name
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   Tag:
     properties:
       - name
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
   # Testing uploads
   Company:
@@ -215,17 +305,15 @@ entities:
       - { name: content, type: text }
     validation:
       title: { required: true }
-
-    # Testing single entity with the ContactPage entity.
-  AboutPage:
-    single: true
-    nameSingular: About content
-    slug: about-content
-    properties:
-      - { name: title, type: string }
-      - { name: content, type: text }
-    validation:
-      title: { required: true }
+    policies:
+      create:
+        - access: public
+      read:
+        - access: public
+      update:
+        - access: public
+      delete:
+        - access: public
 
 # Testing endpoints
 endpoints:

--- a/packages/core/manifest/e2e/tests/authorization.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/authorization.e2e-spec.ts
@@ -31,10 +31,58 @@ describe('Authorization (e2e)', () => {
   })
 
   describe('Rules', () => {
-    it('should have public access by default', async () => {
+    it('should have admin access by default', async () => {
       const listResponse = await global.request.get('/collections/owners')
+      const createResponse = await global.request
+        .post('/collections/owners')
+        .send({
+          name: 'new owner'
+        })
+      const showResponse = await global.request.get('/collections/owners/1')
 
-      expect(listResponse.status).toBe(200)
+      const updateResponse = await global.request
+        .put('/collections/owners/1')
+        .send({
+          name: 'updated owner'
+        })
+      const deleteResponse = await global.request.delete(
+        '/collections/owners/1'
+      )
+
+      const adminListResponse = await global.request
+        .get('/collections/owners')
+        .set('Authorization', 'Bearer ' + adminToken)
+
+      const adminCreateResponse = await global.request
+        .post('/collections/owners')
+        .send({
+          name: 'new owner'
+        })
+        .set('Authorization', 'Bearer ' + adminToken)
+      const adminShowResponse = await global.request
+        .get('/collections/owners/1')
+        .set('Authorization', 'Bearer ' + adminToken)
+      const adminUpdateResponse = await global.request
+        .put('/collections/owners/1')
+        .send({
+          name: 'updated owner'
+        })
+        .set('Authorization', 'Bearer ' + adminToken)
+      const adminDeleteResponse = await global.request
+        .delete('/collections/owners/1')
+        .set('Authorization', 'Bearer ' + adminToken)
+
+      expect(listResponse.status).toBe(403)
+      expect(showResponse.status).toBe(403)
+      expect(createResponse.status).toBe(403)
+      expect(updateResponse.status).toBe(403)
+      expect(deleteResponse.status).toBe(403)
+
+      expect(adminListResponse.status).toBe(200)
+      expect(adminShowResponse.status).toBe(200)
+      expect(adminCreateResponse.status).toBe(201)
+      expect(adminUpdateResponse.status).toBe(200)
+      expect(adminDeleteResponse.status).toBe(200)
     })
 
     it('should allow access to public rules to everyone', async () => {

--- a/packages/core/manifest/scripts/watch/nodemon.json
+++ b/packages/core/manifest/scripts/watch/nodemon.json
@@ -1,5 +1,6 @@
 {
   "watch": ["manifest/*.yml", "manifest/handlers/*.js"],
   "ext": "yml,js",
-  "exec": "node node_modules/manifest/dist/manifest/src/main.js"
+  "exec": "node node_modules/manifest/dist/manifest/src/main.js",
+  "ignore": ["*.lock", "**/*.lock"]
 }

--- a/packages/core/manifest/src/auth/auth.controller.ts
+++ b/packages/core/manifest/src/auth/auth.controller.ts
@@ -53,7 +53,6 @@ export class AuthController {
   }
 
   @Get(':entity/me')
-  @Rule('read')
   public async getCurrentUser(
     @Param('entity') _entity: string,
     @Req() req: Request

--- a/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
@@ -30,7 +30,8 @@ import {
   AUTHENTICABLE_PROPS,
   DEFAULT_IMAGE_SIZES,
   DEFAULT_SEED_COUNT,
-  FORBIDDEN_ACCESS_POLICY
+  FORBIDDEN_ACCESS_POLICY,
+  PUBLIC_ACCESS_POLICY
 } from '../../constants'
 
 import { ManifestService } from './manifest.service'
@@ -273,7 +274,7 @@ export class EntityManifestService {
         signup: entitySchema.authenticable
           ? this.policyService.transformPolicies(
               entitySchema.policies?.signup,
-              ADMIN_ACCESS_POLICY
+              PUBLIC_ACCESS_POLICY
             )
           : [FORBIDDEN_ACCESS_POLICY]
       }

--- a/packages/core/manifest/src/open-api/tests/open-api.endpoint.service.spec.ts
+++ b/packages/core/manifest/src/open-api/tests/open-api.endpoint.service.spec.ts
@@ -2,13 +2,20 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { OpenApiEndpointService } from '../services/open-api.endpoint.service'
 import { EndpointManifest } from '../../../../types/src'
 import { API_PATH, ENDPOINTS_PATH } from '../../constants'
+import { OpenApiUtilsService } from '../services/open-api-utils.service'
 
 describe('OpenApiEndpointService', () => {
   let service: OpenApiEndpointService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OpenApiEndpointService]
+      providers: [
+        OpenApiEndpointService,
+        {
+          provide: OpenApiUtilsService,
+          useValue: { getSecurityRequirements: jest.fn() }
+        }
+      ]
     }).compile()
 
     service = module.get<OpenApiEndpointService>(OpenApiEndpointService)


### PR DESCRIPTION
## Description

This PR fixes the "npm manifest:seed" command that is broken on stackblitz (manifest.new).

It also fixes the CI that caused failing tests on PRs.


## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
