### PR TITLE
feat: add animated skeleton loaders and spinner buttons

### DIFF
--- a/.changeset/add-skeleton-loaders.md
+++ b/.changeset/add-skeleton-loaders.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add animated skeleton loaders and spinner buttons across the frontend

--- a/.changeset/add-skeleton-loaders.md
+++ b/.changeset/add-skeleton-loaders.md
@@ -1,5 +1,5 @@
 ---
-'manifest': minor
+"manifest": minor
 ---
 
 Add animated skeleton loaders and spinner buttons across the frontend

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -323,7 +323,7 @@ const CustomProviderForm: Component<Props> = (props) => {
           class="btn btn--primary provider-detail__action"
           disabled={!canSubmit()}
         >
-          {busy() ? (isEdit() ? 'Saving...' : 'Creating...') : isEdit() ? 'Save changes' : 'Create'}
+          {busy() ? <span class="spinner" /> : isEdit() ? 'Save changes' : 'Create'}
         </button>
 
         <Show when={isEdit()}>

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -1,16 +1,16 @@
-import { createSignal, createEffect, Show, type Component } from "solid-js";
-import { Portal } from "solid-js/web";
-import { setEmailProvider, testEmailProvider, testSavedEmailProvider } from "../services/api.js";
-import { authClient } from "../services/auth-client.js";
-import { isLocalMode } from "../services/local-mode.js";
-import { toast } from "../services/toast-store.js";
+import { createSignal, createEffect, Show, type Component } from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { setEmailProvider, testEmailProvider, testSavedEmailProvider } from '../services/api.js';
+import { authClient } from '../services/auth-client.js';
+import { isLocalMode } from '../services/local-mode.js';
+import { toast } from '../services/toast-store.js';
 
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
 
 const PROVIDER_NAMES: Record<string, string> = {
-  resend: "Resend",
-  mailgun: "Mailgun",
-  sendgrid: "SendGrid",
+  resend: 'Resend',
+  mailgun: 'Mailgun',
+  sendgrid: 'SendGrid',
 };
 
 interface Props {
@@ -25,40 +25,43 @@ interface Props {
 }
 
 const EmailProviderModal: Component<Props> = (props) => {
-  const [provider, setProvider] = createSignal("resend");
-  const [apiKey, setApiKey] = createSignal("");
-  const [domain, setDomain] = createSignal("");
-  const [notificationEmail, setNotificationEmail] = createSignal("");
+  const [provider, setProvider] = createSignal('resend');
+  const [apiKey, setApiKey] = createSignal('');
+  const [domain, setDomain] = createSignal('');
+  const [notificationEmail, setNotificationEmail] = createSignal('');
   const [saving, setSaving] = createSignal(false);
   const [testing, setTesting] = createSignal(false);
-  const [keyError, setKeyError] = createSignal("");
-  const [domainError, setDomainError] = createSignal("");
+  const [keyError, setKeyError] = createSignal('');
+  const [domainError, setDomainError] = createSignal('');
   const [editingKey, setEditingKey] = createSignal(false);
 
   const session = authClient.useSession();
 
-  const hasExistingKey = () => props.editMode && !!props.existingKeyPrefix && provider() === props.initialProvider;
+  const hasExistingKey = () =>
+    props.editMode && !!props.existingKeyPrefix && provider() === props.initialProvider;
 
   const maskedKey = () => {
-    const prefix = props.existingKeyPrefix ?? "";
-    return prefix + "••••••••";
+    const prefix = props.existingKeyPrefix ?? '';
+    return prefix + '••••••••';
   };
 
   createEffect(() => {
     if (props.open) {
       setProvider(props.initialProvider);
-      setApiKey("");
+      setApiKey('');
       const hasKey = props.editMode && !!props.existingKeyPrefix;
       setEditingKey(!hasKey);
-      setDomain(props.existingDomain ?? "");
-      const defaultEmail = props.existingNotificationEmail ?? (!isLocalMode() ? session()?.data?.user?.email ?? "" : "");
+      setDomain(props.existingDomain ?? '');
+      const defaultEmail =
+        props.existingNotificationEmail ??
+        (!isLocalMode() ? (session()?.data?.user?.email ?? '') : '');
       setNotificationEmail(defaultEmail);
-      setKeyError("");
-      setDomainError("");
+      setKeyError('');
+      setDomainError('');
     }
   });
 
-  const needsDomain = () => provider() === "mailgun";
+  const needsDomain = () => provider() === 'mailgun';
 
   const validateFields = (): boolean => {
     let valid = true;
@@ -67,39 +70,39 @@ const EmailProviderModal: Component<Props> = (props) => {
 
     // Skip API key validation when keeping the existing key
     if (!editingKey() && hasExistingKey()) {
-      setKeyError("");
+      setKeyError('');
     } else if (!key) {
-      setKeyError("API key is required");
+      setKeyError('API key is required');
       valid = false;
     } else if (key.length < 8) {
-      setKeyError("API key must be at least 8 characters");
+      setKeyError('API key must be at least 8 characters');
       valid = false;
-    } else if (provider() === "resend" && !key.startsWith("re_")) {
-      setKeyError("Resend API key must start with re_");
+    } else if (provider() === 'resend' && !key.startsWith('re_')) {
+      setKeyError('Resend API key must start with re_');
       valid = false;
-    } else if (provider() === "sendgrid" && !key.startsWith("SG.")) {
-      setKeyError("SendGrid API key must start with SG.");
+    } else if (provider() === 'sendgrid' && !key.startsWith('SG.')) {
+      setKeyError('SendGrid API key must start with SG.');
       valid = false;
     } else {
-      setKeyError("");
+      setKeyError('');
     }
 
     if (needsDomain()) {
       if (!dom) {
-        setDomainError("Domain is required");
+        setDomainError('Domain is required');
         valid = false;
       } else if (!DOMAIN_RE.test(dom)) {
-        setDomainError("Invalid domain format");
+        setDomainError('Invalid domain format');
         valid = false;
       } else {
-        setDomainError("");
+        setDomainError('');
       }
     } else {
       if (dom && !DOMAIN_RE.test(dom)) {
-        setDomainError("Invalid domain format");
+        setDomainError('Invalid domain format');
         valid = false;
       } else {
-        setDomainError("");
+        setDomainError('');
       }
     }
 
@@ -118,7 +121,7 @@ const EmailProviderModal: Component<Props> = (props) => {
     const recipient = getTestRecipient();
 
     if (!recipient) {
-      toast.error("Enter a notification email to send the test to");
+      toast.error('Enter a notification email to send the test to');
       return false;
     }
 
@@ -133,7 +136,7 @@ const EmailProviderModal: Component<Props> = (props) => {
       const result = await testEmailProvider(testData);
 
       if (!result.success) {
-        toast.error(result.error ?? "Email test failed — check your credentials");
+        toast.error(result.error ?? 'Email test failed — check your credentials');
         return false;
       }
       return true;
@@ -147,7 +150,7 @@ const EmailProviderModal: Component<Props> = (props) => {
   const runTestSaved = async (): Promise<boolean> => {
     const recipient = getTestRecipient();
     if (!recipient) {
-      toast.error("Enter a notification email to send the test to");
+      toast.error('Enter a notification email to send the test to');
       return false;
     }
 
@@ -155,7 +158,7 @@ const EmailProviderModal: Component<Props> = (props) => {
     try {
       const result = await testSavedEmailProvider(recipient);
       if (!result.success) {
-        toast.error(result.error ?? "Email test failed — check your credentials");
+        toast.error(result.error ?? 'Email test failed — check your credentials');
         return false;
       }
       return true;
@@ -187,7 +190,12 @@ const EmailProviderModal: Component<Props> = (props) => {
 
     setSaving(true);
     try {
-      const saveData: { provider: string; apiKey?: string; domain?: string; notificationEmail?: string } = {
+      const saveData: {
+        provider: string;
+        apiKey?: string;
+        domain?: string;
+        notificationEmail?: string;
+      } = {
         provider: provider(),
       };
       if (!keepingExistingKey) saveData.apiKey = apiKey().trim();
@@ -207,8 +215,8 @@ const EmailProviderModal: Component<Props> = (props) => {
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter") handleSave();
-    if (e.key === "Escape") props.onClose();
+    if (e.key === 'Enter') handleSave();
+    if (e.key === 'Escape') props.onClose();
   };
 
   const busy = () => saving() || testing();
@@ -225,146 +233,171 @@ const EmailProviderModal: Component<Props> = (props) => {
   };
 
   const buttonLabel = () => {
-    if (testing()) return "Testing...";
-    if (saving()) return "Saving...";
-    return props.editMode ? "Test & Save" : "Test & Connect";
+    if (testing()) return 'Testing...';
+    if (saving()) return 'Saving...';
+    return props.editMode ? 'Test & Save' : 'Test & Connect';
   };
 
   const keyPlaceholder = () => {
     switch (provider()) {
-      case "resend": return "re_xxxx...";
-      case "sendgrid": return "SG.xxxx...";
-      default: return "key-xxxx...";
+      case 'resend':
+        return 're_xxxx...';
+      case 'sendgrid':
+        return 'SG.xxxx...';
+      default:
+        return 'key-xxxx...';
     }
   };
 
   return (
     <Portal>
-    <Show when={props.open}>
-      <div class="modal-overlay" onClick={() => props.onClose()}>
-        <div
-          class="modal-card"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="provider-modal-title"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <h2 class="modal-card__title" id="provider-modal-title">
-            {props.editMode ? "Edit email provider" : "Configure email provider"}
-          </h2>
-          <p class="modal-card__desc">
-            Enter your API credentials to enable email alert delivery.
-          </p>
-
-          <label class="modal-card__field-label">Provider</label>
-          <div class="provider-modal-picker">
-            <button
-              class="provider-modal-option"
-              classList={{ "provider-modal-option--active": provider() === "resend" }}
-              onClick={() => { setProvider("resend"); setKeyError(""); }}
-              type="button"
-            >
-              <img src="/logos/resend.svg" alt="" class="provider-modal-option__logo" />
-              <span>Resend</span>
-            </button>
-            <button
-              class="provider-modal-option"
-              classList={{ "provider-modal-option--active": provider() === "mailgun" }}
-              onClick={() => { setProvider("mailgun"); setKeyError(""); }}
-              type="button"
-            >
-              <img src="/logos/mailgun.svg" alt="" class="provider-modal-option__logo" />
-              <span>Mailgun</span>
-            </button>
-            <button
-              class="provider-modal-option"
-              classList={{ "provider-modal-option--active": provider() === "sendgrid" }}
-              onClick={() => { setProvider("sendgrid"); setKeyError(""); }}
-              type="button"
-            >
-              <img src="/logos/sendgrid.svg" alt="" class="provider-modal-option__logo" />
-              <span>SendGrid</span>
-            </button>
-          </div>
-
-          <label class="modal-card__field-label">API Key</label>
-          <Show
-            when={editingKey() || !hasExistingKey()}
-            fallback={
-              <div class="masked-key">
-                <span class="masked-key__value">{maskedKey()}</span>
-                <button
-                  class="btn btn--ghost masked-key__edit"
-                  type="button"
-                  onClick={() => { setEditingKey(true); setApiKey(""); }}
-                >
-                  Change
-                </button>
-              </div>
-            }
+      <Show when={props.open}>
+        <div class="modal-overlay" onClick={() => props.onClose()}>
+          <div
+            class="modal-card"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="provider-modal-title"
+            onClick={(e) => e.stopPropagation()}
           >
-            <input
-              class="modal-card__input"
-              classList={{ "modal-card__input--error": !!keyError() }}
-              type="password"
-              placeholder={keyPlaceholder()}
-              value={apiKey()}
-              onInput={(e) => { setApiKey(e.currentTarget.value); setKeyError(""); }}
-              onKeyDown={handleKeyDown}
-              autofocus
-            />
-          </Show>
-          <Show when={keyError()}>
-            <p class="modal-card__field-error">{keyError()}</p>
-          </Show>
+            <h2 class="modal-card__title" id="provider-modal-title">
+              {props.editMode ? 'Edit email provider' : 'Configure email provider'}
+            </h2>
+            <p class="modal-card__desc">
+              Enter your API credentials to enable email alert delivery.
+            </p>
 
-          <Show when={needsDomain()}>
-            <label class="modal-card__field-label">Sending domain</label>
-            <input
-              class="modal-card__input"
-              classList={{ "modal-card__input--error": !!domainError() }}
-              type="text"
-              placeholder="e.g. notifications.mycompany.com"
-              value={domain()}
-              onInput={(e) => { setDomain(e.currentTarget.value); setDomainError(""); }}
-              onKeyDown={handleKeyDown}
-            />
-            <Show when={domainError()}>
-              <p class="modal-card__field-error">{domainError()}</p>
+            <label class="modal-card__field-label">Provider</label>
+            <div class="provider-modal-picker">
+              <button
+                class="provider-modal-option"
+                classList={{ 'provider-modal-option--active': provider() === 'resend' }}
+                onClick={() => {
+                  setProvider('resend');
+                  setKeyError('');
+                }}
+                type="button"
+              >
+                <img src="/logos/resend.svg" alt="" class="provider-modal-option__logo" />
+                <span>Resend</span>
+              </button>
+              <button
+                class="provider-modal-option"
+                classList={{ 'provider-modal-option--active': provider() === 'mailgun' }}
+                onClick={() => {
+                  setProvider('mailgun');
+                  setKeyError('');
+                }}
+                type="button"
+              >
+                <img src="/logos/mailgun.svg" alt="" class="provider-modal-option__logo" />
+                <span>Mailgun</span>
+              </button>
+              <button
+                class="provider-modal-option"
+                classList={{ 'provider-modal-option--active': provider() === 'sendgrid' }}
+                onClick={() => {
+                  setProvider('sendgrid');
+                  setKeyError('');
+                }}
+                type="button"
+              >
+                <img src="/logos/sendgrid.svg" alt="" class="provider-modal-option__logo" />
+                <span>SendGrid</span>
+              </button>
+            </div>
+
+            <label class="modal-card__field-label">API Key</label>
+            <Show
+              when={editingKey() || !hasExistingKey()}
+              fallback={
+                <div class="masked-key">
+                  <span class="masked-key__value">{maskedKey()}</span>
+                  <button
+                    class="btn btn--ghost masked-key__edit"
+                    type="button"
+                    onClick={() => {
+                      setEditingKey(true);
+                      setApiKey('');
+                    }}
+                  >
+                    Change
+                  </button>
+                </div>
+              }
+            >
+              <input
+                class="modal-card__input"
+                classList={{ 'modal-card__input--error': !!keyError() }}
+                type="password"
+                placeholder={keyPlaceholder()}
+                value={apiKey()}
+                onInput={(e) => {
+                  setApiKey(e.currentTarget.value);
+                  setKeyError('');
+                }}
+                onKeyDown={handleKeyDown}
+                autofocus
+              />
             </Show>
-          </Show>
+            <Show when={keyError()}>
+              <p class="modal-card__field-error">{keyError()}</p>
+            </Show>
 
-          <label class="modal-card__field-label">Notification email</label>
-          <input
-            class="modal-card__input"
-            type="email"
-            placeholder={!isLocalMode() ? (session()?.data?.user?.email ?? "you@example.com") : "you@example.com"}
-            value={notificationEmail()}
-            onInput={(e) => setNotificationEmail(e.currentTarget.value)}
-            onKeyDown={handleKeyDown}
-          />
-          <p class="modal-card__field-hint">Where threshold alerts will be sent.</p>
+            <Show when={needsDomain()}>
+              <label class="modal-card__field-label">Sending domain</label>
+              <input
+                class="modal-card__input"
+                classList={{ 'modal-card__input--error': !!domainError() }}
+                type="text"
+                placeholder="e.g. notifications.mycompany.com"
+                value={domain()}
+                onInput={(e) => {
+                  setDomain(e.currentTarget.value);
+                  setDomainError('');
+                }}
+                onKeyDown={handleKeyDown}
+              />
+              <Show when={domainError()}>
+                <p class="modal-card__field-error">{domainError()}</p>
+              </Show>
+            </Show>
 
-          <div class="modal-card__footer modal-card__footer--split">
-            <button
-              class="btn btn--ghost"
-              onClick={handleTestOnly}
-              disabled={busy() || isDisabled()}
-              type="button"
-            >
-              {testing() ? "Sending..." : "Send test email"}
-            </button>
-            <button
-              class="btn btn--primary"
-              onClick={handleSave}
-              disabled={busy() || isDisabled()}
-            >
-              {buttonLabel()}
-            </button>
+            <label class="modal-card__field-label">Notification email</label>
+            <input
+              class="modal-card__input"
+              type="email"
+              placeholder={
+                !isLocalMode()
+                  ? (session()?.data?.user?.email ?? 'you@example.com')
+                  : 'you@example.com'
+              }
+              value={notificationEmail()}
+              onInput={(e) => setNotificationEmail(e.currentTarget.value)}
+              onKeyDown={handleKeyDown}
+            />
+            <p class="modal-card__field-hint">Where threshold alerts will be sent.</p>
+
+            <div class="modal-card__footer modal-card__footer--split">
+              <button
+                class="btn btn--ghost"
+                onClick={handleTestOnly}
+                disabled={busy() || isDisabled()}
+                type="button"
+              >
+                {testing() ? <span class="spinner" /> : 'Send test email'}
+              </button>
+              <button
+                class="btn btn--primary"
+                onClick={handleSave}
+                disabled={busy() || isDisabled()}
+              >
+                {buttonLabel()}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    </Show>
+      </Show>
     </Portal>
   );
 };

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -43,16 +43,18 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   const handleRemove = async (index: number) => {
     setRemovingIndex(index);
     const updated = props.fallbacks.filter((_, i) => i !== index);
+    // Optimistic: remove from UI immediately
+    props.onUpdate(updated);
     try {
       if (updated.length === 0) {
         await clearFallbacks(props.agentName, props.tier);
       } else {
         await setFallbacks(props.agentName, props.tier, updated);
       }
-      props.onUpdate(updated);
       toast.success('Fallback removed');
     } catch {
-      // error toast from fetchMutate
+      // Revert on failure
+      props.onUpdate(props.fallbacks);
     } finally {
       setRemovingIndex(null);
     }
@@ -114,7 +116,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
           onClick={props.onAddFallback}
           disabled={props.adding || removingIndex() !== null}
         >
-          {props.adding ? 'Adding...' : '+ Add fallback'}
+          {props.adding ? <span class="spinner" /> : '+ Add fallback'}
         </button>
       </Show>
     </div>

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -42,6 +42,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
 
   const handleRemove = async (index: number) => {
     setRemovingIndex(index);
+    const original = [...props.fallbacks];
     const updated = props.fallbacks.filter((_, i) => i !== index);
     // Optimistic: remove from UI immediately
     props.onUpdate(updated);
@@ -54,7 +55,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
       toast.success('Fallback removed');
     } catch {
       // Revert on failure
-      props.onUpdate(props.fallbacks);
+      props.onUpdate(original);
     } finally {
       setRemovingIndex(null);
     }

--- a/packages/frontend/src/components/LimitRuleModal.tsx
+++ b/packages/frontend/src/components/LimitRuleModal.tsx
@@ -216,7 +216,7 @@ const LimitRuleModal: Component<Props> = (props) => {
                 disabled={!threshold() || Number(threshold()) <= 0 || saving()}
                 onClick={handleSave}
               >
-                {saving() ? 'Saving...' : isEdit() ? 'Save changes' : 'Create rule'}
+                {saving() ? <span class="spinner" /> : isEdit() ? 'Save changes' : 'Create rule'}
               </button>
             </div>
           </div>

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -424,7 +424,9 @@ const ProviderSelectModal: Component<Props> = (props) => {
                         disabled={busy()}
                         onClick={() => handleDisconnect(provId)}
                       >
-                        Disconnect
+                        <Show when={!busy()} fallback={<span class="spinner" />}>
+                          Disconnect
+                        </Show>
                       </button>
                     </Show>
                   </Show>
@@ -493,21 +495,23 @@ const ProviderSelectModal: Component<Props> = (props) => {
                             aria-label="Disconnect provider"
                             title="Disconnect"
                           >
-                            <svg
-                              width="16"
-                              height="16"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              stroke-width="2"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              aria-hidden="true"
-                            >
-                              <path d="M3 6h18" />
-                              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-                              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-                            </svg>
+                            <Show when={!busy()} fallback={<span class="spinner" />}>
+                              <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                aria-hidden="true"
+                              >
+                                <path d="M3 6h18" />
+                                <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                                <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                              </svg>
+                            </Show>
                           </button>
                         </div>
                       </Show>

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -413,7 +413,9 @@ const ProviderSelectModal: Component<Props> = (props) => {
                         disabled={busy()}
                         onClick={() => handleConnect(provId)}
                       >
-                        Connect
+                        <Show when={!busy()} fallback={<span class="spinner" />}>
+                          Connect
+                        </Show>
                       </button>
                     </Show>
                     <Show when={connected()}>
@@ -455,7 +457,9 @@ const ProviderSelectModal: Component<Props> = (props) => {
                       disabled={busy() || !keyInput().trim()}
                       onClick={() => handleConnect(provId)}
                     >
-                      Connect
+                      <Show when={!busy()} fallback={<span class="spinner" />}>
+                        Connect
+                      </Show>
                     </button>
                   </Show>
 

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -252,13 +252,24 @@ const Limits: Component = () => {
             when={!emailProvider.loading}
             fallback={
               <Show
-                when={emailProvider() !== undefined}
+                when={!!emailProvider()}
                 fallback={
-                  <div
-                    class="panel"
-                    style="display: flex; align-items: center; justify-content: center; min-height: 80px;"
-                  >
-                    <span class="spinner" style="width: 20px; height: 20px;" />
+                  <div class="panel">
+                    <div class="skeleton skeleton--text" style="width: 180px; height: 16px;" />
+                    <div
+                      class="skeleton skeleton--text"
+                      style="width: 280px; height: 13px; margin-top: 6px;"
+                    />
+                    <div style="display: flex; gap: var(--gap-md); margin-top: var(--gap-lg);">
+                      <For each={[1, 2, 3]}>
+                        {() => (
+                          <div
+                            class="skeleton skeleton--rect"
+                            style="flex: 1; height: 64px; border-radius: var(--radius);"
+                          />
+                        )}
+                      </For>
+                    </div>
                   </div>
                 }
               >

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -249,14 +249,54 @@ const Limits: Component = () => {
       <Show when={isLocalMode()}>
         <div style="margin-bottom: var(--gap-lg);">
           <Show
-            when={emailProvider()}
-            fallback={<EmailProviderSetup onConfigured={refetchProvider} />}
+            when={!emailProvider.loading}
+            fallback={
+              <Show
+                when={emailProvider() !== undefined}
+                fallback={
+                  <div
+                    class="panel"
+                    style="display: flex; align-items: center; justify-content: center; min-height: 80px;"
+                  >
+                    <span class="spinner" style="width: 20px; height: 20px;" />
+                  </div>
+                }
+              >
+                <div class="provider-card">
+                  <div class="provider-card__header">
+                    <span class="provider-card__label">Your provider</span>
+                    <div
+                      class="skeleton skeleton--text"
+                      style="width: 16px; height: 16px; border-radius: calc(var(--radius) - 2px);"
+                    />
+                  </div>
+                  <div class="provider-card__body">
+                    <div
+                      class="skeleton skeleton--rect"
+                      style="width: 32px; height: 32px; border-radius: calc(var(--radius) - 2px); flex-shrink: 0;"
+                    />
+                    <div>
+                      <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
+                      <div
+                        class="skeleton skeleton--text"
+                        style="width: 160px; height: 12px; margin-top: 6px;"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </Show>
+            }
           >
-            <ProviderBanner
-              config={emailProvider()!}
-              onEdit={() => setShowEditProvider(true)}
-              onRemove={() => setShowRemoveProvider(true)}
-            />
+            <Show
+              when={emailProvider()}
+              fallback={<EmailProviderSetup onConfigured={refetchProvider} />}
+            >
+              <ProviderBanner
+                config={emailProvider()!}
+                onEdit={() => setShowEditProvider(true)}
+                onRemove={() => setShowRemoveProvider(true)}
+              />
+            </Show>
           </Show>
         </div>
       </Show>
@@ -264,87 +304,126 @@ const Limits: Component = () => {
       <div class="panel">
         <div class="panel__title">Rules</div>
         <Show
-          when={(rules() ?? []).length > 0}
+          when={!rules.loading}
           fallback={
-            <div class="empty-state">
-              <div class="empty-state__title">No rules yet</div>
-              <p>Set up alerts for usage spikes, or hard limits to block requests over budget.</p>
-            </div>
+            <table class="notif-table notif-table--flush">
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>Threshold</th>
+                  <th>Triggered</th>
+                  <th style="text-align: right;">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={[1, 2, 3]}>
+                  {() => (
+                    <tr>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 28px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 80px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 20px;" />
+                      </td>
+                      <td style="text-align: right;">
+                        <div
+                          class="skeleton skeleton--text"
+                          style="width: 16px; margin-left: auto;"
+                        />
+                      </td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
           }
         >
-          <table class="notif-table notif-table--flush">
-            <thead>
-              <tr>
-                <th>Type</th>
-                <th>Threshold</th>
-                <th>Triggered</th>
-                <th style="text-align: right;">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              <For each={rules()}>
-                {(rule) => (
-                  <tr classList={{ 'notif-table__row--disabled': !isActive(rule) }}>
-                    <td>
-                      <div class="limit-type-icons">
-                        <Show when={hasEmailAction(rule.action ?? 'notify')}>
-                          <span class="limit-type-icon" title="Email Alert">
-                            <AlertIcon size={14} />
-                          </span>
-                        </Show>
-                        <Show when={hasBlockAction(rule.action ?? 'notify')}>
-                          <span class="limit-type-icon" title="Hard Limit">
-                            <LimitIcon size={14} />
-                          </span>
-                        </Show>
-                        <Show when={hasEmailAction(rule.action ?? 'notify') && !hasProvider()}>
-                          <span class="limit-warn-tag">
-                            <svg
-                              width="12"
-                              height="12"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              stroke-width="2"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                            >
-                              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-                              <line x1="12" y1="9" x2="12" y2="13" />
-                              <line x1="12" y1="17" x2="12.01" y2="17" />
+          <Show
+            when={(rules() ?? []).length > 0}
+            fallback={
+              <div class="empty-state">
+                <div class="empty-state__title">No rules yet</div>
+                <p>Set up alerts for usage spikes, or hard limits to block requests over budget.</p>
+              </div>
+            }
+          >
+            <table class="notif-table notif-table--flush">
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>Threshold</th>
+                  <th>Triggered</th>
+                  <th style="text-align: right;">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={rules()}>
+                  {(rule) => (
+                    <tr classList={{ 'notif-table__row--disabled': !isActive(rule) }}>
+                      <td>
+                        <div class="limit-type-icons">
+                          <Show when={hasEmailAction(rule.action ?? 'notify')}>
+                            <span class="limit-type-icon" title="Email Alert">
+                              <AlertIcon size={14} />
+                            </span>
+                          </Show>
+                          <Show when={hasBlockAction(rule.action ?? 'notify')}>
+                            <span class="limit-type-icon" title="Hard Limit">
+                              <LimitIcon size={14} />
+                            </span>
+                          </Show>
+                          <Show when={hasEmailAction(rule.action ?? 'notify') && !hasProvider()}>
+                            <span class="limit-warn-tag">
+                              <svg
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                              >
+                                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                                <line x1="12" y1="9" x2="12" y2="13" />
+                                <line x1="12" y1="17" x2="12.01" y2="17" />
+                              </svg>
+                              No provider
+                            </span>
+                          </Show>
+                        </div>
+                      </td>
+                      <td>
+                        <span class="notif-table__mono">{formatThreshold(rule)}</span>{' '}
+                        <span class="notif-table__period">
+                          {(PERIOD_LABELS[rule.period] ?? rule.period).toLowerCase()}
+                        </span>
+                      </td>
+                      <td class="notif-table__mono">{rule.trigger_count ?? 0}</td>
+                      <td>
+                        <div class="notif-table__actions">
+                          <button
+                            class="rule-menu__btn"
+                            onClick={(e) => toggleMenu(rule.id, e)}
+                            aria-label="Rule options"
+                          >
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                              <circle cx="12" cy="5" r="2" />
+                              <circle cx="12" cy="12" r="2" />
+                              <circle cx="12" cy="19" r="2" />
                             </svg>
-                            No provider
-                          </span>
-                        </Show>
-                      </div>
-                    </td>
-                    <td>
-                      <span class="notif-table__mono">{formatThreshold(rule)}</span>{' '}
-                      <span class="notif-table__period">
-                        {(PERIOD_LABELS[rule.period] ?? rule.period).toLowerCase()}
-                      </span>
-                    </td>
-                    <td class="notif-table__mono">{rule.trigger_count ?? 0}</td>
-                    <td>
-                      <div class="notif-table__actions">
-                        <button
-                          class="rule-menu__btn"
-                          onClick={(e) => toggleMenu(rule.id, e)}
-                          aria-label="Rule options"
-                        >
-                          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                            <circle cx="12" cy="5" r="2" />
-                            <circle cx="12" cy="12" r="2" />
-                            <circle cx="12" cy="19" r="2" />
-                          </svg>
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                )}
-              </For>
-            </tbody>
-          </table>
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
+          </Show>
         </Show>
       </div>
 
@@ -457,7 +536,7 @@ const Limits: Component = () => {
                   disabled={!deleteConfirmed() || deleting()}
                   onClick={handleDelete}
                 >
-                  {deleting() ? 'Deleting...' : 'Delete rule'}
+                  {deleting() ? <span class="spinner" /> : 'Delete rule'}
                 </button>
               </div>
             </div>
@@ -494,7 +573,7 @@ const Limits: Component = () => {
                   onClick={handleRemoveProvider}
                   disabled={removingProvider()}
                 >
-                  {removingProvider() ? 'Removing...' : 'Remove'}
+                  {removingProvider() ? <span class="spinner" /> : 'Remove'}
                 </button>
               </div>
             </div>

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -162,7 +162,7 @@ const Login: Component = () => {
             </A>
           </div>
           <button class="auth-form__submit" type="submit" disabled={loading()}>
-            {loading() ? 'Signing in...' : 'Sign in'}
+            {loading() ? <span class="spinner" /> : 'Sign in'}
           </button>
         </form>
         <div class="auth-footer">

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -252,24 +252,64 @@ const MessageLog: Component = () => {
         when={data() !== undefined || !data.loading}
         fallback={
           <div class="panel">
-            <div
-              class="skeleton skeleton--text"
-              style="width: 120px; height: 16px; margin-bottom: 16px;"
-            />
-            <For each={[1, 2, 3, 4, 5, 6, 7, 8]}>
-              {() => (
-                <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
-                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 70px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 40px; height: 14px;" />
-                </div>
-              )}
-            </For>
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
+              <div class="skeleton skeleton--text" style="width: 80px; height: 16px;" />
+              <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
+            </div>
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Message</th>
+                  <th>Cost</th>
+                  <th>Total Tokens</th>
+                  <th>Input</th>
+                  <th>Output</th>
+                  <th>Model</th>
+                  <th>Cache</th>
+                  <th>Duration</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}>
+                  {() => (
+                    <tr>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 90px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 55px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 40px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 40px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 35px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 35px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 110px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 90px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 35px;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 50px;" />
+                      </td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
           </div>
         }
       >

--- a/packages/frontend/src/pages/ModelPrices.tsx
+++ b/packages/frontend/src/pages/ModelPrices.tsx
@@ -186,21 +186,48 @@ const ModelPrices: Component = () => {
       <Show
         when={!data.loading}
         fallback={
-          <div class="panel">
-            <div
-              class="skeleton skeleton--text"
-              style="width: 120px; height: 16px; margin-bottom: 16px;"
-            />
-            <For each={[1, 2, 3, 4, 5, 6, 7, 8]}>
-              {() => (
-                <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
-                  <div class="skeleton skeleton--text" style="width: 200px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 100px; height: 14px;" />
-                  <div class="skeleton skeleton--text" style="width: 100px; height: 14px;" />
+          <div class="panel" style="min-height: 600px;">
+            <div class="model-filter">
+              <div class="model-filter__row">
+                <div
+                  class="skeleton skeleton--text"
+                  style="width: 280px; height: 36px; border-radius: var(--radius);"
+                />
+                <div class="model-filter__summary">
+                  <div class="skeleton skeleton--text" style="width: 80px;" />
                 </div>
-              )}
-            </For>
+              </div>
+            </div>
+            <table class="data-table" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th>Model</th>
+                  <th>Provider</th>
+                  <th>Cost to send / 1M tokens</th>
+                  <th>Cost to receive / 1M tokens</th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}>
+                  {() => (
+                    <tr>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 70%;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 60%;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 50%;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 50%;" />
+                      </td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
           </div>
         }
       >

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -199,32 +199,29 @@ const Overview: Component = () => {
         when={data() !== undefined || !data.loading}
         fallback={
           <>
-            <div class="chart-card" style="min-height: 360px;">
+            <div class="chart-card">
               <div class="chart-card__header">
-                <div class="chart-card__stat" style="flex: 1;">
-                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                  <div
-                    class="skeleton skeleton--text"
-                    style="width: 100px; height: 28px; margin-top: 6px;"
-                  />
+                <div class="chart-card__stat chart-card__stat--active">
+                  <span class="chart-card__label">Cost</span>
+                  <div class="chart-card__value-row">
+                    <div class="skeleton skeleton--text" style="width: 80px; height: 28px;" />
+                  </div>
                 </div>
-                <div class="chart-card__stat" style="flex: 1;">
-                  <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
-                  <div
-                    class="skeleton skeleton--text"
-                    style="width: 100px; height: 28px; margin-top: 6px;"
-                  />
+                <div class="chart-card__stat">
+                  <span class="chart-card__label">Token usage</span>
+                  <div class="chart-card__value-row">
+                    <div class="skeleton skeleton--text" style="width: 70px; height: 28px;" />
+                  </div>
                 </div>
-                <div class="chart-card__stat" style="flex: 1; border-right: none;">
-                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                  <div
-                    class="skeleton skeleton--text"
-                    style="width: 80px; height: 28px; margin-top: 6px;"
-                  />
+                <div class="chart-card__stat">
+                  <span class="chart-card__label">Messages</span>
+                  <div class="chart-card__value-row">
+                    <div class="skeleton skeleton--text" style="width: 50px; height: 28px;" />
+                  </div>
                 </div>
               </div>
               <div class="chart-card__body">
-                <div class="skeleton skeleton--rect" style="width: 100%; height: 240px;" />
+                <div class="skeleton skeleton--rect" style="width: 100%; height: 260px;" />
               </div>
             </div>
             <div class="panel">
@@ -232,8 +229,10 @@ const Overview: Component = () => {
                 class="panel__title"
                 style="display: flex; justify-content: space-between; align-items: center;"
               >
-                <div class="skeleton skeleton--text" style="width: 120px; height: 16px;" />
-                <div class="skeleton skeleton--text" style="width: 70px; height: 14px;" />
+                Recent Messages
+                <span class="view-more-link" style="pointer-events: none; opacity: 0.4;">
+                  View more
+                </span>
               </div>
               <table class="data-table">
                 <thead>
@@ -251,22 +250,22 @@ const Overview: Component = () => {
                     {() => (
                       <tr>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 60px;" />
+                          <div class="skeleton skeleton--text" style="width: 70%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 60px;" />
+                          <div class="skeleton skeleton--text" style="width: 50%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 50px;" />
+                          <div class="skeleton skeleton--text" style="width: 50%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 80px;" />
+                          <div class="skeleton skeleton--text" style="width: 70%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 60px;" />
+                          <div class="skeleton skeleton--text" style="width: 40%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 40px;" />
+                          <div class="skeleton skeleton--text" style="width: 50%;" />
                         </td>
                       </tr>
                     )}
@@ -275,14 +274,10 @@ const Overview: Component = () => {
               </table>
             </div>
             <div class="panel" style="margin-top: var(--gap-lg);">
-              <div
-                class="skeleton skeleton--text"
-                style="width: 100px; height: 16px; margin-bottom: 4px;"
-              />
-              <div
-                class="skeleton skeleton--text"
-                style="width: 200px; height: 12px; margin-bottom: 16px;"
-              />
+              <div class="panel__title">Cost by Model</div>
+              <p style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); margin: -8px 0 12px;">
+                How much each AI model is costing you
+              </p>
               <table class="data-table">
                 <thead>
                   <tr>
@@ -297,16 +292,16 @@ const Overview: Component = () => {
                     {() => (
                       <tr>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 100px;" />
+                          <div class="skeleton skeleton--text" style="width: 60%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 50px;" />
+                          <div class="skeleton skeleton--text" style="width: 40%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 70px;" />
+                          <div class="skeleton skeleton--text" style="width: 50%;" />
                         </td>
                         <td>
-                          <div class="skeleton skeleton--text" style="width: 50px;" />
+                          <div class="skeleton skeleton--text" style="width: 40%;" />
                         </td>
                       </tr>
                     )}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -229,21 +229,90 @@ const Overview: Component = () => {
             </div>
             <div class="panel">
               <div
+                class="panel__title"
+                style="display: flex; justify-content: space-between; align-items: center;"
+              >
+                <div class="skeleton skeleton--text" style="width: 120px; height: 16px;" />
+                <div class="skeleton skeleton--text" style="width: 70px; height: 14px;" />
+              </div>
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Message</th>
+                    <th>Cost</th>
+                    <th>Model</th>
+                    <th>Tokens</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={[1, 2, 3, 4, 5]}>
+                    {() => (
+                      <tr>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 60px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 60px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 50px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 80px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 60px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 40px;" />
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+            </div>
+            <div class="panel" style="margin-top: var(--gap-lg);">
+              <div
                 class="skeleton skeleton--text"
-                style="width: 120px; height: 16px; margin-bottom: 16px;"
+                style="width: 100px; height: 16px; margin-bottom: 4px;"
               />
-              <For each={[1, 2, 3, 4, 5]}>
-                {() => (
-                  <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
-                    <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                    <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                    <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
-                    <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
-                    <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                    <div class="skeleton skeleton--text" style="width: 40px; height: 14px;" />
-                  </div>
-                )}
-              </For>
+              <div
+                class="skeleton skeleton--text"
+                style="width: 200px; height: 12px; margin-bottom: 16px;"
+              />
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Model</th>
+                    <th>Tokens</th>
+                    <th>% of total</th>
+                    <th>Cost</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={[1, 2, 3]}>
+                    {() => (
+                      <tr>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 100px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 50px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 70px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 50px;" />
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
             </div>
           </>
         }

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -125,7 +125,7 @@ const Register: Component = () => {
                 />
               </label>
               <button class="auth-form__submit" type="submit" disabled={loading()}>
-                {loading() ? 'Creating account...' : 'Create account'}
+                {loading() ? <span class="spinner" /> : 'Create account'}
               </button>
             </form>
             <p class="auth-terms">

--- a/packages/frontend/src/pages/ResetPassword.tsx
+++ b/packages/frontend/src/pages/ResetPassword.tsx
@@ -1,28 +1,28 @@
-import { A, useSearchParams } from "@solidjs/router";
-import { Title, Meta } from "@solidjs/meta";
-import { type Component, createSignal, Show } from "solid-js";
-import { authClient } from "../services/auth-client.js";
+import { A, useSearchParams } from '@solidjs/router';
+import { Title, Meta } from '@solidjs/meta';
+import { type Component, createSignal, Show } from 'solid-js';
+import { authClient } from '../services/auth-client.js';
 
 const RequestResetForm: Component = () => {
-  const [email, setEmail] = createSignal("");
+  const [email, setEmail] = createSignal('');
   const [sent, setSent] = createSignal(false);
-  const [error, setError] = createSignal("");
+  const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
-    setError("");
+    setError('');
     setLoading(true);
 
     const { error: authError } = await authClient.requestPasswordReset({
       email: email(),
-      redirectTo: "/reset-password",
+      redirectTo: '/reset-password',
     });
 
     setLoading(false);
 
     if (authError) {
-      setError(authError.message ?? "Failed to send reset email");
+      setError(authError.message ?? 'Failed to send reset email');
       return;
     }
 
@@ -34,7 +34,9 @@ const RequestResetForm: Component = () => {
       <div class="auth-header">
         <h1 class="auth-header__title">Reset your password</h1>
         <p class="auth-header__subtitle">
-          {sent() ? "Check your email for a reset link" : "Enter your email to receive a reset link"}
+          {sent()
+            ? 'Check your email for a reset link'
+            : 'Enter your email to receive a reset link'}
         </p>
       </div>
 
@@ -53,31 +55,33 @@ const RequestResetForm: Component = () => {
             />
           </label>
           <button class="auth-form__submit" type="submit" disabled={loading()}>
-            {loading() ? "Sending..." : "Send reset link"}
+            {loading() ? <span class="spinner" /> : 'Send reset link'}
           </button>
         </form>
       </Show>
 
       <div class="auth-footer">
-        <A href="/login" class="auth-footer__link">Back to sign in</A>
+        <A href="/login" class="auth-footer__link">
+          Back to sign in
+        </A>
       </div>
     </>
   );
 };
 
 const SetNewPasswordForm: Component<{ token: string }> = (props) => {
-  const [password, setPassword] = createSignal("");
-  const [confirmPassword, setConfirmPassword] = createSignal("");
-  const [error, setError] = createSignal("");
+  const [password, setPassword] = createSignal('');
+  const [confirmPassword, setConfirmPassword] = createSignal('');
+  const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
   const [success, setSuccess] = createSignal(false);
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
-    setError("");
+    setError('');
 
     if (password() !== confirmPassword()) {
-      setError("Passwords do not match");
+      setError('Passwords do not match');
       return;
     }
 
@@ -91,7 +95,7 @@ const SetNewPasswordForm: Component<{ token: string }> = (props) => {
     setLoading(false);
 
     if (authError) {
-      setError(authError.message ?? "Failed to reset password");
+      setError(authError.message ?? 'Failed to reset password');
       return;
     }
 
@@ -103,22 +107,27 @@ const SetNewPasswordForm: Component<{ token: string }> = (props) => {
       <div class="auth-header">
         <h1 class="auth-header__title">Set new password</h1>
         <p class="auth-header__subtitle">
-          {success() ? "Your password has been reset" : "Enter your new password"}
+          {success() ? 'Your password has been reset' : 'Enter your new password'}
         </p>
       </div>
 
-      <Show when={!success()} fallback={
-        <>
-          <div class="auth-form">
-            <div class="auth-form__success">
-              Your password has been updated. You can now sign in with your new password.
+      <Show
+        when={!success()}
+        fallback={
+          <>
+            <div class="auth-form">
+              <div class="auth-form__success">
+                Your password has been updated. You can now sign in with your new password.
+              </div>
             </div>
-          </div>
-          <div class="auth-footer">
-            <A href="/login" class="auth-footer__link">Sign in</A>
-          </div>
-        </>
-      }>
+            <div class="auth-footer">
+              <A href="/login" class="auth-footer__link">
+                Sign in
+              </A>
+            </div>
+          </>
+        }
+      >
         <form class="auth-form" onSubmit={handleSubmit}>
           {error() && <div class="auth-form__error">{error()}</div>}
           <label class="auth-form__label">
@@ -146,12 +155,14 @@ const SetNewPasswordForm: Component<{ token: string }> = (props) => {
             />
           </label>
           <button class="auth-form__submit" type="submit" disabled={loading()}>
-            {loading() ? "Resetting..." : "Reset password"}
+            {loading() ? <span class="spinner" /> : 'Reset password'}
           </button>
         </form>
 
         <div class="auth-footer">
-          <A href="/login" class="auth-footer__link">Back to sign in</A>
+          <A href="/login" class="auth-footer__link">
+            Back to sign in
+          </A>
         </div>
       </Show>
     </>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -56,10 +56,8 @@ const Routing: Component = () => {
     () => agentName(),
     getAvailableModels,
   );
-  const [connectedProviders, { refetch: refetchProviders }] = createResource(
-    () => agentName(),
-    getProviders,
-  );
+  const [connectedProviders, { refetch: refetchProviders, mutate: mutateProviders }] =
+    createResource(() => agentName(), getProviders);
   const [customProviders, { refetch: refetchCustomProviders }] = createResource(
     () => agentName(),
     getCustomProviders,
@@ -199,6 +197,9 @@ const Routing: Component = () => {
 
   const handleDisable = async () => {
     setDisabling(true);
+    // Optimistic: mark all providers inactive so the UI switches immediately
+    const prevProviders = connectedProviders();
+    mutateProviders((prev) => prev?.map((p) => ({ ...p, is_active: false })));
     try {
       await deactivateAllProviders(agentName());
       await Promise.all([
@@ -209,7 +210,8 @@ const Routing: Component = () => {
       ]);
       setInstructionModal('disable');
     } catch {
-      // error toast from fetchMutate
+      // Revert on failure
+      mutateProviders(prevProviders);
     } finally {
       setDisabling(false);
     }
@@ -256,21 +258,11 @@ const Routing: Component = () => {
       <Show
         when={!connectedProviders.loading}
         fallback={
-          <div class="routing-cards">
-            <For each={STAGES}>
-              {(stage) => (
-                <div class="routing-card">
-                  <div class="routing-card__header">
-                    <span class="routing-card__tier">{stage.label}</span>
-                    <span class="routing-card__desc">{stage.desc}</span>
-                  </div>
-                  <div class="routing-card__body">
-                    <div class="skeleton skeleton--text" style="width: 160px; height: 14px;" />
-                    <div class="skeleton skeleton--text" style="width: 200px; height: 12px; margin-top: 6px;" />
-                  </div>
-                </div>
-              )}
-            </For>
+          <div
+            class="panel"
+            style="display: flex; align-items: center; justify-content: center; min-height: 260px;"
+          >
+            <span class="spinner" style="width: 24px; height: 24px;" />
           </div>
         }
       >
@@ -365,8 +357,14 @@ const Routing: Component = () => {
                       when={!tiers.loading}
                       fallback={
                         <div class="routing-card__body">
-                          <div class="skeleton skeleton--text" style="width: 160px; height: 14px;" />
-                          <div class="skeleton skeleton--text" style="width: 200px; height: 12px; margin-top: 6px;" />
+                          <div
+                            class="skeleton skeleton--text"
+                            style="width: 160px; height: 14px;"
+                          />
+                          <div
+                            class="skeleton skeleton--text"
+                            style="width: 200px; height: 12px; margin-top: 6px;"
+                          />
                         </div>
                       }
                     >
@@ -387,47 +385,65 @@ const Routing: Component = () => {
                         >
                           {(modelName) => (
                             <>
-                              <div class="routing-card__override">
-                                {(() => {
-                                  const provId = providerIdForModel(modelName(), models() ?? []);
-                                  if (provId?.startsWith('custom:')) {
-                                    const cp = customProviders()?.find(
-                                      (c) => `custom:${c.id}` === provId,
-                                    );
-                                    const letter = (cp?.name ?? 'C').charAt(0).toUpperCase();
-                                    return (
-                                      <span class="routing-card__override-icon">
-                                        <span
-                                          class="provider-card__logo-letter"
-                                          style={{
-                                            background: 'var(--custom-provider-color)',
-                                            width: '16px',
-                                            height: '16px',
-                                            'font-size': '9px',
-                                            'border-radius': '50%',
-                                          }}
-                                        >
-                                          {letter}
-                                        </span>
-                                      </span>
-                                    );
-                                  }
-                                  return (
-                                    <Show when={provId}>
-                                      {(pid) => (
+                              <Show
+                                when={changingTier() !== stage.id}
+                                fallback={
+                                  <>
+                                    <div class="routing-card__override">
+                                      <div
+                                        class="skeleton skeleton--text"
+                                        style="width: 140px; height: 14px;"
+                                      />
+                                    </div>
+                                    <div
+                                      class="skeleton skeleton--text"
+                                      style="width: 180px; height: 12px; margin-top: 6px;"
+                                    />
+                                  </>
+                                }
+                              >
+                                <div class="routing-card__override">
+                                  {(() => {
+                                    const provId = providerIdForModel(modelName(), models() ?? []);
+                                    if (provId?.startsWith('custom:')) {
+                                      const cp = customProviders()?.find(
+                                        (c) => `custom:${c.id}` === provId,
+                                      );
+                                      const letter = (cp?.name ?? 'C').charAt(0).toUpperCase();
+                                      return (
                                         <span class="routing-card__override-icon">
-                                          {providerIcon(pid(), 16)}
+                                          <span
+                                            class="provider-card__logo-letter"
+                                            style={{
+                                              background: 'var(--custom-provider-color)',
+                                              width: '16px',
+                                              height: '16px',
+                                              'font-size': '9px',
+                                              'border-radius': '50%',
+                                            }}
+                                          >
+                                            {letter}
+                                          </span>
                                         </span>
-                                      )}
-                                    </Show>
-                                  );
-                                })()}
-                                <span class="routing-card__main">{labelFor(modelName())}</span>
-                                <Show when={!isManual()}>
-                                  <span class="routing-card__auto-tag">auto</span>
-                                </Show>
-                              </div>
-                              <span class="routing-card__sub">{priceLabel(modelName())}</span>
+                                      );
+                                    }
+                                    return (
+                                      <Show when={provId}>
+                                        {(pid) => (
+                                          <span class="routing-card__override-icon">
+                                            {providerIcon(pid(), 16)}
+                                          </span>
+                                        )}
+                                      </Show>
+                                    );
+                                  })()}
+                                  <span class="routing-card__main">{labelFor(modelName())}</span>
+                                  <Show when={!isManual()}>
+                                    <span class="routing-card__auto-tag">auto</span>
+                                  </Show>
+                                </div>
+                                <span class="routing-card__sub">{priceLabel(modelName())}</span>
+                              </Show>
                             </>
                           )}
                         </Show>
@@ -440,7 +456,12 @@ const Routing: Component = () => {
                               onClick={() => setDropdownTier(stage.id)}
                               disabled={changingTier() === stage.id}
                             >
-                              {changingTier() === stage.id ? 'Changing...' : 'Change'}
+                              <Show
+                                when={changingTier() !== stage.id}
+                                fallback={<span class="spinner" />}
+                              >
+                                Change
+                              </Show>
                             </button>
                             <Show when={isManual()}>
                               <button
@@ -448,7 +469,7 @@ const Routing: Component = () => {
                                 onClick={() => handleReset(stage.id)}
                                 disabled={resettingTier() === stage.id || resettingAll()}
                               >
-                                {resettingTier() === stage.id ? 'Resetting...' : 'Reset'}
+                                {resettingTier() === stage.id ? <span class="spinner" /> : 'Reset'}
                               </button>
                             </Show>
                           </div>
@@ -490,7 +511,7 @@ const Routing: Component = () => {
               onClick={() => setConfirmDisable(true)}
               disabled={disabling()}
             >
-              {disabling() ? 'Disabling...' : 'Disable Routing'}
+              {disabling() ? <span class="spinner" /> : 'Disable Routing'}
             </button>
             <Show when={hasOverrides()}>
               <button
@@ -499,7 +520,7 @@ const Routing: Component = () => {
                 onClick={handleResetAll}
                 disabled={resettingAll() || resettingTier() !== null}
               >
-                {resettingAll() ? 'Resetting...' : 'Reset all to auto'}
+                {resettingAll() ? <span class="spinner" /> : 'Reset all to auto'}
               </button>
             </Show>
             <div style="flex: 1;" />
@@ -598,7 +619,7 @@ const Routing: Component = () => {
                   await handleDisable();
                 }}
               >
-                {disabling() ? 'Disabling...' : 'Disable'}
+                {disabling() ? <span class="spinner" /> : 'Disable'}
               </button>
             </div>
           </div>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -258,12 +258,73 @@ const Routing: Component = () => {
       <Show
         when={!connectedProviders.loading}
         fallback={
-          <div
-            class="panel"
-            style="display: flex; align-items: center; justify-content: center; min-height: 260px;"
+          <Show
+            when={
+              connectedProviders() !== undefined && connectedProviders()?.some((p) => p.is_active)
+            }
+            fallback={
+              <div
+                class="panel"
+                style="display: flex; align-items: center; justify-content: center; min-height: 260px;"
+              >
+                <span class="spinner" style="width: 24px; height: 24px;" />
+              </div>
+            }
           >
-            <span class="spinner" style="width: 24px; height: 24px;" />
-          </div>
+            <div class="routing-providers-info">
+              <span class="routing-providers-info__icons">
+                <span class="routing-providers-info__icon">
+                  <div class="skeleton" style="width: 16px; height: 16px; border-radius: 50%;" />
+                </span>
+                <span class="routing-providers-info__icon">
+                  <div class="skeleton" style="width: 16px; height: 16px; border-radius: 50%;" />
+                </span>
+              </span>
+              <span class="routing-providers-info__label">
+                <div class="skeleton skeleton--text" style="width: 80px;" />
+              </span>
+            </div>
+            <div class="routing-cards">
+              <For each={STAGES}>
+                {(stage) => (
+                  <div class="routing-card">
+                    <div class="routing-card__header">
+                      <span class="routing-card__tier">{stage.label}</span>
+                      <span class="routing-card__desc">{stage.desc}</span>
+                    </div>
+                    <div class="routing-card__body">
+                      <div class="routing-card__override">
+                        <span class="routing-card__override-icon">
+                          <div
+                            class="skeleton"
+                            style="width: 16px; height: 16px; border-radius: 50%;"
+                          />
+                        </span>
+                        <div class="skeleton skeleton--text" style="width: 140px; height: 14px;" />
+                      </div>
+                      <div
+                        class="skeleton skeleton--text"
+                        style="width: 200px; height: 12px; margin-top: 6px;"
+                      />
+                    </div>
+                    <div class="routing-card__right">
+                      <div class="routing-card__actions">
+                        <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+            <div class="routing-footer">
+              <div
+                class="skeleton skeleton--text"
+                style="width: 120px; height: 32px; border-radius: var(--radius);"
+              />
+              <div style="flex: 1;" />
+              <div class="skeleton skeleton--text" style="width: 130px; height: 14px;" />
+            </div>
+          </Show>
         }
       >
         <Show

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -202,19 +202,21 @@ const Routing: Component = () => {
     mutateProviders((prev) => prev?.map((p) => ({ ...p, is_active: false })));
     try {
       await deactivateAllProviders(agentName());
-      await Promise.all([
-        refetchProviders(),
-        refetchCustomProviders(),
-        refetchTiers(),
-        refetchModels(),
-      ]);
-      setInstructionModal('disable');
     } catch {
-      // Revert on failure
+      // Revert on failure only when the deactivation itself fails
       mutateProviders(prevProviders);
-    } finally {
       setDisabling(false);
+      return;
     }
+    // Refetch in background — deactivation already succeeded so no revert needed
+    await Promise.all([
+      refetchProviders(),
+      refetchCustomProviders(),
+      refetchTiers(),
+      refetchModels(),
+    ]).catch(() => {});
+    setInstructionModal('disable');
+    setDisabling(false);
   };
 
   const handleProviderUpdate = async () => {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -145,7 +145,9 @@ const Settings: Component = () => {
               onClick={handleSave}
               disabled={saving() || name().trim() === agentName()}
             >
-              <span aria-live="polite">{saved() ? 'Saved' : saving() ? 'Saving...' : 'Save'}</span>
+              <span aria-live="polite">
+                {saved() ? 'Saved' : saving() ? <span class="spinner" /> : 'Save'}
+              </span>
             </button>
           </div>
         </div>
@@ -205,7 +207,7 @@ const Settings: Component = () => {
                 onClick={handleRotate}
                 disabled={rotating()}
               >
-                {rotating() ? 'Rotating...' : 'Rotate key'}
+                {rotating() ? <span class="spinner" /> : 'Rotate key'}
               </button>
             </div>
           </div>
@@ -320,7 +322,7 @@ const Settings: Component = () => {
                 }
               }}
             >
-              {deleting() ? 'Deleting...' : 'Delete this agent'}
+              {deleting() ? <span class="spinner" /> : 'Delete this agent'}
             </button>
           </div>
         </div>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -146,7 +146,16 @@ const Settings: Component = () => {
               disabled={saving() || name().trim() === agentName()}
             >
               <span aria-live="polite">
-                {saved() ? 'Saved' : saving() ? <span class="spinner" /> : 'Save'}
+                {saved() ? (
+                  'Saved'
+                ) : saving() ? (
+                  <>
+                    <span class="spinner" />
+                    <span class="sr-only">Saving…</span>
+                  </>
+                ) : (
+                  'Save'
+                )}
               </span>
             </button>
           </div>
@@ -207,7 +216,14 @@ const Settings: Component = () => {
                 onClick={handleRotate}
                 disabled={rotating()}
               >
-                {rotating() ? <span class="spinner" /> : 'Rotate key'}
+                {rotating() ? (
+                  <>
+                    <span class="spinner" />
+                    <span class="sr-only">Rotating…</span>
+                  </>
+                ) : (
+                  'Rotate key'
+                )}
               </button>
             </div>
           </div>
@@ -322,7 +338,14 @@ const Settings: Component = () => {
                 }
               }}
             >
-              {deleting() ? <span class="spinner" /> : 'Delete this agent'}
+              {deleting() ? (
+                <>
+                  <span class="spinner" />
+                  <span class="sr-only">Deleting…</span>
+                </>
+              ) : (
+                'Delete this agent'
+              )}
             </button>
           </div>
         </div>

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -95,7 +95,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
               onClick={handleCreate}
               disabled={!name().trim() || creating()}
             >
-              {creating() ? 'Creating...' : 'Create'}
+              {creating() ? <span class="spinner" /> : 'Create'}
             </button>
           </div>
         </div>

--- a/packages/frontend/src/styles/skeleton.css
+++ b/packages/frontend/src/styles/skeleton.css
@@ -1,0 +1,27 @@
+/* ── Skeleton Loaders ─────────────────────────────── */
+.skeleton {
+  background: hsl(var(--muted));
+  border-radius: calc(var(--radius) - 2px);
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+.skeleton--text {
+  display: block;
+  height: 14px;
+}
+
+.skeleton--rect {
+  display: block;
+}
+
+@keyframes skeleton-pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/packages/frontend/src/styles/skeleton.css
+++ b/packages/frontend/src/styles/skeleton.css
@@ -14,6 +14,36 @@
   display: block;
 }
 
+/* ── Spinner ──────────────────────────────────────── */
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid hsl(var(--muted));
+  border-top-color: hsl(var(--foreground));
+  border-radius: 50%;
+  animation: spinner-spin 0.6s linear infinite;
+}
+
+.btn .spinner {
+  margin: 0 12px;
+  border-color: hsl(var(--primary-foreground) / 0.3);
+  border-top-color: hsl(var(--primary-foreground));
+}
+
+.btn--outline .spinner,
+.btn--ghost .spinner,
+.btn--danger .spinner {
+  border-color: hsl(var(--muted));
+  border-top-color: hsl(var(--foreground));
+}
+
+@keyframes spinner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @keyframes skeleton-pulse {
   0% {
     opacity: 1;

--- a/packages/frontend/src/styles/skeleton.css
+++ b/packages/frontend/src/styles/skeleton.css
@@ -32,10 +32,14 @@
 }
 
 .btn--outline .spinner,
-.btn--ghost .spinner,
-.btn--danger .spinner {
+.btn--ghost .spinner {
   border-color: hsl(var(--muted));
   border-top-color: hsl(var(--foreground));
+}
+
+.btn--danger .spinner {
+  border-color: hsl(var(--destructive-foreground) / 0.3);
+  border-top-color: hsl(var(--destructive-foreground));
 }
 
 @keyframes spinner-spin {

--- a/packages/frontend/src/styles/skeleton.css
+++ b/packages/frontend/src/styles/skeleton.css
@@ -48,6 +48,19 @@
   }
 }
 
+/* ── Screen-reader only ──────────────────────────── */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 @keyframes skeleton-pulse {
   0% {
     opacity: 1;

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -1,22 +1,23 @@
-@import "./fonts.css";
-@import "./layout.css";
-@import "./auth.css";
-@import "./cards.css";
-@import "./charts.css";
-@import "./controls.css";
-@import "./custom-select.css";
-@import "./data.css";
-@import "./agents.css";
-@import "./modals.css";
-@import "./tokens.css";
-@import "./wizard.css";
-@import "./notifications.css";
-@import "./limits.css";
-@import "./routing.css";
-@import "./tooltip.css";
-@import "./toast.css";
-@import "./model-filter.css";
-@import "./version-indicator.css";
+@import './fonts.css';
+@import './layout.css';
+@import './auth.css';
+@import './cards.css';
+@import './charts.css';
+@import './controls.css';
+@import './custom-select.css';
+@import './data.css';
+@import './agents.css';
+@import './modals.css';
+@import './tokens.css';
+@import './wizard.css';
+@import './notifications.css';
+@import './limits.css';
+@import './routing.css';
+@import './tooltip.css';
+@import './toast.css';
+@import './model-filter.css';
+@import './version-indicator.css';
+@import './skeleton.css';
 
 /* ── shadcn/ui design tokens — Light (default) ───── */
 @layer base {
@@ -117,11 +118,9 @@
   --gap-xl: 32px;
   --gap-2xl: 48px;
 
-  --font-family:
-    "DM Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --font-heading:
-    "Bricolage Grotesque", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  --font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-heading: 'Bricolage Grotesque', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-base: 0.9375rem;
@@ -148,8 +147,8 @@
 body {
   font-family: var(--font-family);
   font-feature-settings:
-    "rlig" 1,
-    "calt" 1;
+    'rlig' 1,
+    'calt' 1;
   background: hsl(var(--background));
   color: hsl(var(--foreground));
   line-height: 1.6;
@@ -158,7 +157,12 @@ body {
   overflow-x: hidden;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-heading);
 }
 

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -336,7 +336,8 @@ describe("CustomProviderForm", () => {
     fireEvent.click(screen.getByText("Create"));
 
     await waitFor(() => {
-      expect(screen.getByText("Creating...")).toBeDefined();
+      const btn = document.querySelector("button.btn--primary") as HTMLButtonElement;
+      expect(btn.querySelector(".spinner")).not.toBeNull();
     });
 
     resolveSubmit!({
@@ -666,7 +667,8 @@ describe("CustomProviderForm — edit mode", () => {
     fireEvent.click(screen.getByText("Save changes"));
 
     await waitFor(() => {
-      expect(screen.getByText("Saving...")).toBeDefined();
+      const btn = document.querySelector("button.btn--primary") as HTMLButtonElement;
+      expect(btn.querySelector(".spinner")).not.toBeNull();
     });
 
     resolveSubmit!({ ...initialData });

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -135,7 +135,7 @@ describe("FallbackList", () => {
     expect(mockSetFallbacks).not.toHaveBeenCalled();
   });
 
-  it("does not call onUpdate when setFallbacks rejects", async () => {
+  it("reverts optimistic removal when setFallbacks rejects", async () => {
     mockSetFallbacks.mockRejectedValue(new Error("API error"));
     const onUpdate = vi.fn();
     const { container } = render(() => (
@@ -152,10 +152,13 @@ describe("FallbackList", () => {
     await waitFor(() => {
       expect(mockSetFallbacks).toHaveBeenCalled();
     });
-    expect(onUpdate).not.toHaveBeenCalled();
+    // First call: optimistic removal, second call: revert with original list
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenNthCalledWith(1, ["model-b"]);
+    expect(onUpdate).toHaveBeenNthCalledWith(2, ["model-a", "model-b"]);
   });
 
-  it("does not call onUpdate when clearFallbacks rejects", async () => {
+  it("reverts optimistic removal when clearFallbacks rejects", async () => {
     mockClearFallbacks.mockRejectedValue(new Error("API error"));
     const onUpdate = vi.fn();
     const { container } = render(() => (
@@ -172,7 +175,10 @@ describe("FallbackList", () => {
     await waitFor(() => {
       expect(mockClearFallbacks).toHaveBeenCalled();
     });
-    expect(onUpdate).not.toHaveBeenCalled();
+    // First call: optimistic removal, second call: revert with original list
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenNthCalledWith(1, []);
+    expect(onUpdate).toHaveBeenNthCalledWith(2, ["model-a"]);
   });
 
   it("displays display_name when model info has one", () => {
@@ -306,14 +312,14 @@ describe("FallbackList", () => {
     expect(addBtn!.classList.contains("routing-action")).toBe(true);
   });
 
-  it("shows Adding... and disables add button when adding prop is true", () => {
-    render(() => (
+  it("shows spinner and disables add button when adding prop is true", () => {
+    const { container } = render(() => (
       <FallbackList {...defaultProps} fallbacks={[]} adding={true} />
     ));
 
-    const addBtn = screen.getByText("Adding...");
-    expect(addBtn).toBeDefined();
-    expect((addBtn as HTMLButtonElement).disabled).toBe(true);
+    const addBtn = container.querySelector(".fallback-list__add") as HTMLButtonElement;
+    expect(addBtn.querySelector(".spinner")).not.toBeNull();
+    expect(addBtn.disabled).toBe(true);
   });
 
   it("disables add button when adding is false but not disabled", () => {

--- a/packages/frontend/tests/components/LimitRuleModal.test.tsx
+++ b/packages/frontend/tests/components/LimitRuleModal.test.tsx
@@ -437,7 +437,7 @@ describe("LimitRuleModal", () => {
     fireEvent.click(btn);
 
     await vi.waitFor(() => {
-      expect(btn.textContent).toBe("Saving...");
+      expect(btn.querySelector(".spinner")).not.toBeNull();
       expect(btn.disabled).toBe(true);
     });
 

--- a/packages/frontend/tests/pages/Limits-interactions.test.tsx
+++ b/packages/frontend/tests/pages/Limits-interactions.test.tsx
@@ -336,7 +336,7 @@ describe("Limits page interactions", () => {
     fireEvent.click(deleteBtn);
 
     await vi.waitFor(() => {
-      expect(deleteBtn.textContent).toBe("Deleting...");
+      expect(deleteBtn.querySelector(".spinner")).not.toBeNull();
       expect(deleteBtn.disabled).toBe(true);
     });
 
@@ -370,7 +370,7 @@ describe("Limits page interactions", () => {
     fireEvent.click(removeBtn);
 
     await vi.waitFor(() => {
-      expect(removeBtn.textContent).toBe("Removing...");
+      expect(removeBtn.querySelector(".spinner")).not.toBeNull();
       expect(removeBtn.disabled).toBe(true);
     });
 

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: "test-agent" }),
@@ -115,9 +115,11 @@ describe("Limits page", () => {
     expect(screen.getByText("+ Create rule")).toBeDefined();
   });
 
-  it("renders empty state when no rules", () => {
+  it("renders empty state when no rules", async () => {
     render(() => <Limits />);
-    expect(screen.getByText("No rules yet")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText("No rules yet")).toBeDefined();
+    });
     expect(screen.getByText("Set up alerts for usage spikes, or hard limits to block requests over budget.")).toBeDefined();
   });
 
@@ -178,10 +180,12 @@ describe("Limits page", () => {
     expect(screen.getByTestId("cloud-email-info")).toBeDefined();
   });
 
-  it("shows email provider setup in local mode", () => {
+  it("shows email provider setup in local mode", async () => {
     mockIsLocalMode = true;
     render(() => <Limits />);
-    expect(screen.getByTestId("email-setup")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("email-setup")).toBeDefined();
+    });
   });
 
   it("hides email provider setup in cloud mode", () => {

--- a/packages/frontend/tests/pages/Login.test.tsx
+++ b/packages/frontend/tests/pages/Login.test.tsx
@@ -106,7 +106,8 @@ describe("Login", () => {
     fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
     fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Signing in");
+      const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.querySelector(".spinner")).not.toBeNull();
     });
   });
 

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -104,7 +104,8 @@ describe("Register", () => {
     fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass123" } });
     fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Creating account");
+      const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.querySelector(".spinner")).not.toBeNull();
     });
   });
 

--- a/packages/frontend/tests/pages/ResetPassword.test.tsx
+++ b/packages/frontend/tests/pages/ResetPassword.test.tsx
@@ -96,7 +96,8 @@ describe("ResetPassword - Request form (no token)", () => {
     fireEvent.input(emailInput, { target: { value: "test@test.com" } });
     fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Sending...");
+      const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.querySelector(".spinner")).not.toBeNull();
     });
   });
 });
@@ -193,7 +194,8 @@ describe("ResetPassword - Set new password form (with token)", () => {
     fireEvent.input(inputs[1], { target: { value: "newpass123" } });
     fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resetting...");
+      const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.querySelector(".spinner")).not.toBeNull();
     });
   });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -295,8 +295,8 @@ describe("Routing — enabled state (providers active)", () => {
     fireEvent.click(resetBtn);
 
     await waitFor(() => {
-      expect(screen.getByText("Resetting...")).toBeDefined();
-      expect((screen.getByText("Resetting...") as HTMLButtonElement).disabled).toBe(true);
+      expect(resetBtn.querySelector(".spinner")).not.toBeNull();
+      expect(resetBtn.disabled).toBe(true);
     });
 
     resolveReset!();
@@ -319,12 +319,12 @@ describe("Routing — enabled state (providers active)", () => {
     let resolveResetAll: () => void;
     vi.mocked(resetAllTiers).mockReturnValue(new Promise<void>((r) => { resolveResetAll = r; }) as any);
     render(() => <Routing />);
-    const resetAllBtn = await screen.findByText("Reset all to auto");
+    const resetAllBtn = await screen.findByText("Reset all to auto") as HTMLButtonElement;
     fireEvent.click(resetAllBtn);
 
     await waitFor(() => {
-      expect(screen.getByText("Resetting...")).toBeDefined();
-      expect((screen.getByText("Resetting...") as HTMLButtonElement).disabled).toBe(true);
+      expect(resetAllBtn.querySelector(".spinner")).not.toBeNull();
+      expect(resetAllBtn.disabled).toBe(true);
     });
 
     resolveResetAll!();
@@ -860,8 +860,9 @@ describe("Routing — fallback management", () => {
     fireEvent.click(modalButtons[0]);
 
     await waitFor(() => {
-      expect(screen.getByText("Adding...")).toBeDefined();
-      expect((screen.getByText("Adding...") as HTMLButtonElement).disabled).toBe(true);
+      const addBtn = document.querySelector(".fallback-list__add") as HTMLButtonElement;
+      expect(addBtn.querySelector(".spinner")).not.toBeNull();
+      expect(addBtn.disabled).toBe(true);
     });
 
     resolveSetFallbacks!();

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -59,6 +59,7 @@ vi.mock("../../src/services/api.js", () => ({
   deleteCustomProvider: vi.fn().mockResolvedValue({ ok: true }),
   setFallbacks: vi.fn().mockResolvedValue([]),
   clearFallbacks: vi.fn().mockResolvedValue(undefined),
+  getModelPrices: vi.fn().mockResolvedValue([]),
 }));
 
 import Routing from "../../src/pages/Routing";

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -174,7 +174,7 @@ describe("Workspace", () => {
     fireEvent.input(input, { target: { value: "new-agent" } });
     fireEvent.click(screen.getByText("Create"));
     await vi.waitFor(() => {
-      const btns = document.querySelectorAll(".modal-card button.btn--primary");
+      const btns = container.querySelectorAll(".modal-card button.btn--primary");
       const createBtn = btns[btns.length - 1] as HTMLButtonElement;
       expect(createBtn.querySelector(".spinner")).not.toBeNull();
       expect(createBtn.disabled).toBe(true);

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -174,10 +174,11 @@ describe("Workspace", () => {
     fireEvent.input(input, { target: { value: "new-agent" } });
     fireEvent.click(screen.getByText("Create"));
     await vi.waitFor(() => {
-      expect(screen.getByText("Creating...")).toBeDefined();
+      const btns = document.querySelectorAll(".modal-card button.btn--primary");
+      const createBtn = btns[btns.length - 1] as HTMLButtonElement;
+      expect(createBtn.querySelector(".spinner")).not.toBeNull();
+      expect(createBtn.disabled).toBe(true);
     });
-    const createBtn = screen.getByText("Creating...") as HTMLButtonElement;
-    expect(createBtn.disabled).toBe(true);
     resolveCreate!({ agent: { name: "new-agent" }, apiKey: "k" });
   });
 


### PR DESCRIPTION
## Summary
- Add pulse-animated skeleton loaders (`.skeleton` CSS with `@keyframes skeleton-pulse`) to the Overview page and all loading states
- Replace all "Loading..." text with inline spinner buttons across forms and actions (login, register, disconnect, delete, save, etc.)
- Fix danger button spinner color to use `--destructive-foreground`
- Add `skeleton.css` with `.skeleton`, `.skeleton--text`, `.skeleton--rect`, and `.spinner` classes
- Improve Overview skeleton fallback with proper `<table>` structure matching real content layout (Recent Messages + Cost by Model)

## Test plan
- [x] All 1308 frontend tests pass (72 suites)
- [x] All 2188 backend tests pass (129 suites)
- [x] All 284 plugin tests pass (13 suites)
- [x] Frontend line coverage: 99.76%
- [x] Backend line coverage: 99.89%
- [x] Plugin line coverage: 100%
- [x] Visual: skeleton pulse animation works in both light and dark themes
- [x] Visual: spinners display correctly in primary, outline, ghost, and danger buttons
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added animated skeleton loaders and inline spinner buttons across the frontend to replace text-based loading and improve perceived performance. Pages now use layout-matched skeletons; actions show consistent spinners.

- **New Features**
  - Added `skeleton.css` with `.skeleton`, `.skeleton--text`, `.skeleton--rect`, and `.spinner`; replaced loading text with spinners across auth, settings, workspace, provider modals, forms, and primary actions.
  - Built realistic skeleton tables for Overview (Recent Messages + Cost by Model), MessageLog, ModelPrices, Limits (rules), and Routing cards.
  - Context-aware loaders for Routing and Limits: spinner when providers are unknown, skeleton when known.

- **Bug Fixes**
  - Buttons: danger spinner now uses `--destructive-foreground`; connect/disconnect (including icon-only actions) show spinners while in progress.
  - Optimistic updates hardened: routing disable only reverts on API failure; fallback removals capture original state and revert on errors.
  - Accessibility: added `sr-only` helper and screen-reader text alongside spinners in Settings.
  - Tests: added missing `getModelPrices` mock in Routing tests to prevent unhandled rejections.

<sup>Written for commit 1ae7370561f81fff8336c385c2336ad136e3b83e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
