### PR TITLE
proxy: add native OpenAI subscription Responses adapter support for tool calls

### DIFF
--- a/.changeset/six-snakes-clean.md
+++ b/.changeset/six-snakes-clean.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add native OpenAI subscription Responses adapter support for tool calls, including tool transcript translation, streaming function-call events, and null or multipart content normalization.

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-adapter.spec.ts
@@ -79,6 +79,17 @@ describe('ChatGPT Adapter', () => {
       expect(input[0].content[0].type).toBe('input_text');
     });
 
+    it('normalizes null content into an empty text part', () => {
+      const body = {
+        messages: [{ role: 'user', content: null }],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: '' }] },
+      ]);
+    });
+
     it('remaps content to "output_text" for assistant messages', () => {
       const body = {
         messages: [
@@ -142,7 +153,7 @@ describe('ChatGPT Adapter', () => {
       const input = result.input as { role: string }[];
 
       expect(input).toHaveLength(3);
-      expect(input.every((m) => m.role !== 'system' && m.role !== 'developer')).toBe(true);
+      expect(input.every((message) => message.role !== 'system' && message.role !== 'developer')).toBe(true);
     });
 
     it('handles missing messages gracefully', () => {
@@ -174,6 +185,182 @@ describe('ChatGPT Adapter', () => {
       const result = toResponsesRequest(body, 'gpt-5');
 
       expect(result.instructions).toBe('You are a helpful assistant.');
+    });
+
+    it('falls back to default instructions when developer content is null', () => {
+      const body = {
+        messages: [
+          { role: 'developer', content: null },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result.instructions).toBe('You are a helpful assistant.');
+      expect(result.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'Hi' }] },
+      ]);
+    });
+
+    it('converts assistant tool_calls to Responses API function_call items', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'Search for cats' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'search', arguments: '{"q":"cats"}' },
+              },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_1', content: '{"results":["cat1"]}' },
+          { role: 'assistant', content: 'I found some cats!' },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+      const input = result.input as Record<string, unknown>[];
+
+      expect(input).toHaveLength(4);
+      expect(input[1]).toEqual({
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'search',
+        arguments: '{"q":"cats"}',
+      });
+      expect(input[2]).toEqual({
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: '{"results":["cat1"]}',
+      });
+      expect(input[3]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'I found some cats!' }],
+      });
+    });
+
+    it('emits text content before function_call items when assistant has both', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'Let me search for that.',
+            tool_calls: [
+              { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{}' } },
+            ],
+          },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+      const input = result.input as Record<string, unknown>[];
+
+      expect(input[0]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Let me search for that.' }],
+      });
+      expect(input[1]).toEqual(expect.objectContaining({ type: 'function_call', name: 'search' }));
+    });
+
+    it('preserves array-form assistant text before function_call items', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Let me search for that.' }],
+            tool_calls: [
+              { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{}' } },
+            ],
+          },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+      const input = result.input as Record<string, unknown>[];
+
+      expect(input[0]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Let me search for that.' }],
+      });
+      expect(input[1]).toEqual(expect.objectContaining({ type: 'function_call', name: 'search' }));
+    });
+
+    it('converts tool message to function_call_output', () => {
+      const body = {
+        messages: [{ role: 'tool', tool_call_id: 'call_1', content: 'result data' }],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: 'result data',
+        },
+      ]);
+    });
+
+    it('extracts text from array-form tool message content', () => {
+      const body = {
+        messages: [
+          {
+            role: 'tool',
+            tool_call_id: 'call_1',
+            content: [{ type: 'text', text: 'result data' }],
+          },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: 'result data',
+        },
+      ]);
+    });
+
+    it('converts function role messages to function_call_output', () => {
+      const body = {
+        messages: [{ role: 'function', content: '{"temp":72}' }],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result.input).toHaveLength(1);
+      expect((result.input as Record<string, unknown>[])[0]).toEqual(
+        expect.objectContaining({
+          type: 'function_call_output',
+          output: '{"temp":72}',
+        }),
+      );
+    });
+
+    it('converts Chat Completions tools to Responses API format', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'get_weather',
+              description: 'Get weather for a location',
+              parameters: { type: 'object', properties: { location: { type: 'string' } } },
+            },
+          },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get weather for a location',
+          parameters: { type: 'object', properties: { location: { type: 'string' } } },
+        },
+      ]);
     });
   });
 
