### PR TITLE
fix: _in filter

### DIFF
--- a/.changeset/nice-clocks-impress.md
+++ b/.changeset/nice-clocks-impress.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fixed In operator on filterQuery

--- a/package-lock.json
+++ b/package-lock.json
@@ -29840,7 +29840,7 @@
       }
     },
     "packages/core/manifest": {
-      "version": "4.11.10",
+      "version": "4.11.11",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.744.0",
@@ -29992,7 +29992,7 @@
     },
     "packages/js-sdk": {
       "name": "@mnfst/sdk",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
@@ -95,6 +95,29 @@ describe('Collection CRUD (e2e)', () => {
 
       expect(response.status).toBe(400)
     })
+
+    it('should filter items using _in filter', async () => {
+      const response = await global.request.get(
+        `/collections/dogs?name_in=${dummyDog.name},Rex`
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.body.data.length).toBeGreaterThanOrEqual(1)
+      expect(response.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: dummyDog.name })
+        ])
+      )
+    })
+
+    it('should return an empty array if no items match _in filter', async () => {
+      const response = await global.request.get(
+        `/collections/dogs?name_in=NonExistentName`
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.body.data.length).toBe(0)
+    })
   })
 
   describe('GET /collections/:entity/select-options', () => {

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -645,7 +645,7 @@ export class CrudService {
 
         // "In" is a bit special as it expects an array of values.
         if (operator === WhereOperator.In) {
-          let inValues: string[] = value.split(',')
+          const inValues: string[] = value.split(',')
           query.andWhere(`${whereKey} ${operator} (:...value_${index})`, {
             [`value_${index}`]: inValues
           })

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -643,21 +643,18 @@ export class CrudService {
           }
         }
 
-        let whereCondition: string
-
         // "In" is a bit special as it expects an array of values.
         if (operator === WhereOperator.In) {
-          value = JSON.parse(`[${value}]`)
-          whereCondition = `${whereKey} ${operator} (:...value_${index})`
+          let inValues: string[] = value.split(',')
+          query.andWhere(`${whereKey} ${operator} (:...value_${index})`, {
+            [`value_${index}`]: inValues
+          })
         } else {
           // For other operators, just use the value directly.
-          whereCondition = `${whereKey} ${operator} :value_${index}`
+          query.andWhere(`${whereKey} ${operator} :value_${index}`, {
+            [`value_${index}`]: value
+          })
         }
-
-        // Finally and the where query.
-        query.andWhere(whereCondition, {
-          [`value_${index}`]: value
-        })
       })
 
     return query

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -643,13 +643,19 @@ export class CrudService {
           }
         }
 
+        let whereCondition: string
+
         // "In" is a bit special as it expects an array of values.
         if (operator === WhereOperator.In) {
           value = JSON.parse(`[${value}]`)
+          whereCondition = `${whereKey} ${operator} (:...value_${index})`
+        } else {
+          // For other operators, just use the value directly.
+          whereCondition = `${whereKey} ${operator} :value_${index}`
         }
 
         // Finally and the where query.
-        query.andWhere(`${whereKey} ${operator} :value_${index}`, {
+        query.andWhere(whereCondition, {
           [`value_${index}`]: value
         })
       })

--- a/packages/core/manifest/src/crud/tests/crud.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/crud.service.spec.ts
@@ -75,6 +75,7 @@ describe('CrudService', () => {
 
   const queryBuilder: SelectQueryBuilder<any> = {
     where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     getOne: jest.fn().mockReturnValue(Promise.resolve(dummyItem))
@@ -224,7 +225,25 @@ describe('CrudService', () => {
     })
 
     it('should return all entities with filters', async () => {
-      // TODO: Implement test
+      const entitySlug = 'test'
+      const result = await service.findAll({
+        entitySlug,
+        queryParams: { 
+          name_eq: 'Superman',
+          age_gte: '25',
+          age_lte: '35',
+          color_like: 'blue',
+          color_in: 'blue,red,green'
+        }
+      })
+
+      expect(result).toEqual(dummyPaginator)
+      expect(queryBuilder.andWhere).toHaveBeenCalledTimes(5)
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('entity.name = :value_0', { value_0: 'Superman' })
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('entity.age >= :value_1', { value_1: '25' })
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('entity.age <= :value_2', { value_2: '35' })
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('entity.color like :value_3', { value_3: 'blue' })
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('entity.color in (:...value_4)', { value_4: ['blue', 'red', 'green'] })
     })
   })
 


### PR DESCRIPTION
## Description
This PR attempts to fix the implementation of the "Included in" (_in) filter so that it behaves as described in the [official documentation](https://manifest.build/docs/crud#get-a-list-of-items).

## Related Issues
#418 
## How can it be tested?
Follow the Get Started section of the `CONTRIBUTING.md` file and once the project is running, test the `_in` filter with a request like:
`GET /api/collections/users?name_in=Soap,Bacon`

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
