### PR TITLE
Update signin signup UI

### DIFF
--- a/.changeset/thick-kangaroos-marry.md
+++ b/.changeset/thick-kangaroos-marry.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+display app name on admin login and register page

--- a/packages/core/admin/src/app/modules/auth/views/login/login.component.html
+++ b/packages/core/admin/src/app/modules/auth/views/login/login.component.html
@@ -4,15 +4,8 @@
       <div class="columns">
         <div class="column col-login">
           <div>
-            <img
-              src="/assets/images/logo.svg"
-              alt="manifest logo"
-              class="mb-3"
-              width="264"
-            />
-
-            <h2 class="title is-4">Sign in</h2>
-
+            <h1 class="is-size-3 has-text-weight-bold">Portfolio App</h1>
+            <h2 class="title is-5 mt-2">Sign in to your admin panel</h2>
             <div class="has-text-left" *ngIf="form">
               <div class="field mb-5">
                 <div class="control">
@@ -46,6 +39,17 @@
               >
                 Login
               </button>
+              <div
+                class="is-flex is-align-items-center is-justify-content-flex-end my-3"
+              >
+                <span style="margin-top: 9px">Built with</span>
+                <img
+                  src="/assets/images/logo.svg"
+                  alt="manifest logo"
+                  class="ml-3"
+                  width="94"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/packages/core/admin/src/app/modules/auth/views/login/login.component.html
+++ b/packages/core/admin/src/app/modules/auth/views/login/login.component.html
@@ -2,10 +2,10 @@
   <div class="hero-body">
     <div class="container has-text-centered">
       <div class="columns">
-        <div class="column col-login">
+        <div class="column col-login" *ngIf="appName">
           <div>
             <h1 class="is-size-3 has-text-weight-bold">
-              {{ ' {{ ' }}appName{{ ' }} ' }}
+              {{ appName }}
             </h1>
             <h2 class="title is-5 mt-2">Sign in to your admin panel</h2>
             <div class="has-text-left" *ngIf="form">

--- a/packages/core/admin/src/app/modules/auth/views/login/login.component.html
+++ b/packages/core/admin/src/app/modules/auth/views/login/login.component.html
@@ -4,7 +4,9 @@
       <div class="columns">
         <div class="column col-login">
           <div>
-            <h1 class="is-size-3 has-text-weight-bold">Portfolio App</h1>
+            <h1 class="is-size-3 has-text-weight-bold">
+              {{ ' {{ ' }}appName{{ ' }} ' }}
+            </h1>
             <h2 class="title is-5 mt-2">Sign in to your admin panel</h2>
             <div class="has-text-left" *ngIf="form">
               <div class="field mb-5">

--- a/packages/core/admin/src/app/modules/auth/views/login/login.component.ts
+++ b/packages/core/admin/src/app/modules/auth/views/login/login.component.ts
@@ -7,6 +7,7 @@ import { PropType } from '@repo/types'
 
 import { AuthService } from '../../auth.service'
 import { DEFAULT_ADMIN_CREDENTIALS } from '../../../../../constants'
