### PR TITLE
feat(frontend): add Product Hunt popup CTA for launch

### DIFF
--- a/.changeset/product-hunt-upvote-popup.md
+++ b/.changeset/product-hunt-upvote-popup.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add a one-time Product Hunt launch popup in the dashboard with a persistent dismiss state

--- a/.changeset/product-hunt-upvote-popup.md
+++ b/.changeset/product-hunt-upvote-popup.md
@@ -1,5 +1,5 @@
 ---
-'manifest': patch
+"manifest": patch
 ---
 
 Add a one-time Product Hunt launch popup in the dashboard with a persistent dismiss state

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ OpenClaw costs
 <p align="center">
   <a href="https://github.com/mnfst/manifest/stargazers"><img src="https://img.shields.io/github/stars/mnfst/manifest?style=flat" alt="GitHub stars" /></a>
   &nbsp;
+  <a href="https://www.producthunt.com/products/manifest-361?utm_source=badge-follow&utm_medium=badge&utm_campaign=badge-manifest-361"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1186856&theme=light&size=small" alt="Product Hunt" width="86" height="32" /></a>
+  &nbsp;
   <a href="https://www.npmjs.com/package/manifest"><img src="https://img.shields.io/npm/v/manifest?color=cb3837&label=npm" alt="npm version" /></a>
   &nbsp;
   <a href="https://www.npmjs.com/package/manifest"><img src="https://img.shields.io/npm/dw/manifest?color=cb3837" alt="npm downloads" /></a>

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Sidebar from './components/Sidebar.jsx';
 import AuthGuard from './components/AuthGuard.jsx';
 import { connectSse } from './services/sse.js';
 import VersionIndicator from './components/VersionIndicator.jsx';
