### PR TITLE
fix: resolve ClaWHub suspicious flag on manifest skill

### DIFF
--- a/.changeset/fix-skill-metadata.md
+++ b/.changeset/fix-skill-metadata.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: update SKILL.md to resolve ClaWHub suspicious flag — add openclaw binary requirement metadata, fix gateway restart command, add user confirmation prompts, and disclose API key storage location

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: manifest
 description: Install and configure the Manifest observability plugin for OpenClaw agents. Use when the user wants to set up Manifest telemetry, connect an agent to Manifest, configure an API key or endpoint, troubleshoot plugin connection issues, or check if the Manifest plugin is running.
+metadata: {"openclaw":{"requires":{"bins":["openclaw"]}}}
 ---
 
 # Manifest Setup
@@ -11,11 +12,15 @@ Follow these steps **in order**. Do not skip ahead.
 
 Stop the gateway first to avoid hot-reload issues during configuration.
 
+Show the user the command below and ask for confirmation before running it.
+
 ```bash
 openclaw gateway stop
 ```
 
 ## Step 2 — Install the plugin
+
+Show the user the command below and ask for confirmation before running it.
 
 ```bash
 openclaw plugins install manifest
@@ -36,7 +41,11 @@ Ask the user:
 
 Wait for a key starting with `mnfst_`. If the key doesn't match, tell the user the format looks incorrect and ask them to try again.
 
+> **Note:** Your API key will be stored in `~/.openclaw/openclaw.json` under `plugins.entries.manifest.config.apiKey`. It persists on disk until you remove it.
+
 ## Step 4 — Configure the plugin
+
+Show the user the command below and ask for confirmation before running it.
 
 ```bash
 openclaw config set plugins.entries.manifest.config.apiKey "USER_API_KEY"
@@ -46,14 +55,18 @@ Replace `USER_API_KEY` with the actual key the user provided.
 
 Ask the user if they have a custom endpoint. If not, the default (`https://app.manifest.build/api/v1/otlp`) is used automatically. If they do:
 
+Show the user the command below and ask for confirmation before running it.
+
 ```bash
 openclaw config set plugins.entries.manifest.config.endpoint "USER_ENDPOINT"
 ```
 
 ## Step 5 — Start the gateway
 
+Show the user the command below and ask for confirmation before running it.
+
 ```bash
-openclaw gateway install
+openclaw gateway restart
 ```
 
 ## Step 6 — Verify


### PR DESCRIPTION
## Summary
- Add `metadata` frontmatter with `requires.bins: ["openclaw"]` so ClaWHub knows the skill depends on the OpenClaw CLI
- Fix Step 5 command from `openclaw gateway install` to `openclaw gateway restart`
- Add user confirmation prompts before every bash command execution
- Disclose API key storage location (`~/.openclaw/openclaw.json`) in Step 3

## Test plan
- [ ] Verify ClaWHub no longer flags the skill as suspicious after republish
- [ ] Confirm `openclaw gateway restart` is the correct command per plugin README
