### PR TITLE
Path to regexp issue

### DIFF
--- a/.changeset/olive-tigers-smell.md
+++ b/.changeset/olive-tigers-smell.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+fixed path error on windows with handler files, thanks @akvgergo

--- a/package-lock.json
+++ b/package-lock.json
@@ -29705,7 +29705,7 @@
       }
     },
     "packages/core/manifest": {
-      "version": "4.12.1",
+      "version": "4.12.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.744.0",
@@ -29731,6 +29731,7 @@
         "mysql2": "^3.12.0",
         "node-fetch": "^3.3.2",
         "nodemon": "^3.1.9",
+        "path-to-regexp": "^3.3.0",
         "pg": "^8.13.3",
         "pluralize": "^8.0.0",
         "reflect-metadata": "^0.2.1",
@@ -30304,7 +30305,7 @@
       "name": "@repo/types"
     },
     "packages/create-manifest": {
-      "version": "1.1.9",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.5.1",
@@ -30359,7 +30360,7 @@
     },
     "packages/js-sdk": {
       "name": "@mnfst/sdk",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/packages/core/manifest/package.json
+++ b/packages/core/manifest/package.json
@@ -99,6 +99,7 @@
     "mysql2": "^3.12.0",
     "node-fetch": "^3.3.2",
     "nodemon": "^3.1.9",
+    "path-to-regexp": "^3.3.0",
     "pg": "^8.13.3",
     "pluralize": "^8.0.0",
     "reflect-metadata": "^0.2.1",

--- a/scripts/update-package.js
+++ b/scripts/update-package.js
@@ -1,4 +1,5 @@
 // This script updates the package.json files with the latest version of the "manifest" package.
+// It skips updates for beta releases to avoid updating examples with unstable versions.
 
 const fs = require('fs')
 const path = require('path')
@@ -16,7 +17,53 @@ const FOLDERS = [
   '../../../examples/website/validation'
 ]
 
+function getCurrentVersion() {
+  try {
+    const packageJsonPath = path.join(process.cwd(), 'package.json')
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    return packageJson.version
+  } catch (err) {
+    console.error('Failed to read current package version:', err.message)
+    return null
+  }
+}
+
+function isBetaVersion(version) {
+  if (!version) return false
+
+  // Check for common beta patterns: beta, alpha, rc, pre, etc.
+  const betaPatterns = [
+    /beta/i,
+    /alpha/i,
+    /rc/i,
+    /pre/i,
+    /-\d+$/, // Matches versions ending with -1, -2, etc.
+    /\d+\.\d+\.\d+-.+/ // Matches any version with a prerelease identifier
+  ]
+
+  return betaPatterns.some((pattern) => pattern.test(version))
+}
+
 function updatePackage() {
+  const currentVersion = getCurrentVersion()
+
+  if (!currentVersion) {
+    console.error('Cannot determine current version. Aborting update.')
+    return
+  }
+
+  console.log(`Current version: ${currentVersion}`)
+
+  if (isBetaVersion(currentVersion)) {
+    console.log(
+      'ⓘ Beta version detected. Skipping example updates to avoid unstable releases.'
+    )
+    console.log('Examples will only be updated for stable releases.')
+    return
+  }
+
+  console.log('✅ Stable version detected. Proceeding with example updates...')
+
   FOLDERS.forEach((folder) => {
     const packageJsonPath = path.join(folder, 'package.json')
 


### PR DESCRIPTION
## Description

Fix error with handler files path on Windows with node 24: https://discordapp.com/channels/1089907785178812499/1385305565684568275

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
