### PR TITLE
fix: AgentGuard 404 in local mode, hide Settings, add rename API

### DIFF
--- a/.changeset/fix-agent-guard-local-mode.md
+++ b/.changeset/fix-agent-guard-local-mode.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: resolve AgentGuard 404 on page refresh in local mode, hide Settings tab in local mode, and add agent rename API endpoint

--- a/package-lock.json
+++ b/package-lock.json
@@ -13155,7 +13155,7 @@
     },
     "packages/manifest-server": {
       "name": "@mnfst/server",
-      "version": "5.4.2",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",
@@ -13220,7 +13220,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.8.0",
+      "version": "5.9.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -15,6 +15,7 @@ describe('AgentsController', () => {
   let mockRotateKey: jest.Mock;
   let mockConfigGet: jest.Mock;
   let mockDeleteAgent: jest.Mock;
+  let mockRenameAgent: jest.Mock;
 
   const origMode = process.env['MANIFEST_MODE'];
 
@@ -32,6 +33,7 @@ describe('AgentsController', () => {
     mockRotateKey = jest.fn().mockResolvedValue({ apiKey: 'mnfst_new_key_123' });
     mockConfigGet = jest.fn().mockReturnValue('');
     mockDeleteAgent = jest.fn().mockResolvedValue(undefined);
+    mockRenameAgent = jest.fn().mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       imports: [CacheModule.register()],
@@ -43,7 +45,7 @@ describe('AgentsController', () => {
         },
         {
           provide: AggregationService,
-          useValue: { deleteAgent: mockDeleteAgent },
+          useValue: { deleteAgent: mockDeleteAgent, renameAgent: mockRenameAgent },
         },
         {
           provide: ApiKeyGeneratorService,
@@ -105,6 +107,14 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ apiKey: 'mnfst_new_key_123' });
     expect(mockRotateKey).toHaveBeenCalledWith('u1', 'bot-1');
+  });
+
+  it('renames agent and returns success', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.renameAgent(user as never, 'bot-1', { name: 'bot-renamed' } as never);
+
+    expect(result).toEqual({ renamed: true, name: 'bot-renamed' });
+    expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed');
   });
 
   it('deletes agent and returns success', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, ForbiddenException, Get, Param, Post, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Delete, ForbiddenException, Get, Param, Patch, Post, UseInterceptors } from '@nestjs/common';
 import { CacheTTL } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
 import { readFileSync, existsSync } from 'fs';
@@ -10,6 +10,7 @@ import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
+import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
 
