### PR TITLE
feat: make PROVIDER_TIMEOUT_MS configurable via environment variable

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -22,6 +22,11 @@ BETTER_AUTH_URL=http://localhost:3001
 # ── API Key (optional) ──────────────────────────────
 # API_KEY=                   # Secret for programmatic access via X-API-Key header
 
+# ── LLM Proxy ────────────────────────────────────────
+# Per-attempt timeout (ms) for upstream provider requests in the LLM proxy.
+# Set strictly below your client's timeout so the fallback chain has room to run.
+# PROVIDER_TIMEOUT_MS=180000
+
 # ── Email provider (optional, unified) ──────────────
 # Used for BOTH Better Auth transactional emails (login verification,
 # password reset) and threshold alert notifications when no per-user

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1739,4 +1739,59 @@ describe('ProviderClient', () => {
       ).rejects.toThrow('key=***');
     });
   });
+
+  describe('PROVIDER_TIMEOUT_MS env override', () => {
+    const originalEnv = process.env.PROVIDER_TIMEOUT_MS;
+
+    afterEach(() => {
+      if (originalEnv === undefined) delete process.env.PROVIDER_TIMEOUT_MS;
+      else process.env.PROVIDER_TIMEOUT_MS = originalEnv;
+    });
+
+    async function captureTimeoutMs(envValue: string | undefined): Promise<number> {
+      if (envValue === undefined) delete process.env.PROVIDER_TIMEOUT_MS;
+      else process.env.PROVIDER_TIMEOUT_MS = envValue;
+
+      const timeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+      timeoutSpy.mockClear();
+
+      let observed = -1;
+      await jest.isolateModulesAsync(async () => {
+        const { ProviderClient: FreshClient } = await import('../provider-client');
+        const fresh = new FreshClient();
+        mockFetch.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+        await fresh.forward({
+          provider: 'openai',
+          apiKey: 'sk-test',
+          model: 'gpt-4',
+          body,
+          stream: false,
+        });
+        observed = timeoutSpy.mock.calls[0]?.[0] ?? -1;
+      });
+
+      timeoutSpy.mockRestore();
+      return observed;
+    }
+
+    it('defaults to 180000 ms when env var is unset', async () => {
+      expect(await captureTimeoutMs(undefined)).toBe(180_000);
+    });
+
+    it('uses the configured value when env var is a positive integer', async () => {
+      expect(await captureTimeoutMs('45000')).toBe(45_000);
+    });
+
+    it('falls back to 180000 ms when env var is non-numeric', async () => {
+      expect(await captureTimeoutMs('abc')).toBe(180_000);
+    });
+
+    it('falls back to 180000 ms when env var is negative', async () => {
+      expect(await captureTimeoutMs('-1')).toBe(180_000);
+    });
+
+    it('falls back to 180000 ms when env var is zero', async () => {
+      expect(await captureTimeoutMs('0')).toBe(180_000);
+    });
+  });
 });

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -29,7 +29,7 @@ export interface ForwardResult {
   isChatGpt: boolean;
 }
 
-const PROVIDER_TIMEOUT_MS = 180_000;
+const PROVIDER_TIMEOUT_MS = parseInt(process.env.PROVIDER_TIMEOUT_MS ?? '', 10) || 180_000;
 
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -29,7 +29,11 @@ export interface ForwardResult {
   isChatGpt: boolean;
 }
 
-const PROVIDER_TIMEOUT_MS = parseInt(process.env.PROVIDER_TIMEOUT_MS ?? '', 10) || 180_000;
+const parsedProviderTimeout = Number.parseInt(process.env.PROVIDER_TIMEOUT_MS ?? '', 10);
+const PROVIDER_TIMEOUT_MS =
+  Number.isFinite(parsedProviderTimeout) && parsedProviderTimeout > 0
+    ? parsedProviderTimeout
+    : 180_000;
 
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").


### PR DESCRIPTION
## Summary

Fixes #1583

- Replaces the hardcoded `180_000` ms timeout in `provider-client.ts` with a value read from `process.env.PROVIDER_TIMEOUT_MS`, falling back to `180_000` if unset or invalid.

## Problem

With matching 180s timeouts between Manifest and upstream clients (e.g. OpenClaw), both fire simultaneously. The client disconnects first, causing Manifest to see `signal.aborted = true` from the client disconnect and re-throw instead of triggering the fallback chain.

## Solution

```typescript
const PROVIDER_TIMEOUT_MS = parseInt(process.env.PROVIDER_TIMEOUT_MS ?? '', 10) || 180_000;
```

Self-hosted users can now set a lower timeout in `docker-compose.yml`:

```yaml
environment:
  PROVIDER_TIMEOUT_MS: 45000
```

With 45s per attempt: primary (45s) + fallback 1 (45s) + fallback 2 (45s) = 135s — well within a typical 300s upstream timeout, allowing the fallback chain to complete.

## Test plan

- [ ] No `PROVIDER_TIMEOUT_MS` env var set → timeout defaults to `180_000`
- [ ] `PROVIDER_TIMEOUT_MS=45000` → timeout uses `45000`
- [ ] `PROVIDER_TIMEOUT_MS=abc` (invalid) → timeout falls back to `180_000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the provider request timeout configurable via `PROVIDER_TIMEOUT_MS` instead of a fixed 180s. The value must be a finite positive integer; otherwise we default to 180000 ms to prevent proxy crashes and allow fallbacks, with `.env.example` guidance and tests covering default, valid, and invalid values.

<sup>Written for commit fbd445eabe6aebdb9e8bb77253d21a417783a19b. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1607?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

