### PR TITLE
feat: add dynamic model discovery for GitHub Copilot

### DIFF
--- a/.changeset/copilot-dynamic-discovery.md
+++ b/.changeset/copilot-dynamic-discovery.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+feat: add dynamic model discovery for GitHub Copilot subscription provider

--- a/packages/backend/src/routing/model-discovery/model-discovery.module.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.module.ts
@@ -5,10 +5,11 @@ import { CustomProvider } from '../../entities/custom-provider.entity';
 import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { ProviderModelFetcherService } from './provider-model-fetcher.service';
 import { ModelDiscoveryService } from './model-discovery.service';
+import { CopilotTokenService } from '../proxy/copilot-token.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserProvider, CustomProvider]), ModelPricesModule],
-  providers: [ProviderModelFetcherService, ModelDiscoveryService],
+  providers: [ProviderModelFetcherService, ModelDiscoveryService, CopilotTokenService],
   exports: [ModelDiscoveryService, ProviderModelFetcherService],
 })
 export class ModelDiscoveryModule {}

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -93,6 +93,7 @@ describe('ModelDiscoveryService', () => {
     registerModels: jest.Mock;
     getConfirmedModels: jest.Mock;
   };
+  let mockCopilotTokenService: { getCopilotToken: jest.Mock };
 
   beforeEach(() => {
     providerRepo = makeMockRepo();
@@ -106,6 +107,9 @@ describe('ModelDiscoveryService', () => {
       registerModels: jest.fn(),
       getConfirmedModels: jest.fn().mockReturnValue(null),
     };
+    mockCopilotTokenService = {
+      getCopilotToken: jest.fn().mockResolvedValue('tid=exchanged-copilot-token'),
+    };
 
     mockDecrypt.mockReturnValue('decrypted-key');
     mockGetSecret.mockReturnValue('secret-32-chars-long-xxxxxxxxxx');
@@ -117,6 +121,7 @@ describe('ModelDiscoveryService', () => {
       fetcher as unknown as ProviderModelFetcherService,
       mockPricingSync as never,
       mockModelRegistry as unknown as ProviderModelRegistryService,
+      mockCopilotTokenService as never,
     );
   });
 
@@ -235,6 +240,7 @@ describe('ModelDiscoveryService', () => {
         fetcher as unknown as ProviderModelFetcherService,
         null,
         null,
+        null,
       );
 
       const models = [makeModel({ id: 'some-model' })];
@@ -329,6 +335,7 @@ describe('ModelDiscoveryService', () => {
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
         mockPricingSync as never,
+        null,
         null,
       );
 
@@ -1101,11 +1108,85 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).not.toHaveBeenCalled();
     });
 
+    it('should exchange Copilot GitHub token before fetching models', async () => {
+      mockDecrypt.mockReturnValue('ghu_github_oauth_token');
+      mockCopilotTokenService.getCopilotToken.mockResolvedValue('tid=copilot-api-token');
+
+      const models = [makeModel({ id: 'copilot/claude-opus-4.6', provider: 'copilot' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'copilot',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-github-token',
+        }),
+      );
+
+      expect(mockCopilotTokenService.getCopilotToken).toHaveBeenCalledWith(
+        'ghu_github_oauth_token',
+      );
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'copilot',
+        'tid=copilot-api-token',
+        'subscription',
+        undefined,
+      );
+    });
+
+    it('should fall back to known models when Copilot token exchange fails', async () => {
+      mockDecrypt.mockReturnValue('ghu_expired_token');
+      mockCopilotTokenService.getCopilotToken.mockRejectedValue(
+        new Error('Copilot token exchange failed: 401'),
+      );
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'copilot',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-expired-token',
+        }),
+      );
+
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should skip Copilot token exchange when copilotTokenService is null', async () => {
+      const serviceNoCopilot = new ModelDiscoveryService(
+        providerRepo as never,
+        customProviderRepo as never,
+        fetcher as unknown as ProviderModelFetcherService,
+        mockPricingSync as never,
+        mockModelRegistry as unknown as ProviderModelRegistryService,
+        null,
+      );
+
+      mockDecrypt.mockReturnValue('ghu_github_token');
+      fetcher.fetch.mockResolvedValue([]);
+
+      await serviceNoCopilot.discoverModels(
+        makeProvider({
+          provider: 'copilot',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-token',
+        }),
+      );
+
+      // Without copilotTokenService, raw GitHub token is passed to fetcher
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'copilot',
+        'ghu_github_token',
+        'subscription',
+        undefined,
+      );
+    });
+
     it('should return knownModels fallback when pricingSync is null', async () => {
       const serviceNoPricing = new ModelDiscoveryService(
         providerRepo as never,
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
+        null,
         null,
         null,
       );

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.ts
@@ -10,6 +10,7 @@ import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
 import { computeQualityScore } from '../../database/quality-score.util';
 import { PricingSyncService } from '../../database/pricing-sync.service';
 import { parseOAuthTokenBlob } from '../openai-oauth.types';
+import { CopilotTokenService } from '../proxy/copilot-token.service';
 import {
   findOpenRouterPrefix,
   lookupWithVariants,
@@ -37,6 +38,9 @@ export class ModelDiscoveryService {
     @Optional()
     @Inject(ProviderModelRegistryService)
     private readonly modelRegistry: ProviderModelRegistryService | null,
+    @Optional()
+    @Inject(CopilotTokenService)
+    private readonly copilotTokenService: CopilotTokenService | null,
   ) {}
 
   async discoverModels(provider: UserProvider): Promise<DiscoveredModel[]> {
@@ -62,6 +66,15 @@ export class ModelDiscoveryService {
           if (lowerProvider === 'minimax' && blob.u) {
             endpointOverride = blob.u;
           }
+        }
+      } else if (lowerProvider === 'copilot' && this.copilotTokenService) {
+        try {
+          apiKey = await this.copilotTokenService.getCopilotToken(apiKey);
+        } catch {
+          this.logger.warn(
+            'Copilot token exchange failed for model discovery — falling back to known models',
+          );
+          apiKey = '';
         }
       }
     }

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.spec.ts
@@ -31,6 +31,7 @@ describe('ProviderModelFetcherService', () => {
       'gemini',
       'openrouter',
       'ollama',
+      'copilot',
     ];
     for (const id of expected) {
       expect(PROVIDER_CONFIGS[id]).toBeDefined();
@@ -817,6 +818,90 @@ describe('ProviderModelFetcherService', () => {
           }),
         }),
       );
+    });
+  });
+
+  /* ── Copilot parser ── */
+
+  describe('parseCopilot (via copilot provider)', () => {
+    it('should parse Copilot models and add copilot/ prefix', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'claude-opus-4.6', object: 'model' },
+            { id: 'gpt-4o', object: 'model' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=copilot-token');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          id: 'copilot/claude-opus-4.6',
+          displayName: 'claude-opus-4.6',
+          provider: 'copilot',
+          contextWindow: 128000,
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          qualityScore: 3,
+        }),
+      );
+      expect(result[1].id).toBe('copilot/gpt-4o');
+    });
+
+    it('should send correct Copilot headers', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+
+      await service.fetch('copilot', 'tid=test-token');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.githubcopilot.com/models',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer tid=test-token',
+            'Editor-Version': 'vscode/1.100.0',
+            'Copilot-Integration-Id': 'vscode-chat',
+          }),
+        }),
+      );
+    });
+
+    it('should return [] for empty data array', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+      expect(result).toEqual([]);
+    });
+
+    it('should filter out entries with missing or empty id', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'valid-model' }, { name: 'no-id-field' }, { id: '' }],
+        }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('copilot/valid-model');
+    });
+
+    it('should return [] when data is not an array', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: 'not-array' }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+      expect(result).toEqual([]);
     });
   });
 

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
@@ -212,6 +212,34 @@ function parseOpenaiSubscription(body: unknown, provider: string): DiscoveredMod
     });
 }
 
