### PR TITLE
fix: trigger fallbacks on provider transport failures

### DIFF
--- a/.changeset/green-lamps-relax.md
+++ b/.changeset/green-lamps-relax.md
@@ -1,5 +1,4 @@
----
-'manifest': patch
+"manifest": patch
 ---
 
 Trigger proxy fallbacks when the primary provider fails at the transport layer before returning an HTTP response.

--- a/.changeset/green-lamps-relax.md
+++ b/.changeset/green-lamps-relax.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Trigger proxy fallbacks when the primary provider fails at the transport layer before returning an HTTP response.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1169,6 +1169,71 @@ describe('ProxyService', () => {
       expect(result.meta.model).toBe('claude-sonnet-4');
     });
 
+    it('tries fallback model when primary throws a transport error', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey
+        .mockResolvedValueOnce('sk-test')
+        .mockResolvedValueOnce('sk-ant');
+      providerClient.forward
+        .mockRejectedValueOnce(new Error('fetch failed'))
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: true,
+          isChatGpt: false,
+        });
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: ['claude-sonnet-4'] },
+      ] as never);
+      pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+      const primaryError = JSON.parse(result.meta.primaryErrorBody ?? '{}') as {
+        error?: { message?: string };
+      };
+
+      expect(result.meta.fallbackFromModel).toBe('gpt-4o');
+      expect(result.meta.fallbackIndex).toBe(0);
+      expect(result.meta.primaryErrorStatus).toBe(503);
+      expect(primaryError.error?.message).toBe('Failed to reach upstream provider');
+      expect(result.meta.model).toBe('claude-sonnet-4');
+    });
+
+    it('sanitizes transport error details when no fallback models are configured', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockRejectedValue(
+        new TypeError('Failed to parse URL from https://bad.example/v1?key=secret-token'),
+      );
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: null },
+      ] as never);
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+      const errorBody = JSON.parse(await result.forward.response.text()) as {
+        error?: { message?: string };
+      };
+
+      expect(result.forward.response.status).toBe(503);
+      expect(errorBody.error?.message).toBe(
+        'Failed to reach upstream provider: Failed to parse URL from https://bad.example/v1?key=***',
+      );
+    });
+
     it('returns original error when no fallback models configured', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
@@ -1329,6 +1394,53 @@ describe('ProxyService', () => {
       });
     });
 
