### PR TITLE
fix(proxy): normalize Mistral tool-call IDs in OpenAI-compatible payloads

### DIFF
--- a/.changeset/few-cobras-wink.md
+++ b/.changeset/few-cobras-wink.md
@@ -1,5 +1,5 @@
 ---
-'manifest': patch
+"manifest": patch
 ---
 
 Normalize OpenAI-style tool call IDs when forwarding chat completions to Mistral so fallback requests remain compatible with Mistral's 9-character alphanumeric tool-call ID requirement.

--- a/.changeset/few-cobras-wink.md
+++ b/.changeset/few-cobras-wink.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Normalize OpenAI-style tool call IDs when forwarding chat completions to Mistral so fallback requests remain compatible with Mistral's 9-character alphanumeric tool-call ID requirement.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -871,6 +871,64 @@ describe('ProviderClient', () => {
       expect(sentBody.messages[1].tool_call_id).toBe(validToolCallId);
     });
 
+    it('does not rewrite later valid Mistral tool call ids when generated ids would collide', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const invalidToolCallId = 'call005AKQn2j5TEr4S6i3zNN59moT';
+      const validToolCallId = 'tc0000001';
+      const bodyWithPotentialCollision = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: invalidToolCallId,
+                type: 'function',
+                function: { name: 'search', arguments: '{}' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            tool_call_id: invalidToolCallId,
+            content: '{"status":"invalid"}',
+          },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: validToolCallId,
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            tool_call_id: validToolCallId,
+            content: '{"status":"valid"}',
+          },
+        ],
+      };
+
+      await client.forward(
+        'mistral',
+        'sk-mi',
+        'mistral-small',
+        bodyWithPotentialCollision as unknown as Record<string, unknown>,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const normalizedInvalidId = sentBody.messages[0].tool_calls[0].id;
+      expect(normalizedInvalidId).toMatch(/^[A-Za-z0-9]{9}$/);
+      expect(normalizedInvalidId).not.toBe(validToolCallId);
+      expect(sentBody.messages[1].tool_call_id).toBe(normalizedInvalidId);
+      expect(sentBody.messages[2].tool_calls[0].id).toBe(validToolCallId);
+      expect(sentBody.messages[3].tool_call_id).toBe(validToolCallId);
+    });
+
     it('preserves all fields for OpenAI', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward('openai', 'sk-test', 'gpt-4o', bodyWithOpenAiFields, false);

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -790,6 +790,87 @@ describe('ProviderClient', () => {
       expect(sentBody.messages[1].reasoning_content).toBeUndefined();
     });
 
+    it('normalizes non-compliant tool call ids for Mistral while preserving references', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const originalToolCallId = 'call005AKQn2j5TEr4S6i3zNN59moT';
+      const bodyWithToolCalls = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: originalToolCallId,
+                type: 'function',
+                function: { name: 'search', arguments: '{}' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            tool_call_id: originalToolCallId,
+            content: '{"status":"ok"}',
+          },
+        ],
+      };
+
+      await client.forward(
+        'mistral',
+        'sk-mi',
+        'mistral-small',
+        bodyWithToolCalls as unknown as Record<string, unknown>,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const normalizedToolCallId = sentBody.messages[0].tool_calls[0].id;
+      expect(normalizedToolCallId).toMatch(/^[A-Za-z0-9]{9}$/);
+      expect(normalizedToolCallId).not.toBe(originalToolCallId);
+      expect(sentBody.messages[1].tool_call_id).toBe(normalizedToolCallId);
+      const originalAssistantMessage = bodyWithToolCalls.messages[0] as {
+        tool_calls: Array<{ id: string }>;
+      };
+      expect(originalAssistantMessage.tool_calls[0].id).toBe(originalToolCallId);
+      expect(bodyWithToolCalls.messages[1].tool_call_id).toBe(originalToolCallId);
+    });
+
+    it('preserves valid 9-character alphanumeric tool call ids for Mistral', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const validToolCallId = 'Ab12Cd34E';
+      const bodyWithValidToolCallId = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: validToolCallId,
+                type: 'function',
+                function: { name: 'search', arguments: '{}' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            tool_call_id: validToolCallId,
+            content: '{"status":"ok"}',
+          },
+        ],
+      };
+
+      await client.forward(
+        'mistral',
+        'sk-mi',
+        'mistral-small',
+        bodyWithValidToolCallId as unknown as Record<string, unknown>,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[0].tool_calls[0].id).toBe(validToolCallId);
+      expect(sentBody.messages[1].tool_call_id).toBe(validToolCallId);
+    });
+
     it('preserves all fields for OpenAI', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward('openai', 'sk-test', 'gpt-4o', bodyWithOpenAiFields, false);

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -34,6 +34,7 @@ const OPENAI_ONLY_FIELDS = new Set([
  * Nested message fields may still need target-aware cleanup.
  */
 const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
+const MISTRAL_TOOL_CALL_ID_REGEX = /^[A-Za-z0-9]{9}$/;
 
 function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;
@@ -45,6 +46,36 @@ function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: s
   if (!Array.isArray(messages)) return messages;
 
   const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
+  const isMistral = endpointKey === 'mistral';
+  const mistralIdMap = new Map<string, string>();
+  const usedMistralIds = new Set<string>();
+  let generatedMistralIdCounter = 0;
+
+  const nextGeneratedMistralId = (): string => {
+    do {
+      generatedMistralIdCounter += 1;
+      const candidate = `tc${generatedMistralIdCounter.toString(36).padStart(7, '0')}`;
+      if (!usedMistralIds.has(candidate)) return candidate;
+    } while (true);
+  };
+
+  const normalizeMistralToolCallId = (toolCallId: unknown): unknown => {
+    if (!isMistral || typeof toolCallId !== 'string') return toolCallId;
+    const existing = mistralIdMap.get(toolCallId);
+    if (existing) return existing;
+
+    if (MISTRAL_TOOL_CALL_ID_REGEX.test(toolCallId) && !usedMistralIds.has(toolCallId)) {
+      mistralIdMap.set(toolCallId, toolCallId);
+      usedMistralIds.add(toolCallId);
+      return toolCallId;
+    }
+
+    const rewritten = nextGeneratedMistralId();
+    mistralIdMap.set(toolCallId, rewritten);
+    usedMistralIds.add(rewritten);
+    return rewritten;
+  };
+
   return messages.map((message) => {
     if (!message || typeof message !== 'object' || Array.isArray(message)) {
       return message;
@@ -54,6 +85,22 @@ function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: s
     if (!preserveReasoningContent) {
       delete cleaned.reasoning_content;
     }
+
+    if (isMistral && Array.isArray(cleaned.tool_calls)) {
+      cleaned.tool_calls = cleaned.tool_calls.map((toolCall) => {
+        if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) {
+          return toolCall;
+        }
+        const cleanedToolCall = { ...(toolCall as Record<string, unknown>) };
+        cleanedToolCall.id = normalizeMistralToolCallId(cleanedToolCall.id);
+        return cleanedToolCall;
+      });
+    }
+
+    if (isMistral && 'tool_call_id' in cleaned) {
+      cleaned.tool_call_id = normalizeMistralToolCallId(cleaned.tool_call_id);
+    }
+
     return cleaned;
   });
 }

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -48,14 +48,41 @@ function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: s
   const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
   const isMistral = endpointKey === 'mistral';
   const mistralIdMap = new Map<string, string>();
-  const usedMistralIds = new Set<string>();
+  const reservedMistralIds = new Set<string>();
   let generatedMistralIdCounter = 0;
+
+  const reserveMistralToolCallId = (toolCallId: unknown): void => {
+    if (!isMistral || typeof toolCallId !== 'string') return;
+    if (MISTRAL_TOOL_CALL_ID_REGEX.test(toolCallId)) {
+      reservedMistralIds.add(toolCallId);
+    }
+  };
+
+  if (isMistral) {
+    for (const message of messages) {
+      if (!message || typeof message !== 'object' || Array.isArray(message)) {
+        continue;
+      }
+      const rawMessage = message as Record<string, unknown>;
+      if (Array.isArray(rawMessage.tool_calls)) {
+        for (const toolCall of rawMessage.tool_calls) {
+          if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) {
+            continue;
+          }
+          reserveMistralToolCallId((toolCall as Record<string, unknown>).id);
+        }
+      }
+      if ('tool_call_id' in rawMessage) {
+        reserveMistralToolCallId(rawMessage.tool_call_id);
+      }
+    }
+  }
 
   const nextGeneratedMistralId = (): string => {
     do {
       generatedMistralIdCounter += 1;
       const candidate = `tc${generatedMistralIdCounter.toString(36).padStart(7, '0')}`;
-      if (!usedMistralIds.has(candidate)) return candidate;
+      if (!reservedMistralIds.has(candidate)) return candidate;
     } while (true);
   };
 
@@ -64,15 +91,15 @@ function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: s
     const existing = mistralIdMap.get(toolCallId);
     if (existing) return existing;
 
-    if (MISTRAL_TOOL_CALL_ID_REGEX.test(toolCallId) && !usedMistralIds.has(toolCallId)) {
+    if (MISTRAL_TOOL_CALL_ID_REGEX.test(toolCallId)) {
       mistralIdMap.set(toolCallId, toolCallId);
-      usedMistralIds.add(toolCallId);
+      reservedMistralIds.add(toolCallId);
       return toolCallId;
     }
 
     const rewritten = nextGeneratedMistralId();
     mistralIdMap.set(toolCallId, rewritten);
-    usedMistralIds.add(rewritten);
+    reservedMistralIds.add(rewritten);
     return rewritten;
   };
 


### PR DESCRIPTION
## Summary
- normalize tool-call ids to Mistral-compatible 9-char alphanumeric values when forwarding OpenAI-format chat payloads to Mistral
- preserve id linkage by rewriting both assistant `tool_calls[].id` and matching tool message `tool_call_id` using the same per-request mapping
- keep already-valid Mistral ids unchanged
- add regression tests covering normalization, linkage, and non-mutation

Closes #1182

## Why
Mistral rejects OpenAI-style tool call ids like `call005AKQn2j5TEr4S6i3zNN59moT`. Fallbacks reuse the original transcript across providers, so Mistral fallback attempts can fail deterministically on id format even when earlier fallback behavior is otherwise correct.

## Validation

### Automated
```bash
npm test --workspace=packages/backend -- provider-client.spec.ts --runInBand
```
Expected: suite passes; includes tests asserting Mistral id normalization and preserved `tool_call_id` references.

### Manual repro
1. Configure a routing chain where a request with tool-call transcript can fallback to Mistral.
2. Send a conversation containing an assistant tool call id like `call005AKQn2j5TEr4S6i3zNN59moT` and a tool message referencing that id.
3. Verify the fallback request to Mistral succeeds schema validation (no `invalid_function_call` about id length/charset).
4. Verify non-Mistral OpenAI-compatible providers still receive unchanged tool call ids.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes tool-call IDs to Mistral’s 9-character alphanumeric format when forwarding OpenAI-style chat payloads, preserving links between assistant tool calls and tool messages. Adds collision-safe ID generation so Mistral fallbacks don’t fail on ID format. Closes #1182.

- **Bug Fixes**
  - Rewrites assistant `tool_calls[].id` and matching `tool_call_id` via a per-request map; keeps valid 9-char IDs unchanged.
  - Pre-scans to reserve existing valid IDs and generates `tc` + base36 IDs (e.g., `tc0000001`), skipping collisions.
  - Applies only to `mistral`; passthrough for `openai` and `openrouter`.
  - Tests cover normalization, collision avoidance (including not clobbering later valid IDs), linkage preservation, and non-mutation.

<sup>Written for commit f1fac8cfa2d22a12e67e0bfc63dca47b2d56eaf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

