### PR TITLE
fix: improve local mode startup reliability and auth UX

### DIFF
--- a/.changeset/fix-local-mode-sqlite-preflight.md
+++ b/.changeset/fix-local-mode-sqlite-preflight.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Fix local mode server failing silently when better-sqlite3 native binary is missing. The pre-flight check now instantiates an in-memory database to exercise the native addon, surfacing a clear error message before the backend import triggers the same failure deep in auth.instance.js. Also fixes AuthGuard showing a blank page during session checks by adding a loading state and refreshing the session after auto-login.

--- a/packages/frontend/tests/components/AuthGuard.test.tsx
+++ b/packages/frontend/tests/components/AuthGuard.test.tsx
@@ -42,24 +42,24 @@ describe("AuthGuard", () => {
     expect(screen.getByText("Protected content")).toBeDefined();
   });
 
-  it("renders nothing when session is pending", () => {
+  it("shows loading state when session is pending", () => {
     mockSessionData = { data: null, isPending: true };
     const { container } = render(() => (
       <AuthGuard>
         <span>Protected content</span>
       </AuthGuard>
     ));
-    expect(container.textContent).toBe("");
+    expect(container.textContent).toContain("Loading...");
   });
 
-  it("renders nothing when no session data", () => {
+  it("shows loading state when no session data", () => {
     mockSessionData = { data: null, isPending: false };
     const { container } = render(() => (
       <AuthGuard>
         <span>Protected content</span>
       </AuthGuard>
     ));
-    expect(container.textContent).toBe("");
+    expect(container.textContent).toContain("Loading...");
   });
 
   it("navigates to login when no session and auto-login fails", async () => {


### PR DESCRIPTION
## Summary

- **Fix silent server crash on missing native binary**: The `better-sqlite3` pre-flight check in `@mnfst/server` only loaded the JS wrapper (`require('better-sqlite3')`) without testing the native addon. Now it instantiates `new Database(':memory:').close()` to catch missing `.node` binaries with a clear, actionable error message before the backend import fails deep in `auth.instance.js`.
- **Fix blank page during local auto-login**: `AuthGuard` rendered `fallback={null}` (white screen) while checking the session. Replaced with a loading indicator using existing `auth-layout` CSS classes. Also fixed a race condition where the Better Auth client never picked up the session cookie set by the raw `fetch("/api/auth/local-session")` call — now calls `refetch()` to update the reactive signal without a full page reload.
- **Fix cookie domain mismatch**: Set `BETTER_AUTH_URL` to `http://127.0.0.1:{port}` in local mode so Better Auth's `baseURL` matches the actual access URL instead of defaulting to `localhost`.

## Test plan

- [x] Frontend tests pass (452/452)
- [x] manifest-server tests pass (3/3)
- [ ] Install plugin via `openclaw plugins install manifest`, set local mode, verify dashboard loads at `http://127.0.0.1:2099/`
- [ ] Verify cloud mode is unaffected (redirect to `/login` still works)
