### PR TITLE
fix: start embedded server eagerly in OpenClaw plugin

### DIFF
--- a/.changeset/fix-plugin-server-startup.md
+++ b/.changeset/fix-plugin-server-startup.md
@@ -1,0 +1,18 @@
+---
+"manifest": patch
+---
+
+fix: start embedded server eagerly instead of deferring to OpenClaw callback
+
+The plugin previously only registered a deferred `start()` callback via
+`api.registerService()`, relying on OpenClaw to invoke it. Newer OpenClaw
+versions may not invoke the callback, causing the server to never bind.
+
+Now the server starts eagerly during `register()`, with the existing
+`checkExistingServer()` health-check guard preventing double-starts if
+OpenClaw also calls the callback.
+
+The dashboard banner is now only logged after the server is confirmed
+running via health check, instead of prematurely during registration.
+
+Closes #1472, closes #1474.

--- a/packages/openclaw-plugins/manifest/__tests__/local-mode.test.ts
+++ b/packages/openclaw-plugins/manifest/__tests__/local-mode.test.ts
@@ -146,6 +146,9 @@ describe("registerLocalMode", () => {
 
       expect(mockServerStart).not.toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Dashboard: http://127.0.0.1:2099"),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
         expect.stringContaining("Reusing existing server"),
       );
     });
@@ -173,7 +176,31 @@ describe("registerLocalMode", () => {
         expect.objectContaining({ port: 2099, host: "127.0.0.1" }),
       );
       expect(logger.info).toHaveBeenCalledWith(
-        expect.stringContaining("Dashboard ->"),
+        expect.stringContaining("Dashboard: http://127.0.0.1:2099"),
+      );
+    });
+
+    it("includes custom host and port in dashboard banner", async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(new Error("ECONNREFUSED"));
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "healthy" }),
+        });
+      });
+
+      const logger = makeLogger();
+      const api = { registerService: jest.fn() };
+
+      registerLocalMode(api, 3099, "0.0.0.0", logger);
+
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("http://0.0.0.0:3099"),
       );
     });
 
@@ -235,6 +262,9 @@ describe("registerLocalMode", () => {
       const serviceCall = api.registerService.mock.calls[0][0];
       await serviceCall.start();
 
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Dashboard: http://127.0.0.1:2099"),
+      );
       expect(logger.info).toHaveBeenCalledWith(
         expect.stringContaining("Reusing existing server"),
       );

--- a/packages/openclaw-plugins/manifest/__tests__/register.test.ts
+++ b/packages/openclaw-plugins/manifest/__tests__/register.test.ts
@@ -103,21 +103,12 @@ describe("manifest plugin registration", () => {
     expect(registerLocalMode).toHaveBeenCalledWith(api, 2099, "127.0.0.1", api.logger);
   });
 
-  it("logs dashboard URL before starting server", () => {
+  it("logs loading message during registration", () => {
     const api = makeApi();
     plugin.register(api);
 
     expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("http://127.0.0.1:2099"),
-    );
-  });
-
-  it("logs dashboard URL with custom port and host", () => {
-    const api = makeApi({ port: 3099, host: "0.0.0.0" });
-    plugin.register(api);
-
-    expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("http://0.0.0.0:3099"),
+      expect.stringContaining("Loading embedded server"),
     );
   });
 });

--- a/packages/openclaw-plugins/manifest/src/index.ts
+++ b/packages/openclaw-plugins/manifest/src/index.ts
@@ -23,11 +23,7 @@ module.exports = {
     const port = typeof inner.port === 'number' && inner.port > 0 ? inner.port : 2099;
     const host = typeof inner.host === 'string' && inner.host.length > 0 ? inner.host : '127.0.0.1';
 
-    logger.info(
-      `\n[🦚 Manifest] Dashboard: http://${host}:${port}\n` +
-        '[🦚 Manifest] The plugin starts an embedded server.\n' +
-        '[🦚 Manifest] Open the dashboard to connect a provider and start routing.',
-    );
+    logger.info('[🦚 Manifest] Loading embedded server...');
 
     registerLocalMode(api, port, host, logger);
   },

--- a/packages/openclaw-plugins/manifest/src/local-mode.ts
+++ b/packages/openclaw-plugins/manifest/src/local-mode.ts
@@ -51,51 +51,67 @@ export function registerLocalMode(api: any, port: number, host: string, logger: 
     return;
   }
 