@@ -58,6 +59,16 @@ export class AgentsController {
   async rotateAgentKey(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
     const result = await this.apiKeyGenerator.rotateKey(user.id, agentName);
     return { apiKey: result.apiKey };
+  }
+
+  @Patch('agents/:agentName')
+  async renameAgent(
+    @CurrentUser() user: AuthUser,
+    @Param('agentName') agentName: string,
+    @Body() body: RenameAgentDto,
+  ) {
+    await this.aggregation.renameAgent(user.id, agentName, body.name);
+    return { renamed: true, name: body.name };
   }
 
   @Delete('agents/:agentName')

--- a/packages/backend/src/common/dto/rename-agent.dto.spec.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.spec.ts
@@ -1,0 +1,44 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { RenameAgentDto } from './rename-agent.dto';
+
+describe('RenameAgentDto', () => {
+  it('accepts valid agent names', async () => {
+    for (const name of ['my-agent', 'agent_1', 'TestBot', 'a']) {
+      const dto = plainToInstance(RenameAgentDto, { name });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('rejects empty name', async () => {
+    const dto = plainToInstance(RenameAgentDto, { name: '' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects missing name', async () => {
+    const dto = plainToInstance(RenameAgentDto, {});
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects names with spaces', async () => {
+    const dto = plainToInstance(RenameAgentDto, { name: 'has spaces' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects names with special characters', async () => {
+    const dto = plainToInstance(RenameAgentDto, { name: 'agent@home!' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects names longer than 100 characters', async () => {
+    const dto = plainToInstance(RenameAgentDto, { name: 'a'.repeat(101) });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/backend/src/common/dto/rename-agent.dto.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsNotEmpty, MinLength, MaxLength, Matches } from 'class-validator';
+
+export class RenameAgentDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(100)
+  @Matches(/^[a-zA-Z0-9_-]+$/, { message: 'Agent name must contain only letters, numbers, dashes, and underscores' })
+  name!: string;
+}

--- a/packages/backend/src/common/utils/crypto.util.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.spec.ts
@@ -1,0 +1,121 @@
+import { getEncryptionSecret, encrypt, decrypt, isEncrypted } from './crypto.util';
+
+jest.mock('../../common/constants/local-mode.constants', () => ({
+  getLocalAuthSecret: jest.fn(),
+}));
+
+describe('getEncryptionSecret', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env['MANIFEST_ENCRYPTION_KEY'];
+    delete process.env['BETTER_AUTH_SECRET'];
+    delete process.env['MANIFEST_MODE'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('returns MANIFEST_ENCRYPTION_KEY when it is >= 32 chars', () => {
+    const key = 'a'.repeat(32);
+    process.env['MANIFEST_ENCRYPTION_KEY'] = key;
+    expect(getEncryptionSecret()).toBe(key);
+  });
+
+  it('returns BETTER_AUTH_SECRET when MANIFEST_ENCRYPTION_KEY is not set and secret is >= 32 chars', () => {
+    const secret = 'b'.repeat(64);
+    process.env['BETTER_AUTH_SECRET'] = secret;
+    expect(getEncryptionSecret()).toBe(secret);
+  });
+
+  it('prefers MANIFEST_ENCRYPTION_KEY over BETTER_AUTH_SECRET', () => {
+    const encKey = 'e'.repeat(32);
+    const authSecret = 'a'.repeat(64);
+    process.env['MANIFEST_ENCRYPTION_KEY'] = encKey;
+    process.env['BETTER_AUTH_SECRET'] = authSecret;
+    expect(getEncryptionSecret()).toBe(encKey);
+  });
+
+  it('falls through to local mode when key is too short', () => {
+    process.env['BETTER_AUTH_SECRET'] = 'short';
+    process.env['MANIFEST_MODE'] = 'local';
+    const mockSecret = 'local-secret-' + 'x'.repeat(32);
+    const { getLocalAuthSecret } = require('../../common/constants/local-mode.constants');
+    (getLocalAuthSecret as jest.Mock).mockReturnValue(mockSecret);
+    expect(getEncryptionSecret()).toBe(mockSecret);
+  });
+
+  it('calls getLocalAuthSecret in local mode when no env key is set', () => {
+    process.env['MANIFEST_MODE'] = 'local';
+    const mockSecret = 'local-fallback-' + 'y'.repeat(32);
+    const { getLocalAuthSecret } = require('../../common/constants/local-mode.constants');
+    (getLocalAuthSecret as jest.Mock).mockReturnValue(mockSecret);
+    expect(getEncryptionSecret()).toBe(mockSecret);
+  });
+
+  it('throws when no key is set and not in local mode', () => {
+    expect(() => getEncryptionSecret()).toThrow(
+      'Encryption secret required. Set MANIFEST_ENCRYPTION_KEY or BETTER_AUTH_SECRET (>=32 chars).',
+    );
+  });
+
+  it('throws when key exists but is shorter than 32 chars and not in local mode', () => {
+    process.env['BETTER_AUTH_SECRET'] = 'only-31-chars-long-xxxxxxxxxx!';
+    expect(() => getEncryptionSecret()).toThrow(
+      'Encryption secret required.',
+    );
+  });
+});
+
+describe('encrypt / decrypt', () => {
+  const secret = 'test-secret-that-is-long-enough-for-scrypt';
+
+  it('round-trips plaintext', () => {
+    const plaintext = 'hello world';
+    const ciphertext = encrypt(plaintext, secret);
+    expect(decrypt(ciphertext, secret)).toBe(plaintext);
+  });
+
+  it('produces different ciphertext each call (random salt/iv)', () => {
+    const plaintext = 'deterministic?';
+    const a = encrypt(plaintext, secret);
+    const b = encrypt(plaintext, secret);
+    expect(a).not.toBe(b);
+  });
+
+  it('decrypt throws on malformed ciphertext', () => {
+    expect(() => decrypt('not:valid', secret)).toThrow('Invalid ciphertext format');
+  });
+
+  it('decrypt throws on tampered ciphertext', () => {
+    const ciphertext = encrypt('secret data', secret);
+    const parts = ciphertext.split(':');
+    // Flip a character in the encrypted portion
+    parts[3] = 'AAAA' + parts[3].slice(4);
+    expect(() => decrypt(parts.join(':'), secret)).toThrow();
+  });
+});
+
+describe('isEncrypted', () => {
+  const secret = 'test-secret-that-is-long-enough-for-scrypt';
+
+  it('returns true for a valid encrypted string', () => {
+    const ciphertext = encrypt('test', secret);
+    expect(isEncrypted(ciphertext)).toBe(true);
+  });
+
+  it('returns false for plain text', () => {
+    expect(isEncrypted('just-a-plain-string')).toBe(false);
+  });
+
+  it('returns false for wrong number of parts', () => {
+    expect(isEncrypted('a:b:c')).toBe(false);
+  });
+
+  it('returns false when parts are not valid base64', () => {
+    expect(isEncrypted('not!base64:not!base64:not!base64:not!base64')).toBe(false);
+  });
+});

--- a/packages/backend/src/common/utils/crypto.util.ts
+++ b/packages/backend/src/common/utils/crypto.util.ts
@@ -18,12 +18,19 @@ export function getEncryptionSecret(): string {
   const key =
     process.env['MANIFEST_ENCRYPTION_KEY'] ||
     process.env['BETTER_AUTH_SECRET'];
-  if (!key || key.length < 32) {
-    throw new Error(
-      'Encryption secret required. Set MANIFEST_ENCRYPTION_KEY or BETTER_AUTH_SECRET (>=32 chars).',
-    );
+  if (key && key.length >= 32) {
+    return key;
   }
-  return key;
+
+  // Local mode: use persistent local auth secret
+  if (process.env['MANIFEST_MODE'] === 'local') {
+    const { getLocalAuthSecret } = require('../../common/constants/local-mode.constants');
+    return getLocalAuthSecret();
+  }
+
+  throw new Error(
+    'Encryption secret required. Set MANIFEST_ENCRYPTION_KEY or BETTER_AUTH_SECRET (>=32 chars).',
+  );
 }
 
 export function encrypt(plaintext: string, secret: string): string {

--- a/packages/backend/src/routing/routing.controller.spec.ts
+++ b/packages/backend/src/routing/routing.controller.spec.ts
@@ -20,6 +20,7 @@ describe('RoutingController', () => {
       setOverride: jest.fn().mockResolvedValue({}),
       clearOverride: jest.fn().mockResolvedValue(undefined),
       resetAllOverrides: jest.fn().mockResolvedValue(undefined),
+      getKeyPrefix: jest.fn().mockReturnValue(null),
     };
     mockPricingCache = {
       getAll: jest.fn().mockReturnValue([]),
@@ -38,12 +39,13 @@ describe('RoutingController', () => {
       mockRoutingService.getProviders.mockResolvedValue([
         { id: 'p1', provider: 'openai', is_active: true, connected_at: '2025-01-01', api_key_encrypted: 'enc' },
       ]);
+      mockRoutingService.getKeyPrefix.mockReturnValue('sk-proj-');
 
       const result = await controller.getProviders(mockUser);
 
       expect(mockRoutingService.getProviders).toHaveBeenCalledWith('user-1');
       expect(result).toEqual([
-        { id: 'p1', provider: 'openai', is_active: true, has_api_key: true, connected_at: '2025-01-01' },
+        { id: 'p1', provider: 'openai', is_active: true, has_api_key: true, key_prefix: 'sk-proj-', connected_at: '2025-01-01' },
       ]);
     });
 
@@ -51,12 +53,14 @@ describe('RoutingController', () => {
       mockRoutingService.getProviders.mockResolvedValue([
         { id: 'p1', provider: 'openai', is_active: true, connected_at: '2025-01-01', api_key_encrypted: 'secret', user_id: 'u1' },
       ]);
+      mockRoutingService.getKeyPrefix.mockReturnValue('sk-proj-');
 
       const result = await controller.getProviders(mockUser);
 
       expect(result[0]).not.toHaveProperty('api_key_encrypted');
       expect(result[0]).not.toHaveProperty('user_id');
       expect(result[0]).toHaveProperty('has_api_key', true);
+      expect(result[0]).toHaveProperty('key_prefix', 'sk-proj-');
     });
 
     it('should return empty array when no providers', async () => {

--- a/packages/backend/src/routing/routing.controller.ts
+++ b/packages/backend/src/routing/routing.controller.ts
@@ -36,6 +36,7 @@ export class RoutingController {
       provider: p.provider,
       is_active: p.is_active,
       has_api_key: !!p.api_key_encrypted,
+      key_prefix: this.routingService.getKeyPrefix(p.api_key_encrypted),
       connected_at: p.connected_at,
     }));
   }

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -544,6 +544,55 @@ describe('RoutingService', () => {
     });
   });
 
+  /* ── getKeyPrefix ── */
+
+  describe('getKeyPrefix', () => {
+    it('should return null when encryptedKey is null', () => {
+      const result = service.getKeyPrefix(null);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when encryptedKey is empty string', () => {
+      const result = service.getKeyPrefix('');
+      expect(result).toBeNull();
+    });
+
+    it('should return first 8 chars of decrypted key', async () => {
+      const { encrypt, getEncryptionSecret } = await import(
+        '../common/utils/crypto.util'
+      );
+      const secret = getEncryptionSecret();
+      const encrypted = encrypt('sk-abcdefghijklmnop', secret);
+
+      const result = service.getKeyPrefix(encrypted);
+      expect(result).toBe('sk-abcde');
+    });
+
+    it('should return custom length prefix', async () => {
+      const { encrypt, getEncryptionSecret } = await import(
+        '../common/utils/crypto.util'
+      );
+      const secret = getEncryptionSecret();
+      const encrypted = encrypt('sk-abcdefghijklmnop', secret);
+
+      const result = service.getKeyPrefix(encrypted, 4);
+      expect(result).toBe('sk-a');
+    });
+
+    it('should return null and log warning when decrypt throws', () => {
+      const warnSpy = jest.spyOn(
+        (service as any).logger,
+        'warn',
+      );
+
+      const result = service.getKeyPrefix('invalid:encrypted:data');
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to decrypt API key for prefix extraction',
+      );
+    });
+  });
+
   /* ── getProviderApiKey ── */
 
   describe('getProviderApiKey', () => {

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -271,6 +271,19 @@ export class RoutingService {
     }
   }
 
+  /* ── Key prefix extraction ── */
+
+  getKeyPrefix(encryptedKey: string | null, length = 8): string | null {
+    if (!encryptedKey) return null;
+    try {
+      const decrypted = decrypt(encryptedKey, getEncryptionSecret());
+      return decrypted.substring(0, length);
+    } catch {
+      this.logger.warn('Failed to decrypt API key for prefix extraction');
+      return null;
+    }
+  }
+
   /* ── Runtime helper ── */
 
   async getEffectiveModel(

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -1,7 +1,9 @@
-import { useParams, useNavigate, useLocation } from "@solidjs/router";
-import { createResource, createEffect, Show, type ParentComponent } from "solid-js";
+import { useParams, useLocation } from "@solidjs/router";
+import { createResource, createMemo, Show, type ParentComponent } from "solid-js";
 import ErrorState from "./ErrorState.jsx";
+import NotFound from "../pages/NotFound.jsx";
 import { getAgents } from "../services/api.js";
+import { isLocalMode, checkLocalMode } from "../services/local-mode.js";
 
 interface Agent {
   agent_name: string;
@@ -13,30 +15,46 @@ interface AgentsData {
 
 const AgentGuard: ParentComponent = (props) => {
   const params = useParams<{ agentName: string }>();
-  const navigate = useNavigate();
   const location = useLocation<{ newAgent?: boolean }>();
-  const [data, { refetch }] = createResource(() => getAgents() as Promise<AgentsData>);
 
-  createEffect(() => {
-    if (location.state?.newAgent) return;
+  // Wait for the mode check to resolve before deciding what to do.
+  // checkLocalMode() is already called by AuthGuard, so this just awaits
+  // the existing promise (no extra network request).
+  const [mode] = createResource(() => checkLocalMode());
+
+  const [data, { refetch }] = createResource(
+    // Only fetch agents in cloud mode (mode resolved and not local)
+    () => mode() === false ? true : false,
+    () => getAgents() as Promise<AgentsData>,
+  );
+
+  const agentExists = createMemo(() => {
+    // Local mode: agent is guaranteed to exist (bootstrapped by LocalBootstrapService)
+    if (isLocalMode()) return true;
+    if (location.state?.newAgent) return true;
     const list = data()?.agents;
-    if (!list) return;
-    const exists = list.some(
+    if (!list) return true; // still loading or no data yet — don't block
+    return list.some(
       (a) => a.agent_name === decodeURIComponent(params.agentName),
     );
-    if (!exists) {
-      navigate("/404", { replace: true });
-    }
   });
 
   return (
-    <Show when={!data.loading} fallback={null}>
-      <Show when={!data.error} fallback={
-        <ErrorState error={data.error} onRetry={refetch} />
-      }>
-        <Show when={data()?.agents}>
-          {props.children}
+    <Show when={mode() !== undefined} fallback={null}>
+      <Show when={isLocalMode()} fallback={
+        <Show when={!data.loading} fallback={null}>
+          <Show when={!data.error} fallback={
+            <ErrorState error={data.error} onRetry={refetch} />
+          }>
+            <Show when={data()?.agents}>
+              <Show when={agentExists()} fallback={<NotFound />}>
+                {props.children}
+              </Show>
+            </Show>
+          </Show>
         </Show>
+      }>
+        {props.children}
       </Show>
     </Show>
   );

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -295,10 +295,6 @@ const EmailProviderModal: Component<Props> = (props) => {
                   type="button"
                   onClick={() => { setEditingKey(true); setApiKey(""); }}
                 >
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-                  </svg>
                   Change
                 </button>
               </div>

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Show, createSignal, onCleanup, onMount, type Component } from "solid-js
 import { useAgentName } from "../services/routing.js";
 import { authClient } from "../services/auth-client.js";
 import { checkLocalMode, isLocalMode } from "../services/local-mode.js";
+import { displayName } from "../services/display-name.js";
 
 const GITHUB_REPO = "mnfst/manifest";
 const STAR_DISMISSED_KEY = "github-star-dismissed";
@@ -43,10 +44,16 @@ const Header: Component = () => {
   };
 
   const user = () => session()?.data?.user;
+  const effectiveName = () => {
+    if (isLocalMode()) {
+      const custom = displayName();
+      if (custom) return custom;
+    }
+    return user()?.name ?? "User";
+  };
   const initials = () => {
-    const u = user();
-    if (!u?.name) return "?";
-    return u.name.charAt(0).toUpperCase();
+    const name = effectiveName();
+    return name.charAt(0).toUpperCase();
   };
 
   const handleLogout = async () => {
@@ -129,8 +136,10 @@ const Header: Component = () => {
           <Show when={menuOpen()}>
             <div class="header__dropdown" role="menu">
               <div class="header__dropdown-header">
-                <span class="header__dropdown-name">{user()?.name ?? "User"}</span>
-                <span class="header__dropdown-email">{user()?.email ?? ""}</span>
+                <span class="header__dropdown-name">{effectiveName()}</span>
+                <Show when={!isLocalMode()}>
+                  <span class="header__dropdown-email">{user()?.email ?? ""}</span>
+                </Show>
               </div>
               <div class="header__dropdown-divider" />
               <A href="/account" class="header__dropdown-item" role="menuitem" onClick={() => setMenuOpen(false)}>

--- a/packages/frontend/src/components/NotificationRuleModal.tsx
+++ b/packages/frontend/src/components/NotificationRuleModal.tsx
@@ -112,7 +112,7 @@ const NotificationRuleModal: Component<Props> = (props) => {
             autofocus
           />
 
-          <p style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); margin: 4px 0 12px;">
+          <p class="modal-card__field-hint">
             {metricType() === "cost"
               ? "Set a dollar amount. You'll be notified when costs exceed this."
               : "A typical conversation uses 1,000\u20135,000 tokens."}

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -311,14 +311,14 @@ const ProviderSelectModal: Component<Props> = (props) => {
                           aria-label="Current API key (masked)"
                         />
                         <button
-                          class="btn btn--primary btn--sm"
+                          class="btn btn--outline btn--sm"
                           onClick={() => {
                             setEditing(true);
                             setKeyInput("");
                             setValidationError(null);
                           }}
                         >
-                          Update Key
+                          Change
                         </button>
                         <button
                           class="provider-detail__disconnect-icon"

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -1,5 +1,5 @@
 import { createSignal, For, Show, type Component } from "solid-js";
-import { PROVIDERS } from "../services/providers.js";
+import { PROVIDERS, validateApiKey } from "../services/providers.js";
 import { providerIcon } from "./ProviderIcon.js";
 import { connectProvider, disconnectProvider, type RoutingProvider } from "../services/api.js";
 import { toast } from "../services/toast-store.js";
@@ -11,52 +11,102 @@ interface Props {
 }
 
 const ProviderSelectModal: Component<Props> = (props) => {
-  const [busy, setBusy] = createSignal<string | null>(null);
-  const [expanded, setExpanded] = createSignal<string | null>(null);
-  const [keyInputs, setKeyInputs] = createSignal<Record<string, string>>({});
+  const [selectedProvider, setSelectedProvider] = createSignal<string | null>(null);
+  const [busy, setBusy] = createSignal(false);
+  const [keyInput, setKeyInput] = createSignal("");
+  const [editing, setEditing] = createSignal(false);
+  const [validationError, setValidationError] = createSignal<string | null>(null);
+  const [direction, setDirection] = createSignal<"forward" | "back" | null>(null);
 
-  const getProvider = (provId: string) =>
+  const getProviderData = (provId: string) =>
     props.providers.find((p) => p.provider === provId);
 
   const isConnected = (provId: string): boolean => {
-    const p = getProvider(provId);
+    const p = getProviderData(provId);
     return !!p && p.is_active && p.has_api_key;
   };
 
-  const toggleExpand = (provId: string) => {
-    setExpanded((cur) => (cur === provId ? null : provId));
+  const isOllamaConnected = (provId: string): boolean => {
+    const p = getProviderData(provId);
+    return !!p && p.is_active && provId === "ollama";
   };
 
-  const getKeyInput = (provId: string) => keyInputs()[provId] ?? "";
+  const getKeyPrefixDisplay = (provId: string): string => {
+    const p = getProviderData(provId);
+    if (p?.key_prefix) return `${p.key_prefix}${"•".repeat(8)}`;
+    return "••••••••••••";
+  };
 
-  const setKeyInput = (provId: string, value: string) => {
-    setKeyInputs((prev) => ({ ...prev, [provId]: value }));
+  const openDetail = (provId: string) => {
+    setDirection("forward");
+    setSelectedProvider(provId);
+    setKeyInput("");
+    setEditing(false);
+    setValidationError(null);
+  };
+
+  const goBack = () => {
+    setDirection("back");
+    setSelectedProvider(null);
+    setKeyInput("");
+    setEditing(false);
+    setValidationError(null);
   };
 
   const handleConnect = async (provId: string) => {
-    const key = getKeyInput(provId);
-    const isOllama = provId === "ollama";
-    if (!isOllama && !key.trim()) return;
+    const provDef = PROVIDERS.find((p) => p.id === provId)!;
+    const isOllama = provDef.noKeyRequired;
 
-    setBusy(provId);
+    if (!isOllama) {
+      const result = validateApiKey(provDef, keyInput());
+      if (!result.valid) {
+        setValidationError(result.error!);
+        return;
+      }
+    }
+
+    setBusy(true);
     try {
       await connectProvider({
         provider: provId,
-        apiKey: isOllama ? undefined : key.trim(),
+        apiKey: isOllama ? undefined : keyInput().trim(),
       });
-      toast.success(`${provId} connected`);
-      setKeyInput(provId, "");
-      setExpanded(null);
+      toast.success(`${provDef.name} connected`);
+      goBack();
       props.onUpdate();
     } catch {
       // error toast from fetchMutate
     } finally {
-      setBusy(null);
+      setBusy(false);
+    }
+  };
+
+  const handleUpdateKey = async (provId: string) => {
+    const provDef = PROVIDERS.find((p) => p.id === provId)!;
+    const result = validateApiKey(provDef, keyInput());
+    if (!result.valid) {
+      setValidationError(result.error!);
+      return;
+    }
+
+    setBusy(true);
+    try {
+      await connectProvider({
+        provider: provId,
+        apiKey: keyInput().trim(),
+      });
+      toast.success(`${provDef.name} key updated`);
+      goBack();
+      props.onUpdate();
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      setBusy(false);
     }
   };
 
   const handleDisconnect = async (provId: string) => {
-    setBusy(provId);
+    setBusy(true);
     try {
       const result = await disconnectProvider(provId);
       if (result?.notifications?.length) {
@@ -64,12 +114,12 @@ const ProviderSelectModal: Component<Props> = (props) => {
           toast.error(msg);
         }
       }
-      setExpanded(null);
+      goBack();
       props.onUpdate();
     } catch {
       // error toast from fetchMutate
     } finally {
-      setBusy(null);
+      setBusy(false);
     }
   };
 
@@ -86,36 +136,35 @@ const ProviderSelectModal: Component<Props> = (props) => {
         aria-modal="true"
         aria-labelledby="provider-modal-title"
       >
-        <div class="routing-modal__header">
-          <div>
-            <div class="routing-modal__title" id="provider-modal-title">Connect providers</div>
-            <div class="routing-modal__subtitle">
-              Add your API keys to enable routing through each provider
+        {/* ── List View ── */}
+        <Show when={selectedProvider() === null}>
+          <div
+            class="provider-modal__view"
+            classList={{ "provider-modal__view--from-left": direction() === "back" }}
+          >
+          <div class="routing-modal__header">
+            <div>
+              <div class="routing-modal__title" id="provider-modal-title">Connect providers</div>
+              <div class="routing-modal__subtitle">
+                Add your API keys to enable routing through each provider
+              </div>
             </div>
+            <button class="modal__close" onClick={props.onClose} aria-label="Close">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+              </svg>
+            </button>
           </div>
-          <button class="modal__close" onClick={props.onClose} aria-label="Close">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M18 6 6 18" /><path d="m6 6 12 12" />
-            </svg>
-          </button>
-        </div>
 
-        <div class="provider-modal__list">
-          <For each={PROVIDERS}>
-            {(prov) => {
-              const connected = () => isConnected(prov.id);
-              const isExpanded = () => expanded() === prov.id;
-              const isBusy = () => busy() === prov.id;
-              const isOllama = prov.id === "ollama";
+          <div class="provider-modal__list">
+            <For each={PROVIDERS}>
+              {(prov) => {
+                const connected = () => isConnected(prov.id) || isOllamaConnected(prov.id);
 
-              return (
-                <div>
+                return (
                   <button
                     class="provider-toggle"
-                    classList={{ "provider-toggle--active": connected() }}
-                    onClick={() => toggleExpand(prov.id)}
-                    disabled={isBusy()}
-                    aria-expanded={isExpanded()}
+                    onClick={() => openDetail(prov.id)}
                   >
                     <span class="provider-toggle__icon">
                       {providerIcon(prov.id, 20) ?? (
@@ -129,80 +178,194 @@ const ProviderSelectModal: Component<Props> = (props) => {
                     </span>
                     <span class="provider-toggle__info">
                       <span class="provider-toggle__name">{prov.name}</span>
-                      <span class="provider-toggle__subtitle">{prov.subtitle}</span>
                     </span>
                     <span
-                      class="provider-toggle__badge"
-                      classList={{ "provider-toggle__badge--connected": connected() }}
+                      class="provider-toggle__switch"
+                      classList={{ "provider-toggle__switch--on": connected() }}
                     >
-                      {connected() ? "Connected" : "Not connected"}
+                      <span class="provider-toggle__switch-thumb" />
                     </span>
                   </button>
+                );
+              }}
+            </For>
+          </div>
 
-                  <Show when={isExpanded()}>
-                    <div class="provider-toggle__expand">
-                      <Show when={!isOllama}>
-                        <div class="provider-toggle__key-row">
-                          <input
-                            class="provider-toggle__key-input"
-                            type="password"
-                            placeholder={connected() ? "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022" : `Enter ${prov.name} API key`}
-                            aria-label={`${prov.name} API key`}
-                            value={getKeyInput(prov.id)}
-                            onInput={(e) => setKeyInput(prov.id, e.currentTarget.value)}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter") handleConnect(prov.id);
-                            }}
-                          />
-                          <button
-                            class="btn btn--primary btn--sm"
-                            disabled={isBusy() || !getKeyInput(prov.id).trim()}
-                            onClick={() => handleConnect(prov.id)}
-                          >
-                            {connected() ? "Update key" : "Connect"}
-                          </button>
-                        </div>
-                      </Show>
+          <div class="provider-modal__footer">
+            <button class="btn btn--primary" onClick={props.onClose}>Done</button>
+          </div>
+          </div>
+        </Show>
 
-                      <Show when={isOllama}>
-                        <div class="provider-toggle__key-row">
-                          <span style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
-                            No API key required for local models
-                          </span>
-                          <Show when={!connected()}>
-                            <button
-                              class="btn btn--primary btn--sm"
-                              disabled={isBusy()}
-                              onClick={() => handleConnect(prov.id)}
-                            >
-                              Connect
-                            </button>
-                          </Show>
-                        </div>
-                      </Show>
+        {/* ── Detail View ── */}
+        <Show when={selectedProvider() !== null}>
+          <div class="provider-modal__view provider-modal__view--from-right">
+          {(() => {
+            const provId = selectedProvider()!;
+            const provDef = PROVIDERS.find((p) => p.id === provId)!;
+            const connected = () => isConnected(provId) || isOllamaConnected(provId);
+            const isOllama = provDef.noKeyRequired;
 
-                      <Show when={connected()}>
-                        <div class="provider-toggle__key-row" style="margin-top: 8px;">
-                          <button
-                            class="btn btn--outline btn--sm provider-toggle__disconnect-btn"
-                            disabled={isBusy()}
-                            onClick={() => handleDisconnect(prov.id)}
-                          >
-                            Disconnect
-                          </button>
-                        </div>
-                      </Show>
+            return (
+              <div class="provider-detail">
+                {/* Back arrow */}
+                <button class="provider-detail__back" onClick={goBack} aria-label="Back to providers">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="m15 18-6-6 6-6" />
+                  </svg>
+                </button>
+
+                {/* Title */}
+                <div class="routing-modal__header" style="border: none; padding: 0; margin-bottom: 20px;">
+                  <div>
+                    <div class="routing-modal__title">Connect providers</div>
+                    <div class="routing-modal__subtitle">
+                      Add your API keys to enable routing through each provider
                     </div>
-                  </Show>
+                  </div>
                 </div>
-              );
-            }}
-          </For>
-        </div>
 
-        <div class="provider-modal__footer">
-          <button class="btn btn--primary" onClick={props.onClose}>Done</button>
-        </div>
+                {/* Provider row */}
+                <div class="provider-detail__header">
+                  <span class="provider-detail__icon">
+                    {providerIcon(provId, 28) ?? (
+                      <span
+                        class="provider-card__logo-letter"
+                        style={{ background: provDef.color, width: "32px", height: "32px", "font-size": "13px" }}
+                      >
+                        {provDef.initial}
+                      </span>
+                    )}
+                  </span>
+                  <div class="provider-detail__title-group">
+                    <div class="provider-detail__name">{provDef.name}</div>
+                  </div>
+                </div>
+
+                {/* Ollama (no key) */}
+                <Show when={isOllama}>
+                  <div class="provider-detail__field">
+                    <span class="provider-detail__no-key">No API key required for local models</span>
+                  </div>
+                  <Show when={!connected()}>
+                    <button
+                      class="btn btn--primary provider-detail__action"
+                      disabled={busy()}
+                      onClick={() => handleConnect(provId)}
+                    >
+                      Connect
+                    </button>
+                  </Show>
+                  <Show when={connected()}>
+                    <button
+                      class="btn btn--outline provider-detail__action provider-detail__disconnect"
+                      disabled={busy()}
+                      onClick={() => handleDisconnect(provId)}
+                    >
+                      Disconnect
+                    </button>
+                  </Show>
+                </Show>
+
+                {/* Non-Ollama: not yet connected */}
+                <Show when={!isOllama && !connected()}>
+                  <div class="provider-detail__field">
+                    <label class="provider-detail__label">API Key</label>
+                    <input
+                      class="provider-detail__input"
+                      classList={{ "provider-detail__input--error": !!validationError() }}
+                      type="password"
+                      placeholder={provDef.keyPlaceholder}
+                      aria-label={`${provDef.name} API key`}
+                      value={keyInput()}
+                      onInput={(e) => {
+                        setKeyInput(e.currentTarget.value);
+                        setValidationError(null);
+                      }}
+                      onKeyDown={(e) => { if (e.key === "Enter") handleConnect(provId); }}
+                    />
+                    <Show when={validationError()}>
+                      <div class="provider-detail__error">{validationError()}</div>
+                    </Show>
+                  </div>
+                  <button
+                    class="btn btn--primary provider-detail__action"
+                    disabled={busy() || !keyInput().trim()}
+                    onClick={() => handleConnect(provId)}
+                  >
+                    Connect
+                  </button>
+                </Show>
+
+                {/* Non-Ollama: already connected */}
+                <Show when={!isOllama && connected()}>
+                  <div class="provider-detail__field">
+                    <label class="provider-detail__label">API Key</label>
+                    <Show when={!editing()}>
+                      <div class="provider-detail__key-row">
+                        <input
+                          class="provider-detail__input provider-detail__input--disabled"
+                          type="text"
+                          value={getKeyPrefixDisplay(provId)}
+                          disabled
+                          aria-label="Current API key (masked)"
+                        />
+                        <button
+                          class="btn btn--primary btn--sm"
+                          onClick={() => {
+                            setEditing(true);
+                            setKeyInput("");
+                            setValidationError(null);
+                          }}
+                        >
+                          Update Key
+                        </button>
+                        <button
+                          class="provider-detail__disconnect-icon"
+                          disabled={busy()}
+                          onClick={() => handleDisconnect(provId)}
+                          aria-label="Disconnect provider"
+                          title="Disconnect"
+                        >
+                          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M3 6h18" /><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" /><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                          </svg>
+                        </button>
+                      </div>
+                    </Show>
+                    <Show when={editing()}>
+                      <input
+                        class="provider-detail__input"
+                        classList={{ "provider-detail__input--error": !!validationError() }}
+                        type="password"
+                        placeholder={provDef.keyPlaceholder}
+                        aria-label={`New ${provDef.name} API key`}
+                        value={keyInput()}
+                        onInput={(e) => {
+                          setKeyInput(e.currentTarget.value);
+                          setValidationError(null);
+                        }}
+                        onKeyDown={(e) => { if (e.key === "Enter") handleUpdateKey(provId); }}
+                      />
+                      <Show when={validationError()}>
+                        <div class="provider-detail__error">{validationError()}</div>
+                      </Show>
+                      <button
+                        class="btn btn--primary provider-detail__action"
+                        disabled={busy() || !keyInput().trim()}
+                        onClick={() => handleUpdateKey(provId)}
+                        style="margin-top: 12px;"
+                      >
+                        Save
+                      </button>
+                    </Show>
+                  </div>
+                </Show>
+              </div>
+            );
+          })()}
+          </div>
+        </Show>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/RoutingInstructionModal.tsx
+++ b/packages/frontend/src/components/RoutingInstructionModal.tsx
@@ -24,11 +24,6 @@ const RoutingInstructionModal: Component<Props> = (props) => {
     `openclaw config set agents.defaults.model.primary ${selectedModel()}\nopenclaw gateway restart`;
   const command = () => (isEnable() ? ENABLE_CMD : disableCmd());
 
-  const description = () =>
-    isEnable()
-      ? "Set manifest/auto as your default model so requests are routed through Manifest:"
-      : "Pick the model to switch back to, then run the command:";
-
   return (
     <Show when={props.open}>
       <div
@@ -57,11 +52,17 @@ const RoutingInstructionModal: Component<Props> = (props) => {
             </button>
           </div>
 
-          <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-            {description()}
-          </p>
+          <Show when={isEnable()}>
+            <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
+              Run the following command in your agent's terminal to route all requests through Manifest:
+            </p>
+          </Show>
 
           <Show when={!isEnable()}>
+            <p style="margin: 0 0 14px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
+              1. Pick the model to switch back to.
+            </p>
+
             <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px;">
               {FALLBACK_MODELS.map((m) => (
                 <button
@@ -72,6 +73,10 @@ const RoutingInstructionModal: Component<Props> = (props) => {
                 </button>
               ))}
             </div>
+
+            <p style="margin: 0 0 14px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
+              2. Now run this command in your agent's terminal to restore direct model access:
+            </p>
           </Show>
 
           <div class="modal-terminal">

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -48,9 +48,11 @@ const Sidebar: Component = () => {
         </A>
 
         <div class="sidebar__section-label">MANAGE</div>
-        <A href={path("/settings")} class="sidebar__link" classList={{ active: isActive("/settings") }} aria-current={isActive("/settings") ? "page" : undefined}>
-          Settings
-        </A>
+        <Show when={!isLocalMode()}>
+          <A href={path("/settings")} class="sidebar__link" classList={{ active: isActive("/settings") }} aria-current={isActive("/settings") ? "page" : undefined}>
+            Settings
+          </A>
+        </Show>
         <Show when={isLocalMode()}>
           <A
             href={path("/routing")}

--- a/packages/frontend/src/pages/Account.tsx
+++ b/packages/frontend/src/pages/Account.tsx
@@ -3,12 +3,14 @@ import { useNavigate } from "@solidjs/router";
 import { Title, Meta } from "@solidjs/meta";
 import { authClient } from "../services/auth-client.js";
 import { checkLocalMode, isLocalMode } from "../services/local-mode.js";
+import { displayName, setDisplayName } from "../services/display-name.js";
 
 const Account: Component = () => {
   const navigate = useNavigate();
   const session = authClient.useSession();
   const [copied, setCopied] = createSignal(false);
   const [theme, setTheme] = createSignal<"light" | "dark" | "system">("system");
+  const [localName, setLocalName] = createSignal("");
 
   const userName = () => session()?.data?.user?.name ?? "";
   const userEmail = () => session()?.data?.user?.email ?? "";
@@ -16,6 +18,7 @@ const Account: Component = () => {
 
   onMount(() => {
     checkLocalMode();
+    setLocalName(displayName() || "Local User");
     const stored = localStorage.getItem("theme");
     if (stored === "dark" || stored === "light") {
       setTheme(stored);
@@ -103,6 +106,32 @@ const Account: Component = () => {
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                 )}
               </button>
+            </div>
+          </div>
+        </div>
+      </Show>
+
+      {/* Profile — local mode */}
+      <Show when={isLocalMode()}>
+        <h3 class="settings-section__title">Profile</h3>
+        <div class="settings-card">
+          <div class="settings-card__row">
+            <div class="settings-card__label">
+              <span class="settings-card__label-title">Display name</span>
+              <span class="settings-card__label-desc">Name shown throughout the dashboard.</span>
+            </div>
+            <div class="settings-card__control">
+              <label for="local-display-name" class="sr-only">Display name</label>
+              <input
+                class="settings-card__input"
+                type="text"
+                id="local-display-name"
+                value={localName()}
+                onInput={(e) => setLocalName(e.currentTarget.value)}
+                onBlur={() => setDisplayName(localName())}
+                onKeyDown={(e) => { if (e.key === "Enter") { setDisplayName(localName()); e.currentTarget.blur(); } }}
+                placeholder="Local User"
+              />
             </div>
           </div>
         </div>

--- a/packages/frontend/src/pages/Notifications.tsx
+++ b/packages/frontend/src/pages/Notifications.tsx
@@ -1,17 +1,11 @@
-import { Meta, Title } from "@solidjs/meta";
-import { useParams } from "@solidjs/router";
-import {
-  createResource,
-  createSignal,
-  For,
-  Show,
-  type Component,
-} from "solid-js";
-import EmailProviderModal from "../components/EmailProviderModal.jsx";
-import EmailProviderSetup from "../components/EmailProviderSetup.jsx";
-import ErrorState from "../components/ErrorState.jsx";
-import NotificationRuleModal from "../components/NotificationRuleModal.jsx";
-import ProviderBanner from "../components/ProviderBanner.jsx";
+import { Meta, Title } from '@solidjs/meta';
+import { useParams } from '@solidjs/router';
+import { createResource, createSignal, For, Show, type Component } from 'solid-js';
+import EmailProviderModal from '../components/EmailProviderModal.jsx';
+import EmailProviderSetup from '../components/EmailProviderSetup.jsx';
+import ErrorState from '../components/ErrorState.jsx';
+import NotificationRuleModal from '../components/NotificationRuleModal.jsx';
+import ProviderBanner from '../components/ProviderBanner.jsx';
 import {
   deleteNotificationRule,
   getEmailProvider,
@@ -19,17 +13,22 @@ import {
   removeEmailProvider,
   updateNotificationRule,
   type NotificationRule,
-} from "../services/api.js";
-import { formatMetricType } from "../services/formatters.js";
-import { toast } from "../services/toast-store.js";
+} from '../services/api.js';
+import { formatMetricType } from '../services/formatters.js';
+import { toast } from '../services/toast-store.js';
 
 function formatThreshold(rule: NotificationRule): string {
-  if (rule.metric_type === "cost") return `$${Number(rule.threshold).toFixed(2)}`;
+  if (rule.metric_type === 'cost') return `$${Number(rule.threshold).toFixed(2)}`;
   return Number(rule.threshold).toLocaleString();
 }
 
 function periodLabel(period: string): string {
-  const map: Record<string, string> = { hour: "Per hour", day: "Per day", week: "Per week", month: "Per month" };
+  const map: Record<string, string> = {
+    hour: 'Per hour',
+    day: 'Per day',
+    week: 'Per week',
+    month: 'Per month',
+  };
   return map[period] ?? period;
 }
 
@@ -51,7 +50,7 @@ const Notifications: Component = () => {
   );
 
   const hasProvider = () => !!emailProvider();
-  const hasRules = () => !!(rules()?.length);
+  const hasRules = () => !!rules()?.length;
 
   const openCreate = () => {
     setEditingRule(null);
@@ -67,7 +66,7 @@ const Notifications: Component = () => {
     try {
       const newActive = rule.is_active ? false : true;
       await updateNotificationRule(rule.id, { is_active: newActive });
-      toast.success(`Rule ${newActive ? "enabled" : "disabled"}`);
+      toast.success(`Rule ${newActive ? 'enabled' : 'disabled'}`);
       refetch();
     } catch {
       // error toast already shown by fetchMutate
@@ -77,7 +76,7 @@ const Notifications: Component = () => {
   const handleDelete = async (ruleId: string) => {
     try {
       await deleteNotificationRule(ruleId);
-      toast.success("Rule deleted");
+      toast.success('Rule deleted');
       refetch();
     } catch {
       // error toast already shown by fetchMutate
@@ -87,7 +86,7 @@ const Notifications: Component = () => {
   const handleRemoveProvider = async () => {
     try {
       await removeEmailProvider();
-      toast.success("Email provider removed");
+      toast.success('Email provider removed');
       refetchProvider();
     } catch {
       // error toast already shown by fetchMutate
@@ -97,16 +96,30 @@ const Notifications: Component = () => {
   return (
     <div class="container--sm">
       <Title>{agentName()} - Notifications | Manifest</Title>
-      <Meta name="description" content={`Set up alerts when ${agentName()} exceeds usage or cost limits.`} />
+      <Meta
+        name="description"
+        content={`Set up alerts when ${agentName()} exceeds usage or cost limits.`}
+      />
 
       <div class="page-header">
         <div>
           <h1>Notifications</h1>
-          <span class="breadcrumb">{agentName()} &rsaquo; Manage your alerts and email provider</span>
+          <span class="breadcrumb">
+            {agentName()} &rsaquo; Manage your alerts and email provider
+          </span>
         </div>
         <Show when={hasProvider()}>
           <button class="btn btn--primary" onClick={openCreate}>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
               <line x1="12" y1="5" x2="12" y2="19" />
               <line x1="5" y1="12" x2="19" y2="12" />
             </svg>
@@ -117,12 +130,7 @@ const Notifications: Component = () => {
 
       <Show when={!emailProvider.loading}>
         {/* Provider section */}
-        <Show
-          when={hasProvider()}
-          fallback={
-            <EmailProviderSetup onConfigured={refetchProvider} />
-          }
-        >
+        <Show when={hasProvider()} fallback={<EmailProviderSetup onConfigured={refetchProvider} />}>
           <ProviderBanner
             config={emailProvider()!}
             onEdit={() => setEditProviderOpen(true)}
@@ -131,7 +139,7 @@ const Notifications: Component = () => {
 
           <EmailProviderModal
             open={editProviderOpen()}
-            initialProvider={emailProvider()?.provider ?? "resend"}
+            initialProvider={emailProvider()?.provider ?? 'resend'}
             editMode={true}
             existingKeyPrefix={emailProvider()?.keyPrefix}
             existingDomain={emailProvider()?.domain}
@@ -143,36 +151,53 @@ const Notifications: Component = () => {
 
         {/* Rules section */}
         <Show when={!rules.loading}>
-          <Show when={!rules.error} fallback={
-            <ErrorState error={rules.error} onRetry={refetch} />
-          }>
-            <Show when={hasRules()} fallback={
-              <Show when={hasProvider()}>
-                <div class="empty-state">
-                  <div class="empty-state__title">No alerts configured</div>
-                  <p>Create your first alert to get notified when usage or costs exceed your limits.</p>
-                  <button class="btn btn--primary" style="margin-top: var(--gap-md);" onClick={openCreate}>
-                    Create alert
-                  </button>
-                </div>
-              </Show>
-            }>
+          <Show when={!rules.error} fallback={<ErrorState error={rules.error} onRetry={refetch} />}>
+            <Show
+              when={hasRules()}
+              fallback={
+                <Show when={hasProvider()}>
+                  <div class="empty-state">
+                    <div class="empty-state__title">No alerts configured</div>
+                    <p>
+                      Create your first alert to get notified when token usage or costs exceed your
+                      limits.
+                    </p>
+                    <button
+                      class="btn btn--primary"
+                      style="margin-top: var(--gap-md);"
+                      onClick={openCreate}
+                    >
+                      Create alert
+                    </button>
+                  </div>
+                </Show>
+              }
+            >
               {/* Warning when rules exist but no provider */}
               <Show when={!hasProvider()}>
                 <div class="notif-hint">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
                     <circle cx="12" cy="12" r="10" />
                     <line x1="12" y1="16" x2="12" y2="12" />
                     <line x1="12" y1="8" x2="12.01" y2="8" />
                   </svg>
                   <p>
-                    You must configure a valid email provider for your alerts to be delivered.
-                    The rules below are currently inactive.
+                    You must configure a valid email provider for your alerts to be delivered. The
+                    rules below are currently inactive.
                   </p>
                 </div>
               </Show>
 
-              <div class="settings-card" classList={{ "settings-card--disabled": !hasProvider() }}>
+              <div class="settings-card" classList={{ 'settings-card--disabled': !hasProvider() }}>
                 <table class="notif-table">
                   <thead>
                     <tr>
@@ -186,7 +211,11 @@ const Notifications: Component = () => {
                   <tbody>
                     <For each={rules()}>
                       {(rule) => (
-                        <tr class={rule.is_active && hasProvider() ? "" : "notif-table__row--disabled"}>
+                        <tr
+                          class={
+                            rule.is_active && hasProvider() ? '' : 'notif-table__row--disabled'
+                          }
+                        >
                           <td>{formatMetricType(rule.metric_type)}</td>
                           <td class="notif-table__mono">{formatThreshold(rule)}</td>
                           <td>{periodLabel(rule.period)}</td>
@@ -197,7 +226,16 @@ const Notifications: Component = () => {
                               onClick={() => openEdit(rule)}
                               aria-label="Edit rule"
                             >
-                              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                              <svg
+                                width="15"
+                                height="15"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                              >
                                 <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
                                 <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
                               </svg>
@@ -215,7 +253,16 @@ const Notifications: Component = () => {
                               onClick={() => handleDelete(rule.id)}
                               aria-label="Delete rule"
                             >
-                              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                              <svg
+                                width="15"
+                                height="15"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                              >
                                 <polyline points="3 6 5 6 21 6" />
                                 <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
                               </svg>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -68,7 +68,7 @@ const Settings: Component = () => {
     }
   };
 
-  const TABS = () => isLocalMode() ? ["General"] as const : ["General", "Integration"] as const;
+  const TABS = () => isLocalMode() ? [] as const : ["General", "Integration"] as const;
   type Tab = "General" | "Integration";
   const [tab, setTab] = createSignal<Tab>("General");
 
@@ -83,24 +83,24 @@ const Settings: Component = () => {
         </div>
       </div>
 
-      <div class="panel__tabs" style="margin-bottom: var(--gap-xl);">
-        <For each={TABS()}>
-          {(t) => (
-            <button
-              class="panel__tab"
-              classList={{ "panel__tab--active": tab() === t }}
-              onClick={() => setTab(t)}
-            >
-              {t}
-            </button>
-          )}
-        </For>
-      </div>
+      <Show when={TABS().length > 0}>
+        <div class="panel__tabs" style="margin-bottom: var(--gap-xl);">
+          <For each={TABS()}>
+            {(t) => (
+              <button
+                class="panel__tab"
+                classList={{ "panel__tab--active": tab() === t }}
+                onClick={() => setTab(t)}
+              >
+                {t}
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
 
       {/* -- Tab: General ----------------------------- */}
       <Show when={tab() === "General"}>
-        <h3 class="settings-section__title">Agent name</h3>
-
         <div class="settings-card">
           <div class="settings-card__row">
             <div class="settings-card__label">

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -261,6 +261,7 @@ export interface RoutingProvider {
   provider: string;
   is_active: boolean;
   has_api_key: boolean;
+  key_prefix?: string | null;
   connected_at: string;
 }
 

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -93,6 +93,14 @@ export function rotateAgentKey(agentName: string) {
   });
 }
 
+export function renameAgent(currentName: string, newName: string) {
+  return fetchMutate<{ renamed: boolean; name: string }>(`${BASE_URL}/agents/${encodeURIComponent(currentName)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: newName }),
+  });
+}
+
 export function deleteAgent(agentName: string) {
   return fetchMutate(`${BASE_URL}/agents/${encodeURIComponent(agentName)}`, {
     method: "DELETE",

--- a/packages/frontend/src/services/display-name.ts
+++ b/packages/frontend/src/services/display-name.ts
@@ -1,0 +1,21 @@
+import { createSignal } from "solid-js";
+
+const STORAGE_KEY = "manifest-display-name";
+
+const [name, setNameRaw] = createSignal(
+  localStorage.getItem(STORAGE_KEY) || "",
+);
+
+export function displayName(): string {
+  return name();
+}
+
+export function setDisplayName(value: string): void {
+  const trimmed = value.trim();
+  if (trimmed) {
+    localStorage.setItem(STORAGE_KEY, trimmed);
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+  setNameRaw(trimmed);
+}

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -7,6 +7,10 @@ export interface ProviderDef {
   initial: string;
   subtitle: string;
   models: { label: string; value: string }[];
+  keyPrefix: string;
+  minKeyLength: number;
+  keyPlaceholder: string;
+  noKeyRequired?: boolean;
 }
 
 export const PROVIDERS: ProviderDef[] = [
@@ -16,6 +20,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#10a37f",
     initial: "O",
     subtitle: "GPT-4o, GPT-4.1, o3, o4",
+    keyPrefix: "sk-",
+    minKeyLength: 50,
+    keyPlaceholder: "sk-...",
     models: [
       { label: "GPT-4o", value: "gpt-4o" },
       { label: "GPT-4o Mini", value: "gpt-4o-mini" },
@@ -40,6 +47,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#d97757",
     initial: "A",
     subtitle: "Claude Opus 4, Sonnet 4.5, Haiku",
+    keyPrefix: "sk-ant-",
+    minKeyLength: 50,
+    keyPlaceholder: "sk-ant-...",
     models: [
       { label: "Claude Opus 4.6", value: "claude-opus-4-6" },
       { label: "Claude Opus 4", value: "claude-opus-4" },
@@ -68,6 +78,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#4285f4",
     initial: "G",
     subtitle: "Gemini 2.5, Gemini 2.0 Flash",
+    keyPrefix: "AIza",
+    minKeyLength: 39,
+    keyPlaceholder: "AIza...",
     models: [
       { label: "Gemini 2.5 Pro", value: "gemini-2.5-pro" },
       { label: "Gemini 2.5 Pro (Preview)", value: "gemini-2.5-pro-preview-05-06" },
@@ -89,6 +102,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#4d6bfe",
     initial: "D",
     subtitle: "DeepSeek V3, R1",
+    keyPrefix: "sk-",
+    minKeyLength: 30,
+    keyPlaceholder: "sk-...",
     models: [
       { label: "DeepSeek V3", value: "deepseek-chat" },
       { label: "DeepSeek V3", value: "deepseek-v3" },
@@ -107,6 +123,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#f97316",
     initial: "M",
     subtitle: "Mistral Large, Codestral, Pixtral",
+    keyPrefix: "",
+    minKeyLength: 32,
+    keyPlaceholder: "API key",
     models: [
       { label: "Mistral Large", value: "mistral-large" },
       { label: "Mistral Large (25.01)", value: "mistral-large-latest" },
@@ -130,6 +149,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#555555",
     initial: "X",
     subtitle: "Grok 3, Grok 2",
+    keyPrefix: "xai-",
+    minKeyLength: 50,
+    keyPlaceholder: "xai-...",
     models: [
       { label: "Grok 3", value: "grok-3" },
       { label: "Grok 3 Mini", value: "grok-3-mini" },
@@ -145,6 +167,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#6236ff",
     initial: "Qw",
     subtitle: "Qwen3, Qwen2.5, QwQ",
+    keyPrefix: "sk-",
+    minKeyLength: 30,
+    keyPlaceholder: "sk-...",
     models: [
       { label: "Qwen3 235B A22B", value: "qwen3-235b-a22b" },
       { label: "Qwen3 32B", value: "qwen3-32b" },
@@ -167,20 +192,15 @@ export const PROVIDERS: ProviderDef[] = [
     color: "#1a1a2e",
     initial: "Ki",
     subtitle: "Kimi k2, Moonshot v1",
+    keyPrefix: "sk-",
+    minKeyLength: 30,
+    keyPlaceholder: "sk-...",
     models: [
       { label: "Kimi k2", value: "kimi-k2" },
       { label: "Moonshot v1 128K", value: "moonshot-v1-128k" },
       { label: "Moonshot v1 32K", value: "moonshot-v1-32k" },
       { label: "Moonshot v1 8K", value: "moonshot-v1-8k" },
     ],
-  },
-  {
-    id: "ollama",
-    name: "Ollama",
-    color: "#808080",
-    initial: "OL",
-    subtitle: "Run models locally",
-    models: [],
   },
 ];
 
@@ -224,6 +244,32 @@ export const STAGES: StageDef[] = [
 
 export function getProvider(id: string): ProviderDef | undefined {
   return PROVIDERS.find((p) => p.id === id);
+}
+
+export function validateApiKey(
+  provider: ProviderDef,
+  key: string,
+): { valid: boolean; error?: string } {
+  if (provider.noKeyRequired) return { valid: true };
+
+  const trimmed = key.trim();
+  if (!trimmed) return { valid: false, error: "API key is required" };
+
+  if (provider.keyPrefix && !trimmed.startsWith(provider.keyPrefix)) {
+    return {
+      valid: false,
+      error: `${provider.name} keys start with "${provider.keyPrefix}"`,
+    };
+  }
+
+  if (provider.minKeyLength && trimmed.length < provider.minKeyLength) {
+    return {
+      valid: false,
+      error: `Key is too short (minimum ${provider.minKeyLength} characters)`,
+    };
+  }
+
+  return { valid: true };
 }
 
 export function getModelLabel(providerId: string, modelValue: string): string {

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -137,7 +137,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--gap-xl);
-  padding: var(--gap-md) 0;
+  padding: var(--gap-lg);
   border-bottom: 1px solid hsl(var(--border));
 }
 

--- a/packages/frontend/src/styles/modals.css
+++ b/packages/frontend/src/styles/modals.css
@@ -161,7 +161,12 @@
   font-size: var(--font-size-sm);
   font-weight: 500;
   color: hsl(var(--foreground));
+  margin-top: var(--gap-md);
   margin-bottom: 6px;
+}
+
+.modal-card__field-label:first-of-type {
+  margin-top: 0;
 }
 
 .modal-card__input {
@@ -178,7 +183,7 @@
   transition:
     border-color var(--transition-fast),
     box-shadow var(--transition-fast);
-  margin-bottom: var(--gap-lg);
+  margin-bottom: 0;
   box-sizing: border-box;
 }
 
@@ -251,6 +256,7 @@
 .modal-card__footer {
   display: flex;
   justify-content: flex-end;
+  margin-top: var(--gap-xl);
 }
 
 .modal-card__footer .btn:disabled {

--- a/packages/frontend/src/styles/notifications.css
+++ b/packages/frontend/src/styles/notifications.css
@@ -118,7 +118,7 @@
 }
 
 .notification-toggle__slider::after {
-  content: "";
+  content: '';
   position: absolute;
   width: 16px;
   height: 16px;
@@ -176,7 +176,9 @@
   cursor: pointer;
   text-align: left;
   font-family: var(--font-family);
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 .provider-setup-card:hover {
@@ -224,7 +226,9 @@
   font-size: var(--font-size-sm);
   font-weight: 500;
   color: hsl(var(--muted-foreground));
-  transition: border-color var(--transition-fast), color var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .provider-modal-option:hover {
@@ -263,7 +267,7 @@
   font-size: var(--font-size-base);
   font-weight: 600;
   color: hsl(var(--foreground));
-  margin-bottom: var(--gap-md);
+  margin-bottom: 0;
 }
 
 .provider-card__actions {
@@ -328,7 +332,9 @@
   background: transparent;
   color: hsl(var(--muted-foreground));
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .provider-card__menu-btn:hover {

--- a/packages/frontend/src/styles/notifications.css
+++ b/packages/frontend/src/styles/notifications.css
@@ -140,7 +140,6 @@
 /* ── Modal Select ─────────────────────────────────── */
 .notification-modal__select {
   width: 100%;
-  margin-bottom: var(--gap-lg);
   height: 2.5rem;
 }
 
@@ -209,7 +208,6 @@
 .provider-modal-picker {
   display: flex;
   gap: var(--gap-sm);
-  margin-bottom: var(--gap-lg);
 }
 
 .provider-modal-option {
@@ -219,7 +217,7 @@
   gap: 8px;
   padding: 10px 14px;
   background: hsl(var(--background));
-  border: 2px solid hsl(var(--border));
+  border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   cursor: pointer;
   font-family: var(--font-family);
@@ -387,12 +385,11 @@
   display: flex;
   align-items: center;
   gap: var(--gap-sm);
-  padding: 0 14px;
+  padding: 0 1px 0 14px;
   height: 2.5rem;
   background: hsl(var(--muted) / 0.4);
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
-  margin-bottom: var(--gap-lg);
 }
 
 .masked-key__value {
@@ -418,7 +415,7 @@
 }
 
 .modal-card__field-error {
-  margin: 4px 0 var(--gap-lg);
+  margin: 4px 0 0;
   padding: 0;
   font-size: var(--font-size-xs);
   color: hsl(var(--destructive));
@@ -426,7 +423,7 @@
 }
 
 .modal-card__field-hint {
-  margin: 4px 0 var(--gap-md);
+  margin: 4px 0 0;
   padding: 0;
   font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -281,6 +281,13 @@
 
 .provider-detail__key-row .provider-detail__input {
   flex: 1;
+  min-width: 0;
+}
+
+.provider-detail__key-row .btn {
+  height: 2.25rem;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .provider-detail__action {
@@ -304,8 +311,8 @@
 }
 
 .provider-detail__disconnect-icon {
-  width: 32px;
-  height: 32px;
+  width: 2.25rem;
+  height: 2.25rem;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -15,7 +15,7 @@
 .provider-toggle {
   display: flex;
   align-items: center;
-  gap: var(--gap-md);
+  gap: var(--gap-sm);
   width: 100%;
   padding: 10px 24px;
   background: none;
@@ -47,6 +47,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  color: hsl(var(--foreground));
 }
 
 .provider-toggle__info {
@@ -157,6 +158,218 @@
 
 .provider-toggle__disconnect-btn:hover {
   background: hsl(var(--destructive) / 0.08);
+}
+
+/* ── Provider detail view (two-step modal) ────────── */
+.provider-detail {
+  padding: 20px 24px 24px;
+  overflow: hidden;
+}
+
+.provider-detail__header {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  margin-bottom: 20px;
+}
+
+.provider-detail__back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  margin-bottom: 12px;
+  transition: color var(--transition-fast);
+}
+
+.provider-detail__back:hover {
+  color: hsl(var(--foreground));
+}
+
+.provider-detail__icon {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: hsl(var(--foreground));
+}
+
+.provider-detail__title-group {
+  flex: 1;
+  min-width: 0;
+}
+
+.provider-detail__name {
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.provider-detail__subtitle {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+}
+
+.provider-detail__field {
+  margin-bottom: 16px;
+}
+
+.provider-detail__label {
+  display: block;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  margin-bottom: 6px;
+}
+
+.provider-detail__input {
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 12px;
+  background: hsl(var(--muted) / 0.4);
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family);
+  outline: none;
+  transition: border-color var(--transition-fast);
+  box-sizing: border-box;
+}
+
+.provider-detail__input:focus {
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+}
+
+.provider-detail__input::placeholder {
+  color: hsl(var(--muted-foreground) / 0.6);
+}
+
+.provider-detail__input--disabled {
+  opacity: 0.7;
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.05em;
+  cursor: not-allowed;
+}
+
+.provider-detail__input--error {
+  border-color: hsl(var(--destructive));
+}
+
+.provider-detail__input--error:focus {
+  box-shadow: 0 0 0 2px hsl(var(--destructive) / 0.2);
+}
+
+.provider-detail__error {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--destructive));
+  margin-top: 4px;
+}
+
+.provider-detail__key-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.provider-detail__key-row .provider-detail__input {
+  flex: 1;
+}
+
+.provider-detail__action {
+  width: auto;
+  margin-top: 4px;
+  float: right;
+}
+
+.provider-detail__no-key {
+  font-size: var(--font-size-sm);
+  color: hsl(var(--muted-foreground));
+}
+
+.provider-detail__disconnect {
+  color: hsl(var(--destructive));
+  border-color: hsl(var(--destructive) / 0.3);
+}
+
+.provider-detail__disconnect:hover {
+  background: hsl(var(--destructive) / 0.08);
+}
+
+.provider-detail__disconnect-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.provider-detail__disconnect-icon:hover {
+  background: hsl(var(--muted) / 0.5);
+  color: hsl(var(--foreground));
+}
+
+.provider-detail__disconnect-icon:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Modal view transitions ────────────────────────── */
+.provider-modal__view {
+  animation: modalSlideIn 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.provider-modal__view--from-left {
+  animation-name: modalSlideFromLeft;
+}
+
+.provider-modal__view--from-right {
+  animation-name: modalSlideFromRight;
+}
+
+@keyframes modalSlideFromRight {
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes modalSlideFromLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes modalSlideIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* ── Provider list (kept for legacy references) ───── */

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -33,39 +33,36 @@
   margin: 0 0 var(--gap-xl);
 }
 
-/* ── Provider selector button ─────────────────────── */
-.routing-providers-btn {
+/* ── Page header with connect button ──────────────── */
+.routing-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+/* ── Provider info display ───────────────────────── */
+.routing-providers-info {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
-  cursor: pointer;
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  color: hsl(var(--foreground));
-  transition: border-color var(--transition-fast);
   margin-bottom: var(--gap-lg);
 }
 
-.routing-providers-btn:hover {
-  border-color: hsl(var(--foreground) / 0.3);
-}
-
-.routing-providers-btn__icons {
+.routing-providers-info__icons {
   display: inline-flex;
   align-items: center;
   gap: 4px;
 }
 
-.routing-providers-btn__icon {
+.routing-providers-info__icon {
   display: flex;
   align-items: center;
+  position: relative;
+  cursor: default;
 }
 
-.routing-providers-btn__label {
+.routing-providers-info__label {
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: hsl(var(--muted-foreground));
 }

--- a/packages/frontend/src/styles/wizard.css
+++ b/packages/frontend/src/styles/wizard.css
@@ -66,10 +66,15 @@
 .modal-terminal__body {
   position: relative;
   padding: 14px 16px;
-  background: hsl(222 47% 6%);
+  background: hsl(var(--background));
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   line-height: 1.7;
+  color: hsl(var(--foreground));
+}
+
+.dark .modal-terminal__body {
+  background: hsl(222 47% 6%);
   color: hsl(178 75% 50%);
 }
 
@@ -78,8 +83,12 @@
 }
 
 .modal-terminal__prompt {
-  color: hsl(var(--muted-foreground));
+  color: hsl(var(--chart-1));
   margin-right: 8px;
+}
+
+.dark .modal-terminal__prompt {
+  color: hsl(var(--muted-foreground));
 }
 
 .modal-terminal__code {
@@ -93,19 +102,29 @@
   padding: 6px;
   border: none;
   border-radius: var(--radius);
-  background: hsl(0 0% 100% / 0.1);
-  color: hsl(0 0% 100% / 0.5);
+  background: hsl(0 0% 0% / 0.06);
+  color: hsl(0 0% 0% / 0.4);
   cursor: pointer;
   transition: all var(--transition-fast);
 }
 
 .modal-terminal__copy:hover {
+  background: hsl(0 0% 0% / 0.1);
+  color: hsl(0 0% 0% / 0.7);
+}
+
+.dark .modal-terminal__copy {
+  background: hsl(0 0% 100% / 0.1);
+  color: hsl(0 0% 100% / 0.5);
+}
+
+.dark .modal-terminal__copy:hover {
   background: hsl(0 0% 100% / 0.2);
   color: hsl(0 0% 100% / 0.8);
 }
 
 .modal-terminal__copy:focus-visible {
-  outline: 2px solid hsl(0 0% 100% / 0.6);
+  outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
 }
 
@@ -154,12 +173,17 @@
 .modal-key-box__value {
   display: block;
   padding: 12px 14px;
-  background: hsl(222 47% 6%);
-  color: hsl(178 75% 50%);
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   word-break: break-all;
   line-height: 1.6;
+}
+
+.dark .modal-key-box__value {
+  background: hsl(222 47% 6%);
+  color: hsl(178 75% 50%);
 }
 
 .modal-key-box__warning {

--- a/packages/frontend/tests/components/AgentGuard.test.tsx
+++ b/packages/frontend/tests/components/AgentGuard.test.tsx
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 
-const mockNavigate = vi.fn();
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: "test-agent" }),
-  useNavigate: () => mockNavigate,
   useLocation: () => ({ pathname: "/agents/test-agent", state: null }),
+  A: (props: any) => <a href={props.href}>{props.children}</a>,
 }));
 
 const mockGetAgents = vi.fn();
@@ -13,8 +12,19 @@ vi.mock("../../src/services/api.js", () => ({
   getAgents: () => mockGetAgents(),
 }));
 
+const mockIsLocalMode = vi.fn(() => false);
+const mockCheckLocalMode = vi.fn(() => Promise.resolve(false));
+vi.mock("../../src/services/local-mode.js", () => ({
+  isLocalMode: () => mockIsLocalMode(),
+  checkLocalMode: () => mockCheckLocalMode(),
+}));
+
 vi.mock("../../src/components/ErrorState.jsx", () => ({
   default: (props: any) => <div data-testid="error-state">{props.title || "Error"}</div>,
+}));
+
+vi.mock("@solidjs/meta", () => ({
+  Title: (props: any) => <title>{props.children}</title>,
 }));
 
 import AgentGuard from "../../src/components/AgentGuard";
@@ -22,6 +32,8 @@ import AgentGuard from "../../src/components/AgentGuard";
 describe("AgentGuard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsLocalMode.mockReturnValue(false);
+    mockCheckLocalMode.mockResolvedValue(false);
   });
 
   it("renders children when agent exists", async () => {
@@ -36,20 +48,21 @@ describe("AgentGuard", () => {
     });
   });
 
-  it("navigates to 404 when agent does not exist", async () => {
+  it("renders NotFound inline when agent does not exist", async () => {
     mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "other-agent" }] });
-    render(() => (
+    const { container } = render(() => (
       <AgentGuard>
-        <div>Child</div>
+        <div data-testid="child">Child</div>
       </AgentGuard>
     ));
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/404", { replace: true });
+      expect(container.textContent).toContain("Page not found");
     });
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
   });
 
-  it("renders nothing while loading", () => {
-    mockGetAgents.mockReturnValue(new Promise(() => {}));
+  it("renders nothing while mode is loading", () => {
+    mockCheckLocalMode.mockReturnValue(new Promise(() => {}));
     const { container } = render(() => (
       <AgentGuard>
         <div data-testid="child">Child</div>
@@ -58,11 +71,25 @@ describe("AgentGuard", () => {
     expect(container.querySelector('[data-testid="child"]')).toBeNull();
   });
 
-  it("calls getAgents on mount", async () => {
+  it("calls getAgents in cloud mode", async () => {
     mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "test-agent" }] });
     render(() => <AgentGuard><div>Child</div></AgentGuard>);
     await vi.waitFor(() => {
       expect(mockGetAgents).toHaveBeenCalled();
     });
+  });
+
+  it("renders children immediately in local mode without calling getAgents", async () => {
+    mockIsLocalMode.mockReturnValue(true);
+    mockCheckLocalMode.mockResolvedValue(true);
+    render(() => (
+      <AgentGuard>
+        <div data-testid="child">Child content</div>
+      </AgentGuard>
+    ));
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("child")).toBeDefined();
+    });
+    expect(mockGetAgents).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -79,24 +79,26 @@ describe("ProviderSelectModal", () => {
     expect(screen.getByText("DeepSeek")).toBeDefined();
   });
 
-  it("shows 'Connected' badge for active providers with API keys", () => {
-    render(() => (
+  it("shows toggle switch in 'on' state for connected providers", () => {
+    const { container } = render(() => (
       <ProviderSelectModal
         providers={[connectedProvider]}
         onClose={onClose}
         onUpdate={onUpdate}
       />
     ));
-    const badges = screen.getAllByText("Connected");
-    expect(badges.length).toBeGreaterThanOrEqual(1);
+    const onSwitches = container.querySelectorAll(".provider-toggle__switch--on");
+    expect(onSwitches.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("shows 'Not connected' badge for inactive providers", () => {
-    render(() => (
+  it("shows toggle switch in 'off' state for disconnected providers", () => {
+    const { container } = render(() => (
       <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
     ));
-    const notConnected = screen.getAllByText("Not connected");
-    expect(notConnected.length).toBeGreaterThanOrEqual(1);
+    const allSwitches = container.querySelectorAll(".provider-toggle__switch");
+    const onSwitches = container.querySelectorAll(".provider-toggle__switch--on");
+    expect(allSwitches.length).toBeGreaterThan(0);
+    expect(onSwitches.length).toBe(0);
   });
 
   it("calls onClose when Done button is clicked", () => {
@@ -296,31 +298,6 @@ describe("ProviderSelectModal", () => {
 
       await waitFor(() => {
         expect(mockConnectProvider).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe("Ollama provider", () => {
-    it("shows 'No API key required' for Ollama", () => {
-      render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
-      ));
-      fireEvent.click(screen.getByText("Ollama"));
-      expect(screen.getByText("No API key required for local models")).toBeDefined();
-    });
-
-    it("connects Ollama without API key", async () => {
-      render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
-      ));
-      fireEvent.click(screen.getByText("Ollama"));
-      fireEvent.click(screen.getByText("Connect"));
-
-      await waitFor(() => {
-        expect(mockConnectProvider).toHaveBeenCalledWith({
-          provider: "ollama",
-          apiKey: undefined,
-        });
       });
     });
   });

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -176,7 +176,7 @@ describe("ProviderSelectModal", () => {
       expect(screen.getByLabelText("Disconnect provider")).toBeDefined();
     });
 
-    it("shows 'Update Key' button for connected non-ollama providers", () => {
+    it("shows 'Change' button for connected non-ollama providers", () => {
       render(() => (
         <ProviderSelectModal
           providers={[connectedProvider]}
@@ -185,7 +185,7 @@ describe("ProviderSelectModal", () => {
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
-      expect(screen.getByText("Update Key")).toBeDefined();
+      expect(screen.getByText("Change")).toBeDefined();
     });
 
     it("shows 'Connect' button for non-connected providers", () => {
@@ -405,7 +405,7 @@ describe("ProviderSelectModal", () => {
   });
 
   describe("updating a key", () => {
-    it("switches to edit mode when Update Key is clicked", () => {
+    it("switches to edit mode when Change is clicked", () => {
       render(() => (
         <ProviderSelectModal
           providers={[connectedProvider]}
@@ -414,7 +414,7 @@ describe("ProviderSelectModal", () => {
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
-      fireEvent.click(screen.getByText("Update Key"));
+      fireEvent.click(screen.getByText("Change"));
 
       // Edit mode shows a password input and Save button
       expect(screen.getByLabelText("New OpenAI API key")).toBeDefined();
@@ -430,7 +430,7 @@ describe("ProviderSelectModal", () => {
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
-      fireEvent.click(screen.getByText("Update Key"));
+      fireEvent.click(screen.getByText("Change"));
 
       const input = screen.getByLabelText("New OpenAI API key");
       fireEvent.input(input, { target: { value: VALID_OPENAI_KEY } });

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -47,9 +47,17 @@ describe("Sidebar with agent", () => {
     expect(screen.getByText("MANAGE")).toBeDefined();
   });
 
-  it("renders Settings link", () => {
+  it("hides Settings link in local mode", () => {
+    const { container } = render(() => <Sidebar />);
+    expect(container.textContent).not.toContain("Settings");
+  });
+
+  it("renders Settings link in cloud mode", () => {
+    const prev = mockIsLocalMode;
+    mockIsLocalMode = false;
     render(() => <Sidebar />);
     expect(screen.getByText("Settings")).toBeDefined();
+    mockIsLocalMode = prev;
   });
 
   it("renders Notifications link", () => {
@@ -83,6 +91,8 @@ describe("Sidebar with agent", () => {
   });
 
   it("has correct link hrefs for agent routes", () => {
+    const prev = mockIsLocalMode;
+    mockIsLocalMode = false;
     const { container } = render(() => <Sidebar />);
     expect(container.querySelector('a[href="/agents/test-agent"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/messages"]')).not.toBeNull();
@@ -90,6 +100,7 @@ describe("Sidebar with agent", () => {
     expect(container.querySelector('a[href="/agents/test-agent/notifications"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/model-prices"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/help"]')).not.toBeNull();
+    mockIsLocalMode = prev;
   });
 
   it("marks current page link as active", () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -292,10 +292,14 @@ describe("Routing — enabled state (providers active)", () => {
     expect(screen.getByTestId("provider-modal")).toBeDefined();
   });
 
-  it("calls deactivateAllProviders when Disable Routing is clicked", async () => {
+  it("calls deactivateAllProviders when Disable Routing is confirmed", async () => {
     render(() => <Routing />);
     const disableBtn = await screen.findByText("Disable Routing");
     fireEvent.click(disableBtn);
+
+    // Confirm dialog appears — click the "Disable" button
+    const confirmBtn = await screen.findByText("Disable");
+    fireEvent.click(confirmBtn);
 
     await waitFor(() => {
       expect(mockDeactivateAllProviders).toHaveBeenCalled();
@@ -421,6 +425,9 @@ describe("Routing — helper functions", () => {
     render(() => <Routing />);
     const disableBtn = await screen.findByText("Disable Routing");
     fireEvent.click(disableBtn);
+
+    const confirmBtn = await screen.findByText("Disable");
+    fireEvent.click(confirmBtn);
 
     await waitFor(() => {
       expect(mockDeactivateAllProviders).toHaveBeenCalled();

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -285,9 +285,9 @@ describe("Routing — enabled state (providers active)", () => {
     });
   });
 
-  it("opens provider modal when Manage providers button is clicked", async () => {
+  it("opens provider modal when Connect providers button is clicked", async () => {
     render(() => <Routing />);
-    const provBtn = await screen.findByLabelText("Manage connected providers");
+    const provBtn = await screen.findByText("Connect providers");
     fireEvent.click(provBtn);
     expect(screen.getByTestId("provider-modal")).toBeDefined();
   });
@@ -463,7 +463,7 @@ describe("Routing — handleProviderUpdate", () => {
 
     render(() => <Routing />);
     // Open provider modal
-    const provBtn = await screen.findByLabelText("Manage connected providers");
+    const provBtn = await screen.findByText("Connect providers");
     fireEvent.click(provBtn);
 
     // Trigger update (routing was already enabled)

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
 
 let mockAgentName = "test-agent";
+const mockNavigate = vi.fn();
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: mockAgentName }),
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
   useLocation: () => ({ pathname: `/agents/${mockAgentName}/settings`, state: null }),
 }));
 
@@ -15,10 +16,12 @@ vi.mock("@solidjs/meta", () => ({
 
 const mockGetAgentKey = vi.fn();
 const mockDeleteAgent = vi.fn();
+const mockRenameAgent = vi.fn();
 const mockRotateAgentKey = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getAgentKey: (...args: unknown[]) => mockGetAgentKey(...args),
   deleteAgent: (...args: unknown[]) => mockDeleteAgent(...args),
+  renameAgent: (...args: unknown[]) => mockRenameAgent(...args),
   rotateAgentKey: (...args: unknown[]) => mockRotateAgentKey(...args),
 }));
 
@@ -53,6 +56,7 @@ describe("Settings", () => {
     mockIsLocalMode = false;
     mockGetAgentKey.mockResolvedValue({ keyPrefix: "mnfst_abc", pluginEndpoint: null });
     mockDeleteAgent.mockResolvedValue(undefined);
+    mockRenameAgent.mockResolvedValue({ renamed: true, name: "new-name" });
     mockRotateAgentKey.mockResolvedValue({ apiKey: "new-key" });
   });
 
@@ -141,7 +145,7 @@ describe("Settings", () => {
     expect(saveBtn.disabled).toBe(false);
   });
 
-  it("clicking Save navigates when name changed", async () => {
+  it("clicking Save calls renameAgent API then shows Saved", async () => {
     const { container } = render(() => <Settings />);
     const input = screen.getByLabelText("Agent name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-name" } });
@@ -150,7 +154,27 @@ describe("Settings", () => {
     ) as HTMLButtonElement;
     fireEvent.click(saveBtn);
     await vi.waitFor(() => {
+      expect(mockRenameAgent).toHaveBeenCalledWith("test-agent", "new-name");
+    });
+    await vi.waitFor(() => {
       expect(container.textContent).toContain("Saved");
+    });
+  });
+
+  it("resets name on rename error", async () => {
+    mockRenameAgent.mockRejectedValueOnce(new Error("Conflict"));
+    const { container } = render(() => <Settings />);
+    const input = screen.getByLabelText("Agent name") as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "bad-name" } });
+    const saveBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Save"),
+    ) as HTMLButtonElement;
+    fireEvent.click(saveBtn);
+    await vi.waitFor(() => {
+      expect(mockRenameAgent).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(input.value).toBe("test-agent");
     });
   });
 
@@ -256,28 +280,16 @@ describe("Settings", () => {
       mockIsLocalMode = true;
     });
 
-    it("hides API Key section in local mode", () => {
+    it("redirects to agent overview in local mode", () => {
       const { container } = render(() => <Settings />);
-      expect(container.textContent).not.toContain("API Key");
-      expect(container.textContent).not.toContain("OTLP ingest key");
+      expect(mockNavigate).toHaveBeenCalledWith(`/agents/${mockAgentName}`, { replace: true });
+      expect(container.textContent).toBe("");
     });
 
-    it("hides Integration section in local mode", () => {
+    it("does not render any settings content in local mode", () => {
       const { container } = render(() => <Settings />);
-      expect(container.textContent).not.toContain("Integration");
-    });
-
-    it("hides Danger zone in local mode", () => {
-      const { container } = render(() => <Settings />);
-      expect(container.textContent).not.toContain("Danger zone");
-      expect(container.textContent).not.toContain("Delete agent");
-    });
-
-    it("still shows General section in local mode without tabs", () => {
-      render(() => <Settings />);
-      // Tabs are hidden in local mode but the General content is still rendered
-      expect(screen.queryByText("General")).toBeNull();
-      expect(screen.getByLabelText("Agent name")).toBeDefined();
+      expect(container.textContent).not.toContain("Settings");
+      expect(container.textContent).not.toContain("Agent name");
     });
   });
 });

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -273,9 +273,10 @@ describe("Settings", () => {
       expect(container.textContent).not.toContain("Delete agent");
     });
 
-    it("still shows General section in local mode", () => {
-      const { container } = render(() => <Settings />);
-      expect(screen.getByText("General")).toBeDefined();
+    it("still shows General section in local mode without tabs", () => {
+      render(() => <Settings />);
+      // Tabs are hidden in local mode but the General content is still rendered
+      expect(screen.queryByText("General")).toBeNull();
       expect(screen.getByLabelText("Agent name")).toBeDefined();
     });
   });

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -56,8 +56,8 @@ describe("getModelLabel", () => {
 /* ── PROVIDERS constant ────────────────────────── */
 
 describe("PROVIDERS", () => {
-  it("has 9 providers defined", () => {
-    expect(PROVIDERS).toHaveLength(9);
+  it("has 8 providers defined", () => {
+    expect(PROVIDERS).toHaveLength(8);
   });
 
   it("each provider has required fields", () => {


### PR DESCRIPTION
## Summary
- **Fix AgentGuard 404 on page refresh in local mode**: `isLocalMode()` starts as `null` on page load — the guard now awaits `checkLocalMode()` before rendering, preventing false 404s
- **Skip agent existence validation in local mode**: The agent is guaranteed by `LocalBootstrapService`, so API validation is unnecessary and fragile
- **Hide Settings tab in local mode sidebar**: Prevents rename/delete of the hardcoded `local-agent`
- **Settings page redirects to overview in local mode**: Blocks direct URL access to `/settings` in local mode
- **Add `PATCH /api/v1/agents/:agentName` rename endpoint**: With duplicate name conflict detection, transactional rename across all related tables
- **Wire up rename in frontend**: `renameAgent` API function + Settings save button calls it with error recovery

## Test plan
- [x] `AgentGuard.test.tsx` — 5 tests pass (including local mode skip + cloud mode validation)
- [x] `Settings.test.tsx` — 26 tests pass (including local mode redirect + rename API integration)
- [x] `api.test.ts` — rename API tests (PATCH, URL encoding, error handling)
- [x] `agents.controller.spec.ts` — backend rename endpoint test
- [ ] Manual: start in local mode → navigate agent pages → no 404 on refresh
- [ ] Manual: Settings tab hidden in local sidebar, direct URL redirects to overview
