### PR TITLE
fix: catch misrouted OTLP paths and suppress noise from error logs

### DIFF
--- a/.changeset/otlp-misrouted-paths.md
+++ b/.changeset/otlp-misrouted-paths.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Catch misrouted OTLP path variants and suppress expected errors from logs

--- a/packages/backend/src/common/middleware/http-error-logger.middleware.spec.ts
+++ b/packages/backend/src/common/middleware/http-error-logger.middleware.spec.ts
@@ -159,4 +159,59 @@ describe('httpErrorLogger', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain('ip=');
   });
+
+  it('suppresses 410 responses on /otlp/ paths', () => {
+    const req = mockReq({ originalUrl: '/otlp/v1/metrics' });
+    const res = mockRes(410);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('suppresses 404 responses on /otlp/ paths', () => {
+    const req = mockReq({ originalUrl: '/otlp/v1/traces' });
+    const res = mockRes(404);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('suppresses 410 responses on /api/v1/otlp/ paths', () => {
+    const req = mockReq({ originalUrl: '/api/v1/otlp/v1/metrics' });
+    const res = mockRes(410);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not suppress non-OTLP 410 responses', () => {
+    const req = mockReq({ originalUrl: '/api/v1/some-endpoint' });
+    const res = mockRes(410);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not suppress 500 on OTLP paths', () => {
+    const req = mockReq({ originalUrl: '/otlp/v1/metrics' });
+    const res = mockRes(500);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/backend/src/common/middleware/http-error-logger.middleware.spec.ts
+++ b/packages/backend/src/common/middleware/http-error-logger.middleware.spec.ts
@@ -193,6 +193,39 @@ describe('httpErrorLogger', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it('suppresses 410 on /v1/metrics (stripped OTLP prefix)', () => {
+    const req = mockReq({ originalUrl: '/v1/metrics' });
+    const res = mockRes(410);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('suppresses 410 on /v1/traces (stripped OTLP prefix)', () => {
+    const req = mockReq({ originalUrl: '/v1/traces' });
+    const res = mockRes(410);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not suppress /v1/chat/completions errors', () => {
+    const req = mockReq({ originalUrl: '/v1/chat/completions' });
+    const res = mockRes(400);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('does not suppress non-OTLP 410 responses', () => {
     const req = mockReq({ originalUrl: '/api/v1/some-endpoint' });
     const res = mockRes(410);

--- a/packages/backend/src/common/middleware/http-error-logger.middleware.ts
+++ b/packages/backend/src/common/middleware/http-error-logger.middleware.ts
@@ -3,11 +3,23 @@ import { Request, Response, NextFunction } from 'express';
 
 const logger = new Logger('HttpErrors');
 
+/** Paths from old OTLP clients that are expected 410s — don't log them. */
+const SUPPRESSED_PREFIXES = ['/otlp/', '/api/v1/otlp/'];
+
+function isSuppressed(url: string, status: number): boolean {
+  if (status !== 410 && status !== 404) return false;
+  for (const prefix of SUPPRESSED_PREFIXES) {
+    if (url.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
 export function httpErrorLogger(req: Request, res: Response, next: NextFunction): void {
   const start = Date.now();
 
   res.on('finish', () => {
     if (res.statusCode < 400) return;
+    if (isSuppressed(req.originalUrl, res.statusCode)) return;
 
     const elapsed = Date.now() - start;
     const ua = (req.headers['user-agent'] ?? '').slice(0, 120);

--- a/packages/backend/src/common/middleware/http-error-logger.middleware.ts
+++ b/packages/backend/src/common/middleware/http-error-logger.middleware.ts
@@ -5,11 +5,15 @@ const logger = new Logger('HttpErrors');
 
 /** Paths from old OTLP clients that are expected 410s — don't log them. */
 const SUPPRESSED_PREFIXES = ['/otlp/', '/api/v1/otlp/'];
+const SUPPRESSED_EXACT = ['/v1/metrics', '/v1/traces', '/v1/logs'];
 
 function isSuppressed(url: string, status: number): boolean {
   if (status !== 410 && status !== 404) return false;
   for (const prefix of SUPPRESSED_PREFIXES) {
     if (url.startsWith(prefix)) return true;
+  }
+  for (const path of SUPPRESSED_EXACT) {
+    if (url === path) return true;
   }
   return false;
 }

--- a/packages/backend/src/otlp/otlp-deprecated.controller.spec.ts
+++ b/packages/backend/src/otlp/otlp-deprecated.controller.spec.ts
@@ -70,4 +70,56 @@ describe('OtlpDeprecatedController', () => {
     expect(traces).toBe(metrics);
     expect(metrics).toBe(logs);
   });
+
+  describe('misrouted OTLP variants', () => {
+    const expectedGone = {
+      error: expect.objectContaining({
+        type: 'gone',
+        status: 410,
+        message: expect.stringContaining('/v1/chat/completions'),
+      }),
+    };
+
+    it('misroutedTraces returns 410 with migration message', () => {
+      expect(controller.misroutedTraces()).toEqual(expectedGone);
+    });
+
+    it('misroutedMetrics returns 410 with migration message', () => {
+      expect(controller.misroutedMetrics()).toEqual(expectedGone);
+    });
+
+    it('misroutedLogs returns 410 with migration message', () => {
+      expect(controller.misroutedLogs()).toEqual(expectedGone);
+    });
+
+    it('strippedMetrics returns 410 with migration message', () => {
+      expect(controller.strippedMetrics()).toEqual(expectedGone);
+    });
+
+    it('strippedTraces returns 410 with migration message', () => {
+      expect(controller.strippedTraces()).toEqual(expectedGone);
+    });
+
+    it('strippedLogs returns 410 with migration message', () => {
+      expect(controller.strippedLogs()).toEqual(expectedGone);
+    });
+  });
+
+  describe('wrong chat completions path', () => {
+    it('returns 404 with redirect hint', () => {
+      const result = controller.wrongChatPath();
+      expect(result.error.status).toBe(404);
+      expect(result.error.message).toContain('/v1/chat/completions');
+    });
+
+    it('has invalid_request_error type', () => {
+      const result = controller.wrongChatPath();
+      expect(result.error.type).toBe('invalid_request_error');
+    });
+
+    it('includes the correct baseURL hint', () => {
+      const result = controller.wrongChatPath();
+      expect(result.error.message).toContain('https://app.manifest.build/v1');
+    });
+  });
 });

--- a/packages/backend/src/otlp/otlp-deprecated.controller.ts
+++ b/packages/backend/src/otlp/otlp-deprecated.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, All, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, All, Post, HttpCode, HttpStatus } from '@nestjs/common';
 import { Public } from '../common/decorators/public.decorator';
 
 /**
@@ -18,6 +18,36 @@ const GONE_RESPONSE = {
       'See https://manifest.build/docs/migration for details.',
     type: 'gone',
     status: 410,
+  },
+};
+
+/**
+ * Some old clients prepend /api/v1 to the OTLP path or strip the /otlp prefix,
+ * producing paths like /api/v1/otlp/v1/metrics or /v1/metrics. Catch those too.
+ */
+const GONE_RESPONSE_MISROUTED = {
+  error: {
+    message:
+      'OTLP telemetry endpoints have been removed. ' +
+      'Use the routing proxy at /v1/chat/completions instead. ' +
+      'See https://manifest.build/docs/migration for details.',
+    type: 'gone',
+    status: 410,
+  },
+};
+
+/**
+ * Structured 404 response for /chat/completions (missing /v1 prefix).
+ * The OpenAI SDK appends /chat/completions to the base URL, so users who
+ * set baseURL without the /v1 suffix hit this path.
+ */
+const WRONG_PATH_RESPONSE = {
+  error: {
+    message:
+      'Use /v1/chat/completions (not /chat/completions). ' +
+      'Set your baseURL to https://app.manifest.build/v1',
+    type: 'invalid_request_error',
+    status: 404,
   },
 };
 
@@ -52,5 +82,51 @@ export class OtlpDeprecatedController {
   @HttpCode(HttpStatus.GONE)
   logs() {
     return GONE_RESPONSE;
+  }
+
+  // --- Misrouted OTLP variants (wrong prefix) ---
+
+  @All('api/v1/otlp/v1/traces')
+  @HttpCode(HttpStatus.GONE)
+  misroutedTraces() {
+    return GONE_RESPONSE_MISROUTED;
+  }
+
+  @All('api/v1/otlp/v1/metrics')
+  @HttpCode(HttpStatus.GONE)
+  misroutedMetrics() {
+    return GONE_RESPONSE_MISROUTED;
+  }
+
+  @All('api/v1/otlp/v1/logs')
+  @HttpCode(HttpStatus.GONE)
+  misroutedLogs() {
+    return GONE_RESPONSE_MISROUTED;
+  }
+
+  @All('v1/metrics')
+  @HttpCode(HttpStatus.GONE)
+  strippedMetrics() {
+    return GONE_RESPONSE_MISROUTED;
+  }
+
+  @All('v1/traces')
+  @HttpCode(HttpStatus.GONE)
+  strippedTraces() {
+    return GONE_RESPONSE_MISROUTED;
+  }
+
+  @All('v1/logs')
+  @HttpCode(HttpStatus.GONE)
+  strippedLogs() {
+    return GONE_RESPONSE_MISROUTED;
+  }
+
+  // --- Wrong path for chat completions (missing /v1 prefix) ---
+
+  @Post('chat/completions')
+  @HttpCode(HttpStatus.NOT_FOUND)
+  wrongChatPath() {
+    return WRONG_PATH_RESPONSE;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1498. After deploying the error logger, production logs revealed the error spike is entirely from old OTLP clients:

- **410 Gone** on `/otlp/v1/metrics` — old plugins still sending telemetry (handled by `OtlpDeprecatedController`)
- **404** on `/api/v1/otlp/v1/metrics` — clients prepending wrong prefix (now caught)
- **404** on `/v1/metrics` — clients with stripped prefix (now caught)
- **404** on `/chat/completions` — one user missing the `/v1` prefix in their `baseURL` (now returns helpful hint)

Changes:
- Add misrouted OTLP path variants (`/api/v1/otlp/v1/*`, `/v1/{metrics,traces,logs}`) to `OtlpDeprecatedController` so they return proper 410 + migration message instead of generic 404
- Add `/chat/completions` handler returning 404 with baseURL correction hint
- Suppress expected OTLP 410/404 from the error logger to reduce Railway log noise

## Test plan

- [x] Backend unit tests pass (174 suites, 3410 tests)
- [x] Backend E2E tests pass (14 suites, 99 tests)
- [x] TypeScript compiles cleanly
- [x] New controller endpoints have test coverage
- [x] Middleware suppression logic has test coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catches misrouted OTLP paths and returns clear 410 responses, and suppresses expected OTLP 410/404 entries from error logs to cut noise. Also adds a helpful 404 for `/chat/completions` when `/v1` is missing.

- **Bug Fixes**
  - Route `/api/v1/otlp/v1/*` and `/v1/{metrics,traces,logs}` to the deprecated OTLP controller with 410 + migration message.
  - Add POST `/chat/completions` handler that returns 404 with a hint to use `/v1/chat/completions` and set baseURL to `https://app.manifest.build/v1`.
  - Update `http-error-logger` to ignore 410/404 on `/otlp/*`, `/api/v1/otlp/*`, and stripped `/v1/{metrics,traces,logs}`.

- **Dependencies**
  - Add changeset for `manifest` patch release.

<sup>Written for commit f99db1056c3f0f064f90b5fa62835247430d6bb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