+/* ── GitHub Copilot (subscription-only, OpenAI-compatible /models) ── */
+
+function parseCopilot(body: unknown, provider: string): DiscoveredModel[] {
+  const data = (body as { data?: unknown[] })?.data;
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter((m: unknown) => {
+      const entry = m as OpenAIModelEntry;
+      return typeof entry.id === 'string' && entry.id.length > 0;
+    })
+    .map((m: unknown) => {
+      const entry = m as OpenAIModelEntry;
+      // Copilot API returns bare names (e.g. "claude-opus-4.6");
+      // internal convention uses "copilot/" prefix
+      return {
+        id: `copilot/${entry.id}`,
+        displayName: entry.id,
+        provider,
+        contextWindow: DEFAULT_CONTEXT_WINDOW,
+        inputPricePerToken: 0,
+        outputPricePerToken: 0,
+        capabilityReasoning: false,
+        capabilityCode: false,
+        qualityScore: 3,
+      };
+    });
+}
+
 /* ── Provider configs ── */
 
 export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
@@ -304,6 +332,17 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     endpoint: `${OLLAMA_HOST}/api/tags`,
     buildHeaders: () => ({}),
     parse: parseOllama,
+  },
+  copilot: {
+    endpoint: 'https://api.githubcopilot.com/models',
+    buildHeaders: (key: string) => ({
+      Authorization: `Bearer ${key}`,
+      Accept: 'application/json',
+      'Editor-Version': 'vscode/1.100.0',
+      'Editor-Plugin-Version': 'copilot/1.300.0',
+      'Copilot-Integration-Id': 'vscode-chat',
+    }),
+    parse: parseCopilot,
   },
 };
 


### PR DESCRIPTION
Instead of relying solely on hardcoded knownModels, Copilot now fetches models from api.githubcopilot.com/models using the exchanged Copilot API token. Falls back to hardcoded list if the token exchange or fetch fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dynamic model discovery for GitHub Copilot subscription providers by fetching models from `https://api.githubcopilot.com/models` using an exchanged Copilot API token. Falls back to the hardcoded list if token exchange or fetch fails.

- **New Features**
  - Added `copilot` fetcher config with correct headers and a parser that prefixes `copilot/`.
  - `ModelDiscoveryService` uses `CopilotTokenService` to exchange GitHub tokens before fetching.
  - Graceful fallback to known models when token exchange or fetch fails.
  - Wired `CopilotTokenService` into `ModelDiscoveryModule`.
  - Tests cover token exchange, no-service path, fallback behavior, and parsing.

<sup>Written for commit a6fea217e5bce27fa68eabaf4100b01128c7c9d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

