### PR TITLE
fix(admin): empty dashboard on first screen if currentUser not loaded

### DIFF
--- a/.changeset/green-guests-matter.md
+++ b/.changeset/green-guests-matter.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+fixed empty admin panel if user not loaded yet

--- a/packages/core/admin/src/app/modules/layout/side-menu/side-menu.component.ts
+++ b/packages/core/admin/src/app/modules/layout/side-menu/side-menu.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core'
 import { AppManifest, EntityManifest } from '@repo/types'
 import { ADMIN_CLASS_NAME } from '../../../../constants'
 import { ManifestService } from '../../shared/services/manifest.service'
-import { Title } from '@angular/platform-browser'
 
 @Component({
   selector: 'app-side-menu',
@@ -13,16 +12,11 @@ export class SideMenuComponent implements OnInit {
   collections: EntityManifest[]
   singles: EntityManifest[]
 
-  appName = 'Manifest'
-
   isCollectionsOpen = false
   isSettingsOpen = false
   production: boolean
 
-  constructor(
-    private manifestService: ManifestService,
-    private title: Title
-  ) {}
+  constructor(private manifestService: ManifestService) {}
 
   ngOnInit(): void {
     this.manifestService.getManifest().then((res: AppManifest) => {

--- a/packages/core/admin/src/app/modules/layout/user-menu-item/user-menu-item.component.ts
+++ b/packages/core/admin/src/app/modules/layout/user-menu-item/user-menu-item.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, HostListener, OnInit } from '@angular/core'
 import { Admin } from '../../../typescript/interfaces/admin.interface'
 import { AuthService } from '../../auth/auth.service'
+import { filter } from 'rxjs'
 
 @Component({
   selector: 'app-user-menu-item',
@@ -17,9 +18,11 @@ export class UserMenuItemComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.authService.me().then((admin: Admin) => {
-      this.currentUser = admin
-    })
+    this.authService.currentUser$
+      .pipe(filter((admin) => !!admin))
+      .subscribe((admin: Admin) => {
+        this.currentUser = admin
+      })
   }
 
   @HostListener('document:click', ['$event.target'])


### PR DESCRIPTION
## Description

Sometimes admin panel is empty because the "manifest" API call is triggered before the "me" call

