### PR TITLE
✨ Accept more image formats

### DIFF
--- a/.changeset/dry-buttons-rush.md
+++ b/.changeset/dry-buttons-rush.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+accept more image formats: png, webp, gif, avif, tiff and dzi, thanks @myurtsev

--- a/.changeset/dry-buttons-rush.md
+++ b/.changeset/dry-buttons-rush.md
@@ -1,5 +1,5 @@
 ---
-'manifest': minor
+'manifest': patch
 ---
 
-accept more image formats: png, webp, gif, avif, tiff and dzi, thanks @myurtsev
+accept png image format, thanks @myurtsev

--- a/packages/core/admin/src/app/modules/shared/inputs/image-input/image-input.component.html
+++ b/packages/core/admin/src/app/modules/shared/inputs/image-input/image-input.component.html
@@ -8,7 +8,7 @@
         <input
           class="file-input"
           type="file"
-          accept="image/*"
+          accept=".png, .jpg, .jpeg"
           #imageInput
           (change)="imageInputEvent()"
         />

--- a/packages/core/manifest/src/seed/services/seeder.service.ts
+++ b/packages/core/manifest/src/seed/services/seeder.service.ts
@@ -318,7 +318,7 @@ export class SeederService {
         entityManifest.slug,
         propertyManifest.name,
         {
-          originalname: DUMMY_FILE_NAME,
+          originalname: DUMMY_IMAGE_NAME,
           buffer: dummyImageContent
         },
         propertyManifest.options?.['sizes'] as ImageSizesObject

--- a/packages/core/manifest/src/storage/services/storage.service.ts
+++ b/packages/core/manifest/src/storage/services/storage.service.ts
@@ -116,18 +116,7 @@ export class StorageService {
     for (const sizeName in imageSizes || DEFAULT_IMAGE_SIZES) {
       const imageExtension: string = path.extname(image.originalname)
 
-      if (
-        [
-          '.jpg',
-          '.jpeg',
-          '.png',
-          '.webp',
-          '.gif',
-          '.avif',
-          '.tiff',
-          '.dzi'
-        ].indexOf(imageExtension) === -1
-      ) {
+      if (['.jpg', '.jpeg', '.png'].indexOf(imageExtension) === -1) {
         throw new HttpException(
           `Unsupported image format: ${imageExtension}`,
           400

--- a/packages/core/manifest/src/storage/services/storage.service.ts
+++ b/packages/core/manifest/src/storage/services/storage.service.ts
@@ -113,8 +113,6 @@ export class StorageService {
     const uniqueName: string = uniqid()
     const imagePaths: { [key: string]: string } = {}
 
-    console.log(image.originalname)
-
     for (const sizeName in imageSizes || DEFAULT_IMAGE_SIZES) {
       const imageExtension: string = path.extname(image.originalname)
 


### PR DESCRIPTION
## Description

Accept more image formats: 
- png
- webp
- gif
- tiff
- avif
- dzi

## Related Issues
[Asked on Discord](https://discordapp.com/channels/1089907785178812499/1396908745019097201)

## How can it be tested?

Grab any image from those formats, including transparent PNGs and try upload them. 

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
