### PR TITLE
Enforce HTTPS-only for outbound provider URLs

### DIFF
--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -139,14 +139,14 @@ describe('validatePublicUrl', () => {
 
   it('skips validation in test mode', async () => {
     process.env['NODE_ENV'] = 'test';
-    await expect(validatePublicUrl('http://127.0.0.1:8080')).resolves.toBeUndefined();
+    await expect(validatePublicUrl('https://127.0.0.1:8080')).resolves.toBeUndefined();
   });
 
   it('enforces validation in test mode when SKIP_SSRF_VALIDATION=false', async () => {
     process.env['NODE_ENV'] = 'test';
     process.env['SKIP_SSRF_VALIDATION'] = 'false';
     try {
-      await expect(validatePublicUrl('http://127.0.0.1:8080')).rejects.toThrow(
+      await expect(validatePublicUrl('https://127.0.0.1:8080')).rejects.toThrow(
         'private or internal',
       );
     } finally {
@@ -163,28 +163,36 @@ describe('validatePublicUrl', () => {
     await expect(validatePublicUrl('not-a-url')).rejects.toThrow('Invalid URL format');
   });
 
-  it('rejects non-http/https schemes', async () => {
+  it('rejects non-https schemes', async () => {
     await expect(validatePublicUrl('ftp://example.com')).rejects.toThrow(
-      'Only http and https URLs are allowed',
+      'Only https URLs are allowed',
     );
   });
 
   it('rejects file scheme', async () => {
     await expect(validatePublicUrl('file:///etc/passwd')).rejects.toThrow(
-      'Only http and https URLs are allowed',
+      'Only https URLs are allowed',
+    );
+  });
+
+  it('rejects plaintext http scheme (AC-2 passive exfiltration)', async () => {
+    await expect(validatePublicUrl('http://example.com/api')).rejects.toThrow(
+      'Only https URLs are allowed',
     );
   });
 
   it('rejects IP literal pointing to private network', async () => {
-    await expect(validatePublicUrl('http://127.0.0.1:8080')).rejects.toThrow('private or internal');
+    await expect(validatePublicUrl('https://127.0.0.1:8080')).rejects.toThrow(
+      'private or internal',
+    );
   });
 
   it('rejects IP literal 10.x.x.x', async () => {
-    await expect(validatePublicUrl('http://10.0.0.5/api')).rejects.toThrow('private or internal');
+    await expect(validatePublicUrl('https://10.0.0.5/api')).rejects.toThrow('private or internal');
   });
 
   it('rejects IP literal 192.168.x.x', async () => {
-    await expect(validatePublicUrl('http://192.168.1.100:3000')).rejects.toThrow(
+    await expect(validatePublicUrl('https://192.168.1.100:3000')).rejects.toThrow(
       'private or internal',
     );
   });
@@ -220,9 +228,9 @@ describe('validatePublicUrl', () => {
     );
   });
 
-  it('accepts http scheme', async () => {
+  it('accepts https scheme', async () => {
     mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
-    await expect(validatePublicUrl('http://example.com/api')).resolves.toBeUndefined();
+    await expect(validatePublicUrl('https://example.com/api')).resolves.toBeUndefined();
   });
 
   it('handles non-array lookup result (single object)', async () => {

--- a/packages/backend/src/common/utils/url-validation.ts
+++ b/packages/backend/src/common/utils/url-validation.ts
@@ -77,8 +77,13 @@ export async function validatePublicUrl(url: string): Promise<void> {
     throw new Error('Invalid URL format');
   }
 
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error('Only http and https URLs are allowed');
+  // Require HTTPS for outbound provider traffic. Manifest forwards API keys in
+  // Authorization headers and plaintext prompts/completions to this URL; any
+  // non-TLS hop would expose them to passive wire-sniffing (AC-2 in the Mine
+  // paper, arXiv:2604.08407). validatePublicUrl already rejects private IPs,
+  // so there is no safe loopback/on-prem case that would need plaintext http.
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Only https URLs are allowed');
   }
 
   const hostname = parsed.hostname.replace(/^\[|\]$/g, '');


### PR DESCRIPTION
## Summary
This change enforces HTTPS-only URLs for outbound provider traffic to prevent passive wire-sniffing attacks that could expose API keys and sensitive data.

## Key Changes
- **Strict HTTPS requirement**: Modified `validatePublicUrl()` to reject all non-HTTPS schemes (including plaintext HTTP)
- **Security rationale**: Added detailed comment explaining that Manifest forwards API keys in Authorization headers and plaintext prompts/completions over the network. Any non-TLS hop would expose them to passive wire-sniffing attacks (AC-2 vulnerability as documented in arXiv:2604.08407)
- **Test updates**: Updated all test cases to use HTTPS URLs instead of HTTP, including:
  - Changed test assertions to expect "Only https URLs are allowed" error message
  - Added explicit test case for rejecting plaintext HTTP scheme with AC-2 reference
  - Updated all private IP rejection tests to use HTTPS URLs
  - Updated the positive test case to verify HTTPS acceptance

## Implementation Details
- The validation now rejects `http:` protocol entirely, not just non-HTTP/HTTPS schemes
- Private IP validation remains unchanged and still applies to HTTPS URLs
- Test mode behavior is preserved (skips validation by default, can be enforced with `SKIP_SSRF_VALIDATION=false`)

https://claude.ai/code/session_01KmmN1uvaiDDaE9uacycseY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force HTTPS-only for outbound provider URLs to stop plaintext HTTP requests. This prevents passive interception of API keys and LLM data in transit.

- **Bug Fixes**
  - Allow only `https:` in `validatePublicUrl()`; return "Only https URLs are allowed".
  - Keep private IP and metadata range blocking unchanged and applied to HTTPS.
  - Update tests to use HTTPS and add a case rejecting HTTP; test-mode behavior remains, override with `SKIP_SSRF_VALIDATION=false`.

<sup>Written for commit e4df8ae3c61dd867bc571001db1588360120d959. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

