### PR TITLE
fix(feedback): add error handling for modal feedback submission

### DIFF
--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -110,7 +110,13 @@ const MessageLog: Component = () => {
   const handleFeedbackSubmit = (tags: string[], details: string) => {
     const id = feedbackMessageId();
     if (id) {
-      setMessageFeedback(id, { rating: 'dislike', tags, details });
+      setMessageFeedback(id, { rating: 'dislike', tags, details }).catch(() => {
+        setFeedbackOverrides((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
+      });
     }
     setFeedbackModalOpen(false);
   };

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -168,7 +168,13 @@ const Overview: Component = () => {
   const handleFeedbackSubmit = (tags: string[], details: string) => {
     const id = feedbackMessageId();
     if (id) {
-      setMessageFeedback(id, { rating: 'dislike', tags, details });
+      setMessageFeedback(id, { rating: 'dislike', tags, details }).catch(() => {
+        setFeedbackOverrides((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
+      });
     }
     setFeedbackModalOpen(false);
   };

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -934,6 +934,24 @@ describe("MessageLog", () => {
       expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike", tags: ["Too slow"], details: "test" });
     });
 
+    it("reverts optimistic dislike when modal submit API call fails", async () => {
+      mockSetMessageFeedback
+        .mockResolvedValueOnce(undefined)     // dislike click succeeds
+        .mockRejectedValueOnce(new Error("fail")); // modal submit fails
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      const submitBtn = container.querySelector('[data-testid="feedback-submit"]') as HTMLElement;
+      fireEvent.click(submitBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-dislike")).toBeNull();
+      });
+    });
+
     it("closes feedback modal without submitting", async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetMessages.mockResolvedValue(messagesData);

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -868,6 +868,24 @@ describe("Overview", () => {
       expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike", tags: ["Too slow"], details: "test" });
     });
 
+    it("reverts optimistic dislike when modal submit API call fails", async () => {
+      mockSetMessageFeedback
+        .mockResolvedValueOnce(undefined)     // dislike click succeeds
+        .mockRejectedValueOnce(new Error("fail")); // modal submit fails
+      mockGetOverview.mockResolvedValue(overviewData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      const submitBtn = container.querySelector('[data-testid="feedback-submit"]') as HTMLElement;
+      fireEvent.click(submitBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-dislike")).toBeNull();
+      });
+    });
+
     it("hides feedback column and modal in local mode", async () => {
       mockCheckIsLocalMode.mockResolvedValue(true);
       mockGetOverview.mockResolvedValue(overviewData);


### PR DESCRIPTION
## Summary

- Add `.catch()` to `handleFeedbackSubmit` in both `MessageLog` and `Overview` pages
- When the dislike feedback modal submission API call fails, the optimistic UI override is now properly reverted instead of leaving the button stuck in the "disliked" state

## Test plan

- [x] All 2180 frontend tests pass
- [x] TypeScript compiles cleanly
- [ ] Manually click dislike, select tags, submit modal — verify tags/details are saved
- [ ] Simulate API failure — verify the dislike button reverts to inactive state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stuck "Dislike" state by handling errors when submitting modal feedback. On API failure, the optimistic override is reverted and the button returns to inactive; tests cover this path.

- **Bug Fixes**
  - Added `.catch()` to `setMessageFeedback` in MessageLog and Overview to clear `feedbackOverrides` on failure.
  - Added tests for modal submit failure to verify the dislike state is reverted.

<sup>Written for commit fc4926c03ebf274fa6b8f37e1f8a62131f40b5f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

