### PR TITLE
fix: add postinstall script to rebuild better-sqlite3

### DIFF
--- a/.changeset/better-sqlite3-postinstall.md
+++ b/.changeset/better-sqlite3-postinstall.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Add postinstall script to rebuild better-sqlite3 for the current Node.js runtime

--- a/packages/manifest-server/package.json
+++ b/packages/manifest-server/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "node scripts/copy-assets.js && tsc",
     "prebuild": "rm -rf dist public",
+    "postinstall": "npm rebuild better-sqlite3",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds a `postinstall` script to `@mnfst/server` that runs `npm rebuild better-sqlite3`, ensuring the native addon is always recompiled for the user's Node.js ABI after installation.

## Test plan
- [x] `npm test --workspace=packages/manifest-server` — 3/3 passing
- [x] `npm test --workspace=packages/backend` — 717/717 passing
