### PR TITLE
feat: add capability flags to custom provider models

### DIFF
--- a/.changeset/capability-flags-custom-providers.md
+++ b/.changeset/capability-flags-custom-providers.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add optional `capability_reasoning` and `capability_code` fields to custom provider models, enabling them to reach higher quality scores and be eligible for the reasoning tier

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["manifest-backend", "manifest-frontend", "manifest-shared"]
 }

--- a/packages/backend/src/entities/custom-provider.entity.ts
+++ b/packages/backend/src/entities/custom-provider.entity.ts
@@ -7,6 +7,8 @@ export interface CustomProviderModel {
   input_price_per_million_tokens?: number;
   output_price_per_million_tokens?: number;
   context_window?: number;
+  capability_reasoning?: boolean;
+  capability_code?: boolean;
 }
 
 @Entity('custom_providers')

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -530,6 +530,86 @@ describe('ModelDiscoveryService', () => {
       const result = await service.getModelsForAgent('agent-1');
       expect(result).toHaveLength(1);
     });
+
+    it('should read capability_reasoning from custom provider model data', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [
+            {
+              model_name: 'reasoning-model',
+              capability_reasoning: true,
+              capability_code: false,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(false);
+    });
+
+    it('should read capability_code from custom provider model data', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [
+            {
+              model_name: 'code-model',
+              capability_reasoning: false,
+              capability_code: true,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(result[0].capabilityReasoning).toBe(false);
+      expect(result[0].capabilityCode).toBe(true);
+    });
+
+    it('should default capabilities to false for legacy custom provider models', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [{ model_name: 'legacy-model' }],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(result[0].capabilityReasoning).toBe(false);
+      expect(result[0].capabilityCode).toBe(false);
+    });
+
+    it('should compute quality score dynamically for custom provider models', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [
+            {
+              model_name: 'scored-model',
+              input_price_per_million_tokens: 15,
+              output_price_per_million_tokens: 75,
+              capability_reasoning: true,
+              capability_code: true,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(mockComputeScore).toHaveBeenCalledWith({
+        model_name: 'custom:cp-1/scored-model',
+        input_price_per_token: 15 / 1_000_000,
+        output_price_per_token: 75 / 1_000_000,
+        capability_reasoning: true,
+        capability_code: true,
+        context_window: 128000,
+      });
+      expect(result[0].qualityScore).toBe(3); // mock returns 3
+    });
   });
 
   /* ── getModelForAgent ── */

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -601,7 +601,7 @@ describe('ModelDiscoveryService', () => {
       const result = await service.getModelsForAgent('agent-1');
 
       expect(mockComputeScore).toHaveBeenCalledWith({
-        model_name: 'custom:cp-1/scored-model',
+        model_name: 'scored-model',
         input_price_per_token: 15 / 1_000_000,
         output_price_per_token: 75 / 1_000_000,
         capability_reasoning: true,

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -224,6 +224,8 @@ export class ModelDiscoveryService {
           m.output_price_per_million_tokens != null
             ? m.output_price_per_million_tokens / 1_000_000
             : null;
+        const capReasoning = m.capability_reasoning ?? false;
+        const capCode = m.capability_code ?? false;
         models.push({
           id: modelKey,
           displayName: m.model_name,
@@ -231,9 +233,16 @@ export class ModelDiscoveryService {
           contextWindow: m.context_window ?? 128000,
           inputPricePerToken: inputPerToken,
           outputPricePerToken: outputPerToken,
-          capabilityReasoning: false,
-          capabilityCode: false,
-          qualityScore: 2,
+          capabilityReasoning: capReasoning,
+          capabilityCode: capCode,
+          qualityScore: computeQualityScore({
+            model_name: modelKey,
+            input_price_per_token: inputPerToken,
+            output_price_per_token: outputPerToken,
+            capability_reasoning: capReasoning,
+            capability_code: capCode,
+            context_window: m.context_window ?? 128000,
+          }),
         });
       }
     }

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -236,7 +236,7 @@ export class ModelDiscoveryService {
           capabilityReasoning: capReasoning,
           capabilityCode: capCode,
           qualityScore: computeQualityScore({
-            model_name: modelKey,
+            model_name: m.model_name,
             input_price_per_token: inputPerToken,
             output_price_per_token: outputPerToken,
             capability_reasoning: capReasoning,

--- a/packages/backend/src/routing/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider.service.spec.ts
@@ -190,6 +190,36 @@ describe('CustomProviderService (with mocks)', () => {
       expect(result.models[0].output_price_per_million_tokens).toBe(0);
     });
 
+    it('passes through capability flags to stored models', async () => {
+      const dto = {
+        name: 'Gateway',
+        base_url: 'https://proxy.example.com/v1',
+        models: [
+          {
+            model_name: 'claude-opus',
+            capability_reasoning: true,
+            capability_code: true,
+          },
+        ],
+      };
+      const result = await service.create('agent-1', 'user-1', dto as never);
+
+      expect(result.models[0].capability_reasoning).toBe(true);
+      expect(result.models[0].capability_code).toBe(true);
+    });
+
+    it('stores undefined capabilities when not provided (backward compat)', async () => {
+      const dto = {
+        name: 'Legacy',
+        base_url: 'https://api.example.com/v1',
+        models: [{ model_name: 'old-model' }],
+      };
+      const result = await service.create('agent-1', 'user-1', dto as never);
+
+      expect(result.models[0].capability_reasoning).toBeUndefined();
+      expect(result.models[0].capability_code).toBeUndefined();
+    });
+
     it('creates multiple models in the custom provider', async () => {
       const dto = {
         name: 'Multi',
@@ -393,6 +423,21 @@ describe('CustomProviderService (with mocks)', () => {
       await service.update('agent-1', 'cp-1', 'user-1', { name: 'New Name' } as never);
 
       expect(mockRoutingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('passes through capability flags when models are updated', async () => {
+      const result = await service.update('agent-1', 'cp-1', 'user-1', {
+        models: [
+          {
+            model_name: 'new-model',
+            capability_reasoning: true,
+            capability_code: false,
+          },
+        ],
+      } as never);
+
+      expect(result.models[0].capability_reasoning).toBe(true);
+      expect(result.models[0].capability_code).toBe(false);
     });
 
     it('does not double-recalculate when both models and apiKey change', async () => {

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -91,6 +91,8 @@ export class CustomProviderService {
         input_price_per_million_tokens: m.input_price_per_million_tokens,
         output_price_per_million_tokens: m.output_price_per_million_tokens,
         context_window: m.context_window ?? 128000,
+        capability_reasoning: m.capability_reasoning,
+        capability_code: m.capability_code,
       })),
       created_at: new Date().toISOString(),
     });
@@ -138,6 +140,8 @@ export class CustomProviderService {
         input_price_per_million_tokens: m.input_price_per_million_tokens,
         output_price_per_million_tokens: m.output_price_per_million_tokens,
         context_window: m.context_window ?? 128000,
+        capability_reasoning: m.capability_reasoning,
+        capability_code: m.capability_code,
       }));
     }
 

--- a/packages/backend/src/routing/dto/custom-provider.dto.spec.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.spec.ts
@@ -105,6 +105,57 @@ describe('CreateCustomProviderDto', () => {
     expect(errors.length).toBeGreaterThan(0);
   });
 
+  it('accepts models with capability flags', async () => {
+    const dto = toDto({
+      name: 'Gateway',
+      base_url: 'https://proxy.example.com/v1',
+      models: [
+        {
+          model_name: 'claude-opus',
+          capability_reasoning: true,
+          capability_code: true,
+        },
+      ],
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts models with only one capability flag', async () => {
+    const dto = toDto({
+      name: 'Gateway',
+      base_url: 'https://proxy.example.com/v1',
+      models: [
+        {
+          model_name: 'deepseek-r1',
+          capability_reasoning: true,
+        },
+      ],
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects non-boolean capability_reasoning', async () => {
+    const dto = toDto({
+      name: 'Test',
+      base_url: 'https://api.example.com/v1',
+      models: [{ model_name: 'model-a', capability_reasoning: 'yes' }],
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects non-boolean capability_code', async () => {
+    const dto = toDto({
+      name: 'Test',
+      base_url: 'https://api.example.com/v1',
+      models: [{ model_name: 'model-a', capability_code: 42 }],
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
   it('rejects negative pricing', async () => {
     const dto = toDto({
       name: 'Test',

--- a/packages/backend/src/routing/dto/custom-provider.dto.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.ts
@@ -3,6 +3,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsNumber,
+  IsBoolean,
   IsArray,
   ValidateNested,
   Matches,
@@ -37,6 +38,14 @@ export class CustomProviderModelDto {
   @Min(1)
   @Type(() => Number)
   context_window?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  capability_reasoning?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  capability_code?: boolean;
 }
 
 export class CreateCustomProviderDto {

--- a/packages/backend/test/custom-providers.e2e-spec.ts
+++ b/packages/backend/test/custom-providers.e2e-spec.ts
@@ -307,6 +307,91 @@ describe('Custom Providers (e2e)', () => {
       .expect(200);
   });
 
+  it('creates custom provider with capability flags', async () => {
+    const res = await request(app.getHttpServer())
+      .post(`/api/v1/routing/${agentName}/custom-providers`)
+      .set(headers)
+      .send({
+        name: 'Gateway Provider',
+        base_url: 'https://proxy.example.com/v1',
+        models: [
+          {
+            model_name: 'frontier-model',
+            input_price_per_million_tokens: 15,
+            output_price_per_million_tokens: 75,
+            capability_reasoning: true,
+            capability_code: true,
+          },
+        ],
+      })
+      .expect(201);
+
+    expect(res.body.models[0].capability_reasoning).toBe(true);
+    expect(res.body.models[0].capability_code).toBe(true);
+
+    // Verify available-models reflects capability flags and quality score
+    const modelsRes = await request(app.getHttpServer())
+      .get(`/api/v1/routing/${agentName}/available-models`)
+      .set(headers)
+      .expect(200);
+
+    const model = modelsRes.body.find(
+      (m: { display_name?: string }) => m.display_name === 'frontier-model',
+    );
+    expect(model).toBeDefined();
+    expect(model.capability_reasoning).toBe(true);
+    expect(model.capability_code).toBe(true);
+    // Expensive + dual capabilities = frontier tier (score 5)
+    expect(model.quality_score).toBe(5);
+
+    // Cleanup
+    await request(app.getHttpServer())
+      .delete(`/api/v1/routing/${agentName}/custom-providers/${res.body.id}`)
+      .set(headers)
+      .expect(200);
+  });
+
+  it('custom provider models without capability flags default to false', async () => {
+    const res = await request(app.getHttpServer())
+      .post(`/api/v1/routing/${agentName}/custom-providers`)
+      .set(headers)
+      .send({
+        name: 'Legacy Provider',
+        base_url: 'https://api.example.com/v1',
+        models: [
+          {
+            model_name: 'legacy-model',
+            input_price_per_million_tokens: 1.0,
+            output_price_per_million_tokens: 2.0,
+          },
+        ],
+      })
+      .expect(201);
+
+    // Should not have capability fields in stored models
+    expect(res.body.models[0].capability_reasoning).toBeUndefined();
+    expect(res.body.models[0].capability_code).toBeUndefined();
+
+    // Verify available-models defaults to false
+    const modelsRes = await request(app.getHttpServer())
+      .get(`/api/v1/routing/${agentName}/available-models`)
+      .set(headers)
+      .expect(200);
+
+    const model = modelsRes.body.find(
+      (m: { display_name?: string }) => m.display_name === 'legacy-model',
+    );
+    expect(model).toBeDefined();
+    expect(model.capability_reasoning).toBe(false);
+    expect(model.capability_code).toBe(false);
+
+    // Cleanup
+    await request(app.getHttpServer())
+      .delete(`/api/v1/routing/${agentName}/custom-providers/${res.body.id}`)
+      .set(headers)
+      .expect(200);
+  });
+
   it('stores explicit 0 prices as 0 (not null)', async () => {
     const res = await request(app.getHttpServer())
       .post(`/api/v1/routing/${agentName}/custom-providers`)

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -198,6 +198,8 @@ export interface CustomProviderModel {
   input_price_per_million_tokens?: number;
   output_price_per_million_tokens?: number;
   context_window?: number;
+  capability_reasoning?: boolean;
+  capability_code?: boolean;
 }
 
 export interface CustomProviderData {


### PR DESCRIPTION
## Summary

- Adds optional `capability_reasoning` and `capability_code` boolean fields to the custom provider model schema (entity, DTO, service, model discovery)
- Custom provider models now compute quality scores dynamically via `computeQualityScore()` instead of being hardcoded to score 2
- Models with `capability_reasoning: true` are now eligible for the reasoning tier

This unblocks the use case described in #1047 — users routing built-in providers through a gateway proxy can now set capability flags on custom provider models so they receive proper quality scoring and tier assignment.

Backward-compatible: existing custom providers without these fields default to `false` (no behavior change). No database migration needed (JSON column).

## Test plan

- [x] DTO validation tests: accepts booleans, rejects non-booleans
- [x] Service tests: capability flags pass through in create/update
- [x] Model discovery tests: reads flags from stored data, defaults to false for legacy data, computes quality score dynamically
- [x] E2E tests: creates provider with capability flags, verifies available-models reflects them with correct quality score
- [x] All 3137 backend unit tests pass
- [x] All 98 backend e2e tests pass
- [x] All 1700 frontend tests pass
- [x] 100% line coverage maintained

Closes #1047

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `capability_reasoning` and `capability_code` to custom provider models and computes quality scores dynamically. Previously flags were always false and the score was fixed at 2; now flags drive tiering (including reasoning) and we pass the raw model name to `computeQualityScore()` so quality overrides apply to gateway-proxied models (closes #1047).

- Supports `capability_reasoning` and `capability_code` in backend entity/DTO/service and in the frontend `routing` API types; model discovery returns them, defaulting to false when unspecified.
- Replaces the fixed score with `computeQualityScore()` and sends the raw `model_name` (not `custom:<id>/...`) to enable QUALITY_OVERRIDES matching.
- Backward compatible: fields are optional and default to false; no migration needed (JSON storage).

<sup>Written for commit 1edf0d994020f7f864fcb76e7dff0c5743bf50c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

