### PR TITLE
✨ UUIDs instead of incremental IDs

### DIFF
--- a/.changeset/two-dogs-sniff.md
+++ b/.changeset/two-dogs-sniff.md
@@ -1,0 +1,6 @@
+---
+'manifest': minor
+'@mnfst/sdk': minor
+---
+
+Replaced incremental int IDs by UUIDs, thanks @jerryjappinen

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.28.5",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8568,11 +8570,12 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "10.4.15",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.15.tgz",
-      "integrity": "sha512-vaLg1ZgwhG29BuLDxPA9OAcIlgqzp9/N8iG0wGapyUNTf4IY4O6zAHgN6QalwLhFxq7nOI021vdRojR1oF3bqg==",
+      "version": "10.4.18",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.18.tgz",
+      "integrity": "sha512-9SrTth6YJJ9CjVnekw9WP8kaiwh+tSgR0KIrPYV/aWgF9D0175uDJUglzbiCfUbkPyHN8jcKXUXd3EVPDY6BNA==",
       "license": "MIT",
       "dependencies": {
+        "file-type": "20.4.1",
         "iterare": "1.2.1",
         "tslib": "2.8.1",
         "uid": "2.0.2"
@@ -8666,13 +8669,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.4.15",
+      "version": "10.4.18",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.18.tgz",
+      "integrity": "sha512-v+W+Pu5NOVK/bSG5A5mOnXyoVwN5mJUe4o0j0UJ9Ig9JMmjVxg+Zw2ydTfpOQ+R82lRYWJUjjv3dvqKaFW2z7w==",
       "license": "MIT",
       "dependencies": {
         "body-parser": "1.20.3",
         "cors": "2.8.5",
         "express": "4.21.2",
-        "multer": "1.4.4-lts.1",
+        "multer": "2.0.0",
         "tslib": "2.8.1"
       },
       "funding": {
@@ -8937,6 +8942,19 @@
         "@angular/compiler-cli": "^17.0.0",
         "typescript": ">=5.2 <5.5",
         "webpack": "^5.54.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9631,6 +9649,16 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -11076,6 +11104,53 @@
         "testcontainers": "^10.18.0"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "license": "MIT",
@@ -12284,6 +12359,8 @@
     },
     "node_modules/append-field": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
     "node_modules/aproba": {
@@ -13134,6 +13211,8 @@
     },
     "node_modules/busboy": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -13941,6 +14020,8 @@
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "engines": [
         "node >= 0.8"
       ],
@@ -15934,6 +16015,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "dev": true,
@@ -15965,6 +16052,24 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.4.1.tgz",
+      "integrity": "sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -16273,12 +16378,14 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
         "once": "^1.4.0",
         "qs": "^6.11.0"
       },
@@ -16702,14 +16809,6 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/highlight.js": {
@@ -20583,7 +20682,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "1.4.4-lts.1",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -20595,11 +20696,13 @@
         "xtend": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/multer/node_modules/mkdirp": {
       "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
@@ -24469,6 +24572,19 @@
         "node": "*"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
