### PR TITLE
Persist override provider for routing overrides

### DIFF
--- a/.changeset/fix-openrouter-provider-resolution.md
+++ b/.changeset/fix-openrouter-provider-resolution.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Persist the selected provider for manual routing overrides so OpenRouter-sourced models resolve through the chosen provider instead of being re-inferred from the model name.

--- a/packages/backend/src/database/migrations/1773600000000-AddOverrideProvider.ts
+++ b/packages/backend/src/database/migrations/1773600000000-AddOverrideProvider.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddOverrideProvider1773600000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'tier_assignments',
+      new TableColumn({
+        name: 'override_provider',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('tier_assignments', 'override_provider');
+  }
+}

--- a/packages/backend/src/entities/tier-assignment.entity.spec.ts
+++ b/packages/backend/src/entities/tier-assignment.entity.spec.ts
@@ -7,6 +7,7 @@ describe('TierAssignment entity', () => {
     entity.user_id = 'u1';
     entity.tier = 'complex';
     entity.override_model = 'gpt-4o';
+    entity.override_provider = 'openai';
     entity.auto_assigned_model = 'claude-opus-4-6';
     entity.updated_at = '2025-06-01T00:00:00Z';
 
@@ -14,6 +15,7 @@ describe('TierAssignment entity', () => {
     expect(entity.user_id).toBe('u1');
     expect(entity.tier).toBe('complex');
     expect(entity.override_model).toBe('gpt-4o');
+    expect(entity.override_provider).toBe('openai');
     expect(entity.auto_assigned_model).toBe('claude-opus-4-6');
     expect(entity.updated_at).toBe('2025-06-01T00:00:00Z');
   });
@@ -21,9 +23,11 @@ describe('TierAssignment entity', () => {
   it('should allow nullable fields to be null', () => {
     const entity = new TierAssignment();
     entity.override_model = null;
+    entity.override_provider = null;
     entity.auto_assigned_model = null;
 
     expect(entity.override_model).toBeNull();
+    expect(entity.override_provider).toBeNull();
     expect(entity.auto_assigned_model).toBeNull();
   });
 });

--- a/packages/backend/src/entities/tier-assignment.entity.ts
+++ b/packages/backend/src/entities/tier-assignment.entity.ts
@@ -20,6 +20,9 @@ export class TierAssignment {
   override_model!: string | null;
 
   @Column('varchar', { nullable: true })
+  override_provider!: string | null;
+
+  @Column('varchar', { nullable: true })
   override_auth_type!: 'api_key' | 'subscription' | null;
 
   @Column('varchar', { nullable: true })

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -66,6 +66,11 @@ export class SetOverrideDto {
   model!: string;
 
   @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  provider?: string;
+
+  @IsOptional()
   @IsIn(VALID_AUTH_TYPES)
   authType?: 'api_key' | 'subscription';
 }

--- a/packages/backend/src/routing/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve.service.spec.ts
@@ -166,6 +166,28 @@ describe('ResolveService', () => {
   });
 
   describe('auth_type resolution', () => {
+    it('should prefer stored override_provider over model prefix inference', async () => {
+      mockRoutingService.getTiers.mockResolvedValue([
+        {
+          tier: 'simple',
+          override_model: 'z-ai/glm-5',
+          override_provider: 'openrouter',
+          override_auth_type: 'api_key',
+          auto_assigned_model: 'gpt-4o-mini',
+        },
+        { tier: 'standard', override_model: null, auto_assigned_model: 'gpt-4o' },
+        { tier: 'complex', override_model: null, auto_assigned_model: 'claude-sonnet-4' },
+        { tier: 'reasoning', override_model: null, auto_assigned_model: 'claude-opus-4-6' },
+      ]);
+      mockRoutingService.getEffectiveModel.mockResolvedValue('z-ai/glm-5');
+
+      const result = await service.resolve('agent-1', [{ role: 'user', content: 'hello' }]);
+
+      expect(result.provider).toBe('openrouter');
+      expect(mockDiscoveryService.getModelForAgent).not.toHaveBeenCalled();
+      expect(mockPricingCache.getByModel).not.toHaveBeenCalled();
+    });
+
     it('should propagate override_auth_type from tier assignment', async () => {
       mockRoutingService.getTiers.mockResolvedValue([
         {

--- a/packages/backend/src/routing/resolve.service.ts
+++ b/packages/backend/src/routing/resolve.service.ts
@@ -66,7 +66,7 @@ export class ResolveService {
       };
     }
 
-    const provider = await this.resolveProvider(agentId, model);
+    const provider = await this.resolveProvider(agentId, assignment, model);
     const authType = provider
       ? (assignment.override_auth_type ??
         (await this.routingService.getAuthType(agentId, provider)))
@@ -92,7 +92,7 @@ export class ResolveService {
     }
 
     const model = await this.routingService.getEffectiveModel(agentId, assignment);
-    const provider = model ? await this.resolveProvider(agentId, model) : null;
+    const provider = model ? await this.resolveProvider(agentId, assignment, model) : null;
     const authType = provider
       ? (assignment.override_auth_type ??
         (await this.routingService.getAuthType(agentId, provider)))
@@ -115,7 +115,15 @@ export class ResolveService {
    * 2. Look up in discovered models (cached per-provider)
    * 3. Fall back to pricing cache
    */
-  private async resolveProvider(agentId: string, model: string): Promise<string | null> {
+  private async resolveProvider(
+    agentId: string,
+    assignment: { override_model: string | null; override_provider?: string | null },
+    model: string,
+  ): Promise<string | null> {
+    if (assignment.override_model === model && assignment.override_provider) {
+      return assignment.override_provider;
+    }
+
     // 1. Infer from slash prefix
     const prefix = inferProviderFromModelName(model);
     if (prefix) return prefix;

--- a/packages/backend/src/routing/routing-invalidation.service.ts
+++ b/packages/backend/src/routing/routing-invalidation.service.ts
@@ -38,6 +38,7 @@ export class RoutingInvalidationService {
         `Clearing override ${tier.override_model} for agent ${tier.agent_id} tier ${tier.tier} (model removed)`,
       );
       tier.override_model = null;
+      tier.override_provider = null;
       tier.override_auth_type = null;
       tier.updated_at = new Date().toISOString();
       tiersToSave.push(tier);

--- a/packages/backend/src/routing/routing.controller.spec.ts
+++ b/packages/backend/src/routing/routing.controller.spec.ts
@@ -440,11 +440,16 @@ describe('RoutingController', () => {
 
   describe('setOverride', () => {
     it('should call service with tier and model', async () => {
-      const updated = { tier: 'complex', override_model: 'claude-opus-4-6' };
+      const updated = {
+        tier: 'complex',
+        override_model: 'claude-opus-4-6',
+        override_provider: 'openrouter',
+      };
       mockRoutingService.setOverride.mockResolvedValue(updated);
 
       const result = await controller.setOverride(mockUser, 'test-agent', 'complex', {
         model: 'claude-opus-4-6',
+        provider: 'openrouter',
       });
 
       expect(mockRoutingService.setOverride).toHaveBeenCalledWith(
@@ -452,6 +457,7 @@ describe('RoutingController', () => {
         'user-1',
         'complex',
         'claude-opus-4-6',
+        'openrouter',
         undefined,
       );
       expect(result).toBe(updated);

--- a/packages/backend/src/routing/routing.controller.ts
+++ b/packages/backend/src/routing/routing.controller.ts
@@ -154,7 +154,14 @@ export class RoutingController {
     @Body() body: SetOverrideDto,
   ) {
     const agent = await this.resolveAgentService.resolve(user.id, agentName);
-    return this.routingService.setOverride(agent.id, user.id, tier, body.model, body.authType);
+    return this.routingService.setOverride(
+      agent.id,
+      user.id,
+      tier,
+      body.model,
+      body.provider,
+      body.authType,
+    );
   }
 
   @Delete(':agentName/tiers/:tier')

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -1147,9 +1147,33 @@ describe('RoutingService', () => {
 
       expect(existing.override_model).toBe('claude-opus-4-6');
       expect(mockTierRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({ override_model: 'claude-opus-4-6' }),
+        expect.objectContaining({
+          override_model: 'claude-opus-4-6',
+          override_provider: null,
+        }),
       );
       expect(result.override_model).toBe('claude-opus-4-6');
+    });
+
+    it('should store override_provider when provider is provided', async () => {
+      const existing = Object.assign(new TierAssignment(), {
+        id: 't1',
+        agent_id: 'a1',
+        tier: 'complex',
+        override_model: null,
+        override_provider: null,
+      });
+      mockTierRepo.findOne.mockResolvedValue(existing);
+
+      const result = await service.setOverride('a1', 'u1', 'complex', 'z-ai/glm-5', 'openrouter');
+
+      expect(result.override_provider).toBe('openrouter');
+      expect(mockTierRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          override_model: 'z-ai/glm-5',
+          override_provider: 'openrouter',
+        }),
+      );
     });
 
     it('should store override_auth_type when authType is provided', async () => {
@@ -1167,6 +1191,7 @@ describe('RoutingService', () => {
         'u1',
         'complex',
         'claude-sonnet-4',
+        undefined,
         'subscription',
       );
 
@@ -1207,6 +1232,7 @@ describe('RoutingService', () => {
           user_id: 'u1',
           tier: 'reasoning',
           override_model: 'o1-pro',
+          override_provider: null,
           auto_assigned_model: null,
         }),
       );

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -204,10 +204,17 @@ export class RoutingService {
     const invalidated: { tier: string; modelName: string }[] = [];
     const tiersToSave: TierAssignment[] = [];
     for (const tier of overrides) {
-      const pricing = this.pricingCache.getByModel(tier.override_model!);
-      if (pricing && providerNames.has(pricing.provider.toLowerCase())) {
+      const overrideProvider = tier.override_provider?.toLowerCase();
+      const pricingProvider = this.pricingCache
+        .getByModel(tier.override_model!)
+        ?.provider.toLowerCase();
+      if (
+        (overrideProvider && providerNames.has(overrideProvider)) ||
+        (pricingProvider && providerNames.has(pricingProvider))
+      ) {
         invalidated.push({ tier: tier.tier, modelName: tier.override_model! });
         tier.override_model = null;
+        tier.override_provider = null;
         tier.override_auth_type = null;
         tier.updated_at = new Date().toISOString();
         tiersToSave.push(tier);
@@ -299,6 +306,7 @@ export class RoutingService {
       { agent_id: agentId },
       {
         override_model: null,
+        override_provider: null,
         override_auth_type: null,
         fallback_models: null,
         updated_at: new Date().toISOString(),
@@ -326,6 +334,7 @@ export class RoutingService {
           agent_id: agentId,
           tier,
           override_model: null,
+          override_provider: null,
           override_auth_type: null,
           auto_assigned_model: null,
         }),
@@ -357,6 +366,7 @@ export class RoutingService {
     userId: string,
     tier: string,
     model: string,
+    provider?: string,
     authType?: 'api_key' | 'subscription',
   ): Promise<TierAssignment> {
     const existing = await this.tierRepo.findOne({
@@ -365,6 +375,7 @@ export class RoutingService {
 
     if (existing) {
       existing.override_model = model;
+      existing.override_provider = provider ?? null;
       existing.override_auth_type = authType ?? null;
       if (existing.fallback_models?.includes(model)) {
         const filtered = existing.fallback_models.filter((m) => m !== model);
@@ -382,6 +393,7 @@ export class RoutingService {
       agent_id: agentId,
       tier,
       override_model: model,
+      override_provider: provider ?? null,
       override_auth_type: authType ?? null,
       auto_assigned_model: null,
     });
@@ -398,6 +410,7 @@ export class RoutingService {
     if (!existing) return;
 
     existing.override_model = null;
+    existing.override_provider = null;
     existing.override_auth_type = null;
     existing.updated_at = new Date().toISOString();
     await this.tierRepo.save(existing);
@@ -409,6 +422,7 @@ export class RoutingService {
       { agent_id: agentId },
       {
         override_model: null,
+        override_provider: null,
         override_auth_type: null,
         fallback_models: null,
         updated_at: new Date().toISOString(),

--- a/packages/backend/src/routing/tier-auto-assign.service.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.ts
@@ -82,6 +82,7 @@ export class TierAutoAssignService {
           agent_id: agentId,
           tier,
           override_model: null,
+          override_provider: null,
           auto_assigned_model: best?.model_name ?? null,
         });
       }

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -17,7 +17,7 @@ interface Props {
   tiers: TierAssignment[];
   customProviders?: CustomProviderData[];
   connectedProviders?: RoutingProvider[];
-  onSelect: (tierId: string, modelName: string, authType?: AuthType) => void;
+  onSelect: (tierId: string, modelName: string, providerId: string, authType?: AuthType) => void;
   onClose: () => void;
 }
 
@@ -371,7 +371,9 @@ const ModelPickerModal: Component<Props> = (props) => {
                   {(model) => (
                     <button
                       class="routing-modal__model"
-                      onClick={() => props.onSelect(props.tierId, model.value, activeTab())}
+                      onClick={() =>
+                        props.onSelect(props.tierId, model.value, group.provId, activeTab())
+                      }
                     >
                       <span class="routing-modal__model-label">
                         {model.label}

--- a/packages/frontend/src/components/ModelSelectDropdown.tsx
+++ b/packages/frontend/src/components/ModelSelectDropdown.tsx
@@ -1,8 +1,8 @@
-import { createSignal, createResource, For, Show, type Component } from "solid-js";
-import { getModelPrices } from "../services/api.js";
-import { resolveProviderId } from "../services/routing-utils.js";
-import { PROVIDERS } from "../services/providers.js";
-import { providerIcon } from "./ProviderIcon.js";
+import { createSignal, createResource, For, Show, type Component } from 'solid-js';
+import { getModelPrices } from '../services/api.js';
+import { resolveProviderId } from '../services/routing-utils.js';
+import { PROVIDERS } from '../services/providers.js';
+import { providerIcon } from './ProviderIcon.js';
 
 interface ModelPricesData {
   models: { model_name: string; provider: string }[];
@@ -15,8 +15,8 @@ interface ModelSelectDropdownProps {
 }
 
 function computeCliValue(modelName: string, provider: string): string {
-  if (modelName.includes("/")) return modelName;
-  return `${provider.toLowerCase()}/${modelName}`;
+  const providerId = provider.toLowerCase();
+  return modelName.startsWith(`${providerId}/`) ? modelName : `${providerId}/${modelName}`;
 }
 
 /** Resolve a display label for a model name from the PROVIDERS definitions. */
@@ -26,7 +26,7 @@ function labelForModel(name: string): string {
       if (m.value === name) return m.label;
     }
   }
-  const slash = name.indexOf("/");
+  const slash = name.indexOf('/');
   if (slash !== -1) {
     const bare = name.substring(slash + 1);
     for (const prov of PROVIDERS) {
@@ -41,7 +41,7 @@ function labelForModel(name: string): string {
 
 const ModelSelectDropdown: Component<ModelSelectDropdownProps> = (props) => {
   const [data] = createResource(() => getModelPrices() as Promise<ModelPricesData>);
-  const [search, setSearch] = createSignal("");
+  const [search, setSearch] = createSignal('');
   const [open, setOpen] = createSignal(true);
 
   const groupedModels = () => {
@@ -87,12 +87,12 @@ const ModelSelectDropdown: Component<ModelSelectDropdownProps> = (props) => {
   const handleSelect = (cliValue: string, label: string) => {
     props.onSelect(cliValue, label);
     setOpen(false);
-    setSearch("");
+    setSearch('');
   };
 
   const handleReopen = () => {
     setOpen(true);
-    setSearch("");
+    setSearch('');
   };
 
   return (
@@ -104,15 +104,30 @@ const ModelSelectDropdown: Component<ModelSelectDropdownProps> = (props) => {
           type="button"
           aria-label="Change model selection"
         >
-          <span class="routing-modal__selected-label">{labelForModel(props.selectedValue!.split("/").pop()!)}</span>
+          <span class="routing-modal__selected-label">
+            {labelForModel(props.selectedValue!.split('/').pop()!)}
+          </span>
           <span class="routing-modal__selected-hint">Click to change</span>
         </button>
       </Show>
 
       <Show when={open()}>
         <div class="routing-modal__search-wrap" style="padding: 0;">
-          <svg class="routing-modal__search-icon" style="left: 14px;" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
+          <svg
+            class="routing-modal__search-icon"
+            style="left: 14px;"
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
           </svg>
           <input
             class="routing-modal__search"
@@ -135,9 +150,7 @@ const ModelSelectDropdown: Component<ModelSelectDropdownProps> = (props) => {
               {(group) => (
                 <div class="routing-modal__group">
                   <div class="routing-modal__group-header">
-                    <span class="routing-modal__group-icon">
-                      {providerIcon(group.provId, 16)}
-                    </span>
+                    <span class="routing-modal__group-icon">{providerIcon(group.provId, 16)}</span>
                     <span class="routing-modal__group-name">{group.name}</span>
                   </div>
                   <For each={group.models}>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -71,11 +71,16 @@ const Routing: Component = () => {
   const activeProviders = () => connectedProviders()?.filter((p) => p.is_active) ?? [];
   const getTier = (tierId: string): TierAssignment | undefined =>
     tiers()?.find((t) => t.tier === tierId);
-  const handleOverride = async (tierId: string, modelName: string, authType?: AuthType) => {
+  const handleOverride = async (
+    tierId: string,
+    modelName: string,
+    providerId: string,
+    authType?: AuthType,
+  ) => {
     setDropdownTier(null);
     setChangingTier(tierId);
     try {
-      const updated = await overrideTier(agentName(), tierId, modelName, authType);
+      const updated = await overrideTier(agentName(), tierId, modelName, providerId, authType);
       mutateTiers((prev) => prev?.map((t) => (t.tier === tierId ? updated : t)));
       toast.success('Routing updated');
     } catch {
@@ -89,7 +94,9 @@ const Routing: Component = () => {
     setResettingAll(true);
     try {
       await resetAllTiers(agentName());
-      mutateTiers((prev) => prev?.map((t) => ({ ...t, override_model: null })));
+      mutateTiers((prev) =>
+        prev?.map((t) => ({ ...t, override_model: null, override_provider: null })),
+      );
       toast.success('All tiers reset to auto');
     } catch {
       // error toast from fetchMutate
@@ -105,7 +112,9 @@ const Routing: Component = () => {
       await resetTier(agentName(), tierId);
       mutateTiers((prev) =>
         prev?.map((t) =>
-          t.tier === tierId ? { ...t, override_model: null, fallback_models: [] } : t,
+          t.tier === tierId
+            ? { ...t, override_model: null, override_provider: null, fallback_models: [] }
+            : t,
         ),
       );
       toast.success('Tier reset to auto');
@@ -116,7 +125,12 @@ const Routing: Component = () => {
     }
   };
 
-  const handleAddFallback = async (tierId: string, modelName: string, _authType?: AuthType) => {
+  const handleAddFallback = async (
+    tierId: string,
+    modelName: string,
+    _providerId: string,
+    _authType?: AuthType,
+  ) => {
     setFallbackPickerTier(null);
     const tier = getTier(tierId);
     const current = tier?.fallback_models ?? [];

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -69,6 +69,10 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
     const t = props.tier();
     return t ? effectiveModel(t) : null;
   };
+  const manualProviderId = () => {
+    const t = props.tier();
+    return t?.override_model ? (t.override_provider ?? undefined) : undefined;
+  };
   const isManual = () =>
     props.tier()?.override_model !== null && props.tier()?.override_model !== undefined;
   const hasFallbacks = () => (props.tier()?.fallback_models ?? []).length > 0;
@@ -140,7 +144,8 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
             }
           >
             {(modelName) => {
-              const provId = () => providerIdForModel(modelName(), props.models());
+              const provId = () =>
+                manualProviderId() ?? providerIdForModel(modelName(), props.models());
               const effectiveAuth = (): AuthType | null => {
                 const t = props.tier();
                 if (t?.override_auth_type) return t.override_auth_type;

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -53,7 +53,7 @@ export interface RoutingTierCardProps {
   addingFallback: () => string | null;
   agentName: () => string;
   onDropdownOpen: (tierId: string) => void;
-  onOverride: (tierId: string, model: string, authType?: AuthType) => void;
+  onOverride: (tierId: string, model: string, providerId: string, authType?: AuthType) => void;
   onReset: (tierId: string) => void;
   onFallbackUpdate: (tierId: string, fallbacks: string[]) => void;
   onAddFallback: (tierId: string) => void;

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -452,6 +452,7 @@ export interface TierAssignment {
   agent_id: string;
   tier: string;
   override_model: string | null;
+  override_provider: string | null;
   override_auth_type: AuthType | null;
   auto_assigned_model: string | null;
   fallback_models: string[] | null;
@@ -462,13 +463,19 @@ export function getTierAssignments(agentName: string) {
   return fetchJson<TierAssignment[]>(`/routing/${encodeURIComponent(agentName)}/tiers`);
 }
 
-export function overrideTier(agentName: string, tier: string, model: string, authType?: AuthType) {
+export function overrideTier(
+  agentName: string,
+  tier: string,
+  model: string,
+  provider: string,
+  authType?: AuthType,
+) {
   return fetchMutate<TierAssignment>(
     `${BASE_URL}/routing/${encodeURIComponent(agentName)}/tiers/${encodeURIComponent(tier)}`,
     {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, ...(authType && { authType }) }),
+      body: JSON.stringify({ model, provider, ...(authType && { authType }) }),
     },
   );
 }

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../../src/services/routing-utils.js", () => ({
 import ModelPickerModal from "../../src/components/ModelPickerModal";
 
 const baseTiers = [
-  { id: "1", user_id: "u1", tier: "simple", override_model: null, auto_assigned_model: "gpt-4o-mini", updated_at: "2025-01-01" },
+  { id: "1", user_id: "u1", tier: "simple", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", updated_at: "2025-01-01" },
 ];
 
 const baseModels = [
@@ -67,7 +67,7 @@ describe("ModelPickerModal", () => {
     const claudeButtons = screen.getAllByText("Claude Opus 4.6");
     fireEvent.click(claudeButtons[claudeButtons.length - 1]);
     // Default tab is 'api_key' when no subscription providers are connected
-    expect(onSelect).toHaveBeenCalledWith("simple", "claude-opus-4-6", "api_key");
+    expect(onSelect).toHaveBeenCalledWith("simple", "claude-opus-4-6", "anthropic", "api_key");
   });
 
   it("closes on overlay click", () => {
@@ -262,7 +262,7 @@ describe("ModelPickerModal", () => {
     // Default tab is 'subscription' when subscription providers exist
     const claudeButtons = screen.getAllByText("Claude Opus 4.6");
     fireEvent.click(claudeButtons[claudeButtons.length - 1]);
-    expect(onSelect).toHaveBeenCalledWith("simple", "claude-opus-4-6", "subscription");
+    expect(onSelect).toHaveBeenCalledWith("simple", "claude-opus-4-6", "anthropic", "subscription");
   });
 
   it("filters subscription tab to only subscription providers' models", () => {

--- a/packages/frontend/tests/components/ModelSelectDropdown.test.tsx
+++ b/packages/frontend/tests/components/ModelSelectDropdown.test.tsx
@@ -16,6 +16,7 @@ const testModels = {
     { model_name: "claude-sonnet-4", provider: "Anthropic" },
     { model_name: "gemini-2.5-flash", provider: "Google" },
     { model_name: "deepseek-chat", provider: "DeepSeek" },
+    { model_name: "z-ai/glm-5", provider: "OpenRouter" },
   ],
   lastSyncedAt: "2026-02-28T10:00:00Z",
 };
@@ -90,6 +91,27 @@ describe("ModelSelectDropdown", () => {
     expect(onSelect).toHaveBeenCalledWith("openai/gpt-4o", "GPT-4o");
   });
 
+  it("uses the selected group provider for OpenRouter vendor-prefixed models", async () => {
+    const onSelect = vi.fn();
+    const { container } = await renderAndWait({ onSelect });
+
+    const groups = Array.from(container.querySelectorAll(".routing-modal__group"));
+    const openRouterGroup = groups.find((group) =>
+      group.querySelector(".routing-modal__group-name")?.textContent?.includes("OpenRouter"),
+    );
+
+    expect(openRouterGroup).toBeDefined();
+
+    const glmButton = Array.from(openRouterGroup!.querySelectorAll(".routing-modal__model")).find(
+      (button) => button.textContent?.includes("z-ai/glm-5"),
+    );
+
+    expect(glmButton).toBeDefined();
+    fireEvent.click(glmButton!);
+
+    expect(onSelect).toHaveBeenCalledWith("openrouter/z-ai/glm-5", "glm-5");
+  });
+
   it("shows empty state when no models match search", async () => {
     const { container } = await renderAndWait();
     const input = container.querySelector(".routing-modal__search") as HTMLInputElement;
@@ -152,7 +174,11 @@ describe("computeCliValue", () => {
     expect(computeCliValue("gpt-4o", "OpenAI")).toBe("openai/gpt-4o");
   });
 
-  it("keeps model as-is when it already contains a slash", () => {
+  it("prefixes slash-prefixed models when they belong to a different selected provider", () => {
+    expect(computeCliValue("z-ai/glm-5", "OpenRouter")).toBe("openrouter/z-ai/glm-5");
+  });
+
+  it("keeps model as-is when it already includes the selected provider prefix", () => {
     expect(computeCliValue("openrouter/auto", "OpenRouter")).toBe("openrouter/auto");
   });
 });

--- a/packages/frontend/tests/components/RoutingInstructionModal.test.tsx
+++ b/packages/frontend/tests/components/RoutingInstructionModal.test.tsx
@@ -17,6 +17,7 @@ const testModels = {
     { model_name: "gpt-4o", provider: "OpenAI" },
     { model_name: "claude-sonnet-4", provider: "Anthropic" },
     { model_name: "gemini-2.5-flash", provider: "Google" },
+    { model_name: "z-ai/glm-5", provider: "OpenRouter" },
   ],
   lastSyncedAt: "2026-02-28T10:00:00Z",
 };
@@ -97,6 +98,34 @@ describe("RoutingInstructionModal", () => {
       expect(container.textContent).toContain("openai/gpt-4o");
     });
     expect(container.textContent).not.toContain("<provider/model>");
+  });
+
+  it("uses the provider heading for OpenRouter vendor-prefixed models", async () => {
+    const { container } = render(() => (
+      <RoutingInstructionModal open={true} mode="disable" onClose={() => {}} />
+    ));
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".routing-modal__list")).not.toBeNull();
+    });
+
+    const groups = Array.from(container.querySelectorAll(".routing-modal__group"));
+    const openRouterGroup = groups.find((group) =>
+      group.querySelector(".routing-modal__group-name")?.textContent?.includes("OpenRouter"),
+    );
+
+    expect(openRouterGroup).toBeDefined();
+
+    const glmButton = Array.from(openRouterGroup!.querySelectorAll(".routing-modal__model")).find(
+      (button) => button.textContent?.includes("z-ai/glm-5"),
+    );
+
+    expect(glmButton).toBeDefined();
+    fireEvent.click(glmButton!);
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("openrouter/z-ai/glm-5");
+    });
   });
 
   it("does not show model picker in enable mode", () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -39,10 +39,10 @@ const mockDeactivateAllProviders = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   getTierAssignments: vi.fn().mockResolvedValue([
-    { id: "1", user_id: "u1", tier: "simple", override_model: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
-    { id: "2", user_id: "u1", tier: "standard", override_model: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
-    { id: "3", user_id: "u1", tier: "complex", override_model: "claude-opus-4-6", auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
-    { id: "4", user_id: "u1", tier: "reasoning", override_model: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+    { id: "1", user_id: "u1", tier: "simple", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+    { id: "2", user_id: "u1", tier: "standard", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+    { id: "3", user_id: "u1", tier: "complex", override_model: "claude-opus-4-6", override_provider: "anthropic", auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+    { id: "4", user_id: "u1", tier: "reasoning", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
   ]),
   getAvailableModels: vi.fn().mockResolvedValue([
     { model_name: "gpt-4o-mini", provider: "OpenAI", display_name: "GPT-4o Mini", input_price_per_token: 0.00000015, output_price_per_token: 0.0000006, context_window: 128000, capability_reasoning: false, capability_code: true },
@@ -267,7 +267,7 @@ describe("Routing — enabled state (providers active)", () => {
     fireEvent.click(modelButtons[modelButtons.length - 1]);
 
     await waitFor(() => {
-      expect(overrideTier).toHaveBeenCalledWith("test-agent", "simple", "claude-opus-4-6", "api_key");
+      expect(overrideTier).toHaveBeenCalledWith("test-agent", "simple", "claude-opus-4-6", "anthropic", "api_key");
     });
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith("Routing updated");

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -612,7 +612,7 @@ describe("overrideTier", () => {
     const payload = { id: "1", tier: "tier-1", override_model: "gpt-4o", auto_assigned_model: null, updated_at: "2026-01-01" };
     mockMutateOk(payload);
 
-    const result = await overrideTier("my-agent", "tier-1", "gpt-4o");
+    const result = await overrideTier("my-agent", "tier-1", "gpt-4o", "openai");
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
       "/api/v1/routing/my-agent/tiers/tier-1",
@@ -620,7 +620,7 @@ describe("overrideTier", () => {
         method: "PUT",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: "gpt-4o" }),
+        body: JSON.stringify({ model: "gpt-4o", provider: "openai" }),
       }),
     );
   });
@@ -628,7 +628,7 @@ describe("overrideTier", () => {
   it("encodes tier name in URL", async () => {
     mockMutateOk({});
 
-    await overrideTier("my-agent", "tier 1", "gpt-4o");
+    await overrideTier("my-agent", "tier 1", "gpt-4o", "openai");
     const url = mockFetch.mock.calls[0]?.[0] as string;
     expect(url).toContain("/routing/my-agent/tiers/tier%201");
   });
@@ -636,12 +636,16 @@ describe("overrideTier", () => {
   it("includes authType in body when provided", async () => {
     mockMutateOk({});
 
-    await overrideTier("my-agent", "simple", "claude-sonnet-4", "subscription");
+    await overrideTier("my-agent", "simple", "claude-sonnet-4", "anthropic", "subscription");
     expect(mockFetch).toHaveBeenCalledWith(
       "/api/v1/routing/my-agent/tiers/simple",
       expect.objectContaining({
         method: "PUT",
-        body: JSON.stringify({ model: "claude-sonnet-4", authType: "subscription" }),
+        body: JSON.stringify({
+          model: "claude-sonnet-4",
+          provider: "anthropic",
+          authType: "subscription",
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Problem
Selecting a vendor-prefixed model through OpenRouter only stored `override_model`. During resolution, the backend had to infer the provider back from the model name, which is lossy for OpenRouter-sourced models like `z-ai/glm-5`. That caused routing to resolve the direct vendor provider instead of the provider the user actually selected.

## Fix
- add nullable `override_provider` to tier assignments via migration
- persist `override_provider` whenever a manual tier override is saved
- prefer stored `override_provider` during provider resolution for manual overrides
- clear `override_provider` anywhere an override is cleared or invalidated
- send the selected provider from the routing model picker
- reflect the stored override provider in the routing tier card instead of re-inferring from the model name

## Why this approach
This keeps provider choice as explicit persisted state instead of reconstructing it later from `model_name`, which was the root cause of the OpenRouter mismatch.

## Testing
- `npm test --workspace=packages/backend -- routing/routing.service.spec.ts routing/resolve.service.spec.ts routing/routing.controller.spec.ts entities/tier-assignment.entity.spec.ts`
- `npm test --workspace=packages/frontend -- ModelPickerModal.test.tsx Routing.test.tsx api.test.ts`

Fixes #1159 