### PR TITLE
Fix disclaimer card dark mode contrast

### DIFF
--- a/.changeset/fix-disclaimer-dark-mode.md
+++ b/.changeset/fix-disclaimer-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix subscription disclaimer card contrast in dark mode and rename label from "Experimental" to "Notice"

--- a/packages/frontend/src/components/ProviderSubscriptionTab.tsx
+++ b/packages/frontend/src/components/ProviderSubscriptionTab.tsx
@@ -25,7 +25,7 @@ const ProviderSubscriptionTab: Component<Props> = (props) => {
         setup-token.
       </div>
       <div class="provider-modal__disclaimer">
-        <span class="provider-modal__disclaimer-label">Experimental</span>
+        <span class="provider-modal__disclaimer-label">Notice</span>
         <span>
           Using OAuth from certain providers with AI agents may lead to account restrictions or
           bans. Use at your own risk.

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -59,7 +59,7 @@
   font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
   line-height: 1.5;
-  background: #fbf9f3;
+  background: hsl(var(--muted));
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
 }


### PR DESCRIPTION
## Summary
- Fix subscription disclaimer card background using theme-aware `hsl(var(--muted))` instead of hardcoded light color (`#fbf9f3`)
- Rename "Experimental" label to "Notice" for a more accurate tone

Closes #1196

## Test plan
- [ ] Open the Connect Providers modal → Subscription tab in dark mode
- [ ] Verify the disclaimer card has proper contrast
- [ ] Verify the label reads "Notice" instead of "Experimental"
- [ ] Verify light mode still looks correct
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the subscription disclaimer card contrast in dark mode by switching the background to theme-aware `hsl(var(--muted))`, and renames the label to "Notice". Affects the Connect Providers modal → Subscription tab in both themes; closes #1196.

<sup>Written for commit 2ac2bc25d06e509ccb3d86700a71b688618c615a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
