### PR TITLE
fix: normalize Anthropic short model ids for pricing lookup

### DIFF
--- a/.changeset/short-anthropic-pricing.md
+++ b/.changeset/short-anthropic-pricing.md
@@ -1,0 +1,4 @@
+"manifest": patch
+---
+
+Normalize Anthropic short model ids so pricing lookup resolves Claude 4.6 cost entries across dotted and dashed variants.

--- a/.changeset/short-anthropic-pricing.md
+++ b/.changeset/short-anthropic-pricing.md
@@ -1,3 +1,4 @@
+---
 "manifest": patch
 ---
 

--- a/packages/backend/src/common/utils/anthropic-model-id.ts
+++ b/packages/backend/src/common/utils/anthropic-model-id.ts
@@ -1,0 +1,34 @@
+const ANTHROPIC_PREFIX = 'anthropic/';
+const SHORT_ANTHROPIC_MODEL_RE = /^claude-(opus|sonnet|haiku)-/i;
+const DOTTED_MINOR_RE = /-(\d+)\.(\d{1,2})(?=$|-\d{8}$)/g;
+const DASHED_MINOR_RE = /-(\d+)-(\d{1,2})(?=$|-\d{8}$)/g;
+
+function splitAnthropicPrefix(model: string): { prefix: string; bare: string } {
+  if (model.startsWith(ANTHROPIC_PREFIX)) {
+    return {
+      prefix: ANTHROPIC_PREFIX,
+      bare: model.slice(ANTHROPIC_PREFIX.length),
+    };
+  }
+  return { prefix: '', bare: model };
+}
+
+function supportsShortAnthropicMinorVersion(model: string): boolean {
+  return SHORT_ANTHROPIC_MODEL_RE.test(model);
+}
+
+export function normalizeAnthropicShortModelId(model: string): string {
+  const { prefix, bare } = splitAnthropicPrefix(model);
+  if (!supportsShortAnthropicMinorVersion(bare)) return model;
+  return `${prefix}${bare.replace(DOTTED_MINOR_RE, '-$1-$2')}`;
+}
+
+export function buildAnthropicShortModelIdVariants(model: string): string[] {
+  const normalized = normalizeAnthropicShortModelId(model);
+  const { prefix, bare } = splitAnthropicPrefix(normalized);
+  if (!supportsShortAnthropicMinorVersion(bare)) return [model];
+
+  const variants = new Set<string>([model, normalized]);
+  variants.add(`${prefix}${bare.replace(DASHED_MINOR_RE, '-$1.$2')}`);
+  return [...variants];
+}

--- a/packages/backend/src/model-prices/model-name-normalizer.spec.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.spec.ts
@@ -102,6 +102,12 @@ describe('model-name-normalizer', () => {
       expect(map.get('claude-opus-4-6')).toBe('anthropic/claude-opus-4-6');
     });
 
+    it('indexes Anthropic dash variant when canonical name uses dots', () => {
+      const map = buildAliasMap(['anthropic/claude-sonnet-4.6']);
+      expect(map.get('claude-sonnet-4-6')).toBe('anthropic/claude-sonnet-4.6');
+      expect(map.get('anthropic/claude-sonnet-4-6')).toBe('anthropic/claude-sonnet-4.6');
+    });
+
     it('includes MiniMax mixed-case aliases', () => {
       const map = buildAliasMap(['minimax-m2.5', 'minimax-m1']);
       expect(map.get('MiniMax-M2.5')).toBe('minimax-m2.5');
@@ -208,6 +214,11 @@ describe('model-name-normalizer', () => {
     it('resolves dot-variant through alias after normalization', () => {
       const map = buildAliasMap(['claude-sonnet-4-5-20250929']);
       expect(resolveModelName('claude-sonnet-4.5', map)).toBe('claude-sonnet-4-5-20250929');
+    });
+
+    it('resolves Anthropic dash variant when canonical name uses dots', () => {
+      const map = buildAliasMap(['anthropic/claude-opus-4.6']);
+      expect(resolveModelName('claude-opus-4-6', map)).toBe('anthropic/claude-opus-4.6');
     });
   });
 });

