### PR TITLE
docs: add nested workspace install instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance for Claude Code when working with this repository.
+
+## Project Overview
+
+Manifest is a monorepo containing tools for building MCP (Model Context Protocol) servers with agentic UI components.
+
+## Repository Structure
+
+```
+packages/
+├── agentic-ui-toolkit/   # Component registry (Next.js) - port 3001
+├── create-manifest/      # CLI for scaffolding new projects
+└── starter/              # Starter template (nested pnpm workspace) - port 3000
+    ├── server/           # MCP server (Express + TypeScript)
+    └── web/              # Web client (Next.js)
+```
+
+## Important: Nested Workspace
+
+The `packages/starter` directory is a **nested pnpm workspace** with its own `pnpm-lock.yaml`. You must install dependencies in both locations:
+
+```bash
+# Root dependencies
+pnpm install
+
+# Starter package dependencies (required!)
+cd packages/starter && pnpm install
+```
+
+## Common Commands
+
+```bash
+# Start development (from root)
+pnpm run dev
+
+# Build all packages
+pnpm run build
+
+# Lint all packages
+pnpm run lint
+
+# Run tests
+pnpm run test
+```
+
+## Development Workflow
+
+1. Run `pnpm install` at the root
+2. Run `pnpm install` in `packages/starter`
+3. Run `pnpm run dev` to start both the registry (port 3001) and starter server (port 3000)
+
+## Testing with ChatGPT
+
+Use ngrok to expose the local MCP server:
+
+```bash
+ngrok http 3000
+```
+
+Connect using: `https://xxxx.ngrok-free.app/mcp`
+
+## Key Files
+
+- `/packages/starter/server/src/index.ts` - Main MCP server entry point
+- `/packages/agentic-ui-toolkit/registry.json` - Component registry definitions
+- `/turbo.json` - Turborepo configuration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,15 @@ cd manifest
 pnpm install
 ```
 
-2. Start the development servers:
+2. Install dependencies for the starter package (nested workspace):
+
+```bash
+cd packages/starter
+pnpm install
+cd ../..
+```
+
+3. Start the development servers:
 
 ```bash
 pnpm run dev
@@ -38,7 +46,7 @@ This runs both packages in parallel via Turborepo:
 - **Registry** at `http://localhost:3001` - Component documentation
 - **Starter** at `http://localhost:3000` - Example MCP server
 
-3. Install components from the registry using the shadcn CLI with the `@manifest-dev` namespace:
+4. Install components from the registry using the shadcn CLI with the `@manifest-dev` namespace:
 
 ```bash
 cd packages/starter/web


### PR DESCRIPTION
## Summary
- Update CONTRIBUTING.md to include step for installing dependencies in the `packages/starter` nested workspace
- Add CLAUDE.md with project guidance for Claude Code

The `packages/starter` directory is a nested pnpm workspace that requires its own `pnpm install` command. Without this step, `pnpm run dev` fails with `nodemon: command not found`.

## Test plan
- [ ] Clone fresh repo and follow updated CONTRIBUTING.md instructions
- [ ] Verify `pnpm run dev` works after both install steps
