### PR TITLE
docs(readme): add model switch examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ To use tailsacle to proxy it to your network (needs Tailscale installed in both 
 tailscale serve --bg 2099
 ```
 
+### Activate Manifest
+
+After installing the plugin, set `manifest/auto` as your active OpenClaw model.
+
+**Using Telegram (or other messaging apps)**
+
+```text
+/model manifest/auto
+```
+
+**Using the terminal**
+
+```bash
+openclaw config set agents.defaults.model.primary manifest/auto
+openclaw gateway restart
+```
+
+Run `/model` to verify that `manifest/auto` is active.
+
 ## Features
 
 - **LLM Router** — scores each query and calls the most suitable model


### PR DESCRIPTION
## Summary
- add a README section showing how to switch to `manifest/auto`
- include the Telegram/message-app `/model manifest/auto` command
- include the terminal config command and note how to switch back to a direct OpenClaw model

Refs #1000

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a README "Activate Manifest" guide to set `manifest/auto` as the active model via Telegram (`/model manifest/auto`) or terminal (`openclaw config set agents.defaults.model.primary manifest/auto` + `openclaw gateway restart`), with a note to verify using `/model`. Refs #1000.

<sup>Written for commit 80d0c5510f626bad480ed9c66e1573f89227de8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