+    it('continues fallback chain when a fallback throws a timeout error', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      const timeoutError = new Error('The operation was aborted due to timeout');
+      timeoutError.name = 'TimeoutError';
+
+      routingService.getProviderApiKey
+        .mockResolvedValueOnce('sk-test')
+        .mockResolvedValueOnce('sk-a')
+        .mockResolvedValueOnce('sk-b');
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('overloaded', { status: 500 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        })
+        .mockRejectedValueOnce(timeoutError)
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        });
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: ['model-a', 'model-b'] },
+      ] as never);
+      pricingCache.getByModel.mockReturnValue({ provider: 'ProvA' } as never);
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+      const fallbackError = JSON.parse(result.failedFallbacks?.[0].errorBody ?? '{}') as {
+        error?: { message?: string };
+      };
+
+      expect(result.meta.model).toBe('model-b');
+      expect(result.meta.fallbackIndex).toBe(1);
+      expect(result.failedFallbacks).toHaveLength(1);
+      expect(result.failedFallbacks?.[0].status).toBe(504);
+      expect(fallbackError.error?.message).toBe('Upstream provider request timed out');
+    });
+
     it('stops fallback chain on 424 (fallback exhausted)', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
@@ -1390,6 +1502,55 @@ describe('ProxyService', () => {
 
       expect(routingService.getTiers).not.toHaveBeenCalled();
       expect(result.forward.response.status).toBe(301);
+    });
+
+    it('rethrows aborted provider requests instead of treating them as fallback failures', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockRejectedValue(new Error('aborted'));
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      await expect(
+        service.proxyRequest(
+          'agent-1',
+          'user-1',
+          body,
+          'default',
+          undefined,
+          undefined,
+          abortController.signal,
+        ),
+      ).rejects.toThrow('aborted');
+
+      expect(routingService.getTiers).not.toHaveBeenCalled();
+    });
+
+    it('rethrows non-transport provider errors', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockRejectedValue(new Error('boom'));
+
+      await expect(service.proxyRequest('agent-1', 'user-1', body, 'default')).rejects.toThrow(
+        'boom',
+      );
+
+      expect(routingService.getTiers).not.toHaveBeenCalled();
     });
 
     it('falls back from api_key primary to subscription fallback model', async () => {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -20,6 +20,9 @@ import { Tier, ScorerMessage } from '../scorer/types';
  */
 const SCORING_EXCLUDED_ROLES = new Set(['system', 'developer']);
 const SCORING_RECENT_MESSAGES = 10;
+const PROVIDER_TRANSPORT_ERROR_STATUS = 503;
+const PROVIDER_TIMEOUT_STATUS = 504;
+const GENERIC_FETCH_ERROR_MESSAGE = 'fetch failed';
 
 export interface RoutingMeta {
   tier: Tier;
@@ -129,7 +132,7 @@ export class ProxyService {
     );
 
     const stream = body.stream === true;
-    const forward = await this.forwardToProvider(
+    const forward = await this.tryForwardToProvider(
       resolved.provider,
       apiKey,
       resolved.model,
@@ -280,7 +283,7 @@ export class ProxyService {
         `Fallback ${i}: trying model=${model} provider=${provider} auth_type=${authType} (primary=${primaryModel})`,
       );
 
-      const forward = await this.forwardToProvider(
+      const forward = await this.tryForwardToProvider(
         provider,
         apiKey,
         model,
@@ -320,6 +323,46 @@ export class ProxyService {
       if (unwrapped) return unwrapped;
     }
     return apiKey;
+  }
+
+  private async tryForwardToProvider(
+    provider: string,
+    apiKey: string,
+    model: string,
+    body: Record<string, unknown>,
+    stream: boolean,
+    sessionKey: string,
+    signal?: AbortSignal,
+    authType?: string,
+  ): Promise<ForwardResult> {
+    try {
+      return await this.forwardToProvider(
+        provider,
+        apiKey,
+        model,
+        body,
+        stream,
+        sessionKey,
+        signal,
+        authType,
+      );
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      if (!this.isTransportError(error)) throw error;
+
+      const failureResponse = this.buildTransportErrorResponse(error);
+      const message = this.describeTransportError(error);
+      this.logger.warn(
+        `Provider transport failure: provider=${provider} model=${model} status=${failureResponse.status} message=${message}`,
+      );
+
+      return {
+        response: failureResponse,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      };
+    }
   }
 
   private async enforceLimits(tenantId?: string, agentName?: string): Promise<void> {
@@ -363,6 +406,92 @@ export class ProxyService {
       );
     }
     return false;
+  }
+
+  private isTransportError(error: unknown): boolean {
+    const name = this.getErrorName(error);
+    if (name === 'AbortError' || name === 'TimeoutError') return true;
+
+    const detail = [
+      this.getErrorMessage(error),
+      this.getErrorMessage(this.getErrorCause(error)),
+      this.getErrorCode(error),
+      this.getErrorCode(this.getErrorCause(error)),
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(' ');
+
+    return /(fetch failed|failed to parse url|network|timeout|econnrefused|econnreset|enotfound|ehostunreach|etimedout|und_err_)/i.test(
+      detail,
+    );
+  }
+
+  private buildTransportErrorResponse(error: unknown): Response {
+    const status = this.isTimeoutError(error)
+      ? PROVIDER_TIMEOUT_STATUS
+      : PROVIDER_TRANSPORT_ERROR_STATUS;
+    const message = this.describeTransportError(error);
+
+    return new Response(JSON.stringify({ error: { message } }), {
+      status,
+      statusText: status === PROVIDER_TIMEOUT_STATUS ? 'Gateway Timeout' : 'Service Unavailable',
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  private describeTransportError(error: unknown): string {
+    if (this.isTimeoutError(error)) {
+      return 'Upstream provider request timed out';
+    }
+
+    const detail =
+      this.selectTransportErrorDetail(error) ??
+      this.selectTransportErrorDetail(this.getErrorCause(error));
+
+    if (!detail) return 'Failed to reach upstream provider';
+    return `Failed to reach upstream provider: ${detail}`;
+  }
+
+  private isTimeoutError(error: unknown): boolean {
+    return this.getErrorName(error) === 'TimeoutError';
+  }
+
+  private selectTransportErrorDetail(error: unknown): string | undefined {
+    const message = this.getErrorMessage(error);
+    const code = this.getErrorCode(error);
+
+    if (message && message.toLowerCase() !== GENERIC_FETCH_ERROR_MESSAGE) {
+      return this.sanitizeTransportErrorDetail(message);
+    }
+    if (code) return code;
+    return undefined;
+  }
+
+  private sanitizeTransportErrorDetail(detail: string): string {
+    return detail.replace(/key=[^&\s]+/gi, 'key=***').slice(0, 500);
+  }
+
+  private getErrorName(error: unknown): string | undefined {
+    if (!(error instanceof Error)) return undefined;
+    return error.name;
+  }
+
+  private getErrorMessage(error: unknown): string | undefined {
+    if (error instanceof Error) return error.message;
+    if (!error || typeof error !== 'object') return undefined;
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' ? message : undefined;
+  }
+
+  private getErrorCode(error: unknown): string | undefined {
+    if (!error || typeof error !== 'object') return undefined;
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+
+  private getErrorCause(error: unknown): unknown {
+    if (!(error instanceof Error)) return undefined;
+    return error.cause;
   }
 
   private async forwardToProvider(


### PR DESCRIPTION
## Summary
- normalize transport-level provider failures into retriable upstream responses in the proxy service
- let the existing fallback chain run for invalid URLs, DNS failures, connection errors, and timeouts
- add regression coverage for primary transport failures, timeout failures inside the fallback chain, and non-transport/abort passthrough

## Testing
- npm test --workspace=packages/backend -- proxy.service.spec.ts --runInBand

Fixes #1176

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the proxy trigger model fallbacks when a provider fails at the transport layer (bad URL, DNS, connection errors, timeouts). Transport errors are turned into retriable 503/504 responses so the existing fallback chain runs. Fixes #1176.

- **Bug Fixes**
  - Normalize transport failures into 503 (Service Unavailable) or 504 (Gateway Timeout) with sanitized messages (e.g., masks `key=...`).
  - Continue the fallback chain when a fallback attempt times out; record failure and move to the next model.
  - Do not treat aborted requests or non-transport provider errors as fallback candidates; rethrow instead.
  - Add regression tests for primary transport failures, fallback timeouts, and abort/non-transport passthrough.
  - Use the correct changeset manifest key expected by CI.

<sup>Written for commit b85f5d0dc6181baf4bd481104bff95e19e2df454. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