+import ProductHuntUpvoteModal from './components/ProductHuntUpvoteModal.jsx';
 
 const SseConnector: ParentComponent = (props) => {
   onMount(() => {
@@ -27,6 +28,7 @@ const App: ParentComponent = (props) => {
             Skip to main content
           </a>
           <Header />
+          <ProductHuntUpvoteModal />
           <div class="app-body">
             <Show when={showSidebar()}>
               <Sidebar />

--- a/packages/frontend/src/components/ProductHuntUpvoteModal.tsx
+++ b/packages/frontend/src/components/ProductHuntUpvoteModal.tsx
@@ -95,8 +95,8 @@ const ProductHuntUpvoteModal: Component = () => {
             Manifest on Product Hunt
           </h2>
           <p class="product-hunt-modal__description">
-            Leave an upvote for Manifest so we can keep improving the product and growing our
-            community. Thank you 🙌
+            Manifest is open source and free to use. Support us with an upvote to help us
+            improve the product and grow the community. Thank you 🙌
           </p>
 
           <a

--- a/packages/frontend/src/components/ProductHuntUpvoteModal.tsx
+++ b/packages/frontend/src/components/ProductHuntUpvoteModal.tsx
@@ -1,0 +1,127 @@
+import { createEffect, createSignal, onCleanup, Show, type Component } from 'solid-js';
+import { isLocalMode } from '../services/local-mode.js';
+
+export const PRODUCT_HUNT_UPVOTE_KEY = 'mnfst_product_hunt_upvote_2026_03_23';
+export const PRODUCT_HUNT_FALLBACK_URL =
+  'https://www.producthunt.com/products/manifest-361?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-manifest-361';
+
+const PRODUCT_HUNT_URL =
+  (import.meta.env.VITE_PRODUCT_HUNT_URL as string | undefined) ?? PRODUCT_HUNT_FALLBACK_URL;
+const PRODUCT_HUNT_ALT = 'Manifest - Open Source LLM Router for OpenClaw | Product Hunt';
+const PRODUCT_HUNT_FEATURED_BADGE =
+  'https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1104032&theme=light';
+
+const hasAcknowledgedPrompt = (): boolean => {
+  try {
+    return localStorage.getItem(PRODUCT_HUNT_UPVOTE_KEY) === '1';
+  } catch {
+    return false;
+  }
+};
+
+const acknowledgePrompt = (): void => {
+  try {
+    localStorage.setItem(PRODUCT_HUNT_UPVOTE_KEY, '1');
+  } catch {
+    // Ignore storage failures and still close the modal for this session.
+  }
+};
+
+const ProductHuntUpvoteModal: Component = () => {
+  const [open, setOpen] = createSignal(false);
+
+  const dismiss = () => {
+    acknowledgePrompt();
+    setOpen(false);
+  };
+
+  createEffect(() => {
+    if (!isLocalMode() && !hasAcknowledgedPrompt()) {
+      setOpen(true);
+    }
+  });
+
+  createEffect(() => {
+    if (!open()) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dismiss();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    onCleanup(() => window.removeEventListener('keydown', handleKeyDown));
+  });
+
+  return (
+    <Show when={open()}>
+      <div
+        class="modal-overlay product-hunt-modal__overlay"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) dismiss();
+        }}
+      >
+        <div
+          class="modal-card product-hunt-modal__card"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="product-hunt-upvote-title"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <button
+            class="product-hunt-modal__close"
+            type="button"
+            onClick={dismiss}
+            aria-label="Dismiss Product Hunt popup"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+
+          <h2 class="product-hunt-modal__title" id="product-hunt-upvote-title">
+            Manifest on Product Hunt
+          </h2>
+          <p class="product-hunt-modal__description">
+            Leave an upvote for Manifest so we can keep improving the product and growing our
+            community. Thank you 🙌
+          </p>
+
+          <a
+            href={PRODUCT_HUNT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="product-hunt-modal__featured-badge"
+            onClick={() => {
+              acknowledgePrompt();
+              setOpen(false);
+            }}
+          >
+            <div class="product-hunt-modal__featured-frame">
+              <img
+                src={PRODUCT_HUNT_FEATURED_BADGE}
+                alt={PRODUCT_HUNT_ALT}
+                width="250"
+                height="54"
+              />
+            </div>
+          </a>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default ProductHuntUpvoteModal;

--- a/packages/frontend/src/styles/product-hunt.css
+++ b/packages/frontend/src/styles/product-hunt.css
@@ -1,0 +1,168 @@
+.product-hunt-modal__overlay {
+  background:
+    radial-gradient(circle at top left, rgb(255 97 0 / 0.08), transparent 28%),
+    rgb(247 243 235 / 0.84);
+  backdrop-filter: blur(4px);
+}
+
+.dark .product-hunt-modal__overlay {
+  background:
+    radial-gradient(circle at top left, rgb(255 97 0 / 0.12), transparent 24%), rgb(0 0 0 / 0.74);
+}
+
+.product-hunt-modal__card {
+  position: relative;
+  max-width: 340px;
+  overflow: hidden;
+  border: 1px solid rgb(39 20 7 / 0.08);
+  box-shadow:
+    0 16px 38px rgb(39 20 7 / 0.12),
+    0 0 0 1px rgb(255 255 255 / 0.35) inset;
+  background:
+    linear-gradient(145deg, rgb(255 255 255 / 0.96), rgb(250 246 240 / 0.96)), hsl(var(--card));
+}
+
+.dark .product-hunt-modal__card {
+  border-color: rgb(255 255 255 / 0.08);
+  box-shadow:
+    0 18px 42px rgb(0 0 0 / 0.38),
+    0 0 0 1px rgb(255 255 255 / 0.04) inset;
+  background: linear-gradient(145deg, rgb(28 23 20 / 0.98), rgb(20 17 15 / 0.98)), hsl(var(--card));
+}
+
+.product-hunt-modal__card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(115deg, rgb(255 97 0 / 0.08), transparent 24%);
+  pointer-events: none;
+}
+
+.dark .product-hunt-modal__card::before {
+  background: linear-gradient(115deg, rgb(255 97 0 / 0.12), transparent 24%);
+}
+
+.product-hunt-modal__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgb(39 20 7 / 0.08);
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.72);
+  color: hsl(var(--muted-foreground));
+}
+
+.product-hunt-modal__close:hover {
+  transform: translateY(-1px);
+  background: rgb(255 255 255 / 0.95);
+  color: hsl(var(--foreground));
+}
+
+.dark .product-hunt-modal__close {
+  border-color: rgb(255 255 255 / 0.08);
+  background: rgb(255 255 255 / 0.05);
+}
+
+.dark .product-hunt-modal__close:hover {
+  background: rgb(255 255 255 / 0.1);
+}
+
+.product-hunt-modal__title {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: 1.28rem;
+  line-height: 1.25;
+  letter-spacing: -0.03em;
+  max-width: 18ch;
+}
+
+.product-hunt-modal__description {
+  position: relative;
+  z-index: 1;
+  margin: 8px 0 0;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.88rem;
+  line-height: 1.45;
+  max-width: 34ch;
+}
+
+.product-hunt-modal__featured-badge {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-top: 14px;
+  border: 1px solid rgb(39 20 7 / 0.08);
+  border-radius: 14px;
+  background: rgb(255 255 255 / 0.72);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    transform var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.product-hunt-modal__featured-badge:hover {
+  transform: translateY(-1px);
+  border-color: rgb(255 97 0 / 0.22);
+  box-shadow: 0 10px 20px rgb(39 20 7 / 0.08);
+}
+
+.dark .product-hunt-modal__featured-badge {
+  border-color: rgb(255 255 255 / 0.08);
+  background: rgb(255 255 255 / 0.03);
+}
+
+.dark .product-hunt-modal__featured-badge:hover {
+  border-color: rgb(255 97 0 / 0.28);
+  box-shadow: 0 12px 24px rgb(0 0 0 / 0.18);
+}
+
+.product-hunt-modal__featured-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 62px;
+  min-width: 250px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgb(255 255 255 / 0.88);
+}
+
+.dark .product-hunt-modal__featured-frame {
+  background: rgb(255 255 255 / 0.04);
+}
+
+.product-hunt-modal__featured-frame img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+@media (max-width: 720px) {
+  .product-hunt-modal__card {
+    padding: 16px 16px 14px;
+  }
+
+  .product-hunt-modal__title {
+    max-width: 14ch;
+    font-size: 1.15rem;
+  }
+
+  .product-hunt-modal__featured-badge {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .product-hunt-modal__featured-frame {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -8,6 +8,7 @@
 @import './data.css';
 @import './agents.css';
 @import './modals.css';
+@import './product-hunt.css';
 @import './tokens.css';
 @import './wizard.css';
 @import './notifications.css';

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/frontend/tests/components/ProductHuntUpvoteModal.test.tsx
+++ b/packages/frontend/tests/components/ProductHuntUpvoteModal.test.tsx
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@solidjs/testing-library';
+
+let mockIsLocalMode = false;
+vi.mock('../../src/services/local-mode.js', () => ({
+  isLocalMode: () => mockIsLocalMode,
+}));
+
+import ProductHuntUpvoteModal, {
+  PRODUCT_HUNT_FALLBACK_URL,
+  PRODUCT_HUNT_UPVOTE_KEY,
+} from '../../src/components/ProductHuntUpvoteModal';
+
+beforeEach(() => {
+  localStorage.clear();
+  mockIsLocalMode = false;
+  window.history.replaceState({}, '', '/');
+});
+
+describe('ProductHuntUpvoteModal', () => {
+  it('renders the popup when it has not been dismissed', () => {
+    const { container } = render(() => <ProductHuntUpvoteModal />);
+
+    expect(screen.getByText('Manifest on Product Hunt')).toBeDefined();
+    const link = container.querySelector(
+      '.product-hunt-modal__featured-badge',
+    ) as HTMLAnchorElement;
+    expect(link).toBeDefined();
+    expect(link.getAttribute('href')).toBe(PRODUCT_HUNT_FALLBACK_URL);
+  });
+
+  it('stores the one-time flag when dismissed', async () => {
+    render(() => <ProductHuntUpvoteModal />);
+
+    await fireEvent.click(screen.getByLabelText('Dismiss Product Hunt popup'));
+
+    expect(localStorage.getItem(PRODUCT_HUNT_UPVOTE_KEY)).toBe('1');
+    expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
+  });
+
+  it('stores the one-time flag when the CTA is clicked', async () => {
+    const { container } = render(() => <ProductHuntUpvoteModal />);
+
+    await fireEvent.click(container.querySelector('.product-hunt-modal__featured-badge')!);
+
+    expect(localStorage.getItem(PRODUCT_HUNT_UPVOTE_KEY)).toBe('1');
+    expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
+  });
+
+  it('does not render after it has already been acknowledged', () => {
+    localStorage.setItem(PRODUCT_HUNT_UPVOTE_KEY, '1');
+    const { container } = render(() => <ProductHuntUpvoteModal />);
+
+    expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('does not render in local mode', () => {
+    mockIsLocalMode = true;
+    const { container } = render(() => <ProductHuntUpvoteModal />);
+
+    expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('dismisses on Escape', async () => {
+    render(() => <ProductHuntUpvoteModal />);
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(localStorage.getItem(PRODUCT_HUNT_UPVOTE_KEY)).toBe('1');
+    expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
+  });
+});

--- a/packages/frontend/tests/components/ProductHuntUpvoteModal.test.tsx
+++ b/packages/frontend/tests/components/ProductHuntUpvoteModal.test.tsx
@@ -71,4 +71,39 @@ describe('ProductHuntUpvoteModal', () => {
     expect(localStorage.getItem(PRODUCT_HUNT_UPVOTE_KEY)).toBe('1');
     expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
   });
+
+  it('dismisses when the overlay is clicked, but not when the card is clicked', async () => {
+    const { container } = render(() => <ProductHuntUpvoteModal />);
+
+    await fireEvent.click(container.querySelector('.product-hunt-modal__card')!);
+    expect(screen.getByText('Manifest on Product Hunt')).toBeDefined();
+
+    await fireEvent.click(container.querySelector('.product-hunt-modal__overlay')!);
+    expect(localStorage.getItem(PRODUCT_HUNT_UPVOTE_KEY)).toBe('1');
+    expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
+  });
+
+  it('renders when localStorage.getItem throws', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    render(() => <ProductHuntUpvoteModal />);
+
+    expect(screen.getByText('Manifest on Product Hunt')).toBeDefined();
+    getItemSpy.mockRestore();
+  });
+
+  it('still closes when localStorage.setItem throws', async () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    render(() => <ProductHuntUpvoteModal />);
+
+    await fireEvent.click(screen.getByLabelText('Dismiss Product Hunt popup'));
+
+    expect(screen.queryByText('Manifest on Product Hunt')).toBeNull();
+    setItemSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- add a one-time Product Hunt popup to the frontend shell
- use the official Manifest featured badge as the CTA
- keep the modal scoped to non-local mode, with one-time acknowledgement persisted in localStorage
- add compact popup styles, frontend wiring, and focused popup tests
- include the frontend changeset for the launch popup

## Validation
- attempted in the clean worktree, but local tool dependencies are not installed there (`eslint`, `vite`, `vitest`, `typescript` not resolvable)

## Scope
- surgical popup-only change set: 7 files relative to `upstream/main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time Product Hunt launch popup in the dashboard using the official featured badge to encourage upvotes. Also adds a Product Hunt badge to the README; the popup shows only outside local mode and remembers dismiss in localStorage.

- **New Features**
  - Added `ProductHuntUpvoteModal` and wired it into the app shell.
  - Non-local only; dismiss or CTA click persists a “don’t show again” flag.
  - CTA opens Product Hunt in a new tab; uses `VITE_PRODUCT_HUNT_URL` with a safe fallback.
  - Accessible dialog; closes on Escape or overlay click; refined copy.
  - Scoped styles added and imported via `theme.css`; tests cover visibility, persistence, local-mode behavior, Escape/overlay dismiss, and localStorage failure resilience.

- **Migration**
  - Optionally set `VITE_PRODUCT_HUNT_URL` to override the fallback URL.

<sup>Written for commit eb9b5dfc513cf3f00a1faf555832737f354be5cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