--- a/packages/backend/src/model-prices/model-name-normalizer.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.ts
@@ -1,3 +1,5 @@
+import { buildAnthropicShortModelIdVariants } from '../common/utils/anthropic-model-id';
+
 /**
  * Resolves variant model names (from telemetry) to canonical pricing names.
  *
@@ -75,10 +77,21 @@ export function buildAliasMap(canonicalNames: ReadonlyArray<string>): Map<string
 
   for (const name of canonicalNames) {
     map.set(name, name);
+    for (const variant of buildAnthropicShortModelIdVariants(name)) {
+      if (!map.has(variant)) {
+        map.set(variant, name);
+      }
+    }
+
     // Also index by bare name (e.g. "claude-sonnet-4" → "anthropic/claude-sonnet-4")
     const bare = stripProviderPrefix(name);
     if (bare !== name && !map.has(bare)) {
       map.set(bare, name);
+    }
+    for (const variant of buildAnthropicShortModelIdVariants(bare)) {
+      if (!map.has(variant)) {
+        map.set(variant, name);
+      }
     }
   }
 

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -143,6 +143,19 @@ describe('ModelPricingCacheService', () => {
       expect(result!.provider).toBe('Anthropic');
     });
 
+    it('should resolve dash-variant when cached Anthropic model uses dots', async () => {
+      const orMap = new Map<string, OpenRouterPricingEntry>([
+        ['anthropic/claude-opus-4.6', makeEntry(0.015, 0.075)],
+      ]);
+      mockGetAll.mockReturnValue(orMap);
+      await service.reload();
+
+      const result = service.getByModel('claude-opus-4-6');
+      expect(result).toBeDefined();
+      expect(result!.provider).toBe('Anthropic');
+      expect(result!.model_name).toBe('anthropic/claude-opus-4.6');
+    });
+
     it('should resolve date-suffixed model names', async () => {
       const orMap = new Map<string, OpenRouterPricingEntry>([
         ['openai/gpt-4.1', makeEntry(0.01, 0.02)],

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -715,11 +715,11 @@ describe('ModelDiscoveryService', () => {
       const result = await service.discoverModels(makeProvider({ provider: 'anthropic' }));
 
       expect(result).toHaveLength(2);
-      expect(result[0].id).toBe('claude-opus-4.6');
+      expect(result[0].id).toBe('claude-opus-4-6');
       expect(result[0].displayName).toBe('Claude Opus 4.6');
       expect(result[0].inputPricePerToken).toBe(0.000015);
       expect(result[0].provider).toBe('anthropic');
-      expect(result[1].id).toBe('claude-sonnet-4.6');
+      expect(result[1].id).toBe('claude-sonnet-4-6');
     });
 
     it('should unwrap OAuth blob for OpenAI subscription before fetching', async () => {
@@ -1239,6 +1239,26 @@ describe('ModelDiscoveryService', () => {
       // claude-opus-4 NOT added (covered by claude-opus-4-latest)
       expect(ids).not.toContain('claude-opus-4');
       expect(result[0].provider).toBe('anthropic');
+    });
+
+    it('should normalize Anthropic short-form dot ids from OpenRouter to dash ids', () => {
+      const orMap = new Map([
+        [
+          'anthropic/claude-sonnet-4.6',
+          {
+            input: 0.000003,
+            output: 0.000015,
+            contextWindow: 200000,
+            displayName: 'Claude Sonnet 4.6',
+          },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
+
+      expect(result.map((m) => m.id)).toContain('claude-sonnet-4-6');
+      expect(result.map((m) => m.id)).not.toContain('claude-sonnet-4.6');
     });
 
     it('should apply maxContextWindow cap from subscription capabilities', () => {

--- a/packages/backend/src/routing/model-discovery/model-fallback.ts
+++ b/packages/backend/src/routing/model-discovery/model-fallback.ts
@@ -7,6 +7,7 @@ import {
   getSubscriptionKnownModels,
   getSubscriptionCapabilities,
 } from '../../../../subscription-capabilities';
+import { normalizeAnthropicShortModelId } from '../../common/utils/anthropic-model-id';
 
 interface PricingLookup {
   lookupPricing(key: string): {
@@ -19,6 +20,12 @@ interface PricingLookup {
     string,
     { input: number; output: number; contextWindow?: number; displayName?: string }
   >;
+}
+
+function normalizeProviderModelId(providerId: string, modelId: string): string {
+  return providerId.toLowerCase() === 'anthropic'
+    ? normalizeAnthropicShortModelId(modelId)
+    : modelId;
 }
 
 /**
@@ -99,7 +106,7 @@ export function buildFallbackModels(
 
   for (const [fullId, entry] of pricingSync.getAll()) {
     if (!fullId.startsWith(`${orPrefix}/`)) continue;
-    const modelId = fullId.substring(orPrefix.length + 1);
+    const modelId = normalizeProviderModelId(providerId, fullId.substring(orPrefix.length + 1));
     if (seen.has(modelId)) continue;
     seen.add(modelId);
     models.push({
@@ -141,7 +148,7 @@ export function buildSubscriptionFallbackModels(
   if (pricingSync && orPrefix) {
     for (const [fullId, entry] of pricingSync.getAll()) {
       if (!fullId.startsWith(`${orPrefix}/`)) continue;
-      const modelId = fullId.substring(orPrefix.length + 1);
+      const modelId = normalizeProviderModelId(providerId, fullId.substring(orPrefix.length + 1));
       if (!normalizedKnownPrefixes.some((p: string) => modelId.toLowerCase().startsWith(p))) {
         continue;
       }

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -213,6 +213,40 @@ describe('ProxyService', () => {
     );
   });
 
+  it('normalizes Anthropic dotted model ids before forwarding', async () => {
+    resolveService.resolve.mockResolvedValue({
+      tier: 'complex',
+      model: 'claude-sonnet-4.6',
+      provider: 'Anthropic',
+      confidence: 0.9,
+      score: 0.2,
+      reason: 'scored',
+      auth_type: 'subscription',
+    });
+    routingService.getProviderApiKey.mockResolvedValue('sk-ant-oat');
+    providerClient.forward.mockResolvedValue({
+      response: new Response('{}', { status: 200 }),
+      isGoogle: false,
+      isAnthropic: true,
+      isChatGpt: false,
+    });
+
+    const result = await service.proxyRequest('agent-1', 'user-1', body, 'sess-1');
+
+    expect(result.meta.model).toBe('claude-sonnet-4-6');
+    expect(providerClient.forward).toHaveBeenCalledWith(
+      'Anthropic',
+      'sk-ant-oat',
+      'claude-sonnet-4-6',
+      body,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      'subscription',
+    );
+  });
+
   it('passes tools and tool_choice to the resolver', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'standard',
@@ -1541,6 +1575,55 @@ describe('ProxyService', () => {
         2,
         'agent-1',
         'Anthropic',
+        'subscription',
+      );
+    });
+
+    it('normalizes Anthropic dotted fallback ids before forwarding', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+        auth_type: 'api_key',
+      });
+      routingService.getProviderApiKey
+        .mockResolvedValueOnce('sk-openai')
+        .mockResolvedValueOnce('skst-anthropic-token');
+      routingService.getAuthType.mockResolvedValueOnce('subscription');
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('rate limited', { status: 429 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: true,
+          isChatGpt: false,
+        });
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: ['claude-sonnet-4.6'] },
+      ] as never);
+      pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+
+      expect(result.meta.model).toBe('claude-sonnet-4-6');
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        2,
+        'Anthropic',
+        'skst-anthropic-token',
+        'claude-sonnet-4-6',
+        body,
+        false,
+        undefined,
+        undefined,
+        undefined,
         'subscription',
       );
     });

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -13,6 +13,7 @@ import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from './fallback-sta
 import { inferProviderFromModelName } from '../provider-aliases';
 import { Tier, ScorerMessage } from '../scorer/types';
 import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
+import { normalizeAnthropicShortModelId } from '../../common/utils/anthropic-model-id';
 
 /**
  * Roles excluded from scoring. OpenClaw (and similar tools) inject a large,
@@ -127,16 +128,17 @@ export class ProxyService {
       agentId,
       userId,
     );
+    const primaryModel = this.normalizeProviderModel(resolved.provider, resolved.model);
 
     this.logger.log(
-      `Proxy: tier=${resolved.tier} model=${resolved.model} provider=${resolved.provider} auth_type=${resolved.auth_type} confidence=${resolved.confidence}`,
+      `Proxy: tier=${resolved.tier} model=${primaryModel} provider=${resolved.provider} auth_type=${resolved.auth_type} confidence=${resolved.confidence}`,
     );
 
     const stream = body.stream === true;
     const forward = await this.forwardToProvider(
       resolved.provider,
       resolvedCredentials.apiKey,
-      resolved.model,
+      primaryModel,
       body,
       stream,
       sessionKey,
@@ -159,7 +161,7 @@ export class ProxyService {
           body,
           stream,
           sessionKey,
-          resolved.model,
+          primaryModel,
           signal,
         );
 
@@ -174,7 +176,7 @@ export class ProxyService {
               confidence: resolved.confidence,
               reason: resolved.reason,
               auth_type: resolved.auth_type,
-              fallbackFromModel: resolved.model,
+              fallbackFromModel: primaryModel,
               fallbackIndex: success.fallbackIndex,
               primaryErrorStatus: forward.response.status,
               primaryErrorBody: primaryErrorBody,
@@ -205,7 +207,7 @@ export class ProxyService {
           },
           meta: {
             tier: resolved.tier as Tier,
-            model: resolved.model,
+            model: primaryModel,
             provider: resolved.provider,
             confidence: resolved.confidence,
             reason: resolved.reason,
@@ -222,7 +224,7 @@ export class ProxyService {
       forward,
       meta: {
         tier: resolved.tier as Tier,
-        model: resolved.model,
+        model: primaryModel,
         provider: resolved.provider,
         confidence: resolved.confidence,
         reason: resolved.reason,
@@ -251,25 +253,26 @@ export class ProxyService {
   }> {
     const failures: FailedFallback[] = [];
     for (let i = 0; i < fallbackModels.length; i++) {
-      const model = fallbackModels[i];
-      const pricing = this.pricingCache.getByModel(model);
+      const requestedModel = fallbackModels[i];
+      const pricing = this.pricingCache.getByModel(requestedModel);
 
       // Determine provider: custom prefix → model name inference → pricing cache → user's connected providers
       let provider: string | undefined;
-      if (CustomProviderService.isCustom(model)) {
-        const slashIdx = model.indexOf('/');
-        provider = slashIdx > 0 ? model.substring(0, slashIdx) : model;
+      if (CustomProviderService.isCustom(requestedModel)) {
+        const slashIdx = requestedModel.indexOf('/');
+        provider = slashIdx > 0 ? requestedModel.substring(0, slashIdx) : requestedModel;
       } else {
         provider =
-          inferProviderFromModelName(model) ??
+          inferProviderFromModelName(requestedModel) ??
           pricing?.provider ??
-          (await this.routingService.findProviderForModel(agentId, model));
+          (await this.routingService.findProviderForModel(agentId, requestedModel));
       }
 
       if (!provider) {
-        this.logger.debug(`Fallback ${i}: skipping model=${model} (no provider data)`);
+        this.logger.debug(`Fallback ${i}: skipping model=${requestedModel} (no provider data)`);
         continue;
       }
+      const model = this.normalizeProviderModel(provider, requestedModel);
       const authType = await this.routingService.getAuthType(agentId, provider);
       let apiKey = await this.routingService.getProviderApiKey(agentId, provider, authType);
       if (apiKey === null) {
@@ -435,5 +438,9 @@ export class ProxyService {
       customEndpoint,
       authType,
     );
+  }
+
+  private normalizeProviderModel(provider: string, model: string): string {
+    return provider.toLowerCase() === 'anthropic' ? normalizeAnthropicShortModelId(model) : model;
   }
 }


### PR DESCRIPTION
## Summary
This fixes cost lookup when Anthropic telemetry uses short-form model ids like `claude-opus-4-6` and the pricing cache stores equivalent Anthropic entries under dotted and/or provider-prefixed names.

## Root cause
Anthropic model ids were reaching pricing lookup in dashed short form, while pricing rows could be keyed as `anthropic/claude-opus-4.6` or similar. The mismatch came from two places:
- provider prefix present in pricing data but absent in telemetry
- dot-vs-dash minor version formatting (`4.6` vs `4-6`)

## Changes
- add a narrow Anthropic short-id normalizer
- index both dot and dash Anthropic variants in the pricing alias map
- normalize Anthropic fallback/discovery ids to the provider-native dashed form
- normalize Anthropic runtime forwarding ids so saved dotted overrides/fallbacks also recover cleanly

## Steps To Reproduce
1. Connect Anthropic with a direct API key in Manifest
2. Send a request routed to Claude Sonnet 4.6 or Claude Opus 4.6
3. Open the Messages log or analytics view
4. Before this change, cost shows `—`
5. After this change, cost is populated

## Tests
```bash
/Users/guillaumegay/Documents/Projects/manifest/node_modules/.bin/jest --runInBand 
  src/model-prices/model-name-normalizer.spec.ts 
  src/model-prices/model-pricing-cache.service.spec.ts 
  src/routing/model-discovery/model-discovery.service.spec.ts 
  src/routing/proxy/__tests__/proxy.service.spec.ts
```

Fixes #1179

This PR is intentionally scoped to pricing/model-id normalization only. Anthropic subscription/OAuth behavior from #1193 is being investigated separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Anthropic short model IDs (dot vs dash and missing `anthropic/` prefix) so pricing lookup, discovery, and proxy forwarding consistently resolve and report costs. Fixes #1179 where costs showed as — for `claude-sonnet-4.6`/`claude-opus-4.6` and their dashed variants.

- **Bug Fixes**
  - Added a narrow Anthropic short‑ID normalizer and indexed dashed and dotted variants in the alias map.
  - Normalized Anthropic IDs to dashed form in model discovery, subscription fallback models, and proxy forwarding.
  - Updated tests to cover pricing lookups, discovery output, and runtime forwarding with dotted inputs.
  - Repaired changeset frontmatter to publish a patch.

<sup>Written for commit 57093e397136f32f54dd0cbabdf0ce1b9b03ccd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

