### PR TITLE
feat(plugin): show routing summary in /manifest command

### DIFF
--- a/.changeset/show-manifest-routing-summary.md
+++ b/.changeset/show-manifest-routing-summary.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Show active routing providers and tier model assignments in the `/manifest` command

--- a/packages/backend/src/routing/resolve.controller.spec.ts
+++ b/packages/backend/src/routing/resolve.controller.spec.ts
@@ -3,6 +3,7 @@ import { validate } from 'class-validator';
 import {
   ResolveController,
   RegisterSubscriptionsDto,
+  RoutingSummaryResponse,
   SubscriptionProviderItem,
 } from './resolve.controller';
 import { ResolveService } from './resolve.service';
@@ -12,7 +13,12 @@ import { ResolveResponse } from './dto/resolve-response';
 describe('ResolveController', () => {
   let controller: ResolveController;
   let mockResolveService: { resolve: jest.Mock };
-  let mockRoutingService: { upsertProvider: jest.Mock };
+  let mockRoutingService: {
+    upsertProvider: jest.Mock;
+    getProviders: jest.Mock;
+    getTiers: jest.Mock;
+    getEffectiveModel: jest.Mock;
+  };
 
   const mockResponse: ResolveResponse = {
     tier: 'simple',
@@ -29,6 +35,9 @@ describe('ResolveController', () => {
     };
     mockRoutingService = {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      getProviders: jest.fn().mockResolvedValue([]),
+      getTiers: jest.fn().mockResolvedValue([]),
+      getEffectiveModel: jest.fn().mockResolvedValue(null),
     };
     controller = new ResolveController(
       mockResolveService as unknown as ResolveService,
@@ -93,6 +102,108 @@ describe('ResolveController', () => {
     );
 
     expect(result).toBe(mockResponse);
+  });
+
+  describe('getSummary', () => {
+    it('returns active providers and effective tier models for the current agent', async () => {
+      const req = {
+        ingestionContext: {
+          userId: 'user-42',
+          tenantId: 't1',
+          agentId: 'a1',
+          agentName: 'test-agent',
+        },
+      } as never;
+
+      mockRoutingService.getProviders.mockResolvedValue([
+        { provider: 'openai', auth_type: 'api_key', is_active: true },
+        { provider: 'anthropic', auth_type: 'subscription', is_active: true },
+        { provider: 'deepseek', auth_type: 'api_key', is_active: false },
+      ]);
+      mockRoutingService.getTiers.mockResolvedValue([
+        {
+          tier: 'reasoning',
+          override_model: 'o3',
+          auto_assigned_model: 'o4-mini',
+          fallback_models: ['o4-mini'],
+        },
+        {
+          tier: 'simple',
+          override_model: null,
+          auto_assigned_model: 'gpt-4.1-mini',
+          fallback_models: null,
+        },
+        {
+          tier: 'standard',
+          override_model: null,
+          auto_assigned_model: 'claude-sonnet-4',
+          fallback_models: null,
+        },
+        {
+          tier: 'complex',
+          override_model: 'gpt-4.1',
+          auto_assigned_model: 'claude-opus-4',
+          fallback_models: ['claude-opus-4'],
+        },
+      ]);
+      mockRoutingService.getEffectiveModel.mockImplementation(
+        async (_agentId: string, assignment: { tier: string }) => {
+          switch (assignment.tier) {
+            case 'simple':
+              return 'gpt-4.1-mini';
+            case 'standard':
+              return 'claude-sonnet-4';
+            case 'complex':
+              return 'claude-opus-4';
+            case 'reasoning':
+              return 'o3';
+            default:
+              return null;
+          }
+        },
+      );
+
+      const result = await controller.getSummary(req);
+
+      const expected: RoutingSummaryResponse = {
+        agentName: 'test-agent',
+        providers: [
+          { provider: 'anthropic', auth_type: 'subscription' },
+          { provider: 'openai', auth_type: 'api_key' },
+        ],
+        tiers: [
+          {
+            tier: 'simple',
+            model: 'gpt-4.1-mini',
+            source: 'auto',
+            fallback_models: [],
+          },
+          {
+            tier: 'standard',
+            model: 'claude-sonnet-4',
+            source: 'auto',
+            fallback_models: [],
+          },
+          {
+            tier: 'complex',
+            model: 'claude-opus-4',
+            source: 'auto',
+            fallback_models: ['claude-opus-4'],
+          },
+          {
+            tier: 'reasoning',
+            model: 'o3',
+            source: 'override',
+            fallback_models: ['o4-mini'],
+          },
+        ],
+      };
+
+      expect(result).toEqual(expected);
+      expect(mockRoutingService.getProviders).toHaveBeenCalledWith('a1');
+      expect(mockRoutingService.getTiers).toHaveBeenCalledWith('a1');
+      expect(mockRoutingService.getEffectiveModel).toHaveBeenCalledTimes(4);
+    });
   });
 
   describe('RegisterSubscriptionsDto', () => {

--- a/packages/backend/src/routing/resolve.controller.spec.ts
+++ b/packages/backend/src/routing/resolve.controller.spec.ts
@@ -204,6 +204,58 @@ describe('ResolveController', () => {
       expect(mockRoutingService.getTiers).toHaveBeenCalledWith('a1');
       expect(mockRoutingService.getEffectiveModel).toHaveBeenCalledTimes(4);
     });
+
+    it('fills missing tier assignments with null auto entries', async () => {
+      const req = {
+        ingestionContext: {
+          userId: 'user-42',
+          tenantId: 't1',
+          agentId: 'a1',
+          agentName: 'test-agent',
+        },
+      } as never;
+
+      mockRoutingService.getProviders.mockResolvedValue([]);
+      mockRoutingService.getTiers.mockResolvedValue([
+        {
+          tier: 'simple',
+          override_model: null,
+          auto_assigned_model: 'gpt-4.1-mini',
+          fallback_models: null,
+        },
+      ]);
+      mockRoutingService.getEffectiveModel.mockResolvedValue('gpt-4.1-mini');
+
+      const result = await controller.getSummary(req);
+
+      expect(result.tiers).toEqual([
+        {
+          tier: 'simple',
+          model: 'gpt-4.1-mini',
+          source: 'auto',
+          fallback_models: [],
+        },
+        {
+          tier: 'standard',
+          model: null,
+          source: 'auto',
+          fallback_models: [],
+        },
+        {
+          tier: 'complex',
+          model: null,
+          source: 'auto',
+          fallback_models: [],
+        },
+        {
+          tier: 'reasoning',
+          model: null,
+          source: 'auto',
+          fallback_models: [],
+        },
+      ]);
+      expect(mockRoutingService.getEffectiveModel).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('RegisterSubscriptionsDto', () => {

--- a/packages/backend/src/routing/resolve.controller.spec.ts
+++ b/packages/backend/src/routing/resolve.controller.spec.ts
@@ -256,6 +256,32 @@ describe('ResolveController', () => {
       ]);
       expect(mockRoutingService.getEffectiveModel).toHaveBeenCalledTimes(1);
     });
+
+    it('sorts same-provider entries by auth type and defaults missing auth type to api_key', async () => {
+      const req = {
+        ingestionContext: {
+          userId: 'user-42',
+          tenantId: 't1',
+          agentId: 'a1',
+          agentName: 'test-agent',
+        },
+      } as never;
+
+      mockRoutingService.getProviders.mockResolvedValue([
+        { provider: 'openai', auth_type: 'subscription', is_active: true },
+        { provider: 'openai', auth_type: 'api_key', is_active: true },
+        { provider: 'mistral', is_active: true },
+      ]);
+      mockRoutingService.getTiers.mockResolvedValue([]);
+
+      const result = await controller.getSummary(req);
+
+      expect(result.providers).toEqual([
+        { provider: 'mistral', auth_type: 'api_key' },
+        { provider: 'openai', auth_type: 'api_key' },
+        { provider: 'openai', auth_type: 'subscription' },
+      ]);
+    });
   });
 
   describe('RegisterSubscriptionsDto', () => {

--- a/packages/backend/src/routing/resolve.controller.ts
+++ b/packages/backend/src/routing/resolve.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Post, Req, UseGuards } from '@nestjs/common';
 import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { Request } from 'express';
@@ -9,6 +9,7 @@ import { ResolveService } from './resolve.service';
 import { RoutingService } from './routing.service';
 import { ResolveRequestDto } from './dto/resolve-request.dto';
 import { ResolveResponse } from './dto/resolve-response';
+import { TIERS } from './scorer/types';
 
 export class SubscriptionProviderItem {
   @IsString()
@@ -21,6 +22,24 @@ export class RegisterSubscriptionsDto {
   @ValidateNested({ each: true })
   @Type(() => SubscriptionProviderItem)
   providers!: SubscriptionProviderItem[];
+}
+
+export interface RoutingSummaryProvider {
+  provider: string;
+  auth_type: 'api_key' | 'subscription';
+}
+
+export interface RoutingSummaryTier {
+  tier: string;
+  model: string | null;
+  source: 'auto' | 'override';
+  fallback_models: string[];
+}
+
+export interface RoutingSummaryResponse {
+  agentName: string;
+  providers: RoutingSummaryProvider[];
+  tiers: RoutingSummaryTier[];
 }
 
 @Controller('api/v1/routing')
@@ -47,6 +66,59 @@ export class ResolveController {
       body.max_tokens,
       body.recentTiers,
     );
+  }
+
+  @Get('summary')
+  async getSummary(
+    @Req() req: Request & { ingestionContext: IngestionContext },
+  ): Promise<RoutingSummaryResponse> {
+    const { agentId, agentName } = req.ingestionContext;
+    const [providers, tiers] = await Promise.all([
+      this.routingService.getProviders(agentId),
+      this.routingService.getTiers(agentId),
+    ]);
+
+    const activeProviders = providers
+      .filter((provider) => provider.is_active)
+      .sort(
+        (a, b) => a.provider.localeCompare(b.provider) || a.auth_type.localeCompare(b.auth_type),
+      )
+      .map((provider) => ({
+        provider: provider.provider,
+        auth_type: provider.auth_type ?? 'api_key',
+      }));
+
+    const tiersByName = new Map(tiers.map((tier) => [tier.tier, tier]));
+    const tierSummaries = await Promise.all(
+      TIERS.map(async (tier) => {
+        const assignment = tiersByName.get(tier);
+        if (!assignment) {
+          return {
+            tier,
+            model: null,
+            source: 'auto' as const,
+            fallback_models: [],
+          };
+        }
+
+        const effectiveModel = await this.routingService.getEffectiveModel(agentId, assignment);
+        return {
+          tier,
+          model: effectiveModel,
+          source:
+            assignment.override_model !== null && assignment.override_model === effectiveModel
+              ? ('override' as const)
+              : ('auto' as const),
+          fallback_models: assignment.fallback_models ?? [],
+        };
+      }),
+    );
+
+    return {
+      agentName,
+      providers: activeProviders,
+      tiers: tierSummaries,
+    };
   }
 
   @Post('subscription-providers')

--- a/packages/openclaw-plugin/__tests__/command.test.ts
+++ b/packages/openclaw-plugin/__tests__/command.test.ts
@@ -130,6 +130,46 @@ describe("registerCommand", () => {
     );
   });
 
+  it("formats empty providers, unknown tiers, and api-key auth headers", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: true,
+      authValid: true,
+      agentName: null,
+      error: null,
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        agentName: "custom-agent",
+        providers: [],
+        tiers: [
+          { tier: "custom", model: null, source: "auto", fallback_models: [] },
+        ],
+      }),
+    });
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(
+      api,
+      { ...config, apiKey: "mnfst_test_key", devMode: false },
+      mockLogger,
+    );
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Dev mode: no");
+    expect(result).toContain("Agent: custom-agent");
+    expect(result).toContain("Providers: none");
+    expect(result).toContain("custom -> unassigned (auto)");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:38238/api/v1/routing/summary",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer mnfst_test_key" },
+      }),
+    );
+  });
+
   it("falls back to status output when the routing summary request fails", async () => {
     mockVerify.mockResolvedValueOnce({
       endpointReachable: true,
@@ -150,6 +190,26 @@ describe("registerCommand", () => {
     expect(result).not.toContain("Routing:");
     expect(mockLogger.debug).toHaveBeenCalledWith(
       "[manifest] Routing summary failed (summary down)",
+    );
+  });
+
+  it("stringifies non-Error routing summary failures", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: true,
+      authValid: true,
+      agentName: "test-agent",
+      error: null,
+    });
+    mockFetch.mockRejectedValueOnce("summary-string-error");
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    await cmd.execute();
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      "[manifest] Routing summary failed (summary-string-error)",
     );
   });
 