-  api.registerService({
-    id: 'manifest',
-    start: async () => {
-      logger.debug('[manifest] Service start callback invoked');
-      const alreadyRunning = await checkExistingServer(host, port);
-      if (alreadyRunning) {
-        logger.info(`[manifest] Reusing existing server at http://${host}:${port}`);
-        return;
+  const startServer = async () => {
+    logger.debug('[manifest] Service start callback invoked');
+    const alreadyRunning = await checkExistingServer(host, port);
+    if (alreadyRunning) {
+      logger.info(
+        `\n[🦚 Manifest] Dashboard: http://${host}:${port}\n` +
+          '[🦚 Manifest] Reusing existing server.\n' +
+          '[🦚 Manifest] Open the dashboard to connect a provider and start routing.',
+      );
+      return;
+    }
+
+    try {
+      await serverModule.start({ port, host, dbPath, quiet: true });
+
+      const verified = await checkExistingServer(host, port);
+      if (verified) {
+        logger.info(
+          `\n[🦚 Manifest] Dashboard: http://${host}:${port}\n` +
+            '[🦚 Manifest] The embedded server is running.\n' +
+            '[🦚 Manifest] Open the dashboard to connect a provider and start routing.',
+        );
+        logger.debug(`[manifest] DB: ${dbPath}`);
+      } else {
+        const warnFn = logger.warn ?? logger.info;
+        warnFn(
+          `[manifest] Server started but health check failed.\n` +
+            `  The dashboard may not be accessible at http://${host}:${port}`,
+        );
       }
-
-      try {
-        await serverModule.start({ port, host, dbPath, quiet: true });
-
-        const verified = await checkExistingServer(host, port);
-        if (verified) {
-          logger.info(`[manifest] Dashboard -> http://${host}:${port}`);
-          logger.info(`[manifest]   DB: ${dbPath}`);
-        } else {
-          const warnFn = logger.warn ?? logger.info;
-          warnFn(
-            `[manifest] Server started but health check failed.\n` +
-              `  The dashboard may not be accessible at http://${host}:${port}`,
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('EADDRINUSE') || msg.includes('address already in use')) {
+        const isManifest = await checkExistingServer(host, port);
+        if (isManifest) {
+          logger.info(
+            `\n[🦚 Manifest] Dashboard: http://${host}:${port}\n` +
+              '[🦚 Manifest] Reusing existing server.\n' +
+              '[🦚 Manifest] Open the dashboard to connect a provider and start routing.',
           );
-        }
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes('EADDRINUSE') || msg.includes('address already in use')) {
-          const isManifest = await checkExistingServer(host, port);
-          if (isManifest) {
-            logger.info(`[manifest] Reusing existing server at http://${host}:${port}`);
-          } else {
-            logger.error(
-              `[manifest] Port ${port} is already in use by another process.\n` +
-                `  Change it with: openclaw config set plugins.entries.manifest.config.port ${port + 1}\n` +
-                `  Then restart the gateway.`,
-            );
-          }
         } else {
           logger.error(
-            `[manifest] Failed to start local server: ${msg}\n` +
-              `  Try reinstalling: openclaw plugins install manifest\n` +
-              `  Then restart: openclaw gateway restart`,
+            `[manifest] Port ${port} is already in use by another process.\n` +
+              `  Change it with: openclaw config set plugins.entries.manifest.config.port ${port + 1}\n` +
+              `  Then restart the gateway.`,
           );
         }
+      } else {
+        logger.error(
+          `[manifest] Failed to start local server: ${msg}\n` +
+            `  Try reinstalling: openclaw plugins install manifest\n` +
+            `  Then restart: openclaw gateway restart`,
+        );
       }
-    },
-  });
+    }
+  };
+
+  // Register with OpenClaw for lifecycle management (deferred callback).
+  api.registerService({ id: 'manifest', start: startServer });
+
+  // Also start eagerly — newer OpenClaw versions may not invoke the callback.
+  // checkExistingServer() at the top of startServer() prevents double-starts.
+  startServer().catch(() => {});
 }

--- a/packages/openclaw-plugins/manifest/src/server.ts
+++ b/packages/openclaw-plugins/manifest/src/server.ts
@@ -17,6 +17,7 @@ interface StartOptions {
   port?: number;
   host?: string;
   dbPath?: string;
+  quiet?: boolean;
 }
 
 export async function start(options: StartOptions = {}): Promise<unknown> {


### PR DESCRIPTION
## Summary

Fixes the Manifest OpenClaw plugin failing to bind to port 2099 after OpenClaw upgrades.

- **Root cause:** The plugin registered a deferred `start()` callback via `api.registerService()`, but newer OpenClaw versions may not invoke the callback — the embedded NestJS server never started
- **Fix:** Start the server eagerly during `register()`, with the existing `checkExistingServer()` health-check guard preventing double-starts if OpenClaw also calls the callback later
- **Banner fix:** Dashboard URL is now only logged after the server is confirmed running, not prematurely during registration

Closes #1472
Closes #1474

## Test plan

- [x] Plugin unit tests pass with 100% line coverage
- [x] TypeScript compiles cleanly
- [x] Verified end-to-end with OpenClaw CLI: server binds to port 2099, health check returns healthy, dashboard serves HTTP 200
- [x] Logs show correct sequence: "Loading embedded server..." → "The embedded server is running." (only after health check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eagerly start the embedded server in the `manifest` OpenClaw plugin during registration to fix cases where newer OpenClaw didn’t invoke the deferred start, leaving port 2099 unbound. The dashboard banner now logs only after a successful health check.

- **Bug Fixes**
  - Start server in `register()` and keep `api.registerService()` callback; `checkExistingServer()` prevents double-starts and reuses an existing server.
  - Log “Loading embedded server...” during registration; show the dashboard URL only after the health check passes.
  - Add `quiet` to `StartOptions` for type correctness; update tests for banner timing and custom host/port.

<sup>Written for commit 9d3fb2ee738dc8d0ab1fd3abdab33edda1ff33c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

