### PR TITLE
fix(backend): allow Product Hunt popup badge in CSP

### DIFF
--- a/.changeset/product-hunt-csp-fix.md
+++ b/.changeset/product-hunt-csp-fix.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Allow Product Hunt badge images in the app Content Security Policy so the launch popup renders correctly in production.

--- a/packages/backend/src/common/constants/csp.constants.ts
+++ b/packages/backend/src/common/constants/csp.constants.ts
@@ -1,0 +1,10 @@
+export const MANIFEST_CSP_DIRECTIVES = {
+  defaultSrc: ["'self'"],
+  scriptSrc: ["'self'"],
+  styleSrc: ["'self'", "'unsafe-inline'"],
+  imgSrc: ["'self'", 'data:', 'https://api.producthunt.com'],
+  connectSrc: ["'self'"],
+  fontSrc: ["'self'"],
+  objectSrc: ["'none'"],
+  frameAncestors: ["'none'"],
+};

--- a/packages/backend/src/main.spec.ts
+++ b/packages/backend/src/main.spec.ts
@@ -1,0 +1,7 @@
+import { MANIFEST_CSP_DIRECTIVES } from './common/constants/csp.constants';
+
+describe('MANIFEST_CSP_DIRECTIVES', () => {
+  it('allows Product Hunt badge images in img-src', () => {
+    expect(MANIFEST_CSP_DIRECTIVES.imgSrc).toContain('https://api.producthunt.com');
+  });
+});

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -5,6 +5,7 @@ import compression from 'compression';
 import * as express from 'express';
 import { AppModule } from './app.module';
 import { auth } from './auth/auth.instance';
+import { MANIFEST_CSP_DIRECTIVES } from './common/constants/csp.constants';
 import { LOCAL_USER_ID, LOCAL_EMAIL } from './common/constants/local-mode.constants';
 import { SpaFallbackFilter } from './common/filters/spa-fallback.filter';
 import { isAllowedLocalIp } from './common/utils/local-ip';
@@ -21,16 +22,7 @@ export async function bootstrap() {
   app.use(
     helmet({
       contentSecurityPolicy: {
-        directives: {
-          defaultSrc: ["'self'"],
-          scriptSrc: ["'self'"],
-          styleSrc: ["'self'", "'unsafe-inline'"],
-          imgSrc: ["'self'", 'data:'],
-          connectSrc: ["'self'"],
-          fontSrc: ["'self'"],
-          objectSrc: ["'none'"],
-          frameAncestors: ["'none'"],
-        },
+        directives: MANIFEST_CSP_DIRECTIVES,
       },
     }),
   );


### PR DESCRIPTION
## Summary
- allow `https://api.producthunt.com` in the backend Content Security Policy image sources
- keep the popup using the official Product Hunt embed image
- add a focused backend test for the CSP directives
- add the required manifest changeset for this backend fix

## Validation
- `npm run lint` (passes with pre-existing warnings only)
- `npx tsc --noEmit` in `packages/backend`
- `npm run build --workspace=packages/backend`
- `npm test --workspace=packages/backend -- main.spec.ts`

## Scope
- surgical backend-only fix for the production popup rendering issue


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the backend Content Security Policy to allow Product Hunt badge images, restoring the launch popup in production. Also standardizes the CSP config and adds a focused test.

- **Bug Fixes**
  - Add https://api.producthunt.com to img-src.
  - Move CSP directives to `MANIFEST_CSP_DIRECTIVES` and use in `main.ts`.
  - Add a unit test to verify the allowed image source.
  - Include a manifest changeset for the backend patch.

<sup>Written for commit 91223e19d9e69df97a9dde2dc2e1b2bf169b16ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