@@ -224,28 +411,76 @@ describe('ChatGPT Adapter', () => {
       };
       const result = fromResponsesResponse(data, 'gpt-5');
       const choices = result.choices as { message: { content: string } }[];
+
       expect(choices[0].message.content).toBe('Part 1. Part 2.');
     });
 
-    it('skips non-message output items', () => {
+    it('converts function_call output items to tool_calls', () => {
       const data = {
         output: [
-          { type: 'function_call', name: 'search', arguments: '{}' },
           {
-            type: 'message',
-            content: [{ type: 'output_text', text: 'Result' }],
+            type: 'function_call',
+            call_id: 'call_abc',
+            name: 'get_weather',
+            arguments: '{"location":"Paris"}',
           },
         ],
       };
       const result = fromResponsesResponse(data, 'gpt-5');
-      const choices = result.choices as { message: { content: string } }[];
-      expect(choices[0].message.content).toBe('Result');
+      const choices = result.choices as {
+        message: {
+          content: string | null;
+          tool_calls?: {
+            id: string;
+            type: string;
+            function: { name: string; arguments: string };
+          }[];
+        };
+        finish_reason: string;
+      }[];
+
+      expect(choices[0].message.content).toBeNull();
+      expect(choices[0].message.tool_calls).toEqual([
+        {
+          id: 'call_abc',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"location":"Paris"}' },
+        },
+      ]);
+      expect(choices[0].finish_reason).toBe('tool_calls');
+    });
+
+    it('combines text and function_call output items', () => {
+      const data = {
+        output: [
+          {
+            type: 'message',
+            content: [{ type: 'output_text', text: 'Let me check.' }],
+          },
+          {
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'search',
+            arguments: '{}',
+          },
+        ],
+      };
+      const result = fromResponsesResponse(data, 'gpt-5');
+      const choices = result.choices as {
+        message: { content: string | null; tool_calls?: unknown[] };
+        finish_reason: string;
+      }[];
+
+      expect(choices[0].message.content).toBe('Let me check.');
+      expect(choices[0].message.tool_calls).toHaveLength(1);
+      expect(choices[0].finish_reason).toBe('tool_calls');
     });
 
     it('handles empty output', () => {
       const result = fromResponsesResponse({}, 'gpt-5');
-      const choices = result.choices as { message: { content: string } }[];
-      expect(choices[0].message.content).toBe('');
+      const choices = result.choices as { message: { content: string | null } }[];
+
+      expect(choices[0].message.content).toBeNull();
     });
 
     it('handles output item with no content', () => {
@@ -253,14 +488,16 @@ describe('ChatGPT Adapter', () => {
         output: [{ type: 'message' }],
       };
       const result = fromResponsesResponse(data, 'gpt-5');
-      const choices = result.choices as { message: { content: string } }[];
-      expect(choices[0].message.content).toBe('');
+      const choices = result.choices as { message: { content: string | null } }[];
+
+      expect(choices[0].message.content).toBeNull();
     });
 
     it('defaults usage to zeros when missing', () => {
       const data = { output: [] };
       const result = fromResponsesResponse(data, 'gpt-5');
       const usage = result.usage as Record<string, number>;
+
       expect(usage.prompt_tokens).toBe(0);
       expect(usage.completion_tokens).toBe(0);
       expect(usage.total_tokens).toBe(0);
@@ -301,8 +538,7 @@ describe('ChatGPT Adapter', () => {
       const result = transformResponsesStreamChunk(chunk, 'gpt-5');
 
       expect(result).not.toBeNull();
-      // The finish chunk before [DONE] should contain usage
-      const finishLine = result!.split('\n').find((l) => l.startsWith('data: {'));
+      const finishLine = result!.split('\n').find((line) => line.startsWith('data: {'));
       const json = JSON.parse(finishLine!.replace('data: ', ''));
       expect(json.usage).toEqual({
         prompt_tokens: 10,
@@ -316,6 +552,7 @@ describe('ChatGPT Adapter', () => {
     it('returns null for irrelevant events', () => {
       const chunk = 'event: response.created\ndata: {"id":"resp_123"}';
       const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
       expect(result).toBeNull();
     });
 
@@ -326,6 +563,7 @@ describe('ChatGPT Adapter', () => {
     it('returns null for malformed JSON in delta event', () => {
       const chunk = 'event: response.output_text.delta\ndata: not-json';
       const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
       expect(result).toBeNull();
     });
 
@@ -339,7 +577,6 @@ describe('ChatGPT Adapter', () => {
     });
 
     it('handles pre-processed chunks (data: prefix stripped by parseSseEvents)', () => {
-      // parseSseEvents strips "data: " prefix, so transform receives "event: ...\n{json}"
       const chunk = 'event: response.output_text.delta\n{"delta":"Hi"}';
       const result = transformResponsesStreamChunk(chunk, 'gpt-5');
 
@@ -351,6 +588,61 @@ describe('ChatGPT Adapter', () => {
     it('returns null for empty lines only', () => {
       const result = transformResponsesStreamChunk('   ', 'gpt-5');
       expect(result).toBeNull();
+    });
+
+    it('converts function_call_arguments.delta to tool_calls chunk', () => {
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"delta":"{\\"loc","output_index":0}';
+      const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+      expect(result).not.toBeNull();
+      const json = JSON.parse(result!.replace('data: ', '').trim());
+      expect(json.choices[0].delta.tool_calls[0].function.arguments).toBe('{"loc');
+      expect(json.choices[0].delta.tool_calls[0].index).toBe(0);
+    });
+
+    it('converts output_item.added for function_call to tool_calls header', () => {
+      const data = JSON.stringify({
+        output_index: 0,
+        item: { type: 'function_call', call_id: 'call_abc', name: 'get_weather' },
+      });
+      const chunk = `event: response.output_item.added\ndata: ${data}`;
+      const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+      expect(result).not.toBeNull();
+      const json = JSON.parse(result!.replace('data: ', '').trim());
+      expect(json.choices[0].delta.tool_calls[0]).toEqual(
+        expect.objectContaining({
+          id: 'call_abc',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '' },
+        }),
+      );
+    });
+
+    it('returns null for output_item.added with non-function_call type', () => {
+      const data = JSON.stringify({
+        output_index: 0,
+        item: { type: 'message', role: 'assistant' },
+      });
+      const chunk = `event: response.output_item.added\ndata: ${data}`;
+      const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+      expect(result).toBeNull();
+    });
+
+    it('sets finish_reason to tool_calls when response has function_call output', () => {
+      const data = JSON.stringify({
+        response: {
+          output: [{ type: 'function_call', call_id: 'call_1', name: 'search' }],
+          usage: { input_tokens: 5, output_tokens: 10, total_tokens: 15 },
+        },
+      });
+      const chunk = `event: response.completed\ndata: ${data}`;
+      const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+      expect(result).not.toBeNull();
+      expect(result).toContain('"finish_reason":"tool_calls"');
     });
   });
 });

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -12,6 +12,8 @@ const DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
 interface OpenAiMessage {
   role: string;
   content: unknown;
+  tool_calls?: unknown;
+  tool_call_id?: unknown;
 }
 
 /* ── Request conversion ── */
@@ -21,10 +23,39 @@ export function toResponsesRequest(
   model: string,
 ): Record<string, unknown> {
   const messages = (body.messages ?? []) as OpenAiMessage[];
+  const input: Record<string, unknown>[] = [];
 
-  const input = messages
-    .filter((m) => m.role !== 'system' && m.role !== 'developer')
-    .map((m) => ({ role: m.role, content: convertContent(m.content, m.role) }));
+  for (const message of messages) {
+    if (message.role === 'system' || message.role === 'developer') {
+      continue;
+    }
+
+    if (message.role === 'assistant' && Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+      const assistantText = extractTextContent(message.content);
+      if (assistantText) {
+        input.push({
+          role: 'assistant',
+          content: convertContent(assistantText, 'assistant'),
+        });
+      }
+      input.push(...convertAssistantToolCalls(message.tool_calls));
+      continue;
+    }
+
+    if (message.role === 'tool' || message.role === 'function') {
+      input.push({
+        type: 'function_call_output',
+        call_id: typeof message.tool_call_id === 'string' ? message.tool_call_id : randomUUID(),
+        output: extractTextContent(message.content) ?? JSON.stringify(message.content ?? ''),
+      });
+      continue;
+    }
+
+    input.push({
+      role: message.role,
+      content: convertContent(message.content, message.role),
+    });
+  }
 
   const request: Record<string, unknown> = {
     model,
@@ -33,6 +64,10 @@ export function toResponsesRequest(
     store: false,
     instructions: extractInstructions(messages),
   };
+
+  if (Array.isArray(body.tools)) {
+    request.tools = convertTools(body.tools as Record<string, unknown>[]);
+  }
 
   return request;
 }
@@ -45,18 +80,42 @@ export function fromResponsesResponse(
 ): Record<string, unknown> {
   const output = (data.output ?? []) as Record<string, unknown>[];
   let text = '';
+  const toolCalls: { id: string; type: string; function: { name: string; arguments: string } }[] =
+    [];
 
   for (const item of output) {
-    if (item.type !== 'message') continue;
-    const content = item.content as { type?: string; text?: string }[] | undefined;
-    if (!content) continue;
-    for (const part of content) {
-      if (part.type === 'output_text' && part.text) text += part.text;
+    if (item.type === 'message') {
+      const content = item.content as { type?: string; text?: string }[] | undefined;
+      if (!content) continue;
+      for (const part of content) {
+        if (part.type === 'output_text' && part.text) text += part.text;
+      }
+      continue;
+    }
+
+    if (item.type === 'function_call') {
+      toolCalls.push({
+        id: (item.call_id as string) ?? randomUUID(),
+        type: 'function',
+        function: {
+          name: (item.name as string) ?? '',
+          arguments: (item.arguments as string) ?? '{}',
+        },
+      });
     }
   }
 
   const usage = (data.usage as Record<string, unknown>) ?? {};
   const inputDetails = usage.input_tokens_details as Record<string, number> | undefined;
+
+  const message: Record<string, unknown> = {
+    role: 'assistant',
+    content: text || null,
+  };
+
+  if (toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
 
   return {
     id: `chatcmpl-${randomUUID().replace(/-/g, '').slice(0, 29)}`,
@@ -66,8 +125,8 @@ export function fromResponsesResponse(
     choices: [
       {
         index: 0,
-        message: { role: 'assistant', content: text },
-        finish_reason: 'stop',
+        message,
+        finish_reason: toolCalls.length > 0 ? 'tool_calls' : 'stop',
       },
     ],
     usage: {
@@ -106,7 +165,6 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
 
   if (!eventType && !dataStr) return null;
 
-  // Text delta — the main content event
   if (eventType === 'response.output_text.delta') {
     const data = safeParse(dataStr);
     if (!data) return null;
@@ -114,27 +172,77 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
     return formatSSE({ delta: { content: delta }, finish_reason: null }, model);
   }
 
-  // Response completed — send finish_reason with usage, then [DONE]
+  if (eventType === 'response.function_call_arguments.delta') {
+    const data = safeParse(dataStr);
+    if (!data) return null;
+    const delta = typeof data.delta === 'string' ? data.delta : '';
+    return formatSSE(
+      {
+        delta: {
+          tool_calls: [
+            {
+              index: typeof data.output_index === 'number' ? data.output_index : 0,
+              function: { arguments: delta },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      model,
+    );
+  }
+
+  if (eventType === 'response.output_item.added') {
+    const data = safeParse(dataStr);
+    if (!data) return null;
+    const item = isObjectRecord(data.item) ? data.item : undefined;
+    if (item?.type !== 'function_call') return null;
+    return formatSSE(
+      {
+        delta: {
+          tool_calls: [
+            {
+              index: typeof data.output_index === 'number' ? data.output_index : 0,
+              id: (item.call_id as string) ?? '',
+              type: 'function',
+              function: { name: (item.name as string) ?? '', arguments: '' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      model,
+    );
+  }
+
   if (eventType === 'response.completed') {
     const data = safeParse(dataStr);
-    const respUsage = (data?.response as Record<string, unknown>)?.usage as
-      | Record<string, number>
-      | undefined;
-    const respDetails = (data?.response as Record<string, unknown>)?.usage as
-      | Record<string, unknown>
-      | undefined;
+    const response = isObjectRecord(data?.response) ? data.response : undefined;
+    const responseUsage = response?.usage as Record<string, number> | undefined;
+    const responseUsageDetails = response?.usage as Record<string, unknown> | undefined;
     const cachedTokens =
-      (respDetails?.input_tokens_details as Record<string, number> | undefined)?.cached_tokens ?? 0;
-    const usage = respUsage
+      (responseUsageDetails?.input_tokens_details as Record<string, number> | undefined)
+        ?.cached_tokens ?? 0;
+
+    const usage = responseUsage
       ? {
-          prompt_tokens: respUsage.input_tokens ?? 0,
-          completion_tokens: respUsage.output_tokens ?? 0,
-          total_tokens: respUsage.total_tokens ?? 0,
+          prompt_tokens: responseUsage.input_tokens ?? 0,
+          completion_tokens: responseUsage.output_tokens ?? 0,
+          total_tokens: responseUsage.total_tokens ?? 0,
           cache_read_tokens: cachedTokens,
           cache_creation_tokens: 0,
         }
       : undefined;
-    const finish = formatSSE({ delta: {}, finish_reason: 'stop' }, model, usage);
+
+    const responseOutput = Array.isArray(response?.output)
+      ? (response.output as Array<{ type?: string }>)
+      : [];
+    const hasFunctionCalls = responseOutput.some((item) => item.type === 'function_call');
+    const finish = formatSSE(
+      { delta: {}, finish_reason: hasFunctionCalls ? 'tool_calls' : 'stop' },
+      model,
+      usage,
+    );
     return `${finish}\ndata: [DONE]\n\n`;
   }
 
@@ -143,22 +251,53 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
 
 /* ── Helpers ── */
 
-/**
- * Convert Chat Completions content to Responses API content format.
- * The Responses API uses role-specific content types:
- * - user messages: `input_text`
- * - assistant messages: `output_text`
- *
- * Note: tool/function messages are not supported by the Responses API
- * subscription endpoint. They are passed through as input_text, which
- * may produce unexpected results.
- */
+function convertAssistantToolCalls(toolCalls: unknown[]): Record<string, unknown>[] {
+  return toolCalls.flatMap((toolCall) => {
+    if (!isObjectRecord(toolCall) || !isObjectRecord(toolCall.function)) {
+      return [];
+    }
+
+    return [
+      {
+        type: 'function_call',
+        call_id: typeof toolCall.id === 'string' ? toolCall.id : randomUUID(),
+        name: typeof toolCall.function.name === 'string' ? toolCall.function.name : 'unknown',
+        arguments:
+          typeof toolCall.function.arguments === 'string' ? toolCall.function.arguments : '{}',
+      },
+    ];
+  });
+}
+
+function convertTools(tools: Record<string, unknown>[]): Record<string, unknown>[] {
+  return tools.map((tool) => {
+    if (tool.type === 'function' && isObjectRecord(tool.function)) {
+      return {
+        type: 'function',
+        name: tool.function.name,
+        ...(tool.function.description !== undefined && { description: tool.function.description }),
+        ...(tool.function.parameters !== undefined && { parameters: tool.function.parameters }),
+        ...(tool.function.strict !== undefined && { strict: tool.function.strict }),
+      };
+    }
+
+    return tool;
+  });
+}
+
 function convertContent(content: unknown, role: string): unknown {
   const partType = role === 'assistant' ? 'output_text' : 'input_text';
+
+  if (content === null || content === undefined) {
+    return [{ type: partType, text: '' }];
+  }
+
   if (typeof content === 'string') {
     return [{ type: partType, text: content }];
   }
+
   if (!Array.isArray(content)) return content;
+
   return (content as { type?: string; text?: string }[]).map((part) => {
     if (part.type === 'text') return { ...part, type: partType };
     return part;
@@ -166,28 +305,38 @@ function convertContent(content: unknown, role: string): unknown {
 }
 
 function extractInstructions(messages: OpenAiMessage[]): string {
-  const parts: string[] = [];
-
-  for (const message of messages) {
-    if (message.role !== 'system' && message.role !== 'developer') continue;
-    parts.push(...extractTextParts(message.content));
-  }
-
-  const instructions = parts
-    .map((part) => part.trim())
+  const instructions = messages
+    .filter((message) => message.role === 'system' || message.role === 'developer')
+    .map((message) => extractTextContent(message.content))
+    .filter((content): content is string => Boolean(content))
+    .map((content) => content.trim())
     .filter(Boolean)
     .join('\n\n');
 
   return instructions || DEFAULT_INSTRUCTIONS;
 }
 
-function extractTextParts(content: unknown): string[] {
-  if (typeof content === 'string') return [content];
-  if (!Array.isArray(content)) return [];
+function extractTextContent(content: unknown): string | null {
+  if (typeof content === 'string') return content || null;
+  if (!Array.isArray(content)) return null;
 
-  return (content as Array<Record<string, unknown>>)
-    .filter((part) => part.type === 'text' && typeof part.text === 'string')
-    .map((part) => part.text as string);
+  const text = content
+    .filter(isObjectRecord)
+    .map((part) => {
+      if (!isTextPart(part.type) || typeof part.text !== 'string') return '';
+      return part.text;
+    })
+    .join('');
+
+  return text || null;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isTextPart(type: unknown): boolean {
+  return type === 'text' || type === 'input_text' || type === 'output_text';
 }
 
 function safeParse(str: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- route OpenAI `subscription` traffic through the ChatGPT Responses adapter while preserving the existing Chat Completions contract for Manifest clients
- translate Chat Completions tool definitions and tool history into native Responses API items (`tools`, assistant `tool_calls`, tool outputs), then translate Responses function calls back into Chat Completions, including streaming SSE events
- merge `system` and `developer` prompts into `instructions` and normalize null content so subscription primary and fallback requests no longer fail on `input[n].content` validation errors
- keep proxy fallback handling and metadata intact while allowing OpenAI subscription requests to proceed on the actual supported protocol
- add adapter and proxy regression coverage for null content, developer prompts, native tool calling, and streaming tool-call translation

Closes #1184.

## Why
OpenAI subscription auth does not speak `/v1/chat/completions`; it must use the ChatGPT Responses endpoint. The earlier guard-and-skip approach avoided some failures but did not actually restore tool use on the subscription path. This PR implements the protocol bridge so OpenAI subscription requests can use tools end-to-end without changing the external Chat Completions contract used by the rest of Manifest.

## Validation
- `npm test --workspace=packages/backend -- --runInBand routing/proxy/__tests__/chatgpt-adapter.spec.ts routing/proxy/__tests__/proxy.service.spec.ts`
