### PR TITLE
fix(plugin): add text response for /manifest command

### DIFF
--- a/packages/openclaw-plugin/__tests__/command.test.ts
+++ b/packages/openclaw-plugin/__tests__/command.test.ts
@@ -32,6 +32,7 @@ describe("registerCommand", () => {
       expect.objectContaining({
         name: "manifest",
         description: expect.any(String),
+        handler: expect.any(Function),
         execute: expect.any(Function),
       }),
     );
@@ -46,7 +47,7 @@ describe("registerCommand", () => {
     );
   });
 
-  it("returns status text on successful verify", async () => {
+  it("handler returns status text on successful verify", async () => {
     mockVerify.mockResolvedValueOnce({
       endpointReachable: true,
       authValid: true,
@@ -58,7 +59,7 @@ describe("registerCommand", () => {
     registerCommand(api, config, mockLogger);
 
     const cmd = api.registerCommand.mock.calls[0][0];
-    const result = await cmd.execute();
+    const result = await cmd.handler();
 
     expect(result).toContain("Mode: cloud");
     expect(result).toContain("Endpoint reachable: yes");
@@ -79,13 +80,64 @@ describe("registerCommand", () => {
     registerCommand(api, config, mockLogger);
 
     const cmd = api.registerCommand.mock.calls[0][0];
-    const result = await cmd.execute();
+    const result = await cmd.handler();
 
     expect(result).toContain("Endpoint reachable: no");
     expect(result).toContain("Error: Cannot reach endpoint: ECONNREFUSED");
   });
 
-  it("returns error message when verify throws", async () => {
+  it("execute returns { text, content } on successful verify", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: true,
+      authValid: true,
+      agentName: "test-agent",
+      error: null,
+    });
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result.text).toContain("Mode: cloud");
+    expect(result.text).toContain("Agent: test-agent");
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("Mode: cloud") },
+    ]);
+  });
+
+  it("execute wraps error status in both text and content", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: false,
+      authValid: false,
+      agentName: null,
+      error: "Cannot reach endpoint: ECONNREFUSED",
+    });
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result.text).toContain("Endpoint reachable: no");
+    expect(result.content[0].text).toContain("Error: Cannot reach endpoint: ECONNREFUSED");
+  });
+
+  it("handler returns error message when verify throws", async () => {
+    mockVerify.mockRejectedValueOnce(new Error("network down"));
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.handler();
+
+    expect(result).toContain("Manifest status check failed: network down");
+  });
+
+  it("execute wraps thrown error in text and content", async () => {
     mockVerify.mockRejectedValueOnce(new Error("network down"));
 
     const api = { registerCommand: jest.fn() };
@@ -94,17 +146,20 @@ describe("registerCommand", () => {
     const cmd = api.registerCommand.mock.calls[0][0];
     const result = await cmd.execute();
 
-    expect(result).toContain("Manifest status check failed: network down");
+    expect(result.text).toBe("Manifest status check failed: network down");
+    expect(result.content).toEqual([
+      { type: "text", text: "Manifest status check failed: network down" },
+    ]);
   });
 
-  it("returns stringified error when verify throws a non-Error value", async () => {
+  it("handler returns stringified error when verify throws a non-Error value", async () => {
     mockVerify.mockRejectedValueOnce("string-error");
 
     const api = { registerCommand: jest.fn() };
     registerCommand(api, config, mockLogger);
 
     const cmd = api.registerCommand.mock.calls[0][0];
-    const result = await cmd.execute();
+    const result = await cmd.handler();
 
     expect(result).toContain("Manifest status check failed: string-error");
   });
@@ -121,7 +176,7 @@ describe("registerCommand", () => {
     registerCommand(api, config, mockLogger);
 
     const cmd = api.registerCommand.mock.calls[0][0];
-    const result = await cmd.execute();
+    const result = await cmd.handler();
 
     expect(result).toContain("Mode: cloud");
     expect(result).toContain("Endpoint reachable: yes");

--- a/packages/openclaw-plugin/src/command.ts
+++ b/packages/openclaw-plugin/src/command.ts
@@ -9,7 +9,7 @@ export function registerCommand(api: any, config: ManifestConfig, logger: Plugin
     return;
   }
 
-  const commandHandler = async () => {
+  const formatStatus = async (): Promise<string> => {
     try {
       const check = await verifyConnection(config);
       const lines = [
@@ -34,8 +34,13 @@ export function registerCommand(api: any, config: ManifestConfig, logger: Plugin
   api.registerCommand({
     name: 'manifest',
     description: 'Show Manifest plugin status and connection info',
-    handler: commandHandler,
-    execute: commandHandler,
+    async handler() {
+      return formatStatus();
+    },
+    async execute() {
+      const text = await formatStatus();
+      return { text, content: [{ type: 'text', text }] };
+    },
   });
 
   logger.debug('[manifest] Registered /manifest command');


### PR DESCRIPTION
This fixes the `/manifest` Telegram issue by adjusting the command return shape rather than changing the status-generation logic itself.

The command was returning a plain string, which works for older consumers, but the Telegram path expects a structured reply with a `text` field. Because of that, the gateway had no explicit message body to send back, which is why `/manifest` produced no visible reply in Telegram.

In `packages/openclaw-plugin/src/command.ts`, the fix is kept as narrow as possible. `handler()` still returns the plain status string for backwards compatibility, while `execute()` now returns `{ text, content: [{ type: 'text', text }] }`. This keeps the older path unchanged and gives the newer command path used by Telegram the `text` field it needs.

`packages/openclaw-plugin/__tests__/command.test.ts` was updated to cover both paths explicitly: `handler()` returning plain text, `execute()` returning `{ text, content }`, and the success, error, and thrown-error cases.

This approach fixes the Telegram issue without changing the legacy command contract more than necessary. Instead of changing both `handler()` and `execute()` to a new shape, only `execute()` was changed. That keeps older consumers that still rely on `handler()` working as before, while allowing Telegram to send the `/manifest` reply correctly.

Fixes #1076 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Telegram `/manifest` reply by making the command return a structured `{ text, content }` from `execute()` while keeping `handler()` as a plain string for backward compatibility. Fixes #1076.

- **Bug Fixes**
  - In `packages/openclaw-plugin/src/command.ts`, `handler()` now returns the status string; `execute()` returns `{ text, content: [{ type: 'text', text }] }`.
  - Updated tests in `packages/openclaw-plugin/__tests__/command.test.ts` to cover success, error, and thrown-error paths for both `handler()` and `execute()`.

<sup>Written for commit 051101f477aa654c4b4cdf59ca00079315292140. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

