### PR TITLE
fix: add @mnfst/server as dependency so local mode starts

### DIFF
--- a/.changeset/fix-local-mode-server-dependency.md
+++ b/.changeset/fix-local-mode-server-dependency.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Add `@mnfst/server` as a dependency of the `manifest` plugin so local mode works out of the box

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -16,6 +16,24 @@ Or with environment variables:
 export MANIFEST_API_KEY=mnfst_YOUR_KEY
 ```
 
+## Local mode
+
+Run the full Manifest dashboard locally — no cloud account needed. Data is stored in SQLite at `~/.openclaw/manifest/`.
+
+```bash
+openclaw plugins install manifest
+openclaw config set plugins.entries.manifest.config.mode "local"
+openclaw gateway restart
+```
+
+Open `http://127.0.0.1:2099` to view the dashboard.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `mode` | string | `cloud` | `local` for embedded server, `cloud` for hosted |
+| `port` | number | `2099` | Local server port |
+| `host` | string | `127.0.0.1` | Local server bind address |
+
 ## Configuration
 
 | Option | Type | Default | Description |

--- a/packages/openclaw-plugin/__tests__/build.test.ts
+++ b/packages/openclaw-plugin/__tests__/build.test.ts
@@ -134,4 +134,17 @@ describe("build configuration", () => {
     expect(buildContent).toContain("@opentelemetry/resources");
     expect(buildContent).toContain("stubs/resources.js");
   });
+
+  it("package.json declares @mnfst/server as a dependency", () => {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    expect(pkg.dependencies).toHaveProperty("@mnfst/server");
+  });
+
+  it("build.ts keeps @mnfst/server as external", () => {
+    const buildPath = resolve(__dirname, "../build.ts");
+    const buildContent = readFileSync(buildPath, "utf-8");
+
+    expect(buildContent).toContain("@mnfst/server");
+    expect(buildContent).toMatch(/external.*@mnfst\/server/);
+  });
 });

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -54,6 +54,9 @@
     "telemetry",
     "agent-analytics"
   ],
+  "dependencies": {
+    "@mnfst/server": "^5.2.8"
+  },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^1.30.0",

--- a/packages/openclaw-plugin/src/local-mode.ts
+++ b/packages/openclaw-plugin/src/local-mode.ts
@@ -70,9 +70,17 @@ export function registerLocalMode(
     serverModule = require("@mnfst/server");
   } catch {
     logger.error(
-      "[manifest] @mnfst/server is not installed.\n" +
-        "  Install it with: npm install @mnfst/server\n" +
-        "  Then restart the gateway.",
+      "[manifest] @mnfst/server is not installed. Local mode cannot start.\n" +
+        "  Try reinstalling the plugin:\n" +
+        "    openclaw plugins install manifest && openclaw gateway restart\n" +
+        "\n" +
+        "  If that doesn't help, install the server globally:\n" +
+        "    npm install -g @mnfst/server\n" +
+        "    openclaw gateway restart\n" +
+        "\n" +
+        "  Or switch to cloud mode:\n" +
+        "    openclaw config set plugins.entries.manifest.config.mode cloud\n" +
+        "    openclaw gateway restart",
     );
     return;
   }


### PR DESCRIPTION
## Summary
- Add `@mnfst/server` as a regular `dependency` in the `manifest` plugin so `require("@mnfst/server")` succeeds when local mode is enabled
- Improve the catch-block error message in `local-mode.ts` with actionable recovery steps (reinstall plugin, install globally, or switch to cloud mode)
- Add "Local mode" documentation section to the plugin README
- Add regression tests verifying `@mnfst/server` is declared as a dependency and kept as an esbuild external

## Test plan
- [x] `npm test --workspace=packages/openclaw-plugin` — new tests pass
- [x] `npm run build --workspace=packages/openclaw-plugin` — bundle builds
- [x] `npm ls @mnfst/server --workspace=packages/openclaw-plugin` — shows as direct dependency
- [ ] Smoke test: install plugin in local mode, verify dashboard loads at `:2099`