--- a/packages/openclaw-plugin/__tests__/command.test.ts
+++ b/packages/openclaw-plugin/__tests__/command.test.ts
@@ -6,6 +6,8 @@ jest.mock("../src/verify", () => ({
   verifyConnection: jest.fn(),
 }));
 const mockVerify = verifyConnection as jest.MockedFunction<typeof verifyConnection>;
+const originalFetch = global.fetch;
+const mockFetch = jest.fn();
 
 const mockLogger = {
   info: jest.fn(),
@@ -24,6 +26,25 @@ const config: ManifestConfig = {
 };
 
 describe("registerCommand", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(global, "fetch", {
+      writable: true,
+      value: mockFetch,
+    });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(global, "fetch", {
+      writable: true,
+      value: originalFetch,
+    });
+  });
+
   it("registers /manifest command when registerCommand is available", () => {
     const api = { registerCommand: jest.fn() };
     registerCommand(api, config, mockLogger);
@@ -67,6 +88,48 @@ describe("registerCommand", () => {
     expect(result).not.toContain("Error:");
   });
 
+  it("appends providers and routing tiers when summary is available", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: true,
+      authValid: true,
+      agentName: "test-agent",
+      error: null,
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        agentName: "test-agent",
+        providers: [
+          { provider: "anthropic", auth_type: "subscription" },
+          { provider: "openai", auth_type: "api_key" },
+        ],
+        tiers: [
+          { tier: "simple", model: "gpt-4.1-mini", source: "auto", fallback_models: [] },
+          { tier: "standard", model: "claude-sonnet-4", source: "auto", fallback_models: [] },
+          { tier: "complex", model: "claude-opus-4", source: "auto", fallback_models: [] },
+          { tier: "reasoning", model: "o3", source: "override", fallback_models: [] },
+        ],
+      }),
+    });
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Providers: anthropic (subscription), openai (api key)");
+    expect(result).toContain("Routing:");
+    expect(result).toContain("Simple -> gpt-4.1-mini (auto)");
+    expect(result).toContain("Reasoning -> o3 (override)");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:38238/api/v1/routing/summary",
+      expect.objectContaining({
+        headers: {},
+      }),
+    );
+  });
+
   it("includes error in status text when verify reports one", async () => {
     mockVerify.mockResolvedValueOnce({
       endpointReachable: false,
@@ -83,6 +146,7 @@ describe("registerCommand", () => {
 
     expect(result).toContain("Endpoint reachable: no");
     expect(result).toContain("Error: Cannot reach endpoint: ECONNREFUSED");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("returns error message when verify throws", async () => {

--- a/packages/openclaw-plugin/__tests__/command.test.ts
+++ b/packages/openclaw-plugin/__tests__/command.test.ts
@@ -130,6 +130,29 @@ describe("registerCommand", () => {
     );
   });
 
+  it("falls back to status output when the routing summary request fails", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: true,
+      authValid: true,
+      agentName: "test-agent",
+      error: null,
+    });
+    mockFetch.mockRejectedValueOnce(new Error("summary down"));
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Agent: test-agent");
+    expect(result).not.toContain("Providers:");
+    expect(result).not.toContain("Routing:");
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      "[manifest] Routing summary failed (summary down)",
+    );
+  });
+
   it("includes error in status text when verify reports one", async () => {
     mockVerify.mockResolvedValueOnce({
       endpointReachable: false,

--- a/packages/openclaw-plugin/src/command.ts
+++ b/packages/openclaw-plugin/src/command.ts
@@ -2,6 +2,78 @@ import { ManifestConfig } from './config';
 import { PluginLogger } from './telemetry';
 import { verifyConnection } from './verify';
 
+interface RoutingSummaryProvider {
+  provider: string;
+  auth_type: 'api_key' | 'subscription';
+}
+
+interface RoutingSummaryTier {
+  tier: string;
+  model: string | null;
+  source: 'auto' | 'override';
+  fallback_models: string[];
+}
+
+interface RoutingSummaryResponse {
+  agentName: string;
+  providers: RoutingSummaryProvider[];
+  tiers: RoutingSummaryTier[];
+}
+
+const ROUTING_SUMMARY_TIMEOUT_MS = 5000;
+const TIER_LABELS: Record<string, string> = {
+  simple: 'Simple',
+  standard: 'Standard',
+  complex: 'Complex',
+  reasoning: 'Reasoning',
+};
+
+function buildAuthHeaders(config: ManifestConfig): Record<string, string> {
+  return config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {};
+}
+
+function formatAuthType(authType: 'api_key' | 'subscription'): string {
+  return authType === 'api_key' ? 'api key' : 'subscription';
+}
+
+function formatProviders(providers: RoutingSummaryProvider[]): string {
+  if (providers.length === 0) return 'none';
+  return providers
+    .map((provider) => `${provider.provider} (${formatAuthType(provider.auth_type)})`)
+    .join(', ');
+}
+
+function formatTier(tier: RoutingSummaryTier): string {
+  const label = TIER_LABELS[tier.tier] ?? tier.tier;
+  const model = tier.model ?? 'unassigned';
+  return `${label} -> ${model} (${tier.source})`;
+}
+
+async function fetchRoutingSummary(
+  config: ManifestConfig,
+  logger: PluginLogger,
+): Promise<RoutingSummaryResponse | null> {
+  const baseUrl = config.endpoint.replace(/\/otlp(\/v1)?\/?$/, '');
+
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/routing/summary`, {
+      headers: buildAuthHeaders(config),
+      signal: AbortSignal.timeout(ROUTING_SUMMARY_TIMEOUT_MS),
+    });
+
+    if (!res.ok) {
+      logger.debug(`[manifest] Routing summary unavailable (${res.status})`);
+      return null;
+    }
+
+    return (await res.json()) as RoutingSummaryResponse;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.debug(`[manifest] Routing summary failed (${msg})`);
+    return null;
+  }
+}
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function registerCommand(api: any, config: ManifestConfig, logger: PluginLogger): void {
   if (typeof api.registerCommand !== 'function') {
@@ -18,9 +90,25 @@ export function registerCommand(api: any, config: ManifestConfig, logger: Plugin
         `Endpoint reachable: ${check.endpointReachable ? 'yes' : 'no'}`,
         `Auth valid: ${check.authValid ? 'yes' : 'no'}`,
       ];
-      if (check.agentName) {
-        lines.push(`Agent: ${check.agentName}`);
+
+      const routingSummary =
+        check.endpointReachable && check.authValid
+          ? await fetchRoutingSummary(config, logger)
+          : null;
+      const agentName = routingSummary?.agentName ?? check.agentName;
+
+      if (agentName) {
+        lines.push(`Agent: ${agentName}`);
       }
+
+      if (routingSummary) {
+        lines.push(`Providers: ${formatProviders(routingSummary.providers)}`);
+        lines.push('Routing:');
+        for (const tier of routingSummary.tiers) {
+          lines.push(`  ${formatTier(tier)}`);
+        }
+      }
+
       if (check.error) {
         lines.push(`Error: ${check.error}`);
       }


### PR DESCRIPTION
I would like to enrich the result of /manifest command to show more info such as :

- active routing providers
- current models used : Simple -> ... (auto) or Reasoning -> ... (override)

The plugin now reads a new OTLP-authenticated routing summary endpoint.

It's a first step towards a more broadly used manifest command that'll allow to change configurations such as switching between models.

This PR introduces only read-only changes tho.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a routing summary to `/manifest` showing active providers and each tier’s effective model (auto vs override). Implements a new authenticated `GET /api/v1/routing/summary` and updates the plugin to display it with safe fallbacks.

- **New Features**
  - Backend: `GET /api/v1/routing/summary` returns `agentName`, active providers (auth type), and tiers (`simple`, `standard`, `complex`, `reasoning`) with effective `model`, `source`, and `fallback_models`. Only active providers are returned, sorted by provider then auth type, and missing `auth_type` defaults to `api_key`. Missing tiers default to `auto` with `null` model, and `fallback_models` default to `[]`.
  - Plugin: `/manifest` fetches the summary (5s timeout, Bearer from `apiKey` if set), prints “Providers” and “Routing”, formats auth types (“api key”/“subscription”), shows “unassigned” for `null` models, strips `/otlp` from `endpoint` to derive base URL, and logs/falls back silently if the summary is unavailable.

- **Tests**
  - Backend: cover summary logic for missing tiers, provider sorting, and defaulting `auth_type`.
  - Plugin: cover successful summary output, empty providers and unknown tiers, Authorization header usage, failed requests, and non-Error failures; verify no summary fetch when connection verify fails.

<sup>Written for commit 508f45554576d6b14c7b9eca74e2b8a89dbb32fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



Related to #1081 