### PR TITLE
Add mountedDrive arg to prevent watch issues

### DIFF
--- a/.changeset/friendly-bananas-shop.md
+++ b/.changeset/friendly-bananas-shop.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+added --mountedDrive arg to manifest command to prevent watch issues on integrations

--- a/examples/main-demo/.stackblitzrc
+++ b/examples/main-demo/.stackblitzrc
@@ -1,3 +1,3 @@
 {
-  "startCommand": "npm run manifest"
+  "startCommand": "npm run manifest -- --mountedDrive"
 }

--- a/packages/core/manifest/scripts/watch/nodemon-mounted.json
+++ b/packages/core/manifest/scripts/watch/nodemon-mounted.json
@@ -1,0 +1,14 @@
+{
+  "watch": ["manifest/*.yml", "manifest/handlers/*.js"],
+  "ext": "yml,js",
+  "exec": "node node_modules/manifest/dist/manifest/src/main.js",
+  "legacyWatch": true,
+  "ignore": [
+    "*.lock",
+    "**/*.lock",
+    "*.db",
+    "**/*.db",
+    "*.db-journal",
+    "**/*.db-journal"
+  ]
+}

--- a/packages/core/manifest/scripts/watch/watch.js
+++ b/packages/core/manifest/scripts/watch/watch.js
@@ -23,9 +23,14 @@ const nodemonPath = isPnpm
     )
   : path.join(process.cwd(), 'node_modules', '.bin', nodemonExecutable)
 
+// Check if --mountedDrive argument is present to switch the config file.
+// This is used to avoid issues with file watching when running nodemon from a mounted drive (e.g., Stackblitz, Webcontainers...) .
+const isMountedDrive = process.argv.includes('--mountedDrive')
+const configFile = isMountedDrive ? 'nodemon-mounted.json' : 'nodemon.json'
+
 const nodemon = spawn(
   nodemonPath,
-  ['.', '--config', `${__dirname}/nodemon.json`],
+  ['.', '--config', `${__dirname}/${configFile}`],
   {
     stdio: 'inherit',
     shell: true


### PR DESCRIPTION
## Description

This PR adds a parameter to the manifest command `npm run manifest -- --mountedDrive` to use nodemon `legacyWatch` mode.