+import { ManifestService } from '../../../shared/services/manifest.service'
 
 @Component({
   selector: 'app-login',
@@ -14,6 +15,8 @@ import { DEFAULT_ADMIN_CREDENTIALS } from '../../../../../constants'
   styleUrls: ['./login.component.scss']
 })
 export class LoginComponent implements OnInit {
+  appName: string
+
   suggestedEmail: string
   suggestedPassword: string
 
@@ -24,10 +27,16 @@ export class LoginComponent implements OnInit {
   constructor(
     private readonly authService: AuthService,
     private router: Router,
-    private activatedRoute: ActivatedRoute
+    private activatedRoute: ActivatedRoute,
+    private manifestService: ManifestService
   ) {}
 
   ngOnInit(): void {
+    // Get app name from manifest.
+    this.manifestService.getAppName().then((name) => {
+      this.appName = name
+    })
+
     this.activatedRoute.queryParams.subscribe(async (queryParams: Params) => {
       // Set suggested email and password from query params or default admin credentials.
       if (queryParams['email'] && queryParams['password']) {

--- a/packages/core/admin/src/app/modules/auth/views/register-first-admin/register-first-admin.component.html
+++ b/packages/core/admin/src/app/modules/auth/views/register-first-admin/register-first-admin.component.html
@@ -4,17 +4,12 @@
       <div class="columns">
         <div class="column col-welcome">
           <div class="register-wrap">
-            <img
-              src="/assets/images/logo.svg"
-              alt="manifest logo"
-              class="mb-3"
-              width="264"
-            />
             <div class="card is-bordered">
               <div class="card-content">
                 <div class="content">
-                  <h2 class="title is-2 has-text-weight-bold">Welcome</h2>
-
+                  <h1 class="is-size-3 has-text-weight-bold my-3">
+                    {{ ' {{ ' }}appName{{ ' }} ' }}
+                  </h1>
                   <p class="is-size-5">
                     Welcome to your admin panel. Create your first admin account
                     to continue. You can always change those values later.
@@ -66,6 +61,17 @@
                   </button>
                 </div>
               </div>
+            </div>
+            <div
+              class="is-flex is-align-items-center is-justify-content-flex-end my-3"
+            >
+              <span style="margin-top: 9px">Built with</span>
+              <img
+                src="/assets/images/logo.svg"
+                alt="manifest logo"
+                class="ml-3"
+                width="94"
+              />
             </div>
           </div>
         </div>

--- a/packages/core/admin/src/app/modules/auth/views/register-first-admin/register-first-admin.component.html
+++ b/packages/core/admin/src/app/modules/auth/views/register-first-admin/register-first-admin.component.html
@@ -2,17 +2,18 @@
   <div class="hero-body">
     <div class="container has-text-centered">
       <div class="columns">
-        <div class="column col-welcome">
+        <div class="column col-welcome" *ngIf="appName">
           <div class="register-wrap">
             <div class="card is-bordered">
               <div class="card-content">
                 <div class="content">
                   <h1 class="is-size-3 has-text-weight-bold my-3">
-                    {{ ' {{ ' }}appName{{ ' }} ' }}
+                    {{ appName }}
                   </h1>
                   <p class="is-size-5">
-                    Welcome to your admin panel. Create your first admin account
-                    to continue. You can always change those values later.
+                    Welcome to your admin panel, please create your first admin
+                    account to continue. You can always change those values
+                    later.
                   </p>
 
                   <div class="has-text-left" *ngIf="form">

--- a/packages/core/admin/src/app/modules/auth/views/register-first-admin/register-first-admin.component.ts
+++ b/packages/core/admin/src/app/modules/auth/views/register-first-admin/register-first-admin.component.ts
@@ -5,6 +5,7 @@ import { confirmPasswordValidator } from '../../utlis/confirm-password-validator
 import { AuthService } from '../../auth.service'
 import { Router } from '@angular/router'
 import { FlashMessageService } from '../../../shared/services/flash-message.service'
+import { ManifestService } from '../../../shared/services/manifest.service'
 
 @Component({
   selector: 'app-register-first-admin',
@@ -12,16 +13,24 @@ import { FlashMessageService } from '../../../shared/services/flash-message.serv
   styleUrl: './register-first-admin.component.scss'
 })
 export class RegisterFirstAdminComponent implements OnInit {
+  appName: string
+
   form: FormGroup
   PropType = PropType
 
   constructor(
     private authService: AuthService,
     private router: Router,
-    private flashMessageService: FlashMessageService
+    private flashMessageService: FlashMessageService,
+    private manifestService: ManifestService
   ) {}
 
   ngOnInit(): void {
+    // Get app name from manifest.
+    this.manifestService.getAppName().then((name) => {
+      this.appName = name
+    })
+
     this.form = new FormGroup({
       email: new FormControl('', [Validators.required, Validators.email]),
       password: new FormControl('', [Validators.required]),

--- a/packages/core/admin/src/app/modules/shared/services/manifest.service.ts
+++ b/packages/core/admin/src/app/modules/shared/services/manifest.service.ts
@@ -39,6 +39,23 @@ export class ManifestService {
   }
 
   /**
+   * Gets the app name
+   *
+   * @returns A Promise of the app name.
+   */
+  async getAppName(): Promise<string> {
+    return firstValueFrom(
+      this.http.get<{ name: string }>(
+        `${environment.apiBaseUrl}/manifest/app-name`
+      )
+    )
+      .then((response) => response.name)
+      .catch((error) => {
+        throw error
+      })
+  }
+
+  /**
    * Gets the manifest for a specific entity.
    *
    * @param entitySlug The slug of the entity.

--- a/packages/core/manifest/src/manifest/controllers/manifest.controller.ts
+++ b/packages/core/manifest/src/manifest/controllers/manifest.controller.ts
@@ -7,7 +7,6 @@ import { IsAdminGuard } from '../../auth/guards/is-admin.guard'
 import { EntityManifestService } from '../services/entity-manifest.service'
 
 @Controller('manifest')
-@UseGuards(IsAdminGuard)
 export class ManifestController {
   constructor(
     private manifestService: ManifestService,
@@ -15,14 +14,39 @@ export class ManifestController {
     private authService: AuthService
   ) {}
 
-  @Get()
-  async getAppManifest(@Req() req: Request): Promise<AppManifest> {
-    const isAdmin: boolean = await this.authService.isReqUserAdmin(req)
-
-    return this.manifestService.getAppManifest({ fullVersion: isAdmin })
+  /**
+   * Get the app name. This endpoint is public.
+   *
+   * @returns The app name.
+   */
+  @Get('app-name')
+  async getAppName(): Promise<{ name: string }> {
+    const manifest = this.manifestService.getAppManifest({
+      fullVersion: false
+    })
+    return { name: manifest.name }
   }
 
+  /**
+   * Get the app manifest. This is the main descriptive file of the data structure of the app.
+   *
+   * @returns The app manifest.
+   */
+  @Get()
+  @UseGuards(IsAdminGuard)
+  async getAppManifest(): Promise<AppManifest> {
+    return this.manifestService.getAppManifest({ fullVersion: true })
+  }
+
+  /**
+   * Get the entity manifest for a specific entity. This is the main descriptive file of the data structure of the entity.
+   *
+   * @param slug The slug of the entity.
+   *
+   * @returns The entity manifest.
+   */
   @Get('entities/:slug')
+  @UseGuards(IsAdminGuard)
   async getEntityManifest(
     @Param('slug') slug: string,
     @Req() req: Request

--- a/packages/core/manifest/src/manifest/tests/manifest.controller.spec.ts
+++ b/packages/core/manifest/src/manifest/tests/manifest.controller.spec.ts
@@ -11,7 +11,6 @@ describe('ManifestController', () => {
   let controller: ManifestController
   let authService: AuthService
   let manifestService: ManifestService
-  let entityManifestService: EntityManifestService
 
   const dummyManifest: AppManifest = {
     name: 'Test App'
@@ -50,17 +49,19 @@ describe('ManifestController', () => {
     controller = module.get<ManifestController>(ManifestController)
     authService = module.get<AuthService>(AuthService)
     manifestService = module.get<ManifestService>(ManifestService)
-    entityManifestService = module.get<EntityManifestService>(
-      EntityManifestService
-    )
   })
 
   it('should be defined', () => {
     expect(controller).toBeDefined()
   })
 
+  it('should get the app name', async () => {
+    const appName: { name: string } = await controller.getAppName()
+    expect(appName).toEqual({ name: dummyManifest.name })
+  })
+
   it('should get the app manifest', async () => {
-    const manifest: any = await controller.getAppManifest({} as Request)
+    const manifest: any = await controller.getAppManifest()
 
     expect(manifest).toEqual(dummyManifest)
   })
@@ -68,7 +69,7 @@ describe('ManifestController', () => {
   it('should get the full version of the app manifest if the user is an admin', async () => {
     jest.spyOn(authService, 'isReqUserAdmin').mockResolvedValue(true)
 
-    const manifest: any = await controller.getAppManifest({} as Request)
+    const manifest: any = await controller.getAppManifest()
 
     expect(manifest).toEqual(dummyManifest)
     expect(manifestService.getAppManifest).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description
This PR updates the UI of both the login and signup pages to make it explicit that users are signing in to their own backend admin panel, not to Manifest itself.


## Related Issues
N/A

## How can it be tested?
Confirm that:

- The app name is now used as the main heading
- A clarifying subtitle explains it’s the admin panel
- Manifest logo is shown only in the footer
- Design is clean and responsive

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [ ] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