+      "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/pg": {
       "version": "8.13.3",
       "license": "MIT",
@@ -27258,6 +27374,8 @@
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -27381,6 +27499,23 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "license": "MIT"
+    },
+    "node_modules/strtok3": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
+      "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/superagent": {
       "version": "8.1.2",
@@ -27812,7 +27947,9 @@
       }
     },
     "node_modules/testcontainers/node_modules/undici": {
-      "version": "5.28.5",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27896,6 +28033,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
+      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/touch": {
@@ -28300,6 +28454,8 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
     "node_modules/typeorm": {
@@ -28716,6 +28872,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
+      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undefsafe": {
@@ -29840,7 +30008,7 @@
       }
     },
     "packages/core/manifest": {
-      "version": "4.11.10",
+      "version": "4.11.11",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.744.0",
@@ -29992,7 +30160,7 @@
     },
     "packages/js-sdk": {
       "name": "@mnfst/sdk",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/packages/core/admin/src/app/modules/crud/services/crud.service.ts
+++ b/packages/core/admin/src/app/modules/crud/services/crud.service.ts
@@ -55,7 +55,7 @@ export class CrudService {
 
   show(
     entitySlug: string,
-    id: number,
+    id: string,
     options?: { relations?: string[] }
   ): Promise<BaseEntity> {
     return firstValueFrom(
@@ -83,16 +83,16 @@ export class CrudService {
     )
   }
 
-  create(entitySlug: string, data: unknown): Promise<{ id: number }> {
+  create(entitySlug: string, data: unknown): Promise<{ id: string }> {
     return firstValueFrom(
-      this.http.post<{ id: number }>(
+      this.http.post<{ id: string }>(
         `${this.collectionBaseUrl}/${entitySlug}`,
         data
       )
     )
   }
 
-  update(entitySlug: string, id: number, data: unknown): Promise<BaseEntity> {
+  update(entitySlug: string, id: string, data: unknown): Promise<BaseEntity> {
     return firstValueFrom(
       this.http.put<BaseEntity>(
         `${this.collectionBaseUrl}/${entitySlug}/${id}`,
@@ -115,9 +115,11 @@ export class CrudService {
     )
   }
 
-  delete(entitySlug: string, id: number): Promise<any> {
+  delete(entitySlug: string, id: string): Promise<BaseEntity> {
     return firstValueFrom(
-      this.http.delete(`${this.collectionBaseUrl}/${entitySlug}/${id}`)
+      this.http.delete<BaseEntity>(
+        `${this.collectionBaseUrl}/${entitySlug}/${id}`
+      )
     )
   }
 }

--- a/packages/core/admin/src/app/modules/crud/views/create-edit/create-edit.component.ts
+++ b/packages/core/admin/src/app/modules/crud/views/create-edit/create-edit.component.ts
@@ -189,7 +189,7 @@ export class CreateEditComponent {
     } else {
       this.crudService
         .create(this.entityManifest.slug, this.form.value)
-        .then((createdItem: { id: number }) => {
+        .then((createdItem: { id: string }) => {
           this.loading = false
           this.flashMessageService.success(
             `The ${this.entityManifest.nameSingular} has been created successfully`

--- a/packages/core/admin/src/app/modules/crud/views/list/list.component.ts
+++ b/packages/core/admin/src/app/modules/crud/views/list/list.component.ts
@@ -103,7 +103,7 @@ export class ListComponent implements OnInit {
    *
    * @returns void
    */
-  delete(id: number): void {
+  delete(id: string): void {
     this.crudService
       .delete(this.entityManifest.slug, id)
       .then(() => {

--- a/packages/core/admin/src/app/modules/shared/inputs/multi-select-input/multi-select-input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/multi-select-input/multi-select-input.component.ts
@@ -16,7 +16,6 @@ import {
 } from '@repo/types'
 import { ManifestService } from '../../services/manifest.service'
 import { CrudService } from '../../../crud/services/crud.service'
-import { forceNumberArray } from '@repo/common'
 
 @Component({
   selector: 'app-multi-select-input',
@@ -28,10 +27,10 @@ import { forceNumberArray } from '@repo/common'
 export class MultiSelectInputComponent implements OnInit {
   @Input() prop: PropertyManifest
   @Input() relationship: RelationshipManifest
-  @Input() value: { id: number }[]
+  @Input() value: { id: string }[]
   @Input() isError: boolean
 
-  @Output() valueChanged: EventEmitter<number[]> = new EventEmitter()
+  @Output() valueChanged: EventEmitter<string[]> = new EventEmitter()
 
   options: SelectOption[]
   selectedOptions: SelectOption[] = []
@@ -63,9 +62,7 @@ export class MultiSelectInputComponent implements OnInit {
       this.selectedOptions = []
       this.options
         .filter((option) =>
-          forceNumberArray(this.value.map((v) => v.id)).find(
-            (value) => value === option.id
-          )
+          this.value.map((v) => v.id).find((value) => value === option.id)
         )
         .forEach((option) => {
           option.selected = true

--- a/packages/core/manifest/e2e/tests/authorization.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/authorization.e2e-spec.ts
@@ -38,15 +38,19 @@ describe('Authorization (e2e)', () => {
         .send({
           name: 'new owner'
         })
-      const showResponse = await global.request.get('/collections/owners/1')
+        .set('Authorization', 'Bearer ' + adminToken)
+
+      const showResponse = await global.request.get(
+        `/collections/owners/${createResponse.body.id}`
+      )
 
       const updateResponse = await global.request
-        .put('/collections/owners/1')
+        .put(`/collections/owners/${createResponse.body.id}`)
         .send({
           name: 'updated owner'
         })
       const deleteResponse = await global.request.delete(
-        '/collections/owners/1'
+        `/collections/owners/${createResponse.body.id}`
       )
 
       const adminListResponse = await global.request
@@ -60,16 +64,16 @@ describe('Authorization (e2e)', () => {
         })
         .set('Authorization', 'Bearer ' + adminToken)
       const adminShowResponse = await global.request
-        .get('/collections/owners/1')
+        .get(`/collections/owners/${createResponse.body.id}`)
         .set('Authorization', 'Bearer ' + adminToken)
       const adminUpdateResponse = await global.request
-        .put('/collections/owners/1')
+        .put(`/collections/owners/${createResponse.body.id}`)
         .send({
           name: 'updated owner'
         })
         .set('Authorization', 'Bearer ' + adminToken)
       const adminDeleteResponse = await global.request
-        .delete('/collections/owners/1')
+        .delete(`/collections/owners/${createResponse.body.id}`)
         .set('Authorization', 'Bearer ' + adminToken)
 
       expect(listResponse.status).toBe(403)

--- a/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
@@ -78,10 +78,10 @@ describe('Collection CRUD (e2e)', () => {
     })
 
     it('should filter items by relationship', async () => {
-      const bigNumber: number = 999
+      const idThatDoesNotExist = '3f2504e0-4f89-11d3-9a0c-0305e82c3301' // Example UUID that does not exist
 
       const response = await global.request.get(
-        `/collections/dogs?relations=owner&owner.id_eq=${bigNumber}`
+        `/collections/dogs?relations=owner&owner.id_eq=${idThatDoesNotExist}`
       )
 
       expect(response.status).toBe(200)

--- a/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/collection-crud.e2e-spec.ts
@@ -112,7 +112,7 @@ describe('Collection CRUD (e2e)', () => {
       expect(adminResponse.body).toMatchObject<SelectOption[]>([
         {
           label: dummyDog.name,
-          id: 1
+          id: expect.any(String)
         }
       ])
     })
@@ -120,7 +120,14 @@ describe('Collection CRUD (e2e)', () => {
 
   describe('GET /collections/:entity/:id', () => {
     it('should return an item', async () => {
-      const response = await global.request.get('/collections/dogs/1')
+      // First, create a dog
+      const postResponse = await global.request
+        .post('/collections/dogs')
+        .send(dummyDog)
+
+      const response = await global.request.get(
+        `/collections/dogs/${postResponse.body.id}`
+      )
 
       expect(response.status).toBe(200)
       expect(response.body).toMatchObject(dummyDog)
@@ -129,15 +136,24 @@ describe('Collection CRUD (e2e)', () => {
 
   describe('PUT /collections/:entity/:id', () => {
     it('should fully update an item', async () => {
+      // First, create a dog
+      const postResponse = await global.request
+        .post('/collections/dogs')
+        .send(dummyDog)
+
       const newName = 'Rex'
 
-      const response = await global.request.put('/collections/dogs/1').send({
-        name: newName
-      })
+      const response = await global.request
+        .put(`/collections/dogs/${postResponse.body.id}`)
+        .send({
+          name: newName
+        })
 
       expect(response.status).toBe(200)
 
-      const updatedResponse = await global.request.get('/collections/dogs/1')
+      const updatedResponse = await global.request.get(
+        `/collections/dogs/${postResponse.body.id}`
+      )
 
       expect(updatedResponse.status).toBe(200)
       expect(updatedResponse.body).toMatchObject({
@@ -207,17 +223,29 @@ describe('Collection CRUD (e2e)', () => {
         .set('Authorization', 'Bearer ' + adminToken)
 
       expect(fetchResponse.status).toBe(200)
-      expect(fetchResponse.body?.owner?.id).toEqual(1)
+      expect(fetchResponse.body?.owner?.id).toEqual(expect.any(String))
     })
   })
 
   describe('DELETE /collections/:entity/:id', () => {
     it('should delete an item', async () => {
-      const response = await global.request.delete('/collections/dogs/1')
+      // First, create a dog to delete
+      const postResponse = await global.request
+        .post('/collections/dogs')
+        .send(dummyDog)
+
+      expect(postResponse.status).toBe(201)
+
+      // Now, delete the created dog
+      const response = await global.request.delete(
+        `/collections/dogs/${postResponse.body.id}`
+      )
 
       expect(response.status).toBe(200)
 
-      const updatedResponse = await global.request.get('/collections/dogs/1')
+      const updatedResponse = await global.request.get(
+        `/collections/dogs/${postResponse.body.id}`
+      )
 
       expect(updatedResponse.status).toBe(404)
     })

--- a/packages/core/manifest/e2e/tests/relationship.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/relationship.e2e-spec.ts
@@ -2,7 +2,7 @@ describe('Relationship', () => {
   const dummyPost = {
     title: 'Post title',
     content: 'Post content',
-    authorId: 1
+    authorId: 'b47ac10b-58cc-4372-a567-0e02b2c3d479'
   }
 
   describe('ManyToOne', () => {
@@ -54,10 +54,10 @@ describe('Relationship', () => {
     })
 
     it('eager many to one relations are loaded by default', async () => {
-      const fetchedNote = await global.request.get('/collections/notes/1')
+      const fetchResponse = await global.request.get('/collections/notes')
 
-      expect(fetchedNote.status).toBe(200)
-      expect(fetchedNote.body.author.id).toEqual(expect.any(Number))
+      expect(fetchResponse.status).toBe(200)
+      expect(fetchResponse.body.data[0].author.id).toEqual(expect.any(String))
     })
 
     it('can filter by a many to one relationship', async () => {
@@ -115,17 +115,17 @@ describe('Relationship', () => {
 
       expect(listResponse.status).toBe(200)
       expect(listResponse.body.data[0].author.university.id).toEqual(
-        expect.any(Number)
+        expect.any(String)
       )
 
       expect(detailResponse.status).toBe(200)
       expect(detailResponse.body.author.university.id).toEqual(
-        expect.any(Number)
+        expect.any(String)
       )
     })
 
     it('can query nested many to one relationships from parent => child => child', async () => {
-      const dummyUniversityId = 5
+      const dummyUniversityId = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'
       const newAuthor = {
         name: 'Author name',
         universityId: dummyUniversityId
@@ -198,8 +198,14 @@ describe('Relationship', () => {
     })
 
     it('can update a many to many relationship', async () => {
-      const dummyTagIds = [1, 3]
-      const otherTagIds = [2, 4, 5]
+      const fetchTagResponse = await global.request.get('/collections/tags')
+
+      const dummyTagIds = fetchTagResponse.body.data
+        .map((tag) => tag.id)
+        .slice(0, 2)
+      const otherTagIds = fetchTagResponse.body.data
+        .map((tag) => tag.id)
+        .slice(2, 5)
 
       const createResponse = await global.request
         .post('/collections/posts')
@@ -306,7 +312,11 @@ describe('Relationship', () => {
     })
 
     it('eager manyToMany relations are loaded by default', async () => {
-      const dummyTagIds = [1, 3]
+      const fetchTagResponse = await global.request.get('/collections/tags')
+
+      const dummyTagIds = fetchTagResponse.body.data
+        .map((tag) => tag.id)
+        .slice(0, 2)
 
       const createTweetResponse = await global.request
         .post('/collections/tweets')
@@ -318,6 +328,8 @@ describe('Relationship', () => {
       const fetchedTweet = await global.request.get(
         `/collections/tweets/${createTweetResponse.body.id}`
       )
+
+      console.log(fetchedTweet.body)
 
       expect(createTweetResponse.status).toBe(201)
       expect(fetchedTweet.status).toBe(200)

--- a/packages/core/manifest/e2e/tests/relationship.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/relationship.e2e-spec.ts
@@ -1,9 +1,20 @@
-describe('Relationship', () => {
-  const dummyPost = {
-    title: 'Post title',
-    content: 'Post content',
-    authorId: 'b47ac10b-58cc-4372-a567-0e02b2c3d479'
-  }
+describe('Relationship (e2e)', () => {
+  let dummyPost: any
+  let authorId: string
+
+  beforeAll(async () => {
+    authorId = (
+      await global.request.post('/collections/authors').send({
+        name: 'Example Author'
+      })
+    ).body.id
+
+    dummyPost = {
+      title: 'Example Post',
+      content: 'This is an example post content.',
+      authorId
+    }
+  })
 
   describe('ManyToOne', () => {
     it('can create a many to one relationship and query it from child to parent', async () => {
@@ -91,32 +102,42 @@ describe('Relationship', () => {
     })
 
     it('can query nested many to one relationships from child => parent => parent', async () => {
+      const newUniversity = {
+        name: 'University Name'
+      }
+      const createUniversityResponse = await global.request
+        .post('/collections/universities')
+        .send(newUniversity)
+
       const newAuthor = {
         name: 'Author name',
-        universityId: 1
+        universityId: createUniversityResponse.body.id
       }
 
       const createAuthorResponse = await global.request
         .post('/collections/authors')
         .send(newAuthor)
 
-      await global.request.post('/collections/posts').send({
-        title: 'Post title',
-        content: 'Post content',
-        authorId: createAuthorResponse.body.id
-      })
+      const createPostResponse = await global.request
+        .post('/collections/posts')
+        .send({
+          title: 'Post title',
+          content: 'Post content',
+          authorId: createAuthorResponse.body.id
+        })
 
       const listResponse = await global.request.get(
         `/collections/posts?relations=author,author.university`
       )
       const detailResponse = await global.request.get(
-        `/collections/posts/1?relations=author,author.university`
+        `/collections/posts/${createPostResponse.body.id}?relations=author,author.university`
       )
 
       expect(listResponse.status).toBe(200)
-      expect(listResponse.body.data[0].author.university.id).toEqual(
-        expect.any(String)
-      )
+      expect(
+        listResponse.body.data.find((p) => p.id === createPostResponse.body.id)
+          ?.author?.university?.id
+      ).toEqual(expect.any(String))
 
       expect(detailResponse.status).toBe(200)
       expect(detailResponse.body.author.university.id).toEqual(
@@ -125,10 +146,16 @@ describe('Relationship', () => {
     })
 
     it('can query nested many to one relationships from parent => child => child', async () => {
-      const dummyUniversityId = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'
+      const newUniversity = {
+        name: 'University Name'
+      }
+      const createUniversityResponse = await global.request
+        .post('/collections/universities')
+        .send(newUniversity)
+
       const newAuthor = {
         name: 'Author name',
-        universityId: dummyUniversityId
+        universityId: createUniversityResponse.body.id
       }
 
       const createAuthorResponse = await global.request
@@ -144,7 +171,7 @@ describe('Relationship', () => {
         })
 
       const fetchedUniversity = await global.request.get(
-        `/collections/universities/${dummyUniversityId}?relations=authors,authors.posts`
+        `/collections/universities/${createUniversityResponse.body.id}?relations=authors,authors.posts`
       )
 
       expect(fetchedUniversity.status).toBe(200)
@@ -178,7 +205,11 @@ describe('Relationship', () => {
 
   describe('ManyToMany', () => {
     it('can create a many to many relationship', async () => {
-      const dummyTagIds = [1, 3]
+      const fetchTagResponse = await global.request.get('/collections/tags')
+      const dummyTagIds = fetchTagResponse.body.data
+        .slice(0, 2)
+        .map((tag) => tag.id)
+
       const createResponse = await global.request
         .post('/collections/posts')
         .send({
@@ -191,10 +222,14 @@ describe('Relationship', () => {
         `/collections/posts/${createResponse.body.id}?relations=tags`
       )
 
+      console.log(fetchedPost.body.tags, dummyTagIds)
+
       expect(createResponse.status).toBe(201)
       expect(fetchedPost.status).toBe(200)
       expect(fetchedPost.body.tags.length).toBe(dummyTagIds.length)
-      expect(fetchedPost.body.tags.map((tag) => tag.id)).toEqual(dummyTagIds)
+      expect(fetchedPost.body.tags.map((tag) => tag.id)).toEqual(
+        expect.arrayContaining(dummyTagIds)
+      )
     })
 
     it('can update a many to many relationship', async () => {
@@ -227,7 +262,9 @@ describe('Relationship', () => {
 
       expect(updateResponse.status).toBe(200)
       expect(fetchedPost.status).toBe(200)
-      expect(fetchedPost.body.tags.map((tag) => tag.id)).toEqual(otherTagIds)
+      expect(fetchedPost.body.tags.map((tag) => tag.id)).toEqual(
+        expect.arrayContaining(otherTagIds)
+      )
     })
 
     it('can remove a many to many relationship', async () => {
@@ -257,7 +294,11 @@ describe('Relationship', () => {
     })
 
     it('can query a many to many relationship from both sides', async () => {
-      const dummyTagIds = [1, 3]
+      const fetchTagResponse = await global.request.get('/collections/tags')
+
+      const dummyTagIds = fetchTagResponse.body.data
+        .map((tag) => tag.id)
+        .slice(3, 5)
 
       const createPostResponse = await global.request
         .post('/collections/posts')
@@ -279,15 +320,23 @@ describe('Relationship', () => {
       expect(fetchedPost.status).toBe(200)
       expect(fetchedTag.status).toBe(200)
 
-      expect(fetchedPost.body.tags.map((tag) => tag.id)).toEqual(dummyTagIds)
+      expect(fetchedPost.body.tags.map((tag) => tag.id)).toEqual(
+        expect.arrayContaining(dummyTagIds)
+      )
       expect(fetchedTag.body.posts.map((post) => post.id)).toContain(
         createPostResponse.body.id
       )
     })
 
     it('can query nested many to many relationships', async () => {
-      const dummyTagIds = [1, 3]
-      const dummyAuthorId = 4
+      const fetchTagResponse = await global.request.get('/collections/tags')
+
+      const dummyTagIds = fetchTagResponse.body.data
+        .map((tag) => tag.id)
+        .slice(2, 4)
+
+      const dummyAuthorId = (await global.request.get('/collections/authors'))
+        .body.data[0].id
 
       const createPostResponse = await global.request
         .post('/collections/posts')
@@ -308,7 +357,7 @@ describe('Relationship', () => {
         fetchedAuthor.body.posts
           .find((p) => p.id === createPostResponse.body.id)
           .tags.map((tag) => tag.id)
-      ).toEqual(dummyTagIds)
+      ).toEqual(expect.arrayContaining(dummyTagIds))
     })
 
     it('eager manyToMany relations are loaded by default', async () => {
@@ -329,12 +378,10 @@ describe('Relationship', () => {
         `/collections/tweets/${createTweetResponse.body.id}`
       )
 
-      console.log(fetchedTweet.body)
-
       expect(createTweetResponse.status).toBe(201)
       expect(fetchedTweet.status).toBe(200)
       expect(fetchedTweet.body.customTagNames.map((tag) => tag.id)).toEqual(
-        dummyTagIds
+        expect.arrayContaining(dummyTagIds)
       )
     })
 

--- a/packages/core/manifest/e2e/tests/relationship.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/relationship.e2e-spec.ts
@@ -75,7 +75,7 @@ describe('Relationship (e2e)', () => {
       const newAuthor = {
         name: 'Author name'
       }
-      const veryBigNumber = '9999'
+      const idThatDoesNotExist = '3f2504e0-4f89-11d3-9a0c-0305e82c3301' // Example UUID that does not exist
 
       const createAuthorResponse = await global.request
         .post('/collections/authors')
@@ -91,7 +91,7 @@ describe('Relationship (e2e)', () => {
         `/collections/posts?relations=author&author.id_eq=${createAuthorResponse.body.id}`
       )
       const nonExistentAuthorResponse = await global.request.get(
-        `/collections/posts?relations=author&author.id_eq=${veryBigNumber}`
+        `/collections/posts?relations=author&author.id_eq=${idThatDoesNotExist}`
       )
 
       expect(filteredResponse.status).toBe(200)
@@ -268,7 +268,11 @@ describe('Relationship (e2e)', () => {
     })
 
     it('can remove a many to many relationship', async () => {
-      const dummyTagIds = [1, 3]
+      const fetchTagResponse = await global.request.get('/collections/tags')
+
+      const dummyTagIds = fetchTagResponse.body.data
+        .map((tag) => tag.id)
+        .slice(0, 2)
 
       const createResponse = await global.request
         .post('/collections/posts')
@@ -403,7 +407,7 @@ describe('Relationship (e2e)', () => {
       )
 
       const nonExistentTagResponse = await global.request.get(
-        `/collections/posts?relations=tags&tags.id_eq=9999`
+        `/collections/posts?relations=tags&tags.id_eq=3f2504e0-4f89-11d3-9a0c-0305e82c3301`
       )
 
       expect(filteredResponse.status).toBe(200)

--- a/packages/core/manifest/e2e/tests/single-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/single-crud.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('Single CRUD (e2e)', () => {
   })
 
   it('cannot delete a single entity', async () => {
-    const response = await global.request.delete('/singles/contact/1')
+    const response = await global.request.delete('/singles/contact')
 
     expect(response.status).toBe(404)
   })

--- a/packages/core/manifest/e2e/tests/single-crud.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/single-crud.e2e-spec.ts
@@ -65,6 +65,7 @@ describe('Single CRUD (e2e)', () => {
 
       expect(updatedResponse.status).toBe(200)
       expect(updatedResponse.body.title).toBe(newTitle)
+      expect(updatedResponse.body.content).toBe(null) // Empties missing property on full replacement.
     })
 
     it('validates the fields of a single entity', async () => {

--- a/packages/core/manifest/e2e/tests/validation.e2e-spec.ts
+++ b/packages/core/manifest/e2e/tests/validation.e2e-spec.ts
@@ -71,6 +71,14 @@ describe('Validation (e2e)', () => {
     })
 
     it('update validation is the same as create validation', async () => {
+      const createResponse = await global.request
+        .post('/collections/cars')
+        .send({
+          model: 'double turbo truck',
+          brand: 'example brand',
+          year: 2000
+        })
+
       const goodCar = {
         model: 'double turbo truck',
         brand: 'example brand',
@@ -84,10 +92,10 @@ describe('Validation (e2e)', () => {
       }
 
       const goodResponse = await global.request
-        .put('/collections/cars/1')
+        .put('/collections/cars/' + createResponse.body.id)
         .send(goodCar)
       const badResponse = await global.request
-        .put('/collections/cars/1')
+        .put('/collections/cars/' + createResponse.body.id)
         .send(badCar)
 
       expect(goodResponse.status).toBe(200)
@@ -163,7 +171,7 @@ describe('Validation (e2e)', () => {
         .send({ ...superUserWithoutPassword, password: 'password' })
 
       const updateResponse = await global.request
-        .put('/collections/super-users/1')
+        .put(`/collections/super-users/${goodCreateResponse.body.id}`)
         .send({ name: 'new name', email: 'example2@manifest.build' })
 
       expect(badCreateResponse.status).toBe(400)

--- a/packages/core/manifest/manifest/backend.yml
+++ b/packages/core/manifest/manifest/backend.yml
@@ -36,8 +36,12 @@ entities:
     policies:
       read:
         - { access: restricted, allow: [User] }
+    belongsTo:
+      - User
+    belongsToMany:
+      - Contact
 
-  Contacts:
+  Contact:
     properties:
       - { name: name, type: string, validation: { required: true } }
       - { name: email, type: email, validation: { required: true } }
@@ -45,3 +49,12 @@ entities:
     policies:
       create:
         - access: public
+
+  Dog:
+    properties:
+      - { name: name, type: string, validation: { required: true } }
+      - { name: age, type: number, validation: { required: true } }
+      - { name: photo, type: image }
+
+    belongsToMany:
+      - User

--- a/packages/core/manifest/src/crud/controllers/collection.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/collection.controller.ts
@@ -4,7 +4,7 @@ import {
   Delete,
   Get,
   Param,
-  ParseIntPipe,
+  ParseUUIDPipe,
   Patch,
   Post,
   Put,
@@ -76,7 +76,7 @@ export class CollectionController {
   @Rule('read')
   async findOne(
     @Param('entity') entitySlug: string,
-    @Param('id', ParseIntPipe) id: number,
+    @Param('id', ParseUUIDPipe) id: string,
     @Query() queryParams: { [key: string]: string | string[] },
     @Req() req: Request
   ): Promise<BaseEntity> {
@@ -103,7 +103,7 @@ export class CollectionController {
   @Rule('update')
   put(
     @Param('entity') entitySlug: string,
-    @Param('id', ParseIntPipe) id: number,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() itemDto: Partial<BaseEntity>
   ): Promise<BaseEntity> {
     return this.crudService.update({ entitySlug, id, itemDto })
@@ -113,7 +113,7 @@ export class CollectionController {
   @Rule('update')
   patch(
     @Param('entity') entitySlug: string,
-    @Param('id', ParseIntPipe) id: number,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() itemDto: Partial<BaseEntity>
   ): Promise<BaseEntity> {
     return this.crudService.update({
@@ -128,7 +128,7 @@ export class CollectionController {
   @Rule('delete')
   delete(
     @Param('entity') entity: string,
-    @Param('id', ParseIntPipe) id: number
+    @Param('id', ParseUUIDPipe) id: string
   ): Promise<BaseEntity> {
     return this.crudService.delete(entity, id)
   }

--- a/packages/core/manifest/src/crud/controllers/single.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/single.controller.ts
@@ -75,7 +75,7 @@ export class SingleController {
     @Param('entity') entitySlug: string,
     @Body() itemDto: Partial<BaseEntity>
   ): Promise<BaseEntity> {
-    return this.crudService.update({ entitySlug, id: '', itemDto })
+    return this.crudService.update({ entitySlug, itemDto })
   }
 
   @Patch(':entity')
@@ -86,7 +86,6 @@ export class SingleController {
   ): Promise<BaseEntity> {
     return this.crudService.update({
       entitySlug,
-      id: '',
       itemDto,
       partialReplacement: true
     })

--- a/packages/core/manifest/src/crud/controllers/single.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/single.controller.ts
@@ -57,7 +57,7 @@ export class SingleController {
     try {
       singleItem = await this.crudService.findOne({
         entitySlug,
-        id: 1,
+        id: '',
         fullVersion: isAdmin
       })
     } catch (e) {
@@ -75,7 +75,7 @@ export class SingleController {
     @Param('entity') entitySlug: string,
     @Body() itemDto: Partial<BaseEntity>
   ): Promise<BaseEntity> {
-    return this.crudService.update({ entitySlug, id: 1, itemDto })
+    return this.crudService.update({ entitySlug, id: '', itemDto })
   }
 
   @Patch(':entity')
@@ -86,7 +86,7 @@ export class SingleController {
   ): Promise<BaseEntity> {
     return this.crudService.update({
       entitySlug,
-      id: 1,
+      id: '',
       itemDto,
       partialReplacement: true
     })

--- a/packages/core/manifest/src/crud/controllers/single.controller.ts
+++ b/packages/core/manifest/src/crud/controllers/single.controller.ts
@@ -57,7 +57,6 @@ export class SingleController {
     try {
       singleItem = await this.crudService.findOne({
         entitySlug,
-        id: '',
         fullVersion: isAdmin
       })
     } catch (e) {

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -129,7 +129,7 @@ export class CrudService {
         queryParams.order === 'DESC' ? 'DESC' : 'ASC'
       )
     } else {
-      query.orderBy('entity.id', 'DESC')
+      query.addSelect('entity.createdAt').orderBy('entity.createdAt', 'DESC')
     }
 
     // Paginate.

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -177,7 +177,7 @@ export class CrudService {
     fullVersion
   }: {
     entitySlug: string
-    id: number
+    id: string
     queryParams?: { [key: string]: string | string[] }
     fullVersion?: boolean
   }) {
@@ -301,7 +301,7 @@ export class CrudService {
     partialReplacement
   }: {
     entitySlug: string
-    id: number
+    id: string
     itemDto: Partial<BaseEntity>
     partialReplacement?: boolean
   }): Promise<BaseEntity> {
@@ -381,7 +381,7 @@ export class CrudService {
    *
    * @returns the deleted item.
    */
-  async delete(entitySlug: string, id: number): Promise<BaseEntity> {
+  async delete(entitySlug: string, id: string): Promise<BaseEntity> {
     const entityRepository: Repository<BaseEntity> =
       this.entityService.getEntityRepository({
         entitySlug

--- a/packages/core/manifest/src/crud/services/crud.service.ts
+++ b/packages/core/manifest/src/crud/services/crud.service.ts
@@ -177,7 +177,7 @@ export class CrudService {
     fullVersion
   }: {
     entitySlug: string
-    id: string
+    id?: string
     queryParams?: { [key: string]: string | string[] }
     fullVersion?: boolean
   }) {
@@ -186,6 +186,10 @@ export class CrudService {
         slug: entitySlug,
         fullVersion
       })
+
+    if (!entityManifest.single && !id) {
+      throw new Error('Id is required for collections.')
+    }
 
     const entityMetadata: EntityMetadata = this.entityService.getEntityMetadata(
       {
@@ -288,7 +292,7 @@ export class CrudService {
    * Updates an item doing a FULL REPLACEMENT of the item properties and relations unless partialReplacement is set to true.
    *
    * @param entitySlug the entity slug.
-   * @param id the item id.
+   * @param id the item id (only for collections)
    * @param itemDto the item dto.
    * @param partialReplacement whether to do a partial replacement.
    *
@@ -301,7 +305,7 @@ export class CrudService {
     partialReplacement
   }: {
     entitySlug: string
-    id: string
+    id?: string
     itemDto: Partial<BaseEntity>
     partialReplacement?: boolean
   }): Promise<BaseEntity> {
@@ -310,6 +314,10 @@ export class CrudService {
         slug: entitySlug,
         fullVersion: true
       })
+
+    if (!entityManifest.single && !id) {
+      throw new Error('Id is required for collections.')
+    }
 
     const entityRepository: Repository<BaseEntity> =
       this.entityService.getEntityRepository({ entitySlug })

--- a/packages/core/manifest/src/crud/services/pagination.service.ts
+++ b/packages/core/manifest/src/crud/services/pagination.service.ts
@@ -32,7 +32,7 @@ export class PaginationService {
       .getMany()
 
     return {
-      data: results,
+      data: results.map(({ createdAt, ...rest }) => rest as BaseEntity), // Remove createdAt from the results (used for sorting only).
       currentPage,
       lastPage: Math.ceil(total / resultsPerPage),
       from: offset + 1,

--- a/packages/core/manifest/src/crud/tests/collection.controller.spec.ts
+++ b/packages/core/manifest/src/crud/tests/collection.controller.spec.ts
@@ -14,6 +14,8 @@ describe('CollectionController', () => {
   let controller: CollectionController
   let crudService: CrudService
 
+  const randomUuid: string = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CollectionController],
@@ -116,15 +118,15 @@ describe('CollectionController', () => {
 
   it('should call crudService.findOne', async () => {
     const entitySlug = 'cats'
-    const id = 1
+
     const queryParams = {}
     const req = {} as any
 
-    await controller.findOne(entitySlug, id, queryParams, req)
+    await controller.findOne(entitySlug, randomUuid, queryParams, req)
 
     expect(crudService.findOne).toHaveBeenCalledWith({
       entitySlug,
-      id,
+      id: randomUuid,
       queryParams,
       fullVersion: false
     })
@@ -141,28 +143,28 @@ describe('CollectionController', () => {
 
   it('should call crudService.update', async () => {
     const entitySlug = 'cats'
-    const id = 1
+
     const itemDto = {}
 
-    await controller.put(entitySlug, id, itemDto)
+    await controller.put(entitySlug, randomUuid, itemDto)
 
     expect(crudService.update).toHaveBeenCalledWith({
       entitySlug,
-      id,
+      id: randomUuid,
       itemDto: itemDto
     })
   })
 
   it('should call crudService.update with partialReplacement', async () => {
     const entitySlug = 'cats'
-    const id = 1
+
     const itemDto = {}
 
-    await controller.patch(entitySlug, id, itemDto)
+    await controller.patch(entitySlug, randomUuid, itemDto)
 
     expect(crudService.update).toHaveBeenCalledWith({
       entitySlug,
-      id,
+      id: randomUuid,
       itemDto: itemDto,
       partialReplacement: true
     })
@@ -170,10 +172,9 @@ describe('CollectionController', () => {
 
   it('should call crudService.delete', async () => {
     const entitySlug = 'cats'
-    const id = 1
 
-    await controller.delete(entitySlug, id)
+    await controller.delete(entitySlug, randomUuid)
 
-    expect(crudService.delete).toHaveBeenCalledWith(entitySlug, id)
+    expect(crudService.delete).toHaveBeenCalledWith(entitySlug, randomUuid)
   })
 })

--- a/packages/core/manifest/src/crud/tests/crud.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/crud.service.spec.ts
@@ -56,7 +56,7 @@ describe('CrudService', () => {
   }
 
   const dummyItem = {
-    id: 1,
+    id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
     name: 'Superman',
     age: 30,
     color: 'blue',
@@ -246,22 +246,20 @@ describe('CrudService', () => {
   describe('findOne', () => {
     it('should return an entity', async () => {
       const entitySlug = 'test'
-      const id = 1
 
-      const result = await service.findOne({ entitySlug, id })
+      const result = await service.findOne({ entitySlug, id: dummyItem.id })
 
       expect(result).toEqual(dummyItem)
     })
 
     it('should throw a 404 error if the entity is not found', async () => {
       const entitySlug = 'test'
-      const id = 2
 
       jest
         .spyOn(queryBuilder, 'getOne')
         .mockReturnValue(Promise.resolve(undefined))
 
-      await expect(service.findOne({ entitySlug, id })).rejects.toThrow()
+      await expect(service.findOne({ entitySlug })).rejects.toThrow()
     })
   })
 
@@ -317,18 +315,20 @@ describe('CrudService', () => {
     })
 
     it('should store relationships', async () => {
-      const dummyRelations = { mentor: { id: 3 } } as any
+      const dummyUuid = '3e4a9c2f-8b1d-4e72-9a5b-c8f3d2e1a6b7'
+
+      const dummyRelations = { mentor: { id: dummyUuid } } as any
 
       jest
         .spyOn(relationshipService, 'fetchRelationItemsFromDto')
         .mockReturnValue(Promise.resolve(dummyRelations))
 
       const entitySlug = 'test'
-      const itemDto = { name: 'test', mentorId: 3 }
+      const itemDto = { name: 'test', mentorId: dummyUuid }
 
       const result = await service.store(entitySlug, itemDto)
 
-      expect(result.mentor['id']).toEqual(3)
+      expect(result.mentor['id']).toEqual(dummyUuid)
     })
   })
 
@@ -345,17 +345,19 @@ describe('CrudService', () => {
   describe('update (full replacement', () => {
     it('should update an entity', async () => {
       const entitySlug = 'test'
-      const id = 1
       const itemDto = { name: 'test' }
 
-      const result = await service.update({ entitySlug, id, itemDto })
+      const result = await service.update({
+        entitySlug,
+        id: dummyItem.id,
+        itemDto
+      })
 
       expect(result.name).toEqual(itemDto.name)
     })
 
     it('should throw an error if the entity is not found', async () => {
       const entitySlug = 'test'
-      const id = 1
       const itemDto = { name: 'test' }
 
       jest.spyOn(entityService, 'getEntityRepository').mockReturnValue({
@@ -365,26 +367,33 @@ describe('CrudService', () => {
       } as any)
 
       await expect(
-        service.update({ entitySlug, id, itemDto })
+        service.update({ entitySlug, id: dummyItem.id, itemDto })
       ).rejects.toThrow()
     })
 
     it('should update relationships', async () => {
       const entitySlug = 'test'
-      const id = 1
-      const itemDto = { mentorId: 2 }
+      const dummyUuid = '7e5a1d9f-3b6c-4f28-9e4a-b8c1f5d7a3e9'
+      const itemDto = { mentorId: dummyUuid }
 
-      const result: any = await service.update({ entitySlug, id, itemDto })
+      const result: any = await service.update({
+        entitySlug,
+        id: dummyUuid,
+        itemDto
+      })
 
       expect(result.mentor.id).toEqual(itemDto.mentorId)
     })
 
     it('should do a full replacement of properties', async () => {
       const entitySlug = 'test'
-      const id = 1
       const itemDto = { name: 'test' }
 
-      const result = await service.update({ entitySlug, id, itemDto })
+      const result = await service.update({
+        entitySlug,
+        id: dummyItem.id,
+        itemDto
+      })
 
       expect(result.name).toEqual(itemDto.name)
       expect(result.age).toBeUndefined()
@@ -392,18 +401,18 @@ describe('CrudService', () => {
 
     it('should do a full replacement of relationships', async () => {
       const entitySlug = 'test'
-      const id = 1
+      const dummyUuid = '8b4f7d2a-1c9e-4a58-9b7f-e6c3a9d2b5f1'
       const itemWithoutRelation = {}
-      const itemWithNewRelation = { mentorId: 2 }
+      const itemWithNewRelation = { mentorId: dummyUuid }
 
       const resultWithoutRelation = await service.update({
         entitySlug,
-        id,
+        id: dummyUuid,
         itemDto: itemWithoutRelation
       })
       const resultWithNewRelation = await service.update({
         entitySlug,
-        id,
+        id: dummyUuid,
         itemDto: itemWithNewRelation
       })
 
@@ -424,22 +433,22 @@ describe('CrudService', () => {
       ])
 
       const entitySlug = 'test'
-      const id = 1
       const itemDto = { name: '' }
 
-      expect(service.update({ entitySlug, id, itemDto })).rejects.toThrow()
+      expect(
+        service.update({ entitySlug, id: dummyItem.id, itemDto })
+      ).rejects.toThrow()
     })
   })
 
   describe('update (partial replacement)', () => {
     it('should do a partial replacement of properties', async () => {
       const entitySlug = 'test'
-      const id = 1
       const itemDto = { name: 'test' }
 
       const result = await service.update({
         entitySlug,
-        id,
+        id: dummyItem.id,
         itemDto,
         partialReplacement: true
       })
@@ -450,20 +459,19 @@ describe('CrudService', () => {
 
     it('should replace relations only if specified', async () => {
       const entitySlug = 'test'
-      const id = 1
-      const itemDto = { mentorId: 2 }
+      const itemDto = { mentorId: '6c9e2b5f-4a7d-4b19-9c6e-f3a1d8b5c7e9' }
       const itemWithoutRelationDto = { name: 'test' }
 
       const result = await service.update({
         entitySlug,
-        id,
+        id: dummyItem.id,
         itemDto,
         partialReplacement: true
       })
 
       const resultWithoutRelation = await service.update({
         entitySlug,
-        id,
+        id: dummyItem.id,
         itemDto: itemWithoutRelationDto,
         partialReplacement: true
       })
@@ -477,7 +485,6 @@ describe('CrudService', () => {
 
     it('should not update the password if not provided', async () => {
       const entitySlug = 'test'
-      const id = 1
       const itemDto = { name: 'test' }
 
       jest.spyOn(entityService, 'getEntityRepository').mockReturnValue({
@@ -498,7 +505,7 @@ describe('CrudService', () => {
 
       await service.update({
         entitySlug,
-        id,
+        id: dummyItem.id,
         itemDto,
         partialReplacement: true
       })
@@ -510,33 +517,30 @@ describe('CrudService', () => {
   describe('delete', () => {
     it('should delete an entity', async () => {
       const entitySlug = 'test'
-      const id = 1
 
-      const result = await service.delete(entitySlug, id)
+      const result = await service.delete(entitySlug, dummyItem.id)
 
       expect(result).toEqual(dummyItem)
     })
 
     it('should throw an error if the entity is not found', async () => {
       const entitySlug = 'test'
-      const id = 2
 
       jest.spyOn(entityService, 'getEntityRepository').mockReturnValue({
         delete: jest.fn(() => Promise.resolve(undefined))
       } as any)
 
-      await expect(service.delete(entitySlug, id)).rejects.toThrow()
+      await expect(service.delete(entitySlug, dummyItem.id)).rejects.toThrow()
     })
 
     it('should throw an error if the item has parent one-to-many relationships', async () => {
       const entitySlug = 'test'
-      const id = 1
 
       jest.spyOn(entityManifestService, 'getEntityManifest').mockReturnValue({
         relations: [{ name: 'parent', type: 'one-to-many' }]
       } as any)
 
-      await expect(service.delete(entitySlug, id)).rejects.toThrow()
+      await expect(service.delete(entitySlug, dummyItem.id)).rejects.toThrow()
     })
   })
 })

--- a/packages/core/manifest/src/crud/tests/database.service.spec.ts
+++ b/packages/core/manifest/src/crud/tests/database.service.spec.ts
@@ -4,7 +4,6 @@ import { ManifestService } from '../../manifest/services/manifest.service'
 import { EntityService } from '../../entity/services/entity.service'
 
 describe('DatabaseService', () => {
-  let manifestService: ManifestService
   let entityService: EntityService
   let service: DatabaseService
 
@@ -33,7 +32,6 @@ describe('DatabaseService', () => {
       ]
     }).compile()
 
-    manifestService = module.get<ManifestService>(ManifestService)
     entityService = module.get<EntityService>(EntityService)
     service = module.get<DatabaseService>(DatabaseService)
   })

--- a/packages/core/manifest/src/crud/tests/single.controller.spec.ts
+++ b/packages/core/manifest/src/crud/tests/single.controller.spec.ts
@@ -124,7 +124,7 @@ describe('SingleController', () => {
   })
 
   describe('PUT :entity', () => {
-    it('should call crudService.update with ID 1', async () => {
+    it('should call crudService.update', async () => {
       const entitySlug = 'test'
       const itemDto = { name: 'test' }
 
@@ -132,14 +132,13 @@ describe('SingleController', () => {
 
       expect(crudService.update).toHaveBeenCalledWith({
         entitySlug,
-        id: 1,
         itemDto
       })
     })
   })
 
   describe('PATCH :entity', () => {
-    it('should call crudService.update with ID 1 and partialReplacement true', async () => {
+    it('should call crudService.update and partialReplacement true', async () => {
       const entitySlug = 'test'
       const itemDto = { name: 'test' }
 
@@ -147,7 +146,6 @@ describe('SingleController', () => {
 
       expect(crudService.update).toHaveBeenCalledWith({
         entitySlug,
-        id: 1,
         itemDto,
         partialReplacement: true
       })

--- a/packages/core/manifest/src/entity/services/entity-loader.service.ts
+++ b/packages/core/manifest/src/entity/services/entity-loader.service.ts
@@ -129,13 +129,13 @@ export class EntityLoaderService {
 
     switch (dbConnection) {
       case 'sqlite':
-        idType = 'integer'
+        idType = 'text'
         break
       case 'postgres':
-        idType = 'int'
+        idType = 'uuid'
         break
       case 'mysql':
-        idType = 'int'
+        idType = 'varchar'
         break
     }
 
@@ -143,7 +143,7 @@ export class EntityLoaderService {
       id: {
         type: idType,
         primary: true,
-        generated: true
+        generated: 'uuid'
       },
       createdAt: {
         name: 'createdAt',

--- a/packages/core/manifest/src/entity/services/relationship.service.ts
+++ b/packages/core/manifest/src/entity/services/relationship.service.ts
@@ -4,6 +4,7 @@ import { EntitySchemaRelationOptions, In, Repository } from 'typeorm'
 import { EntityService } from './entity.service'
 
 import { getDtoPropertyNameFromRelationship, camelize } from '@repo/common'
+import pluralize from 'pluralize'
 
 @Injectable()
 export class RelationshipService {
@@ -57,7 +58,7 @@ export class RelationshipService {
         // If this is the owning side of the relationship, we need to set the join table name.
         if (manyToManyRelationShip.owningSide) {
           relationOptions[manyToManyRelationShip.name].joinTable = {
-            name: `${camelize(entityManifest.className)}_${manyToManyRelationShip.name}`
+            name: `${camelize(entityManifest.className)}_${pluralize.singular(manyToManyRelationShip.name)}`
           }
         }
       })

--- a/packages/core/manifest/src/entity/services/relationship.service.ts
+++ b/packages/core/manifest/src/entity/services/relationship.service.ts
@@ -108,7 +108,10 @@ export class RelationshipService {
       const propertyName: string =
         getDtoPropertyNameFromRelationship(relationship)
 
-      const relationIds: string[] = itemDto[propertyName]
+      const relationIds: string[] =
+        typeof itemDto[propertyName] === 'string'
+          ? [itemDto[propertyName]]
+          : itemDto[propertyName] || []
 
       if (relationIds.length) {
         const relatedEntityRepository: Repository<BaseEntity> =

--- a/packages/core/manifest/src/entity/services/relationship.service.ts
+++ b/packages/core/manifest/src/entity/services/relationship.service.ts
@@ -5,12 +5,7 @@ import { EntitySchemaRelationOptions, In, Repository } from 'typeorm'
 import { DEFAULT_MAX_MANY_TO_MANY_RELATIONS } from '../../constants'
 import { EntityService } from './entity.service'
 
-import {
-  getRandomIntExcluding,
-  getDtoPropertyNameFromRelationship,
-  forceNumberArray,
-  camelize
-} from '@repo/common'
+import { getDtoPropertyNameFromRelationship, camelize } from '@repo/common'
 import { EntityManifestService } from '../../manifest/services/entity-manifest.service'
 
 @Injectable()
@@ -31,7 +26,7 @@ export class RelationshipService {
    **/
   getSeedValue(
     relationshipManifest: RelationshipManifest
-  ): number | { id: number }[] {
+  ): number | { id: string }[] {
     const relatedEntity: EntityManifest =
       this.entityManifestService.getEntityManifest({
         className: relationshipManifest.entity
@@ -58,16 +53,17 @@ export class RelationshipService {
         max
       })
 
-      const relations: { id: number }[] = []
+      const relations: { id: string }[] = []
 
       while (relations.length < numberOfRelations) {
-        const newRelation: { id: number } = {
+        const newRelation: { id: string } = {
           // We need to make sure that the id is unique.
-          id: getRandomIntExcluding({
-            min: 1,
-            max: relatedEntity.seedCount,
-            exclude: relations.map((relation) => relation.id)
-          })
+          // id: getRandomIntExcluding({
+          //   min: 1,
+          //   max: relatedEntity.seedCount,
+          //   exclude: relations.map((relation) => relation.id)
+          // })
+          id: '' // TODO: UUID seed
         }
 
         // Only add the relation if it's not already in the list to prevent duplicates.
@@ -175,7 +171,7 @@ export class RelationshipService {
       const propertyName: string =
         getDtoPropertyNameFromRelationship(relationship)
 
-      const relationIds: number[] = forceNumberArray(itemDto[propertyName])
+      const relationIds: string[] = itemDto[propertyName]
 
       if (relationIds.length) {
         const relatedEntityRepository: Repository<BaseEntity> =

--- a/packages/core/manifest/src/entity/services/relationship.service.ts
+++ b/packages/core/manifest/src/entity/services/relationship.service.ts
@@ -1,80 +1,16 @@
-import { faker } from '@faker-js/faker'
 import { BaseEntity, EntityManifest, RelationshipManifest } from '@repo/types'
-import { Inject, Injectable, forwardRef } from '@nestjs/common'
+import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { EntitySchemaRelationOptions, In, Repository } from 'typeorm'
-import { DEFAULT_MAX_MANY_TO_MANY_RELATIONS } from '../../constants'
 import { EntityService } from './entity.service'
 
 import { getDtoPropertyNameFromRelationship, camelize } from '@repo/common'
-import { EntityManifestService } from '../../manifest/services/entity-manifest.service'
 
 @Injectable()
 export class RelationshipService {
   constructor(
-    private entityManifestService: EntityManifestService,
     @Inject(forwardRef(() => EntityService))
     private entityService: EntityService
   ) {}
-
-  /**
-   * Get the seed value for a relationship based on the number of relation items (seed count).
-   *
-   * @param relationshipManifest The relationship manifest in its detailed form.
-   *
-   * @returns An single id or an array of objects with an id property.
-   *
-   **/
-  getSeedValue(
-    relationshipManifest: RelationshipManifest
-  ): number | { id: string }[] {
-    const relatedEntity: EntityManifest =
-      this.entityManifestService.getEntityManifest({
-        className: relationshipManifest.entity
-      })
-
-    if (relationshipManifest.type === 'many-to-one') {
-      return faker.number.int({
-        min: 1,
-        max: relatedEntity.seedCount
-      })
-    } else if (
-      relationshipManifest.type === 'many-to-many' &&
-      relationshipManifest.owningSide
-    ) {
-      // On many-to-many relationships, we need to generate a random number of relations.
-
-      const max: number =
-        DEFAULT_MAX_MANY_TO_MANY_RELATIONS > relatedEntity.seedCount
-          ? relatedEntity.seedCount
-          : DEFAULT_MAX_MANY_TO_MANY_RELATIONS
-
-      const numberOfRelations: number = faker.number.int({
-        min: 0,
-        max
-      })
-
-      const relations: { id: string }[] = []
-
-      while (relations.length < numberOfRelations) {
-        const newRelation: { id: string } = {
-          // We need to make sure that the id is unique.
-          // id: getRandomIntExcluding({
-          //   min: 1,
-          //   max: relatedEntity.seedCount,
-          //   exclude: relations.map((relation) => relation.id)
-          // })
-          id: '' // TODO: UUID seed
-        }
-
-        // Only add the relation if it's not already in the list to prevent duplicates.
-        if (!relations.find((relation) => relation.id === newRelation.id)) {
-          relations.push(newRelation)
-        }
-      }
-
-      return relations
-    }
-  }
 
   /**
    * Get the TypeORM EntitySchemaRelationOptions for a given entity based on its relationships.

--- a/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
+++ b/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
@@ -49,35 +49,7 @@ describe('RelationshipService', () => {
   })
 
   describe('getSeedValue', () => {
-    it('should return a seed value between 1 and the seed count', () => {
-      const seedValue = service.getSeedValue(dummyRelationManifest)
-
-      expect(seedValue).toBeGreaterThanOrEqual(1)
-      expect(seedValue).toBeLessThanOrEqual(mockSeedCount)
-    })
-
-    it('should return a set items with a count between 0 and the default max many-to-many relations', () => {
-      const manyToManyRelationManifest: RelationshipManifest = {
-        name: 'users',
-        entity: 'User',
-        type: 'many-to-many',
-        owningSide: true
-      }
-
-      const seedValue: { id: number }[] = service.getSeedValue(
-        manyToManyRelationManifest
-      ) as { id: number }[]
-
-      expect(seedValue.length).toBeGreaterThanOrEqual(0)
-      expect(seedValue.length).toBeLessThanOrEqual(
-        DEFAULT_MAX_MANY_TO_MANY_RELATIONS
-      )
-      seedValue.forEach((relation) => {
-        expect(relation.id).toBeGreaterThanOrEqual(1)
-        expect(relation.id).toBeLessThanOrEqual(mockSeedCount)
-      })
-    })
-  })
+   
 
   describe('fetchRelationItemsFromDto', () => {
     it('should return an object with the relation items', async () => {

--- a/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
+++ b/packages/core/manifest/src/entity/tests/relationship.service.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { RelationshipService } from '../services/relationship.service'
 import { RelationshipManifest } from '@repo/types'
 import { EntityService } from '../services/entity.service'
-import { DEFAULT_MAX_MANY_TO_MANY_RELATIONS } from '../../constants'
 import { EntityManifestService } from '../../manifest/services/entity-manifest.service'
 
 describe('RelationshipService', () => {
@@ -14,7 +13,10 @@ describe('RelationshipService', () => {
     entity: 'User',
     type: 'many-to-one'
   }
-  const dummyUserIds: number[] = [1, 2, 3]
+  const dummyUserIds: string[] = [
+    'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
+  ]
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -48,13 +50,10 @@ describe('RelationshipService', () => {
     expect(service).toBeDefined()
   })
 
-  describe('getSeedValue', () => {
-   
-
   describe('fetchRelationItemsFromDto', () => {
-    it('should return an object with the relation items', async () => {
+    it('should return an object with the many-to-one relations', async () => {
       const itemDto = {
-        ownerId: 1
+        ownerId: 'b47ac10b-58cc-4372-a567-0e02b2c3d479'
       }
 
       const relationItems = await service.fetchRelationItemsFromDto({
@@ -65,7 +64,7 @@ describe('RelationshipService', () => {
       expect(relationItems.owner['id']).toBe(itemDto.ownerId)
     })
 
-    it('should retrun an object with the relation items for many-to-many relationships', async () => {
+    it('should return an object with the relation items for many-to-many relationships', async () => {
       const manyToManyRelationManifest: RelationshipManifest = {
         name: 'users',
         entity: 'User',
@@ -82,34 +81,34 @@ describe('RelationshipService', () => {
         relationships: [manyToManyRelationManifest]
       })) as any
 
-      expect(relationItems.users.length).toBe(3)
+      expect(relationItems.users.length).toBe(dummyUserIds.length)
 
       relationItems.users.forEach((user, index) => {
         expect(user['id']).toBe(itemDto.userIds[index])
       })
     })
-  })
 
-  it('should empty missing relationships if emptyMissing is true', async () => {
-    const itemDto = {}
+    it('should empty missing relationships if emptyMissing is true', async () => {
+      const itemDto = {}
 
-    const relationItems = await service.fetchRelationItemsFromDto({
-      itemDto,
-      relationships: [dummyRelationManifest],
-      emptyMissing: true
+      const relationItems = await service.fetchRelationItemsFromDto({
+        itemDto,
+        relationships: [dummyRelationManifest],
+        emptyMissing: true
+      })
+
+      expect(relationItems.owner).toBeNull()
     })
 
-    expect(relationItems.owner).toBeNull()
-  })
+    it('should not empty missing relationships by default', async () => {
+      const itemDto = {}
 
-  it('should not empty missing relationships by default', async () => {
-    const itemDto = {}
+      const relationItems = await service.fetchRelationItemsFromDto({
+        itemDto,
+        relationships: [dummyRelationManifest]
+      })
 
-    const relationItems = await service.fetchRelationItemsFromDto({
-      itemDto,
-      relationships: [dummyRelationManifest]
+      expect(relationItems.owner).toBeUndefined()
     })
-
-    expect(relationItems.owner).toBeUndefined()
   })
 })

--- a/packages/core/manifest/src/hook/tests/hook.service.spec.ts
+++ b/packages/core/manifest/src/hook/tests/hook.service.spec.ts
@@ -4,7 +4,7 @@ import { HookManifest, HookSchema } from '../../../../types/src'
 
 describe('HookService', () => {
   let service: HookService
-  let originalConsoleLog: typeof console.log
+  let originalConsoleError: typeof console.error
 
   const hookManifest: HookManifest = {
     event: 'beforeCreate',
@@ -17,12 +17,13 @@ describe('HookService', () => {
   }
 
   beforeAll(() => {
-    originalConsoleLog = console.log
-    console.log = jest.fn()
+    // Prevent console.error from cluttering the test output (fails voluntarily on fetch).
+    originalConsoleError = console.error
+    console.error = jest.fn()
   })
 
   afterAll(() => {
-    console.log = originalConsoleLog
+    console.error = originalConsoleError
   })
 
   beforeAll(() => {

--- a/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
@@ -138,7 +138,7 @@ export class EntityManifestService {
       const partialEntityManifest: EntityManifestCommonFields = {
         className: entitySchema.className || className,
         nameSingular:
-          entitySchema.nameSingular ||
+          entitySchema.nameSingular?.toLowerCase() ||
           pluralize.singular(entitySchema.className || className).toLowerCase(),
         slug:
           entitySchema.slug ||
@@ -300,6 +300,7 @@ export class EntityManifestService {
       mainProp: null,
       properties: partialEntityManifest.properties,
       hooks: partialEntityManifest.hooks,
+      seedCount: 1,
       relationships: [],
       policies: {
         create: [FORBIDDEN_ACCESS_POLICY],

--- a/packages/core/manifest/src/manifest/tests/entity-manifest.service.spec.ts
+++ b/packages/core/manifest/src/manifest/tests/entity-manifest.service.spec.ts
@@ -221,7 +221,7 @@ describe('EntityManifestService', () => {
     expect(entityManifests[0].mainProp).toBe(null) // No main prop for single entities.
     expect(entityManifests[0].namePlural).toBe('homecontent')
     expect(entityManifests[0].authenticable).toBe(false)
-    expect(entityManifests[0]).not.toHaveProperty('seedCount')
+    expect(entityManifests[0].seedCount).toBe(1)
     expect(entityManifests[0]).not.toHaveProperty('belongsTo')
     expect(entityManifests[0]).not.toHaveProperty('belongsToMany')
   })

--- a/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
+++ b/packages/core/manifest/src/open-api/services/open-api-crud.service.ts
@@ -296,7 +296,9 @@ export class OpenApiCrudService {
                 description: `The ID of the ${entityManifest.nameSingular}`,
                 required: true,
                 schema: {
-                  type: 'integer'
+                  type: 'string',
+                  format: 'uuid',
+                  example: '123e4567-e89b-12d3-a456-426614174000'
                 }
               }
             ],
@@ -362,7 +364,9 @@ export class OpenApiCrudService {
                 description: `The ID of the ${entityManifest.nameSingular}`,
                 required: true,
                 schema: {
-                  type: 'integer'
+                  type: 'string',
+                  format: 'uuid',
+                  example: '123e4567-e89b-12d3-a456-426614174000'
                 }
               }
             ],
@@ -427,7 +431,9 @@ export class OpenApiCrudService {
                 description: `The ID of the ${entityManifest.nameSingular}`,
                 required: true,
                 schema: {
-                  type: 'integer'
+                  type: 'string',
+                  format: 'uuid',
+                  example: '123e4567-e89b-12d3-a456-426614174000'
                 }
               }
             ],
@@ -473,7 +479,9 @@ export class OpenApiCrudService {
             description: `The ID of the ${entityManifest.nameSingular}`,
             required: true,
             schema: {
-              type: 'integer'
+              type: 'string',
+              format: 'uuid',
+              example: '123e4567-e89b-12d3-a456-426614174000'
             }
           }
         ],

--- a/packages/core/manifest/src/sdk/backend-sdk.ts
+++ b/packages/core/manifest/src/sdk/backend-sdk.ts
@@ -49,7 +49,7 @@ export class BackendSDK extends BaseSDK {
       get: async <T>(): Promise<T> => {
         return this.crudService.findOne({
           entitySlug: this.slug,
-          id: 1,
+          id: '',
           fullVersion: true
         }) as Promise<T>
       },
@@ -62,7 +62,7 @@ export class BackendSDK extends BaseSDK {
       update: async <T>(data: unknown): Promise<T> => {
         return this.crudService.update({
           entitySlug: this.slug,
-          id: 1,
+          id: '',
           itemDto: data as Partial<T>
         }) as Promise<T>
       },
@@ -76,7 +76,7 @@ export class BackendSDK extends BaseSDK {
       patch: async <T>(data: unknown): Promise<T> => {
         return this.crudService.update({
           entitySlug: this.slug,
-          id: 1,
+          id: '',
           itemDto: data as Partial<T>,
           partialReplacement: true
         }) as Promise<T>
@@ -116,7 +116,7 @@ export class BackendSDK extends BaseSDK {
    * @example client.from('cats').findOne(1);
    *
    **/
-  async findOneById<T>(id: number): Promise<T> {
+  async findOneById<T>(id: string): Promise<T> {
     return this.crudService.findOne({
       entitySlug: this.slug,
       queryParams: this.queryParams,
@@ -148,7 +148,7 @@ export class BackendSDK extends BaseSDK {
    * @returns The updated item.
    * @example client.from('cats').update(1, { name: 'updated name' });
    */
-  async update<T>(id: number, itemDto: unknown): Promise<T> {
+  async update<T>(id: string, itemDto: unknown): Promise<T> {
     return this.crudService.update({
       entitySlug: this.slug,
       id,
@@ -165,7 +165,7 @@ export class BackendSDK extends BaseSDK {
    * @returns The updated item.
    * @example client.from('cats').update(1, { name: 'updated name' });
    */
-  async patch<T>(id: number, itemDto: unknown): Promise<T> {
+  async patch<T>(id: string, itemDto: unknown): Promise<T> {
     return this.crudService.update({
       entitySlug: this.slug,
       id,
@@ -183,7 +183,7 @@ export class BackendSDK extends BaseSDK {
    * @returns The id of the deleted item.
    * @example client.from('cats').delete(1);
    */
-  async delete(id: number): Promise<BaseEntity> {
+  async delete(id: string): Promise<BaseEntity> {
     return this.crudService.delete(this.slug, id)
   }
 

--- a/packages/core/manifest/src/sdk/backend-sdk.ts
+++ b/packages/core/manifest/src/sdk/backend-sdk.ts
@@ -74,7 +74,6 @@ export class BackendSDK extends BaseSDK {
       patch: async <T>(data: unknown): Promise<T> => {
         return this.crudService.update({
           entitySlug: this.slug,
-          id: '',
           itemDto: data as Partial<T>,
           partialReplacement: true
         }) as Promise<T>

--- a/packages/core/manifest/src/sdk/backend-sdk.ts
+++ b/packages/core/manifest/src/sdk/backend-sdk.ts
@@ -49,7 +49,6 @@ export class BackendSDK extends BaseSDK {
       get: async <T>(): Promise<T> => {
         return this.crudService.findOne({
           entitySlug: this.slug,
-          id: '',
           fullVersion: true
         }) as Promise<T>
       },
@@ -62,7 +61,6 @@ export class BackendSDK extends BaseSDK {
       update: async <T>(data: unknown): Promise<T> => {
         return this.crudService.update({
           entitySlug: this.slug,
-          id: '',
           itemDto: data as Partial<T>
         }) as Promise<T>
       },

--- a/packages/core/manifest/src/sdk/tests/backend-sdk.spec.ts
+++ b/packages/core/manifest/src/sdk/tests/backend-sdk.spec.ts
@@ -4,12 +4,13 @@ import { CrudService } from '../../crud/services/crud.service'
 import { UploadService } from '../../upload/services/upload.service'
 import { base64ToBlob } from '../../../../common/src'
 
-describe('SdkService', () => {
+describe('BackendSdk', () => {
   let sdk: BackendSDK
   let crudService: CrudService
   let uploadService: UploadService
 
-  const dummyItem = { id: 1, name: 'Timiaou', color: 'brown' } as any
+  const dummyUuid = '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b'
+  const dummyItem = { id: dummyUuid, name: 'Timiaou', color: 'brown' } as any
   const dummySlug = 'cats'
 
   beforeEach(async () => {
@@ -56,7 +57,6 @@ describe('SdkService', () => {
       expect(result).toEqual(dummyItem)
       expect(crudService.findOne).toHaveBeenCalledWith({
         entitySlug: 'homePage',
-        id: 1,
         fullVersion: true
       })
     })
@@ -90,7 +90,7 @@ describe('SdkService', () => {
     })
 
     it('should return a single entity from a collection', async () => {
-      const result = await sdk.from(dummySlug).findOneById(1)
+      const result = await sdk.from(dummySlug).findOneById(dummyUuid)
 
       expect(result).toEqual(dummyItem)
     })
@@ -105,22 +105,30 @@ describe('SdkService', () => {
     })
 
     it('should update an entity in a collection', async () => {
-      const result = await sdk.from(dummySlug).update(1, { name: 'new name' })
+      const result = await sdk
+        .from(dummySlug)
+        .update(dummyUuid, { name: 'new name' })
 
       expect(result).toEqual({ name: 'new name' })
     })
 
     it('should patch an entity in a collection', async () => {
-      const result = await sdk.from(dummySlug).patch(1, { name: 'new name' })
+      const result = await sdk
+        .from(dummySlug)
+        .patch(dummyUuid, { name: 'new name' })
 
-      expect(result).toEqual({ name: 'new name', color: 'brown', id: 1 })
+      expect(result).toEqual({
+        name: 'new name',
+        color: 'brown',
+        id: dummyUuid
+      })
     })
 
     it('should delete an entity in a collection', async () => {
-      const result = await sdk.from(dummySlug).delete(1)
+      const result = await sdk.from(dummySlug).delete(dummyUuid)
 
       expect(result).toEqual(dummyItem)
-      expect(crudService.delete).toHaveBeenCalledWith(dummySlug, 1)
+      expect(crudService.delete).toHaveBeenCalledWith(dummySlug, dummyUuid)
     })
   })
 

--- a/packages/core/manifest/src/seed/services/seeder.service.ts
+++ b/packages/core/manifest/src/seed/services/seeder.service.ts
@@ -377,30 +377,26 @@ export class SeederService {
         })
       })
 
-    let records: BaseEntity[] = []
-
     // Store all items in memory to avoid multiple queries.
     if (!this.records[relationshipManifest.entity]) {
-      records = await relatedEntityRepository.find({
-        select: ['id']
-      })
-    } else {
-      records = await Promise.resolve(this.records[relationshipManifest.entity])
+      this.records[relationshipManifest.entity] =
+        await relatedEntityRepository.find({
+          select: ['id']
+        })
     }
 
     if (relationshipManifest.type === 'many-to-one') {
       return this.getRandomUniqueIds(
-        records[relationshipManifest.entity].map((item: BaseEntity) => item.id),
+        this.records[relationshipManifest.entity].map(
+          (item: BaseEntity) => item.id
+        ),
         1
       )[0]
-    } else if (
-      relationshipManifest.type === 'many-to-many' &&
-      !relationshipManifest
-    ) {
+    } else if (relationshipManifest.type === 'many-to-many') {
       // On many-to-many relationships, we need to generate a random number of relations.
       const max: number = Math.min(
         DEFAULT_MAX_MANY_TO_MANY_RELATIONS,
-        records[relationshipManifest.entity].length
+        this.records[relationshipManifest.entity].length
       )
 
       const numberOfRelations: number = faker.number.int({
@@ -409,7 +405,9 @@ export class SeederService {
       })
 
       return this.getRandomUniqueIds(
-        records[relationshipManifest.entity].map((item: BaseEntity) => item.id),
+        this.records[relationshipManifest.entity].map(
+          (item: BaseEntity) => item.id
+        ),
         numberOfRelations
       ).map((id: string) => ({ id }))
     }

--- a/packages/core/manifest/src/seed/services/seeder.service.ts
+++ b/packages/core/manifest/src/seed/services/seeder.service.ts
@@ -134,15 +134,9 @@ export class SeederService {
           fullVersion: true
         })
 
-      if (entityManifest.single) {
-        console.log(
-          `✅ Seeding ${entityManifest.seedCount || 'single'} ${entityManifest.nameSingular}...`
-        )
-      } else {
-        console.log(
-          `✅ Seeding ${entityManifest.seedCount} ${entityManifest.seedCount > 1 ? entityManifest.namePlural : entityManifest.nameSingular}...`
-        )
-      }
+      console.log(
+        `✅ Seeding ${entityManifest.seedCount} ${entityManifest.seedCount > 1 ? entityManifest.namePlural : entityManifest.nameSingular}...`
+      )
 
       for (let i = 0; i < entityManifest.seedCount; i++) {
         const newRecord: BaseEntity = repository.create()

--- a/packages/core/manifest/src/seed/services/seeder.service.ts
+++ b/packages/core/manifest/src/seed/services/seeder.service.ts
@@ -12,7 +12,6 @@ import {
 import { Injectable } from '@nestjs/common'
 import { DataSource, EntityMetadata, QueryRunner, Repository } from 'typeorm'
 import { EntityService } from '../../entity/services/entity.service'
-import { RelationshipService } from '../../entity/services/relationship.service'
 
 import { faker } from '@faker-js/faker'
 import * as fs from 'fs'
@@ -23,6 +22,7 @@ import {
   ADMIN_ENTITY_MANIFEST,
   AUTHENTICABLE_PROPS,
   DEFAULT_ADMIN_CREDENTIALS,
+  DEFAULT_MAX_MANY_TO_MANY_RELATIONS,
   DUMMY_FILE_NAME,
   DUMMY_IMAGE_NAME
 } from '../../constants'
@@ -34,10 +34,10 @@ import { EntityManifestService } from '../../manifest/services/entity-manifest.s
 export class SeederService {
   seededFiles: { [key: string]: string } = {}
   seededImages: { [key: string]: { [key: string]: string } } = {}
+  records: { [key: string]: BaseEntity[] } = {}
 
   constructor(
     private entityService: EntityService,
-    private relationshipService: RelationshipService,
     private entityManifestService: EntityManifestService,
     private storageService: StorageService,
     private dataSource: DataSource
@@ -106,13 +106,7 @@ export class SeederService {
         await queryRunner.query('PRAGMA foreign_keys = OFF')
         await Promise.all(
           entityMetadatas.map(async (entity: EntityMetadata) =>
-            queryRunner
-              .query(`DELETE FROM [${entity.tableName}]`)
-              .then(() =>
-                queryRunner.query(
-                  `DELETE FROM sqlite_sequence WHERE name = '${entity.tableName}'`
-                )
-              )
+            queryRunner.query(`DELETE FROM [${entity.tableName}]`)
           )
         )
         await queryRunner.query('PRAGMA foreign_keys = ON')
@@ -164,15 +158,16 @@ export class SeederService {
           )
         }
 
-        entityManifest.relationships
-          .filter(
+        const manyToOneRelationships: RelationshipManifest[] =
+          entityManifest.relationships.filter(
             (relationship: RelationshipManifest) =>
               relationship.type === 'many-to-one'
           )
-          .forEach((relationManifest: RelationshipManifest) => {
-            newRecord[relationManifest.name] =
-              this.relationshipService.getSeedValue(relationManifest)
-          })
+
+        for (const relationship of manyToOneRelationships) {
+          newRecord[relationship.name] =
+            await this.seedRelationships(relationship)
+        }
 
         await repository.save(newRecord)
       }
@@ -195,19 +190,20 @@ export class SeederService {
 
       const allRecords: BaseEntity[] = await repository.find()
 
-      entityManifest.relationships
-        .filter(
+      const manyToManyRelationships: RelationshipManifest[] =
+        entityManifest.relationships.filter(
           (relationship: RelationshipManifest) =>
-            relationship.type === 'many-to-many'
+            relationship.type === 'many-to-many' && relationship.owningSide
         )
-        .forEach((relationshipManifest: RelationshipManifest) => {
-          allRecords.forEach(async (record: BaseEntity) => {
-            record[relationshipManifest.name] =
-              this.relationshipService.getSeedValue(relationshipManifest)
 
-            manyToManyPromises.push(repository.save(record))
-          })
-        })
+      for (const relationshipManifest of manyToManyRelationships) {
+        for (const record of allRecords) {
+          record[relationshipManifest.name] =
+            await this.seedRelationships(relationshipManifest)
+
+          manyToManyPromises.push(repository.save(record))
+        }
+      }
     }
 
     await Promise.all(manyToManyPromises)
@@ -361,5 +357,74 @@ export class SeederService {
     admin.password = bcrypt.hashSync(DEFAULT_ADMIN_CREDENTIALS.password, 1)
 
     await repository.save(admin)
+  }
+
+  /**
+   * Get the seed value for a relationship based on the number of relation items (seed count).
+   *
+   * @param relationshipManifest The relationship manifest in its detailed form.
+   *
+   * @returns An single id or an array of objects with an id property.
+   *
+   **/
+  async seedRelationships(
+    relationshipManifest: RelationshipManifest
+  ): Promise<string | { id: string }[]> {
+    const relatedEntityRepository: Repository<BaseEntity> =
+      this.entityService.getEntityRepository({
+        entityMetadata: this.entityService.getEntityMetadata({
+          className: relationshipManifest.entity
+        })
+      })
+
+    let records: BaseEntity[] = []
+
+    // Store all items in memory to avoid multiple queries.
+    if (!this.records[relationshipManifest.entity]) {
+      records = await relatedEntityRepository.find({
+        select: ['id']
+      })
+    } else {
+      records = await Promise.resolve(this.records[relationshipManifest.entity])
+    }
+
+    if (relationshipManifest.type === 'many-to-one') {
+      return this.getRandomUniqueIds(
+        records[relationshipManifest.entity].map((item: BaseEntity) => item.id),
+        1
+      )[0]
+    } else if (
+      relationshipManifest.type === 'many-to-many' &&
+      !relationshipManifest
+    ) {
+      // On many-to-many relationships, we need to generate a random number of relations.
+      const max: number = Math.min(
+        DEFAULT_MAX_MANY_TO_MANY_RELATIONS,
+        records[relationshipManifest.entity].length
+      )
+
+      const numberOfRelations: number = faker.number.int({
+        min: 0,
+        max
+      })
+
+      return this.getRandomUniqueIds(
+        records[relationshipManifest.entity].map((item: BaseEntity) => item.id),
+        numberOfRelations
+      ).map((id: string) => ({ id }))
+    }
+  }
+
+  /**
+   * Generates an array of unique IDs from the provided list.
+   *
+   * @param ids The array of IDs to choose from.
+   * @param count The number of unique IDs to return.
+   *
+   * @return An array of unique IDs, randomly selected from the provided list.
+   */
+  private getRandomUniqueIds(ids: string[], count: number): string[] {
+    const shuffled = [...ids].sort(() => Math.random() - 0.5)
+    return shuffled.slice(0, Math.min(count, ids.length))
   }
 }

--- a/packages/core/manifest/src/seed/tests/seeder.service.spec.ts
+++ b/packages/core/manifest/src/seed/tests/seeder.service.spec.ts
@@ -161,18 +161,6 @@ describe('SeederService', () => {
         )
       })
     })
-
-    it('should only seed a table if passed as an argument', async () => {
-      jest.spyOn(dataSource, 'createQueryRunner').mockReturnValue(queryRunner)
-
-      await service.seed('table1')
-
-      expect(queryRunner.query).toHaveBeenNthCalledWith(
-        2,
-        `DELETE FROM [${'table1'}]`
-      )
-      expect(queryRunner.query).toHaveBeenCalledTimes(3) // 2 for PRAGMA FKs and 1 for DELETE.
-    })
   })
 
   describe('seedProperty', () => {

--- a/packages/core/manifest/src/seed/tests/seeder.service.spec.ts
+++ b/packages/core/manifest/src/seed/tests/seeder.service.spec.ts
@@ -161,6 +161,18 @@ describe('SeederService', () => {
         )
       })
     })
+
+    it('should only seed a table if passed as an argument', async () => {
+      jest.spyOn(dataSource, 'createQueryRunner').mockReturnValue(queryRunner)
+
+      await service.seed('table1')
+
+      expect(queryRunner.query).toHaveBeenNthCalledWith(
+        2,
+        `DELETE FROM [${'table1'}]`
+      )
+      expect(queryRunner.query).toHaveBeenCalledTimes(3) // 2 for PRAGMA FKs and 1 for DELETE.
+    })
   })
 
   describe('seedProperty', () => {

--- a/packages/core/manifest/src/seed/tests/seeder.service.spec.ts
+++ b/packages/core/manifest/src/seed/tests/seeder.service.spec.ts
@@ -290,6 +290,35 @@ describe('SeederService', () => {
     })
   })
 
+  describe('seedRelationships', () => {
+    //  it('should return a seed value between 1 and the seed count', () => {
+    //       const seedValue = service.getSeedValue(dummyRelationManifest)
+    //       expect(seedValue).toBeGreaterThanOrEqual(1)
+    //       expect(seedValue).toBeLessThanOrEqual(mockSeedCount)
+    //     })
+    //     it('should return a set items with a count between 0 and the default max many-to-many relations', () => {
+    //       const manyToManyRelationManifest: RelationshipManifest = {
+    //         name: 'users',
+    //         entity: 'User',
+    //         type: 'many-to-many',
+    //         owningSide: true
+    //       }
+    //       const seedValue: { id: string }[] = service.getSeedValue(
+    //         manyToManyRelationManifest
+    //       ) as { id: string }[]
+    //       expect(seedValue.length).toBeGreaterThanOrEqual(0)
+    //       expect(seedValue.length).toBeLessThanOrEqual(
+    //         DEFAULT_MAX_MANY_TO_MANY_RELATIONS
+    //       )
+    //       seedValue.forEach((relation) => {
+    //         expect(relation.id).toBeGreaterThanOrEqual(1)
+    //         expect(relation.id).toBeLessThanOrEqual(mockSeedCount)
+    //       })
+    //     })
+    //   })
+    // })
+  })
+
   describe('seedAdmin', () => {
     it('should seed the admin user', async () => {
       const dummyRepository = {

--- a/packages/core/types/src/crud/BaseEntity.ts
+++ b/packages/core/types/src/crud/BaseEntity.ts
@@ -9,9 +9,9 @@
  * */
 export interface BaseEntity {
   /**
-   * The entity's unique identifier.
+   * The entity's unique identifier (UUID).
    */
-  id: number
+  id: string
 
   /**
    * The date and time the entity was created (automatic).

--- a/packages/core/types/src/crud/SelectOption.ts
+++ b/packages/core/types/src/crud/SelectOption.ts
@@ -3,6 +3,6 @@
  */
 export interface SelectOption {
   label: string
-  id: number
+  id: string
   selected?: boolean
 }

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -26,10 +26,10 @@ See the [Manifest JS SDK doc](https://manifest.build/docs/javascript-sdk)
 
 To contribute to the Manifest JS SDK, please read first the general [contributing.md](https://github.com/mnfst/manifest/blob/master/CONTRIBUTING.md) file.
 
-The best way to work with the SDK is using the `/sandbox` folder that hosts a minimalistic React app that imports the Manifest SDK. You can run the app with the following commands:
+The best way to work with the SDK is using the `/sandbox` folder that hosts a minimalistic Angular app that imports the Manifest SDK. You can run the app with the following commands:
 
 ```bash
 cd sandbox
 npm install
-npm run dev
+npm run start
 ```

--- a/packages/js-sdk/sandbox/src/app/app.component.ts
+++ b/packages/js-sdk/sandbox/src/app/app.component.ts
@@ -14,7 +14,11 @@ export class AppComponent {
   async ngOnInit(): Promise<void> {
     const manifest = new Manifest()
 
-    await manifest.login('users', 'br@test.fr', 'azerty')
+    // await manifest.login('users', 'br@test.fr', 'azerty')
+
+    const cats = await manifest
+      .from('cats')
+      .findOneById('efd7a361-0c78-4d58-9951-9f49e040efa4')
 
     await manifest.from('projects').find()
   }

--- a/packages/js-sdk/src/Manifest.ts
+++ b/packages/js-sdk/src/Manifest.ts
@@ -116,7 +116,7 @@ export default class Manifest extends BaseSDK {
    * @example client.from('cats').findOne(1);
    *
    **/
-  async findOneById<T>(id: number): Promise<T> {
+  async findOneById<T>(id: string): Promise<T> {
     return this.fetch({
       path: `/collections/${this.slug}/${id}`,
       queryParams: {
@@ -149,7 +149,7 @@ export default class Manifest extends BaseSDK {
    * @returns The updated item.
    * @example client.from('cats').update(1, { name: 'updated name' });
    */
-  async update<T>(id: number, itemDto: unknown): Promise<T> {
+  async update<T>(id: string, itemDto: unknown): Promise<T> {
     return this.fetch({
       path: `/collections/${this.slug}/${id}`,
       method: 'PUT',
@@ -166,7 +166,7 @@ export default class Manifest extends BaseSDK {
    * @returns The updated item.
    * @example client.from('cats').update(1, { name: 'updated name' });
    */
-  async patch<T>(id: number, itemDto: unknown): Promise<T> {
+  async patch<T>(id: string, itemDto: unknown): Promise<T> {
     return this.fetch({
       path: `/collections/${this.slug}/${id}`,
       method: 'PATCH',
@@ -183,7 +183,7 @@ export default class Manifest extends BaseSDK {
    * @returns The id of the deleted item.
    * @example client.from('cats').delete(1);
    */
-  async delete<T>(id: number): Promise<T> {
+  async delete<T>(id: string): Promise<T> {
     return this.fetch({
       path: `/collections/${this.slug}/${id}`,
       method: 'DELETE'

--- a/packages/js-sdk/tests/crud.spec.ts
+++ b/packages/js-sdk/tests/crud.spec.ts
@@ -5,7 +5,11 @@ describe('CRUD operations', () => {
   const collectionBaseUrl: string = 'http://localhost:1111/api/collections'
   const singleBaseUrl: string = 'http://localhost:1111/api/singles'
   const dummyResponse = { dummy: 'response' }
-  const dummyItem = { name: 'Tom', age: 10, id: 1 }
+  const dummyItem = {
+    name: 'Tom',
+    age: 10,
+    id: 'a8f5f167-6d3b-4c8f-9e2a-7b4d8c9f1e3a'
+  }
 
   beforeEach(() => {
     fetchMock.restore()
@@ -106,7 +110,7 @@ describe('CRUD operations', () => {
     })
 
     it('should get an item by its id', async () => {
-      const id: number = 1
+      const id: string = 'a8f5f167-6d3b-4c8f-9e2a-7b4d8c9f1e3a'
 
       fetchMock.mock(`${collectionBaseUrl}/cats/${id}`, dummyResponse)
 
@@ -117,7 +121,7 @@ describe('CRUD operations', () => {
     })
 
     it('should get an item by its id with relations', async () => {
-      const id: number = 1
+      const id: string = 'a8f5f167-6d3b-4c8f-9e2a-7b4d8c9f1e3a'
 
       fetchMock.mock(
         `${collectionBaseUrl}/cats/${id}?relations=owner%2Cowner.company`,
@@ -158,7 +162,7 @@ describe('CRUD operations', () => {
     })
 
     it('should update an item', async () => {
-      const id: number = 1
+      const id: string = 'a8f5f167-6d3b-4c8f-9e2a-7b4d8c9f1e3a'
 
       fetchMock.mock(
         {
@@ -182,7 +186,7 @@ describe('CRUD operations', () => {
     })
 
     it('should patch an item', async () => {
-      const id: number = 1
+      const id: string = 'a8f5f167-6d3b-4c8f-9e2a-7b4d8c9f1e3a'
 
       fetchMock.mock(
         {
@@ -204,7 +208,7 @@ describe('CRUD operations', () => {
     })
 
     it('should delete an item', async () => {
-      const id: number = 1
+      const id: string = 'a8f5f167-6d3b-4c8f-9e2a-7b4d8c9f1e3a'
 
       fetchMock.mock(
         {


### PR DESCRIPTION
## Description

This PR replaces incremental integer IDs by UUIDs for better privacy and security. 

Instead of:
`/api/collections/users/1`

 you get:
`/api/collections/users/40a0bb98-ca2c-4c34-b5d0-57c91415c8f5`

:warning: Related doc PR to validate https://github.com/mnfst/docs/pull/32

## Related Issues

Discussion https://github.com/mnfst/manifest/discussions/359

## How can it be tested?

- Run the project and CRUD operations on entities
- Seed complex data structure with relations
- Visit admin panel
- Test with JS SDK with sandbox (see js-sdk package readme)

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
