### PR TITLE
feat: improve block header UI layout

### DIFF
--- a/packages/agentic-ui-toolkit/app/blocks/page.tsx
+++ b/packages/agentic-ui-toolkit/app/blocks/page.tsx
@@ -1200,30 +1200,12 @@ function BlocksContent() {
             <div>
               <div className="flex items-center gap-3 mb-1">
                 <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
-                <div className="flex gap-1.5">
-                  {selectedBlock.layouts.map((layout) => (
-                    <span
-                      key={layout}
-                      className={cn(
-                        'px-2 py-0.5 text-xs font-medium rounded-full',
-                        layout === 'inline' &&
-                          'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-                        layout === 'fullscreen' &&
-                          'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-                        layout === 'pip' &&
-                          'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-                      )}
-                    >
-                      {layout}
-                    </span>
-                  ))}
-                  <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1">
-                    <Zap className="w-3 h-3" />
-                    {selectedBlock.actionCount > 0
-                      ? `${selectedBlock.actionCount} action${selectedBlock.actionCount > 1 ? 's' : ''}`
-                      : 'read only'}
-                  </span>
-                </div>
+                <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1">
+                  <Zap className="w-3 h-3" />
+                  {selectedBlock.actionCount > 0
+                    ? `${selectedBlock.actionCount} action${selectedBlock.actionCount > 1 ? 's' : ''}`
+                    : 'read only'}
+                </span>
               </div>
               <p className="text-muted-foreground">
                 {selectedBlock.description}

--- a/packages/agentic-ui-toolkit/components/blocks/install-command-inline.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/install-command-inline.tsx
@@ -35,12 +35,10 @@ const packageManagers: {
 
 interface InstallCommandInlineProps {
   componentName: string
-  version?: string | null
 }
 
 export function InstallCommandInline({
-  componentName,
-  version
+  componentName
 }: InstallCommandInlineProps) {
   const [selectedPm, setSelectedPm] = useState<PackageManager>('npx')
   const [copied, setCopied] = useState(false)
@@ -59,13 +57,6 @@ export function InstallCommandInline({
 
   return (
     <div className="flex items-center gap-2">
-      {/* Version badge */}
-      {version && (
-        <span className="px-2 py-1 text-xs font-mono bg-muted text-muted-foreground rounded-md">
-          v{version}
-        </span>
-      )}
-
       {/* Package manager select */}
       <div className="relative">
         <select

--- a/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
@@ -142,79 +142,88 @@ export function VariantSection({
   const hasPip = layouts.includes('pip')
 
   return (
-    <div className="space-y-4">
-      <h3 className="text-lg font-bold">{name}</h3>
-
-      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3 mb-4">
-        {/* 4 Mode buttons: Icons on mobile/tablet, text on desktop */}
-        <div className="flex items-center gap-1.5">
-          <button
-            onClick={() => setViewMode('inline')}
-            className={cn(
-              'p-1.5 lg:px-3 lg:py-1.5 text-xs font-medium rounded-full transition-colors cursor-pointer',
-              viewMode === 'inline'
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <MessageSquare className="h-3.5 w-3.5 lg:hidden" />
-            <span className="hidden lg:inline">Inline</span>
-          </button>
-          <button
-            disabled={!hasPip}
-            onClick={() => hasPip && setViewMode('pip')}
-            className={cn(
-              'p-1.5 lg:px-3 lg:py-1.5 text-xs font-medium rounded-full transition-colors',
-              viewMode === 'pip'
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:text-foreground',
-              hasPip ? 'cursor-pointer' : 'opacity-40 cursor-not-allowed'
-            )}
-          >
-            <PictureInPicture2 className="h-3.5 w-3.5 lg:hidden" />
-            <span className="hidden lg:inline">PiP</span>
-          </button>
-          <button
-            disabled={!hasFullwidth}
-            onClick={() => hasFullwidth && setViewMode('fullwidth')}
-            className={cn(
-              'p-1.5 lg:px-3 lg:py-1.5 text-xs font-medium rounded-full transition-colors',
-              viewMode === 'fullwidth'
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:text-foreground',
-              hasFullwidth ? 'cursor-pointer' : 'opacity-40 cursor-not-allowed'
-            )}
-          >
-            <Maximize2 className="h-3.5 w-3.5 lg:hidden" />
-            <span className="hidden lg:inline">Fullwidth</span>
-          </button>
-          <button
-            onClick={() => setViewMode('config')}
-            className={cn(
-              'p-1.5 lg:px-3 lg:py-1.5 text-xs font-medium rounded-full transition-colors cursor-pointer',
-              viewMode === 'config'
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <Settings2 className="h-3.5 w-3.5 lg:hidden" />
-            <span className="hidden lg:inline">Config</span>
-          </button>
-          <button
-            onClick={() => setViewMode('code')}
-            className={cn(
-              'p-1.5 lg:px-3 lg:py-1.5 text-xs font-medium rounded-full transition-colors cursor-pointer',
-              viewMode === 'code'
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <span className="hidden lg:inline">Code</span>
-            <span className="lg:hidden">&lt;/&gt;</span>
-          </button>
+    <div className="space-y-3">
+      {/* Row 1: Title + Version (mobile) / Title + Version + Install command (desktop) */}
+      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-2 lg:gap-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-bold">{name}</h3>
+          {sourceCode.version && (
+            <span className="text-xs text-muted-foreground">V{sourceCode.version}</span>
+          )}
         </div>
+        <InstallCommandInline componentName={registryName} />
+      </div>
 
-        <InstallCommandInline componentName={registryName} version={sourceCode.version} />
+      {/* Row 2 (desktop) / Row 3 (mobile): Mode buttons */}
+      <div className="flex items-center gap-1.5">
+        {/* Preview buttons: icon-only on all screen sizes */}
+        <button
+          onClick={() => setViewMode('inline')}
+          className={cn(
+            'p-1.5 text-xs font-medium rounded-full transition-colors cursor-pointer',
+            viewMode === 'inline'
+              ? 'bg-foreground text-background'
+              : 'bg-muted text-muted-foreground hover:text-foreground'
+          )}
+          title="Inline"
+        >
+          <MessageSquare className="h-3.5 w-3.5" />
+        </button>
+        <button
+          disabled={!hasPip}
+          onClick={() => hasPip && setViewMode('pip')}
+          className={cn(
+            'p-1.5 text-xs font-medium rounded-full transition-colors',
+            viewMode === 'pip'
+              ? 'bg-foreground text-background'
+              : 'bg-muted text-muted-foreground hover:text-foreground',
+            hasPip ? 'cursor-pointer' : 'opacity-40 cursor-not-allowed'
+          )}
+          title="Picture in Picture"
+        >
+          <PictureInPicture2 className="h-3.5 w-3.5" />
+        </button>
+        <button
+          disabled={!hasFullwidth}
+          onClick={() => hasFullwidth && setViewMode('fullwidth')}
+          className={cn(
+            'p-1.5 text-xs font-medium rounded-full transition-colors',
+            viewMode === 'fullwidth'
+              ? 'bg-foreground text-background'
+              : 'bg-muted text-muted-foreground hover:text-foreground',
+            hasFullwidth ? 'cursor-pointer' : 'opacity-40 cursor-not-allowed'
+          )}
+          title="Fullwidth"
+        >
+          <Maximize2 className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Config button: icon on mobile, word on desktop */}
+        <button
+          onClick={() => setViewMode('config')}
+          className={cn(
+            'p-1.5 lg:px-3 lg:py-1.5 text-xs font-medium rounded-full transition-colors cursor-pointer',
+            viewMode === 'config'
+              ? 'bg-foreground text-background'
+              : 'bg-muted text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <Settings2 className="h-3.5 w-3.5 lg:hidden" />
+          <span className="hidden lg:inline">Config</span>
+        </button>
+
+        {/* Code button: word on all screen sizes */}
+        <button
+          onClick={() => setViewMode('code')}
+          className={cn(
+            'px-3 py-1.5 text-xs font-medium rounded-full transition-colors cursor-pointer',
+            viewMode === 'code'
+              ? 'bg-foreground text-background'
+              : 'bg-muted text-muted-foreground hover:text-foreground'
+          )}
+        >
+          Code
+        </button>
       </div>
 
       {/* Content based on view mode */}


### PR DESCRIPTION
## Summary
- Remove inline/PiP/Fullwidth layout tags from block page title (keep only action count badge)
- Reorganize variant section header layout for better UX on desktop and mobile
- Make preview buttons (Inline, PiP, Fullwidth) icon-only with tooltips
- Move version display next to block title (e.g., "Default V1.0.0")

## Changes
- **Desktop**: Title + version on left, install commands on right (same row), buttons below
- **Mobile**: 3 rows - title + version, install commands, buttons
- **Preview buttons**: Icon-only on all screen sizes
- **Config button**: Icon on mobile, "Config" text on desktop
- **Code button**: Always shows "Code" text

## Test plan
- [ ] Verify desktop layout: title/version left, commands right, buttons below
- [ ] Verify mobile layout: 3 stacked rows
- [ ] Verify preview buttons show only icons with hover tooltips
- [ ] Verify Config shows icon on mobile, text on desktop
- [ ] Verify version displays next to title
