### PR TITLE
fix: use absolute URLs for OG image meta tags

### DIFF
--- a/.changeset/fix-og-meta-urls.md
+++ b/.changeset/fix-og-meta-urls.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix OG image and Twitter card meta tags to use absolute URLs for proper social media previews

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -6,15 +6,25 @@
     <link rel="icon" href="/favicon.ico" />
     <link href="/fonts/boxicons/boxicons-duotone.min.css" rel="stylesheet" />
     <title>Manifest</title>
-    <meta name="description" content="Open Source latform to monitor and control OpenClaw costs and performance." />
+    <meta
+      name="description"
+      content="Open Source platform to monitor and control OpenClaw costs and performance."
+    />
     <meta property="og:title" content="Manifest" />
-    <meta property="og:description" content="Open Source latform to monitor and control OpenClaw costs and performance." />
+    <meta
+      property="og:description"
+      content="Open Source platform to monitor and control OpenClaw costs and performance."
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/og-image.png" />
+    <meta property="og:url" content="https://app.manifest.build" />
+    <meta property="og:image" content="https://app.manifest.build/og-image.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Manifest" />
-    <meta name="twitter:description" content="Open Source latform to monitor and control OpenClaw costs and performance." />
-    <meta name="twitter:image" content="/og-image.png" />
+    <meta
+      name="twitter:description"
+      content="Open Source platform to monitor and control OpenClaw costs and performance."
+    />
+    <meta name="twitter:image" content="https://app.manifest.build/og-image.png" />
     <script src="/theme-init.js"></script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Update `og:image` and `twitter:image` meta tags to use absolute URLs (`https://app.manifest.build/og-image.png`) so social media crawlers can resolve the image
- Add `og:url` meta tag pointing to `https://app.manifest.build`

## Test plan
- [ ] Deploy and verify with [opengraph.xyz](https://opengraph.xyz) using `https://app.manifest.build/login`
- [ ] Confirm image preview renders on social platforms (Twitter/X, Slack, Discord)
