### PR TITLE
Add comprehensive test suite for routing and frontend services

### DIFF
--- a/packages/backend/src/auth/current-user.decorator.spec.ts
+++ b/packages/backend/src/auth/current-user.decorator.spec.ts
@@ -1,3 +1,7 @@
+// Ensure the Reflect metadata API is initialized before we read decorator
+// metadata below. NestJS normally does this transitively, but this spec
+// exercises the decorator in isolation.
+import 'reflect-metadata';
 import { ExecutionContext } from '@nestjs/common';
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { CurrentUser } from './current-user.decorator';

--- a/packages/backend/src/auth/current-user.decorator.spec.ts
+++ b/packages/backend/src/auth/current-user.decorator.spec.ts
@@ -1,0 +1,43 @@
+import { ExecutionContext } from '@nestjs/common';
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+import { CurrentUser } from './current-user.decorator';
+
+// NestJS param decorators attach their factory via ROUTE_ARGS_METADATA. To unit-test
+// the factory we apply the decorator to a fake handler and pull the factory out of
+// the metadata, then invoke it against a mocked ExecutionContext.
+function getDecoratorFactory(
+  decorator: ReturnType<typeof CurrentUser>,
+): (data: unknown, ctx: ExecutionContext) => unknown {
+  class Probe {
+    handler(@decorator user: unknown) {
+      return user;
+    }
+  }
+  const args = Reflect.getMetadata(ROUTE_ARGS_METADATA, Probe, 'handler');
+  const key = Object.keys(args)[0];
+  return args[key].factory as (data: unknown, ctx: ExecutionContext) => unknown;
+}
+
+function createContext(user: unknown): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ user }) }),
+  } as unknown as ExecutionContext;
+}
+
+describe('@CurrentUser()', () => {
+  const factory = getDecoratorFactory(CurrentUser());
+
+  it('returns request.user from the execution context', () => {
+    const user = { id: 'user_123', email: 'alice@example.com' };
+    expect(factory(undefined, createContext(user))).toBe(user);
+  });
+
+  it('returns undefined when no user is attached to the request', () => {
+    expect(factory(undefined, createContext(undefined))).toBeUndefined();
+  });
+
+  it('ignores the data argument (decorator is not field-scoped)', () => {
+    const user = { id: 'u' };
+    expect(factory('anything', createContext(user))).toBe(user);
+  });
+});

--- a/packages/backend/src/common/utils/sql-dialect.spec.ts
+++ b/packages/backend/src/common/utils/sql-dialect.spec.ts
@@ -1,0 +1,112 @@
+import {
+  computeCutoff,
+  detectDialect,
+  portableSql,
+  sqlCastFloat,
+  sqlCastInterval,
+  sqlDateBucket,
+  sqlHourBucket,
+  sqlNow,
+  sqlSanitizeCost,
+  timestampDefault,
+  timestampType,
+} from './sql-dialect';
+
+describe('sql-dialect', () => {
+  describe('detectDialect', () => {
+    it('always resolves to postgres regardless of input', () => {
+      expect(detectDialect('sqlite')).toBe('postgres');
+      expect(detectDialect('postgres')).toBe('postgres');
+      expect(detectDialect('')).toBe('postgres');
+    });
+  });
+
+  describe('timestamp helpers', () => {
+    it('uses `timestamp` as the column type', () => {
+      expect(timestampType()).toBe('timestamp');
+    });
+
+    it('returns a factory that emits NOW() when invoked', () => {
+      const factory = timestampDefault();
+      expect(typeof factory).toBe('function');
+      expect(factory()).toBe('NOW()');
+    });
+  });
+
+  describe('computeCutoff', () => {
+    const FIXED_NOW = new Date('2026-04-20T12:00:00').getTime();
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(FIXED_NOW);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('subtracts the given number of days and returns a local-ISO string', () => {
+      const out = computeCutoff('7 days');
+      expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+      // No TZ suffix.
+      expect(out.endsWith('Z')).toBe(false);
+      // 7 days before 2026-04-20 is 2026-04-13.
+      expect(out.startsWith('2026-04-13')).toBe(true);
+    });
+
+    it('supports singular day/hour forms', () => {
+      expect(computeCutoff('1 day').startsWith('2026-04-19')).toBe(true);
+      expect(computeCutoff('1 hour').startsWith('2026-04-20T11:')).toBe(true);
+    });
+
+    it('subtracts hours for the "hours" unit', () => {
+      // 24 hours before noon on 2026-04-20 is noon on 2026-04-19.
+      expect(computeCutoff('24 hours').startsWith('2026-04-19T12:')).toBe(true);
+    });
+
+    it('defaults to 24 hours and warns on unrecognized intervals', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const out = computeCutoff('not-an-interval');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('unrecognized interval'));
+      expect(out.startsWith('2026-04-19T12:')).toBe(true);
+      warn.mockRestore();
+    });
+  });
+
+  describe('sqlNow', () => {
+    it('returns a local ISO string for the current time', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-02T03:04:05').getTime());
+      expect(sqlNow()).toBe('2026-01-02T03:04:05');
+      jest.useRealTimers();
+    });
+  });
+
+  describe('SQL expression helpers', () => {
+    it('sqlHourBucket wraps the column in date_trunc + to_char for hour granularity', () => {
+      expect(sqlHourBucket('ts')).toBe(
+        `to_char(date_trunc('hour', ts), 'YYYY-MM-DD"T"HH24:MI:SS')`,
+      );
+    });
+
+    it('sqlDateBucket casts the column to date and formats it', () => {
+      expect(sqlDateBucket('created_at')).toBe(`to_char(created_at::date, 'YYYY-MM-DD')`);
+    });
+
+    it('sqlCastFloat appends ::float', () => {
+      expect(sqlCastFloat('cost')).toBe('cost::float');
+    });
+
+    it('sqlSanitizeCost returns NULL for negative costs', () => {
+      expect(sqlSanitizeCost('cost')).toBe('CASE WHEN cost >= 0 THEN cost ELSE NULL END');
+    });
+
+    it('portableSql is a pass-through', () => {
+      expect(portableSql('SELECT 1')).toBe('SELECT 1');
+    });
+
+    it('sqlCastInterval wraps a named parameter in CAST(... AS interval)', () => {
+      expect(sqlCastInterval('since')).toBe('CAST(:since AS interval)');
+    });
+  });
+});

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -1,0 +1,271 @@
+jest.mock('../../common/utils/url-validation', () => ({
+  validatePublicUrl: jest.fn(),
+}));
+
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { CustomProviderService } from './custom-provider.service';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+import { ProviderService } from '../routing-core/provider.service';
+import { RoutingCacheService } from '../routing-core/routing-cache.service';
+import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { validatePublicUrl } = require('../../common/utils/url-validation');
+
+function makeDeps(overrides: {
+  findOneResults?: (CustomProvider | null)[];
+  findResult?: CustomProvider[];
+  cached?: CustomProvider[] | null;
+}) {
+  const findOne = jest.fn();
+  const find = jest.fn().mockResolvedValue(overrides.findResult ?? []);
+  const insert = jest.fn().mockResolvedValue(undefined);
+  const save = jest.fn().mockResolvedValue(undefined);
+  const remove = jest.fn().mockResolvedValue(undefined);
+
+  const results = overrides.findOneResults ?? [];
+  findOne.mockImplementation(() => Promise.resolve(results.shift() ?? null));
+
+  const repo = { findOne, find, insert, save, remove } as unknown as Repository<CustomProvider>;
+
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: {} });
+  const removeProvider = jest.fn().mockResolvedValue(undefined);
+  const providerService = { upsertProvider, removeProvider } as unknown as ProviderService;
+
+  const getCustomProviders = jest.fn().mockReturnValue(overrides.cached ?? null);
+  const setCustomProviders = jest.fn();
+  const invalidateAgent = jest.fn();
+  const routingCache = {
+    getCustomProviders,
+    setCustomProviders,
+    invalidateAgent,
+  } as unknown as RoutingCacheService;
+
+  const recalculate = jest.fn().mockResolvedValue(undefined);
+  const autoAssign = { recalculate } as unknown as TierAutoAssignService;
+
+  const svc = new CustomProviderService(repo, providerService, routingCache, autoAssign);
+
+  return {
+    svc,
+    findOne,
+    find,
+    insert,
+    save,
+    remove,
+    upsertProvider,
+    removeProvider,
+    getCustomProviders,
+    setCustomProviders,
+    invalidateAgent,
+    recalculate,
+  };
+}
+
+describe('CustomProviderService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (validatePublicUrl as jest.Mock).mockReset();
+    (validatePublicUrl as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('static helpers', () => {
+    it('composes and parses provider keys and model keys', () => {
+      expect(CustomProviderService.providerKey('abc')).toBe('custom:abc');
+      expect(CustomProviderService.modelKey('abc', 'model')).toBe('custom:abc/model');
+      // rawModelName strips through the first "/" so the proxy sends just the upstream name.
+      expect(CustomProviderService.rawModelName('custom:abc/model')).toBe('model');
+      expect(CustomProviderService.rawModelName('plain-model')).toBe('plain-model');
+    });
+
+    it('detects custom provider keys and extracts their id', () => {
+      expect(CustomProviderService.isCustom('custom:abc')).toBe(true);
+      expect(CustomProviderService.isCustom('anthropic')).toBe(false);
+      expect(CustomProviderService.extractId('custom:abc')).toBe('abc');
+    });
+  });
+
+  describe('list', () => {
+    it('returns the cached result when present', async () => {
+      const cached = [{ id: 'cp1' } as CustomProvider];
+      const { svc, find, setCustomProviders } = makeDeps({ cached });
+      const result = await svc.list('agent-1');
+      expect(result).toBe(cached);
+      expect(find).not.toHaveBeenCalled();
+      expect(setCustomProviders).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the DB and populates the cache on a miss', async () => {
+      const rows = [{ id: 'cp1' } as CustomProvider];
+      const { svc, find, setCustomProviders } = makeDeps({
+        cached: null,
+        findResult: rows,
+      });
+      const result = await svc.list('agent-1');
+      expect(result).toBe(rows);
+      expect(find).toHaveBeenCalledWith({ where: { agent_id: 'agent-1' } });
+      expect(setCustomProviders).toHaveBeenCalledWith('agent-1', rows);
+    });
+  });
+
+  describe('create', () => {
+    const dto = {
+      name: 'my-openai',
+      base_url: 'https://openai.example.com',
+      apiKey: 'sk-x',
+      models: [
+        {
+          model_name: 'gpt-custom',
+          input_price_per_million_tokens: 1,
+          output_price_per_million_tokens: 2,
+          // context_window omitted → default 128_000
+        },
+      ],
+    };
+
+    it('throws Conflict when an agent already has a provider with the same name', async () => {
+      const { svc } = makeDeps({ findOneResults: [{ id: 'existing' } as CustomProvider] });
+      await expect(svc.create('agent-1', 'user-1', dto)).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('throws BadRequest when the base URL fails validation', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('not public'));
+      const { svc } = makeDeps({ findOneResults: [null] });
+      await expect(svc.create('agent-1', 'user-1', dto)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('inserts the row, upserts a UserProvider, and defaults context_window to 128k', async () => {
+      const { svc, insert, upsertProvider } = makeDeps({ findOneResults: [null] });
+      const cp = await svc.create('agent-1', 'user-1', dto);
+
+      expect(insert).toHaveBeenCalledTimes(1);
+      expect(cp.agent_id).toBe('agent-1');
+      expect(cp.name).toBe('my-openai');
+      expect(cp.models[0].context_window).toBe(128_000);
+      expect(upsertProvider).toHaveBeenCalledWith('agent-1', 'user-1', `custom:${cp.id}`, 'sk-x');
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFound when the provider does not exist for the agent', async () => {
+      const { svc } = makeDeps({ findOneResults: [null] });
+      await expect(
+        svc.update('agent-1', 'missing', 'user-1', { name: 'x' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws Conflict when renaming collides with an existing provider', async () => {
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'old' } as CustomProvider;
+      const { svc } = makeDeps({
+        findOneResults: [existing, { id: 'other', name: 'new' } as CustomProvider],
+      });
+      await expect(svc.update('agent-1', 'cp1', 'user-1', { name: 'new' })).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+    });
+
+    it('renames and persists when no collision', async () => {
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'old' } as CustomProvider;
+      const { svc, save, invalidateAgent } = makeDeps({
+        findOneResults: [existing, null],
+      });
+      await svc.update('agent-1', 'cp1', 'user-1', { name: 'new' });
+      expect(existing.name).toBe('new');
+      expect(save).toHaveBeenCalledWith(existing);
+      expect(invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('validates and updates base_url when provided', async () => {
+      const existing = {
+        id: 'cp1',
+        agent_id: 'agent-1',
+        name: 'n',
+        base_url: 'a',
+      } as CustomProvider;
+      const { svc } = makeDeps({ findOneResults: [existing] });
+      await svc.update('agent-1', 'cp1', 'user-1', { base_url: 'https://b.example' });
+      expect(validatePublicUrl).toHaveBeenCalledWith('https://b.example');
+      expect(existing.base_url).toBe('https://b.example');
+    });
+
+    it('throws BadRequest when the new base_url fails validation', async () => {
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const { svc } = makeDeps({ findOneResults: [existing] });
+      (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('bad url'));
+      await expect(
+        svc.update('agent-1', 'cp1', 'user-1', { base_url: 'http://bad' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rewrites models (defaulting context_window) and recalculates tiers when the api key is not touched', async () => {
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const { svc, recalculate, upsertProvider } = makeDeps({ findOneResults: [existing] });
+      await svc.update('agent-1', 'cp1', 'user-1', {
+        models: [
+          {
+            model_name: 'm1',
+            input_price_per_million_tokens: 1,
+            output_price_per_million_tokens: 1,
+          },
+        ],
+      });
+      expect(existing.models[0].context_window).toBe(128_000);
+      expect(recalculate).toHaveBeenCalledWith('agent-1');
+      expect(upsertProvider).not.toHaveBeenCalled();
+    });
+
+    it('delegates tier recalculation to provider upsert when the api key is also updated', async () => {
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const { svc, recalculate, upsertProvider } = makeDeps({ findOneResults: [existing] });
+      await svc.update('agent-1', 'cp1', 'user-1', {
+        apiKey: 'sk-new',
+        models: [
+          {
+            model_name: 'm1',
+            input_price_per_million_tokens: 1,
+            output_price_per_million_tokens: 1,
+            context_window: 64_000,
+          },
+        ],
+      });
+      expect(upsertProvider).toHaveBeenCalledWith('agent-1', 'user-1', 'custom:cp1', 'sk-new');
+      // When api key is updated, the upsert triggers its own recalc — service should not double-call.
+      expect(recalculate).not.toHaveBeenCalled();
+      expect(existing.models[0].context_window).toBe(64_000);
+    });
+  });
+
+  describe('remove', () => {
+    it('throws NotFound when the provider is missing', async () => {
+      const { svc } = makeDeps({ findOneResults: [null] });
+      await expect(svc.remove('agent-1', 'cp1')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('deletes the row and attempts provider removal', async () => {
+      const cp = { id: 'cp1', agent_id: 'agent-1' } as CustomProvider;
+      const { svc, removeProvider, remove } = makeDeps({ findOneResults: [cp] });
+      await svc.remove('agent-1', 'cp1');
+      expect(removeProvider).toHaveBeenCalledWith('agent-1', 'custom:cp1');
+      expect(remove).toHaveBeenCalledWith(cp);
+    });
+
+    it('swallows errors from provider removal (partial-state cleanup)', async () => {
+      const cp = { id: 'cp1', agent_id: 'agent-1' } as CustomProvider;
+      const { svc, removeProvider, remove } = makeDeps({ findOneResults: [cp] });
+      removeProvider.mockRejectedValue(new Error('not linked'));
+      await expect(svc.remove('agent-1', 'cp1')).resolves.toBeUndefined();
+      expect(remove).toHaveBeenCalledWith(cp);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns the provider directly from the repository', async () => {
+      const cp = { id: 'cp1' } as CustomProvider;
+      const { svc, findOne } = makeDeps({ findOneResults: [cp] });
+      await expect(svc.getById('cp1')).resolves.toBe(cp);
+      expect(findOne).toHaveBeenCalledWith({ where: { id: 'cp1' } });
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/copilot-device-auth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/copilot-device-auth.service.spec.ts
@@ -1,0 +1,115 @@
+import { CopilotDeviceAuthService } from './copilot-device-auth.service';
+
+const originalFetch = global.fetch;
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('CopilotDeviceAuthService', () => {
+  let svc: CopilotDeviceAuthService;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    svc = new CopilotDeviceAuthService();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('requestDeviceCode', () => {
+    it('POSTs to the GitHub device endpoint with the hard-coded client id and read:user scope', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, {
+          device_code: 'dev-abc',
+          user_code: 'USER-CODE',
+          verification_uri: 'https://github.com/login/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      );
+
+      const out = await svc.requestDeviceCode();
+
+      expect(out.device_code).toBe('dev-abc');
+      expect(out.user_code).toBe('USER-CODE');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://github.com/login/device/code');
+      expect(init.method).toBe('POST');
+      expect(init.headers).toMatchObject({
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      });
+      const params = new URLSearchParams(init.body.toString());
+      expect(params.get('client_id')).toBe('Iv1.b507a08c87ecfe98');
+      expect(params.get('scope')).toBe('read:user');
+    });
+
+    it('throws when GitHub returns a non-2xx status', async () => {
+      fetchMock.mockResolvedValue(mockResponse(503, {}));
+      await expect(svc.requestDeviceCode()).rejects.toThrow(
+        'GitHub device code request failed: 503',
+      );
+    });
+
+    it('throws when GitHub returns a malformed payload (missing device_code or user_code)', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { verification_uri: 'x', expires_in: 1, interval: 1 }),
+      );
+      await expect(svc.requestDeviceCode()).rejects.toThrow(
+        'Invalid device code response from GitHub',
+      );
+    });
+  });
+
+  describe('pollForToken', () => {
+    it('POSTs to the GitHub token endpoint with the device grant type', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'ghs_abc' }));
+      const out = await svc.pollForToken('dev-abc');
+      expect(out).toEqual({ status: 'complete', token: 'ghs_abc' });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://github.com/login/oauth/access_token');
+      const params = new URLSearchParams(init.body.toString());
+      expect(params.get('client_id')).toBe('Iv1.b507a08c87ecfe98');
+      expect(params.get('device_code')).toBe('dev-abc');
+      expect(params.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:device_code');
+    });
+
+    it('maps authorization_pending → pending', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, { error: 'authorization_pending' }));
+      expect(await svc.pollForToken('d')).toEqual({ status: 'pending' });
+    });
+
+    it('maps slow_down, expired_token, and access_denied to their own statuses', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { error: 'slow_down' }));
+      expect((await svc.pollForToken('d')).status).toBe('slow_down');
+
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { error: 'expired_token' }));
+      expect((await svc.pollForToken('d')).status).toBe('expired');
+
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { error: 'access_denied' }));
+      expect((await svc.pollForToken('d')).status).toBe('denied');
+    });
+
+    it('falls back to pending for unrecognised responses and logs a warning', async () => {
+      const warn = jest.spyOn((svc as unknown as { logger: { warn: () => void } }).logger, 'warn');
+      fetchMock.mockResolvedValue(mockResponse(200, { error: 'something_new' }));
+      expect(await svc.pollForToken('d')).toEqual({ status: 'pending' });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unexpected GitHub poll response'));
+    });
+
+    it('throws when GitHub returns a non-2xx status', async () => {
+      fetchMock.mockResolvedValue(mockResponse(500, {}));
+      await expect(svc.pollForToken('d')).rejects.toThrow('GitHub token poll failed: 500');
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/minimax-oauth-helpers.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth-helpers.spec.ts
@@ -1,0 +1,137 @@
+import {
+  buildMinimaxCodeUrl,
+  buildMinimaxResourceUrl,
+  buildMinimaxTokenUrl,
+  DEFAULT_BASE_URL,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_REGION,
+  DEFAULT_RESOURCE_URL,
+  getMinimaxBaseUrl,
+  getMinimaxOauthBaseUrl,
+  getMinimaxResourceUrl,
+  isMinimaxRegion,
+  isOAuthTokenBlob,
+  MINIMAX_BASE_URLS,
+  toAbsoluteExpiryTimestamp,
+  toPollIntervalMs,
+} from './minimax-oauth-helpers';
+
+describe('minimax-oauth-helpers', () => {
+  it('exposes the correct default region and base URLs', () => {
+    expect(DEFAULT_REGION).toBe('global');
+    expect(DEFAULT_BASE_URL).toBe('https://api.minimax.io');
+    expect(DEFAULT_RESOURCE_URL).toBe('https://api.minimax.io/anthropic');
+    expect(MINIMAX_BASE_URLS.cn).toBe('https://api.minimaxi.com');
+  });
+
+  describe('isMinimaxRegion', () => {
+    it('accepts the two known regions', () => {
+      expect(isMinimaxRegion('global')).toBe(true);
+      expect(isMinimaxRegion('cn')).toBe(true);
+    });
+
+    it('rejects anything else (including undefined)', () => {
+      expect(isMinimaxRegion(undefined)).toBe(false);
+      expect(isMinimaxRegion('GLOBAL')).toBe(false);
+      expect(isMinimaxRegion('us')).toBe(false);
+    });
+  });
+
+  describe('URL builders', () => {
+    it('defaults getMinimaxBaseUrl to the global region', () => {
+      expect(getMinimaxBaseUrl()).toBe(MINIMAX_BASE_URLS.global);
+      expect(getMinimaxBaseUrl('cn')).toBe(MINIMAX_BASE_URLS.cn);
+    });
+
+    it('builds the code, token and resource URLs as string concatenations', () => {
+      expect(buildMinimaxCodeUrl('https://api.minimax.io')).toBe(
+        'https://api.minimax.io/oauth/code',
+      );
+      expect(buildMinimaxTokenUrl('https://api.minimax.io')).toBe(
+        'https://api.minimax.io/oauth/token',
+      );
+      expect(buildMinimaxResourceUrl('https://api.minimax.io')).toBe(
+        'https://api.minimax.io/anthropic',
+      );
+    });
+  });
+
+  describe('getMinimaxResourceUrl', () => {
+    it('returns null for falsy input', () => {
+      expect(getMinimaxResourceUrl(undefined)).toBeNull();
+      expect(getMinimaxResourceUrl('')).toBeNull();
+    });
+
+    it('normalises a resource URL through the provider-base-url helper', () => {
+      // The helper is a pass-through for well-formed resource URLs.
+      expect(getMinimaxResourceUrl('https://api.minimax.io/anthropic')).toBe(
+        'https://api.minimax.io/anthropic',
+      );
+    });
+  });
+
+  describe('getMinimaxOauthBaseUrl', () => {
+    it('falls back to the default base URL when the resource URL is missing', () => {
+      expect(getMinimaxOauthBaseUrl(undefined)).toBe(DEFAULT_BASE_URL);
+    });
+
+    it('returns the origin of a normalised resource URL', () => {
+      expect(getMinimaxOauthBaseUrl('https://api.minimaxi.com/anthropic')).toBe(
+        'https://api.minimaxi.com',
+      );
+    });
+  });
+
+  describe('toAbsoluteExpiryTimestamp', () => {
+    it('treats small numbers as seconds-from-now', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+      expect(toAbsoluteExpiryTimestamp(60)).toBe(Date.now() + 60_000);
+      jest.useRealTimers();
+    });
+
+    it('passes already-absolute millisecond timestamps through unchanged', () => {
+      // 10_000_000_001 > 10_000_000_000 threshold → treated as absolute epoch ms.
+      expect(toAbsoluteExpiryTimestamp(10_000_000_001)).toBe(10_000_000_001);
+    });
+  });
+
+  describe('toPollIntervalMs', () => {
+    it('falls back to the default for missing or zero/negative values', () => {
+      expect(toPollIntervalMs(undefined)).toBe(DEFAULT_POLL_INTERVAL_MS);
+      expect(toPollIntervalMs(0)).toBe(DEFAULT_POLL_INTERVAL_MS);
+      expect(toPollIntervalMs(-10)).toBe(DEFAULT_POLL_INTERVAL_MS);
+    });
+
+    it('treats values >= 1000 as already in milliseconds', () => {
+      expect(toPollIntervalMs(1500)).toBe(1500);
+    });
+
+    it('converts small values (assumed to be seconds) to milliseconds', () => {
+      expect(toPollIntervalMs(5)).toBe(5000);
+    });
+  });
+
+  describe('isOAuthTokenBlob', () => {
+    it('accepts a valid blob with or without the optional u field', () => {
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: 1 })).toBe(true);
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: 1, u: 'x' })).toBe(true);
+    });
+
+    it('rejects non-objects and nullish values', () => {
+      expect(isOAuthTokenBlob(null)).toBe(false);
+      expect(isOAuthTokenBlob(undefined)).toBe(false);
+      expect(isOAuthTokenBlob('string')).toBe(false);
+      expect(isOAuthTokenBlob(42)).toBe(false);
+    });
+
+    it('rejects blobs with missing or wrong-typed fields', () => {
+      expect(isOAuthTokenBlob({ r: 'b', e: 1 })).toBe(false);
+      expect(isOAuthTokenBlob({ t: 'a', e: 1 })).toBe(false);
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b' })).toBe(false);
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: 'bad' })).toBe(false);
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: Number.NaN })).toBe(false);
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: 1, u: 42 })).toBe(false);
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
@@ -1,0 +1,304 @@
+import { ConfigService } from '@nestjs/config';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+
+const originalFetch = global.fetch;
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function mockRawResponse(status: number, rawText: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => rawText,
+    json: async () => JSON.parse(rawText),
+  } as unknown as Response;
+}
+
+function createConfig(): ConfigService {
+  return { get: () => undefined } as unknown as ConfigService;
+}
+
+function createProviderService(): {
+  svc: ProviderService;
+  upsertProvider: jest.Mock;
+  recalculateTiers: jest.Mock;
+} {
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
+  const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  return {
+    svc: { upsertProvider, recalculateTiers } as unknown as ProviderService,
+    upsertProvider,
+    recalculateTiers,
+  };
+}
+
+function createDiscovery(): { svc: ModelDiscoveryService; discoverModels: jest.Mock } {
+  const discoverModels = jest.fn().mockResolvedValue(undefined);
+  return { svc: { discoverModels } as unknown as ModelDiscoveryService, discoverModels };
+}
+
+describe('MinimaxOauthService', () => {
+  let fetchMock: jest.Mock;
+  let provider: ReturnType<typeof createProviderService>;
+  let discovery: ReturnType<typeof createDiscovery>;
+  let svc: MinimaxOauthService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    provider = createProviderService();
+    discovery = createDiscovery();
+    svc = new MinimaxOauthService(provider.svc, createConfig(), discovery.svc);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  // --- startAuthorization ---
+
+  async function startFlow(region: 'global' | 'cn' = 'global') {
+    // The code endpoint echoes back a user_code + state. The service generates
+    // the state itself, so we need to capture it from the request and echo it.
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      const body = new URLSearchParams(String(init.body));
+      return mockResponse(200, {
+        user_code: 'USER-CODE',
+        verification_uri: 'https://minimax.example/verify',
+        expired_in: 600,
+        interval: 2,
+        state: body.get('state'),
+      });
+    });
+    return svc.startAuthorization('agent-1', 'user-1', region);
+  }
+
+  describe('startAuthorization', () => {
+    it('POSTs a PKCE-challenge to the region-specific code endpoint and records the pending flow', async () => {
+      const out = await startFlow('global');
+      expect(out.userCode).toBe('USER-CODE');
+      expect(out.verificationUri).toBe('https://minimax.example/verify');
+      expect(out.pollIntervalMs).toBe(2000);
+      expect(out.expiresAt).toBe(Date.now() + 600_000);
+      expect(svc.getPendingCount()).toBe(1);
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://api.minimax.io/oauth/code');
+      const body = new URLSearchParams((init as RequestInit).body as string);
+      expect(body.get('response_type')).toBe('code');
+      expect(body.get('code_challenge_method')).toBe('S256');
+      expect(body.get('code_challenge')?.length).toBeGreaterThan(0);
+    });
+
+    it('hits the CN endpoint when region="cn"', async () => {
+      await startFlow('cn');
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://api.minimaxi.com/oauth/code');
+    });
+
+    it('throws when the code endpoint returns an error', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(500, { error: 'oops' }));
+      await expect(svc.startAuthorization('a', 'u')).rejects.toThrow(
+        'Failed to start MiniMax OAuth',
+      );
+    });
+
+    it('throws when the payload is incomplete', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { state: 'x' }));
+      await expect(svc.startAuthorization('a', 'u')).rejects.toThrow();
+    });
+
+    it('throws when the echoed state does not match the generated flow id', async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, {
+          user_code: 'U',
+          verification_uri: 'https://v',
+          expired_in: 60,
+          state: 'different',
+        }),
+      );
+      await expect(svc.startAuthorization('a', 'u')).rejects.toThrow(
+        'MiniMax OAuth state mismatch',
+      );
+    });
+  });
+
+  // --- pollAuthorization ---
+
+  describe('pollAuthorization', () => {
+    it('reports error for unknown or expired flow ids', async () => {
+      const out = await svc.pollAuthorization('unknown', 'user-1');
+      expect(out.status).toBe('error');
+    });
+
+    it('reports error when the user does not match the flow owner', async () => {
+      const start = await startFlow();
+      const out = await svc.pollAuthorization(start.flowId, 'someone-else');
+      expect(out.status).toBe('error');
+      expect(out.message).toContain('does not match');
+    });
+
+    it('reports error and purges the flow when the pending entry has expired', async () => {
+      const start = await startFlow();
+      jest.advanceTimersByTime(601_000);
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('error');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('returns "pending" when the token endpoint reports a pending approval', async () => {
+      const start = await startFlow();
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { status: 'pending' }));
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('pending');
+      expect(out.pollIntervalMs).toBe(start.pollIntervalMs);
+      // Flow is retained for another poll.
+      expect(svc.getPendingCount()).toBe(1);
+    });
+
+    it('returns error and purges when the token endpoint explicitly reports status=error', async () => {
+      const start = await startFlow();
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { status: 'error' }));
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('error');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('returns error and purges when the token endpoint returns a non-2xx status', async () => {
+      const start = await startFlow();
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(500, { base_resp: { status_msg: 'backend down' } }),
+      );
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('error');
+      expect(out.message).toBe('backend down');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('returns error when the body is non-JSON', async () => {
+      const start = await startFlow();
+      fetchMock.mockResolvedValueOnce(mockRawResponse(200, 'not-json'));
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('error');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('returns error when success payload is missing access/refresh/expiry', async () => {
+      const start = await startFlow();
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { status: 'success' }));
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('error');
+    });
+
+    it('persists the blob and triggers model discovery on success', async () => {
+      const start = await startFlow();
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, {
+          status: 'success',
+          access_token: 'at',
+          refresh_token: 'rt',
+          expired_in: 3600,
+          resource_url: 'https://api.minimax.io/anthropic',
+        }),
+      );
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('success');
+      expect(provider.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'minimax',
+        expect.stringContaining('"t":"at"'),
+        'subscription',
+      );
+      expect(discovery.discoverModels).toHaveBeenCalled();
+      expect(provider.recalculateTiers).toHaveBeenCalledWith('agent-1');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('swallows discovery errors after a successful token exchange', async () => {
+      const start = await startFlow();
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, {
+          status: 'success',
+          access_token: 'at',
+          refresh_token: 'rt',
+          expired_in: 3600,
+        }),
+      );
+      discovery.discoverModels.mockRejectedValue(new Error('boom'));
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      expect(out.status).toBe('success');
+    });
+  });
+
+  // --- refreshAccessToken ---
+
+  describe('refreshAccessToken', () => {
+    it('returns a fresh blob preserving the refresh token when none is returned', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { access_token: 'a2', expired_in: 1800 }));
+      const blob = await svc.refreshAccessToken('old-refresh');
+      expect(blob.t).toBe('a2');
+      expect(blob.r).toBe('old-refresh');
+      expect(blob.e).toBe(Date.now() + 1800_000);
+    });
+
+    it('throws when the endpoint returns a non-2xx status', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(400, {}));
+      await expect(svc.refreshAccessToken('r')).rejects.toThrow('Token refresh failed');
+    });
+
+    it('throws when the refresh payload is incomplete', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(200, { access_token: 'a2' }));
+      await expect(svc.refreshAccessToken('r')).rejects.toThrow(
+        'MiniMax token refresh returned an incomplete payload',
+      );
+    });
+  });
+
+  // --- unwrapToken ---
+
+  describe('unwrapToken', () => {
+    it('returns null for malformed JSON or non-blob shapes', async () => {
+      expect(await svc.unwrapToken('not-json', 'a', 'u')).toBeNull();
+      expect(await svc.unwrapToken(JSON.stringify({}), 'a', 'u')).toBeNull();
+    });
+
+    it('returns the blob unchanged when it is still valid', async () => {
+      const blob = { t: 'a', r: 'r', e: Date.now() + 10 * 60 * 1000 };
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toEqual(blob);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refreshes the blob when near expiry and persists the new one', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 30_000 };
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expired_in: 3600 }),
+      );
+      const out = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      expect(out?.t).toBe('new');
+      expect(provider.upsertProvider).toHaveBeenCalled();
+    });
+
+    it('returns the original blob (not null) when refresh fails', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 30_000 };
+      fetchMock.mockRejectedValueOnce(new Error('network'));
+      const out = await svc.unwrapToken(JSON.stringify(blob), 'a', 'u');
+      expect(out).toEqual(blob);
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
@@ -1,0 +1,265 @@
+import { ConfigService } from '@nestjs/config';
+import { OpenaiOauthService } from './openai-oauth.service';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+
+const originalFetch = global.fetch;
+
+function mockResponse(status: number, body: unknown, text = ''): Response {
+  const jsonBody = body;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => jsonBody,
+    text: async () => text || JSON.stringify(jsonBody),
+  } as unknown as Response;
+}
+
+function createConfig(nodeEnv = 'production'): ConfigService {
+  return {
+    get: (key: string) => {
+      if (key === 'app.nodeEnv') return nodeEnv;
+      if (key === 'OPENAI_OAUTH_CLIENT_ID') return undefined;
+      return undefined;
+    },
+  } as unknown as ConfigService;
+}
+
+function createProviderService(): {
+  svc: ProviderService;
+  upsertProvider: jest.Mock;
+  recalculateTiers: jest.Mock;
+} {
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
+  const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  return {
+    svc: { upsertProvider, recalculateTiers } as unknown as ProviderService,
+    upsertProvider,
+    recalculateTiers,
+  };
+}
+
+function createDiscovery(): { svc: ModelDiscoveryService; discoverModels: jest.Mock } {
+  const discoverModels = jest.fn().mockResolvedValue(undefined);
+  return { svc: { discoverModels } as unknown as ModelDiscoveryService, discoverModels };
+}
+
+describe('OpenaiOauthService', () => {
+  let fetchMock: jest.Mock;
+  let providerService: ReturnType<typeof createProviderService>;
+  let discovery: ReturnType<typeof createDiscovery>;
+  let svc: OpenaiOauthService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    providerService = createProviderService();
+    discovery = createDiscovery();
+    svc = new OpenaiOauthService(providerService.svc, createConfig('production'), discovery.svc);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('generateAuthorizationUrl', () => {
+    it('builds an OAuth URL with PKCE S256 challenge and tracks pending state', async () => {
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1', 'http://localhost:3001');
+      const parsed = new URL(url);
+      expect(parsed.origin + parsed.pathname).toBe('https://auth.openai.com/oauth/authorize');
+      expect(parsed.searchParams.get('response_type')).toBe('code');
+      expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(parsed.searchParams.get('code_challenge')?.length).toBeGreaterThan(0);
+      expect(parsed.searchParams.get('scope')).toBe('openid profile email offline_access');
+      expect(parsed.searchParams.get('redirect_uri')).toBe('http://localhost:1455/auth/callback');
+      expect(parsed.searchParams.get('state')?.length).toBeGreaterThan(0);
+      expect(svc.getPendingCount()).toBe(1);
+    });
+
+    it('cleans up expired pending states on each call', async () => {
+      await svc.generateAuthorizationUrl('a1', 'u1');
+      expect(svc.getPendingCount()).toBe(1);
+      // Advance past the 10-minute TTL.
+      jest.advanceTimersByTime(10 * 60 * 1000 + 1);
+      await svc.generateAuthorizationUrl('a2', 'u2');
+      // The old entry should have been cleaned up; only the new one remains.
+      expect(svc.getPendingCount()).toBe(1);
+    });
+
+    it('uses a custom client id from ConfigService when provided', async () => {
+      const config = {
+        get: (key: string) => (key === 'OPENAI_OAUTH_CLIENT_ID' ? 'custom-client' : 'production'),
+      } as unknown as ConfigService;
+      const customSvc = new OpenaiOauthService(providerService.svc, config, discovery.svc);
+      const url = await customSvc.generateAuthorizationUrl('a', 'u');
+      expect(new URL(url).searchParams.get('client_id')).toBe('custom-client');
+    });
+  });
+
+  describe('exchangeCode', () => {
+    it('rejects unknown states', async () => {
+      await expect(svc.exchangeCode('bogus-state', 'code')).rejects.toThrow(
+        'Invalid or expired OAuth state',
+      );
+    });
+
+    it('rejects (and purges) expired states', async () => {
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      jest.advanceTimersByTime(10 * 60 * 1000 + 1);
+      await expect(svc.exchangeCode(state, 'code')).rejects.toThrow('OAuth state expired');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('exchanges a valid code, stores the blob, and triggers model discovery', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, {
+          access_token: 'access-1',
+          refresh_token: 'refresh-1',
+          expires_in: 3600,
+        }),
+      );
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+
+      await svc.exchangeCode(state, 'auth-code');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [tokenUrl, init] = fetchMock.mock.calls[0];
+      expect(tokenUrl).toBe('https://auth.openai.com/oauth/token');
+      const body = new URLSearchParams(init.body.toString());
+      expect(body.get('grant_type')).toBe('authorization_code');
+      expect(body.get('code')).toBe('auth-code');
+      expect(body.get('code_verifier')?.length).toBeGreaterThan(0);
+
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'openai',
+        expect.stringContaining('"t":"access-1"'),
+        'subscription',
+      );
+      expect(discovery.discoverModels).toHaveBeenCalled();
+      expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');
+      // State is one-time-use.
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('throws when the token endpoint returns an error', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_grant'));
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'bad')).rejects.toThrow('Token exchange failed');
+    });
+
+    it('swallows discovery errors (OAuth success is not rolled back)', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+      );
+      discovery.discoverModels.mockRejectedValue(new Error('boom'));
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).resolves.toBeUndefined();
+      expect(providerService.upsertProvider).toHaveBeenCalled();
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('returns a fresh blob with a new expiry', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, {
+          access_token: 'a2',
+          refresh_token: 'r2',
+          expires_in: 1800,
+        }),
+      );
+      const blob = await svc.refreshAccessToken('old-refresh');
+      expect(blob.t).toBe('a2');
+      expect(blob.r).toBe('r2');
+      expect(blob.e).toBe(Date.now() + 1800 * 1000);
+    });
+
+    it('retains the old refresh token when the server omits a new one', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'a2', expires_in: 60 }));
+      const blob = await svc.refreshAccessToken('old-refresh');
+      expect(blob.r).toBe('old-refresh');
+    });
+
+    it('throws when the refresh endpoint returns a non-2xx status', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}));
+      await expect(svc.refreshAccessToken('r')).rejects.toThrow('Token refresh failed');
+    });
+  });
+
+  describe('unwrapToken', () => {
+    it('returns null for malformed blobs', async () => {
+      expect(await svc.unwrapToken('not-json', 'a', 'u')).toBeNull();
+      expect(await svc.unwrapToken(JSON.stringify({}), 'a', 'u')).toBeNull();
+    });
+
+    it('returns the cached access token when it is still valid', async () => {
+      const blob = { t: 'access', r: 'refresh', e: Date.now() + 10 * 60 * 1000 };
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toBe('access');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refreshes and persists a fresh blob when the token is near expiry', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 30_000 }; // within the 60s skew window
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
+      );
+      const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      expect(token).toBe('new');
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'openai',
+        expect.stringContaining('"t":"new"'),
+        'subscription',
+      );
+    });
+
+    it('returns null when the refresh call fails', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 1000 };
+      fetchMock.mockRejectedValue(new Error('network'));
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toBeNull();
+    });
+  });
+
+  describe('revokeToken', () => {
+    it('POSTs the token to the revoke endpoint', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, {}));
+      await svc.revokeToken('tok');
+      const [revokeUrl, init] = fetchMock.mock.calls[0];
+      expect(revokeUrl).toBe('https://auth.openai.com/oauth/revoke');
+      const body = new URLSearchParams(init.body.toString());
+      expect(body.get('token')).toBe('tok');
+    });
+
+    it('silently logs when the revoke endpoint returns an error', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}, 'bad_token'));
+      await expect(svc.revokeToken('x')).resolves.toBeUndefined();
+    });
+
+    it('silently logs on network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('network'));
+      await expect(svc.revokeToken('x')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearPendingState', () => {
+    it('removes a known pending state', async () => {
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(svc.getPendingCount()).toBe(1);
+      svc.clearPendingState(state);
+      expect(svc.getPendingCount()).toBe(0);
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/cache-injection.spec.ts
+++ b/packages/backend/src/routing/proxy/cache-injection.spec.ts
@@ -1,0 +1,124 @@
+import { injectOpenRouterCacheControl } from './cache-injection';
+
+const EPHEMERAL = { type: 'ephemeral' } as const;
+
+describe('injectOpenRouterCacheControl', () => {
+  it('is a no-op when the body has no messages array', () => {
+    const body: Record<string, unknown> = {};
+    injectOpenRouterCacheControl(body);
+    expect(body).toEqual({});
+  });
+
+  it('converts a string system message into a text block with cache_control', () => {
+    const body = {
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'hi' },
+      ],
+    };
+    injectOpenRouterCacheControl(body);
+    expect(body.messages[0]).toEqual({
+      role: 'system',
+      content: [
+        {
+          type: 'text',
+          text: 'You are a helpful assistant.',
+          cache_control: EPHEMERAL,
+        },
+      ],
+    });
+    // User message is untouched.
+    expect(body.messages[1]).toEqual({ role: 'user', content: 'hi' });
+  });
+
+  it('handles developer-role messages the same as system', () => {
+    const body = {
+      messages: [{ role: 'developer', content: 'system-ish' }],
+    };
+    injectOpenRouterCacheControl(body);
+    expect(body.messages[0].content).toEqual([
+      { type: 'text', text: 'system-ish', cache_control: EPHEMERAL },
+    ]);
+  });
+
+  it('injects cache_control on the last block of a multi-block array content', () => {
+    const body = {
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { type: 'text', text: 'first' },
+            { type: 'text', text: 'second' },
+          ],
+        },
+      ],
+    };
+    injectOpenRouterCacheControl(body);
+    const blocks = body.messages[0].content as Array<Record<string, unknown>>;
+    expect(blocks[0]).toEqual({ type: 'text', text: 'first' });
+    expect(blocks[1]).toEqual({ type: 'text', text: 'second', cache_control: EPHEMERAL });
+  });
+
+  it('only mutates the last system/developer message', () => {
+    const body = {
+      messages: [
+        { role: 'system', content: 'first system' },
+        { role: 'user', content: 'hi' },
+        { role: 'system', content: 'last system' },
+      ],
+    };
+    injectOpenRouterCacheControl(body);
+    // The first system message is untouched.
+    expect(body.messages[0]).toEqual({ role: 'system', content: 'first system' });
+    // The last system message is converted.
+    expect(body.messages[2].content).toEqual([
+      { type: 'text', text: 'last system', cache_control: EPHEMERAL },
+    ]);
+  });
+
+  it('skips array content that is empty (no block to stamp)', () => {
+    const body = {
+      messages: [{ role: 'system', content: [] }],
+    };
+    injectOpenRouterCacheControl(body);
+    expect(body.messages[0].content).toEqual([]);
+  });
+
+  it('does nothing when no system/developer message exists', () => {
+    const body = {
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' },
+      ],
+    };
+    const snapshot = JSON.parse(JSON.stringify(body));
+    injectOpenRouterCacheControl(body);
+    expect(body).toEqual(snapshot);
+  });
+
+  it('injects cache_control on the last tool definition when tools are present', () => {
+    const body = {
+      messages: [{ role: 'system', content: 'x' }],
+      tools: [
+        { type: 'function', function: { name: 'a' } },
+        { type: 'function', function: { name: 'b' } },
+      ],
+    };
+    injectOpenRouterCacheControl(body);
+    expect(body.tools[0]).toEqual({ type: 'function', function: { name: 'a' } });
+    expect(body.tools[1]).toEqual({
+      type: 'function',
+      function: { name: 'b' },
+      cache_control: EPHEMERAL,
+    });
+  });
+
+  it('does not touch tools when the array is empty', () => {
+    const body = {
+      messages: [{ role: 'system', content: 'x' }],
+      tools: [],
+    };
+    injectOpenRouterCacheControl(body);
+    expect(body.tools).toEqual([]);
+  });
+});

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -1,0 +1,301 @@
+import {
+  collectChatGptSseResponse,
+  fromResponsesResponse,
+  toResponsesRequest,
+  transformResponsesStreamChunk,
+} from './chatgpt-adapter';
+
+describe('chatgpt-adapter', () => {
+  describe('toResponsesRequest', () => {
+    it('drops system/developer messages from input but lifts them into instructions', () => {
+      const body = {
+        messages: [
+          { role: 'system', content: 'You are careful.' },
+          { role: 'developer', content: 'Use markdown.' },
+          { role: 'user', content: 'hi' },
+        ],
+      };
+      const req = toResponsesRequest(body, 'gpt-5.2-codex');
+      expect(req.model).toBe('gpt-5.2-codex');
+      expect(req.instructions).toBe('You are careful.\n\nUse markdown.');
+      expect(req.store).toBe(false);
+      expect(req.stream).toBe(true);
+      const input = req.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(1);
+      expect(input[0].role).toBe('user');
+    });
+
+    it('honours explicit stream: false from the caller', () => {
+      const body = {
+        stream: false,
+        messages: [{ role: 'user', content: 'hi' }],
+      };
+      const req = toResponsesRequest(body, 'gpt-5');
+      expect(req.stream).toBe(false);
+    });
+
+    it('converts assistant tool_calls to function_call items and keeps any preceding text', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'run foo' },
+          {
+            role: 'assistant',
+            content: 'thinking…',
+            tool_calls: [{ id: 'call-1', function: { name: 'foo', arguments: '{"a":1}' } }],
+          },
+          { role: 'tool', tool_call_id: 'call-1', content: 'ok' },
+        ],
+      };
+      const req = toResponsesRequest(body, 'gpt-5');
+      const input = req.input as Array<Record<string, unknown>>;
+      // user, assistant text, function_call, function_call_output
+      expect(input).toHaveLength(4);
+      expect(input[0].role).toBe('user');
+      expect(input[1]).toMatchObject({ role: 'assistant' });
+      expect(input[2]).toMatchObject({
+        type: 'function_call',
+        call_id: 'call-1',
+        name: 'foo',
+        arguments: '{"a":1}',
+      });
+      expect(input[3]).toMatchObject({
+        type: 'function_call_output',
+        call_id: 'call-1',
+        output: 'ok',
+      });
+    });
+
+    it('falls back to a UUID call_id when a tool message omits tool_call_id', () => {
+      const body = {
+        messages: [{ role: 'tool', content: 'result' }],
+      };
+      const req = toResponsesRequest(body, 'gpt-5');
+      const input = req.input as Array<Record<string, unknown>>;
+      expect(input[0].type).toBe('function_call_output');
+      expect(typeof input[0].call_id).toBe('string');
+      expect((input[0].call_id as string).length).toBeGreaterThan(0);
+    });
+
+    it('serialises tools through convertTools when provided', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [
+          {
+            type: 'function',
+            function: { name: 'add', parameters: { type: 'object' } },
+          },
+        ],
+      };
+      const req = toResponsesRequest(body, 'gpt-5');
+      expect(req.tools).toEqual([
+        { type: 'function', name: 'add', parameters: { type: 'object' } },
+      ]);
+    });
+  });
+
+  describe('fromResponsesResponse', () => {
+    it('assembles a Chat Completion envelope with text output', () => {
+      const out = fromResponsesResponse(
+        {
+          output: [
+            {
+              type: 'message',
+              content: [
+                { type: 'output_text', text: 'Hello ' },
+                { type: 'output_text', text: 'world' },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+            total_tokens: 12,
+            input_tokens_details: { cached_tokens: 3 },
+          },
+        },
+        'gpt-5',
+      );
+      expect(out.object).toBe('chat.completion');
+      expect(out.model).toBe('gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      expect(choices[0].finish_reason).toBe('stop');
+      expect((choices[0].message as Record<string, unknown>).content).toBe('Hello world');
+      expect(out.usage).toMatchObject({
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+        cache_read_tokens: 3,
+        cache_creation_tokens: 0,
+      });
+    });
+
+    it('assembles a tool_calls envelope and sets finish_reason accordingly', () => {
+      const out = fromResponsesResponse(
+        {
+          output: [{ type: 'function_call', call_id: 'c1', name: 'foo', arguments: '{"x":1}' }],
+        },
+        'gpt-5',
+      );
+      const choices = out.choices as Array<Record<string, unknown>>;
+      expect(choices[0].finish_reason).toBe('tool_calls');
+      const message = choices[0].message as Record<string, unknown>;
+      expect(message.content).toBeNull();
+      expect(message.tool_calls).toEqual([
+        {
+          id: 'c1',
+          type: 'function',
+          function: { name: 'foo', arguments: '{"x":1}' },
+        },
+      ]);
+    });
+
+    it('defaults missing usage fields to zero', () => {
+      const out = fromResponsesResponse({ output: [] }, 'gpt-5');
+      expect(out.usage).toEqual({
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      });
+    });
+
+    it('tolerates message output items with no content field', () => {
+      const out = fromResponsesResponse({ output: [{ type: 'message' }] }, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      expect((choices[0].message as Record<string, unknown>).content).toBeNull();
+    });
+  });
+
+  describe('transformResponsesStreamChunk', () => {
+    function parseFrame(frame: string | null) {
+      if (!frame) return null;
+      const first = frame.split('\n\n')[0];
+      return JSON.parse(first.replace(/^data: /, ''));
+    }
+
+    it('returns null for irrelevant events', () => {
+      expect(
+        transformResponsesStreamChunk('event: response.created\ndata: {}', 'gpt-5'),
+      ).toBeNull();
+      expect(transformResponsesStreamChunk('', 'gpt-5')).toBeNull();
+    });
+
+    it('converts output_text.delta events into a Chat Completion content delta', () => {
+      const chunk = 'event: response.output_text.delta\ndata: {"delta":"hi"}';
+      const parsed = parseFrame(transformResponsesStreamChunk(chunk, 'gpt-5'));
+      expect(parsed.choices[0]).toEqual({
+        index: 0,
+        delta: { content: 'hi' },
+        finish_reason: null,
+      });
+    });
+
+    it('converts function_call_arguments.delta into a tool_calls.arguments delta', () => {
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"delta":"foo","output_index":1}';
+      const parsed = parseFrame(transformResponsesStreamChunk(chunk, 'gpt-5'));
+      expect(parsed.choices[0].delta.tool_calls).toEqual([
+        { index: 1, function: { arguments: 'foo' } },
+      ]);
+    });
+
+    it('converts output_item.added (function_call) into a tool_calls announcement', () => {
+      const chunk =
+        'event: response.output_item.added\ndata: {"output_index":2,"item":{"type":"function_call","call_id":"c1","name":"foo"}}';
+      const parsed = parseFrame(transformResponsesStreamChunk(chunk, 'gpt-5'));
+      expect(parsed.choices[0].delta.tool_calls).toEqual([
+        {
+          index: 2,
+          id: 'c1',
+          type: 'function',
+          function: { name: 'foo', arguments: '' },
+        },
+      ]);
+    });
+
+    it('ignores output_item.added events for non-function items', () => {
+      const chunk =
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"message"}}';
+      expect(transformResponsesStreamChunk(chunk, 'gpt-5')).toBeNull();
+    });
+
+    it('emits a finish frame + [DONE] on response.completed with usage', () => {
+      const chunk =
+        'event: response.completed\ndata: {"response":{"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":1}},"output":[]}}';
+      const raw = transformResponsesStreamChunk(chunk, 'gpt-5');
+      expect(raw).not.toBeNull();
+      expect(raw!.trim().endsWith('data: [DONE]')).toBe(true);
+      const first = raw!.split('\n\n')[0];
+      const parsed = JSON.parse(first.replace(/^data: /, ''));
+      expect(parsed.choices[0].finish_reason).toBe('stop');
+      expect(parsed.usage).toMatchObject({ prompt_tokens: 1, completion_tokens: 2 });
+    });
+
+    it('marks finish_reason=tool_calls when the completed response had function_call items', () => {
+      const chunk =
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}';
+      const raw = transformResponsesStreamChunk(chunk, 'gpt-5');
+      const first = raw!.split('\n\n')[0];
+      const parsed = JSON.parse(first.replace(/^data: /, ''));
+      expect(parsed.choices[0].finish_reason).toBe('tool_calls');
+      // No usage attached.
+      expect(parsed.usage).toBeUndefined();
+    });
+  });
+
+  describe('collectChatGptSseResponse', () => {
+    it('collects text deltas and completed usage into a non-streaming envelope', () => {
+      const sse = [
+        'event: response.output_text.delta\ndata: {"delta":"Hello "}',
+        'event: response.output_text.delta\ndata: {"delta":"world"}',
+        'event: response.completed\ndata: {"response":{"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      expect((choices[0].message as Record<string, unknown>).content).toBe('Hello world');
+      expect(choices[0].finish_reason).toBe('stop');
+      expect(out.usage).toMatchObject({ prompt_tokens: 1, completion_tokens: 2 });
+    });
+
+    it('reconstructs tool calls across multiple deltas and reports finish_reason=tool_calls', () => {
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c1","name":"foo"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"x"}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"\\":1}"}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+      expect(choices[0].finish_reason).toBe('tool_calls');
+      expect(message.tool_calls).toEqual([
+        {
+          id: 'c1',
+          type: 'function',
+          function: { name: 'foo', arguments: '{"x":1}' },
+        },
+      ]);
+    });
+
+    it('ignores malformed SSE events and falls back to zero usage', () => {
+      const sse = 'event: response.output_text.delta\ndata: not-json';
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      expect(out.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+      const choices = out.choices as Array<Record<string, unknown>>;
+      expect((choices[0].message as Record<string, unknown>).content).toBeNull();
+    });
+
+    it('drops function_call_arguments deltas that arrive for an unknown output_index', () => {
+      // No output_item.added ever arrives, so the arguments delta should be ignored.
+      const sse = [
+        'event: response.function_call_arguments.delta\ndata: {"output_index":7,"delta":"lost"}',
+        'event: response.completed\ndata: {"response":{"output":[]}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      expect((choices[0].message as Record<string, unknown>).tool_calls).toBeUndefined();
+      expect(choices[0].finish_reason).toBe('stop');
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/chatgpt-helpers.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-helpers.spec.ts
@@ -1,0 +1,190 @@
+import {
+  convertAssistantToolCalls,
+  convertContent,
+  convertTools,
+  extractInstructions,
+  extractTextContent,
+  formatSSE,
+  isObjectRecord,
+  safeParse,
+} from './chatgpt-helpers';
+import { OpenAIMessage } from './proxy-types';
+
+describe('chatgpt-helpers', () => {
+  describe('isObjectRecord', () => {
+    it('accepts plain object records', () => {
+      expect(isObjectRecord({})).toBe(true);
+      expect(isObjectRecord({ a: 1 })).toBe(true);
+    });
+
+    it('rejects arrays, null, and primitives', () => {
+      expect(isObjectRecord(null)).toBe(false);
+      expect(isObjectRecord(undefined)).toBe(false);
+      expect(isObjectRecord([])).toBe(false);
+      expect(isObjectRecord('x')).toBe(false);
+      expect(isObjectRecord(42)).toBe(false);
+    });
+  });
+
+  describe('safeParse', () => {
+    it('parses valid JSON', () => {
+      expect(safeParse('{"a":1}')).toEqual({ a: 1 });
+    });
+
+    it('returns null for malformed JSON', () => {
+      expect(safeParse('not-json')).toBeNull();
+      expect(safeParse('')).toBeNull();
+    });
+  });
+
+  describe('convertAssistantToolCalls', () => {
+    it('skips entries that are not proper tool call shapes', () => {
+      expect(convertAssistantToolCalls([null, 'string', 42, { function: 'not-object' }])).toEqual(
+        [],
+      );
+    });
+
+    it('produces a function_call entry per tool call with explicit id fallback', () => {
+      const out = convertAssistantToolCalls([
+        { id: 'call-1', function: { name: 'foo', arguments: '{"x":1}' } },
+        { function: { name: 'bar' } }, // id missing → random UUID assigned
+      ]);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toEqual({
+        type: 'function_call',
+        call_id: 'call-1',
+        name: 'foo',
+        arguments: '{"x":1}',
+      });
+      expect(out[1].type).toBe('function_call');
+      expect(out[1].name).toBe('bar');
+      expect(out[1].arguments).toBe('{}');
+      expect(typeof out[1].call_id).toBe('string');
+      expect((out[1].call_id as string).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('convertTools', () => {
+    it('rewrites OpenAI function tools into the Responses API format', () => {
+      const tools = [
+        {
+          type: 'function',
+          function: {
+            name: 'add',
+            description: 'add numbers',
+            parameters: { type: 'object' },
+            strict: true,
+          },
+        },
+      ];
+      expect(convertTools(tools)).toEqual([
+        {
+          type: 'function',
+          name: 'add',
+          description: 'add numbers',
+          parameters: { type: 'object' },
+          strict: true,
+        },
+      ]);
+    });
+
+    it('omits optional fields when absent', () => {
+      const out = convertTools([{ type: 'function', function: { name: 'noop' } }]);
+      expect(out[0]).toEqual({ type: 'function', name: 'noop' });
+    });
+
+    it('passes through non-function tools unchanged', () => {
+      const tool = { type: 'web_search' };
+      expect(convertTools([tool])).toEqual([tool]);
+    });
+  });
+
+  describe('convertContent', () => {
+    it('maps null/undefined content to an empty text part', () => {
+      expect(convertContent(null, 'user')).toEqual([{ type: 'input_text', text: '' }]);
+      expect(convertContent(undefined, 'assistant')).toEqual([{ type: 'output_text', text: '' }]);
+    });
+
+    it('wraps a bare string in the role-appropriate text part', () => {
+      expect(convertContent('hi', 'user')).toEqual([{ type: 'input_text', text: 'hi' }]);
+      expect(convertContent('hi', 'assistant')).toEqual([{ type: 'output_text', text: 'hi' }]);
+    });
+
+    it('renames "text" parts to input_text/output_text but leaves other parts alone', () => {
+      const parts = [
+        { type: 'text', text: 'hello' },
+        { type: 'image_url', image_url: { url: 'x' } },
+      ];
+      expect(convertContent(parts, 'user')).toEqual([
+        { type: 'input_text', text: 'hello' },
+        { type: 'image_url', image_url: { url: 'x' } },
+      ]);
+    });
+
+    it('passes through non-array content unchanged (unusual input)', () => {
+      expect(convertContent({ weird: true }, 'user')).toEqual({ weird: true });
+    });
+  });
+
+  describe('extractInstructions', () => {
+    it('joins system and developer text messages with a blank line between them', () => {
+      const messages: OpenAIMessage[] = [
+        { role: 'system', content: 'A' },
+        { role: 'user', content: 'ignored' },
+        { role: 'developer', content: 'B' },
+      ];
+      expect(extractInstructions(messages)).toBe('A\n\nB');
+    });
+
+    it('falls back to a default when no instructions are present', () => {
+      const messages: OpenAIMessage[] = [{ role: 'user', content: 'hi' }];
+      expect(extractInstructions(messages)).toBe('You are a helpful assistant.');
+    });
+  });
+
+  describe('extractTextContent', () => {
+    it('returns strings directly (or null for empty)', () => {
+      expect(extractTextContent('hi')).toBe('hi');
+      expect(extractTextContent('')).toBeNull();
+    });
+
+    it('joins text-ish parts from a multimodal array', () => {
+      expect(
+        extractTextContent([
+          { type: 'text', text: 'a' },
+          { type: 'input_text', text: 'b' },
+          { type: 'output_text', text: 'c' },
+          { type: 'image_url', url: 'x' },
+        ]),
+      ).toBe('abc');
+    });
+
+    it('returns null for non-array, non-string content and for empty results', () => {
+      expect(extractTextContent(null)).toBeNull();
+      expect(extractTextContent([])).toBeNull();
+      expect(extractTextContent([{ type: 'image_url' }])).toBeNull();
+    });
+  });
+
+  describe('formatSSE', () => {
+    it('emits a chat.completion.chunk SSE frame with the given choice and model', () => {
+      const frame = formatSSE({ delta: { content: 'hi' }, finish_reason: null }, 'gpt-5.2-codex');
+      expect(frame.startsWith('data: ')).toBe(true);
+      expect(frame.endsWith('\n\n')).toBe(true);
+      const parsed = JSON.parse(frame.slice(6).trim());
+      expect(parsed.object).toBe('chat.completion.chunk');
+      expect(parsed.model).toBe('gpt-5.2-codex');
+      expect(parsed.choices[0]).toEqual({
+        index: 0,
+        delta: { content: 'hi' },
+        finish_reason: null,
+      });
+    });
+
+    it('appends usage when provided', () => {
+      const frame = formatSSE({ delta: {}, finish_reason: 'stop' }, 'gpt-5', { prompt_tokens: 1 });
+      const parsed = JSON.parse(frame.slice(6).trim());
+      expect(parsed.usage).toEqual({ prompt_tokens: 1 });
+    });
+  });
+});

--- a/packages/backend/src/routing/resolve/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.spec.ts
@@ -1,0 +1,377 @@
+jest.mock('../../scoring', () => {
+  const scoreRequest = jest.fn();
+  const scanMessages = jest.fn();
+  return { scoreRequest, scanMessages };
+});
+
+import { ResolveService } from './resolve.service';
+import { TierService } from '../routing-core/tier.service';
+import { ProviderKeyService } from '../routing-core/provider-key.service';
+import { SpecificityService } from '../routing-core/specificity.service';
+import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const scoring = require('../../scoring');
+
+function makeService(overrides: {
+  tiers?: unknown[];
+  getEffectiveModel?: jest.Mock;
+  getAuthType?: jest.Mock;
+  hasActiveProvider?: jest.Mock;
+  activeSpecificity?: unknown[];
+  getModelForAgent?: jest.Mock;
+  getByModel?: jest.Mock;
+}) {
+  const tierService: TierService = {
+    getTiers: jest.fn().mockResolvedValue(overrides.tiers ?? []),
+  } as unknown as TierService;
+
+  const providerKeyService: ProviderKeyService = {
+    getEffectiveModel: overrides.getEffectiveModel ?? jest.fn().mockResolvedValue(null),
+    getAuthType: overrides.getAuthType ?? jest.fn().mockResolvedValue('api_key'),
+    hasActiveProvider: overrides.hasActiveProvider ?? jest.fn().mockResolvedValue(false),
+  } as unknown as ProviderKeyService;
+
+  const specificityService: SpecificityService = {
+    getActiveAssignments: jest.fn().mockResolvedValue(overrides.activeSpecificity ?? []),
+  } as unknown as SpecificityService;
+
+  const discoveryService: ModelDiscoveryService = {
+    getModelForAgent: overrides.getModelForAgent ?? jest.fn().mockResolvedValue(null),
+  } as unknown as ModelDiscoveryService;
+
+  const pricingCache: ModelPricingCacheService = {
+    getByModel: overrides.getByModel ?? jest.fn().mockReturnValue(null),
+  } as unknown as ModelPricingCacheService;
+
+  const svc = new ResolveService(
+    tierService,
+    providerKeyService,
+    specificityService,
+    pricingCache,
+    discoveryService,
+  );
+  return {
+    svc,
+    tierService,
+    providerKeyService,
+    specificityService,
+    discoveryService,
+    pricingCache,
+  };
+}
+
+describe('ResolveService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -- resolve() via specificity path --
+
+  describe('specificity path', () => {
+    it('is skipped when no specificity assignments are active', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'simple',
+        confidence: 1,
+        score: 0,
+        reason: 'scored',
+      });
+      scoring.scanMessages.mockReturnValue(null);
+      const { svc } = makeService({ tiers: [] });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'hi' }]);
+      expect(out.tier).toBe('simple');
+      expect(out.reason).toBe('scored');
+      expect(scoring.scoreRequest).toHaveBeenCalled();
+    });
+
+    it('is skipped when scanMessages returns no match', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'standard',
+        confidence: 0.5,
+        score: 10,
+        reason: 'scored',
+      });
+      scoring.scanMessages.mockReturnValue(null);
+      const { svc } = makeService({
+        activeSpecificity: [{ category: 'coding', override_model: 'x', auto_assigned_model: 'x' }],
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'hi' }]);
+      expect(out.reason).toBe('scored');
+    });
+
+    it('returns null (falls through) when the detected category has no matching assignment', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'simple',
+        confidence: 1,
+        score: 0,
+        reason: 'scored',
+      });
+      scoring.scanMessages.mockReturnValue({ category: 'trading', confidence: 0.8 });
+      const { svc } = makeService({
+        activeSpecificity: [{ category: 'coding', override_model: 'x', auto_assigned_model: 'x' }],
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'hi' }]);
+      expect(out.reason).toBe('scored');
+    });
+
+    it('falls through when the matching assignment has no model configured', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'simple',
+        confidence: 1,
+        score: 0,
+        reason: 'scored',
+      });
+      scoring.scanMessages.mockReturnValue({ category: 'coding', confidence: 0.8 });
+      const { svc } = makeService({
+        activeSpecificity: [
+          { category: 'coding', override_model: null, auto_assigned_model: null },
+        ],
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'hi' }]);
+      expect(out.reason).toBe('scored');
+    });
+
+    it('returns the specificity response with provider + auth type when a match hits', async () => {
+      scoring.scanMessages.mockReturnValue({ category: 'coding', confidence: 0.9 });
+      const hasActiveProvider = jest.fn().mockResolvedValue(true);
+      const getAuthType = jest.fn().mockResolvedValue('subscription');
+      const { svc } = makeService({
+        activeSpecificity: [
+          {
+            category: 'coding',
+            override_model: 'anthropic/claude-opus-4',
+            auto_assigned_model: null,
+            override_provider: null,
+            fallback_models: ['anthropic/claude-sonnet-4'],
+          },
+        ],
+        hasActiveProvider,
+        getAuthType,
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'write some code' }]);
+      expect(out.tier).toBe('standard');
+      expect(out.reason).toBe('specificity');
+      expect(out.model).toBe('anthropic/claude-opus-4');
+      expect(out.provider).toBe('anthropic');
+      expect(out.auth_type).toBe('subscription');
+      expect(out.specificity_category).toBe('coding');
+      expect(out.fallback_models).toEqual(['anthropic/claude-sonnet-4']);
+      expect(scoring.scoreRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  // -- resolve() complexity path --
+
+  describe('complexity path', () => {
+    beforeEach(() => {
+      scoring.scanMessages.mockReturnValue(null);
+    });
+
+    it('returns a blank-model response when no tier assignment exists for the scored tier', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'complex',
+        confidence: 0.7,
+        score: 50,
+        reason: 'scored',
+      });
+      const { svc } = makeService({ tiers: [{ tier: 'simple' }] });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'hi' }]);
+      expect(out.model).toBeNull();
+      expect(out.provider).toBeNull();
+      expect(out.tier).toBe('complex');
+    });
+
+    it('returns a blank-model response when getEffectiveModel returns null', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'standard',
+        confidence: 0.5,
+        score: 20,
+        reason: 'scored',
+      });
+      const { svc } = makeService({
+        tiers: [{ tier: 'standard', override_model: null, auto_assigned_model: null }],
+        getEffectiveModel: jest.fn().mockResolvedValue(null),
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'x' }]);
+      expect(out.model).toBeNull();
+      expect(out.provider).toBeNull();
+    });
+
+    it('returns the resolved model + provider when the tier has an active provider', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'reasoning',
+        confidence: 0.9,
+        score: 90,
+        reason: 'scored',
+      });
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'reasoning',
+            override_model: null,
+            auto_assigned_model: 'openai/o1',
+            override_provider: null,
+            override_auth_type: null,
+          },
+        ],
+        getEffectiveModel: jest.fn().mockResolvedValue('openai/o1'),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+        getAuthType: jest.fn().mockResolvedValue('api_key'),
+      });
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'x' }],
+        undefined,
+        undefined,
+        undefined,
+        ['simple', 'standard'],
+      );
+      expect(out.model).toBe('openai/o1');
+      expect(out.provider).toBe('openai');
+      expect(out.auth_type).toBe('api_key');
+    });
+
+    it('respects override_provider when the assignment explicitly pins one', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'standard',
+        confidence: 0.5,
+        score: 20,
+        reason: 'scored',
+      });
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'standard',
+            override_model: 'custom-model',
+            override_provider: 'openrouter',
+            auto_assigned_model: null,
+            override_auth_type: null,
+          },
+        ],
+        getEffectiveModel: jest.fn().mockResolvedValue('custom-model'),
+        getAuthType: jest.fn().mockResolvedValue('api_key'),
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'hi' }]);
+      expect(out.provider).toBe('openrouter');
+    });
+
+    it('falls back to discovered models when prefix inference misses or provider not connected', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'simple',
+        confidence: 1,
+        score: 0,
+        reason: 'scored',
+      });
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'simple',
+            override_model: null,
+            auto_assigned_model: 'weird-model',
+            override_provider: null,
+            override_auth_type: null,
+          },
+        ],
+        getEffectiveModel: jest.fn().mockResolvedValue('weird-model'),
+        hasActiveProvider: jest.fn().mockResolvedValue(false),
+        getModelForAgent: jest.fn().mockResolvedValue({ provider: 'xyz' }),
+        getAuthType: jest.fn().mockResolvedValue('api_key'),
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'x' }]);
+      expect(out.provider).toBe('xyz');
+    });
+
+    it('falls back to pricing cache (ignoring OpenRouter entries) as a last resort', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'simple',
+        confidence: 1,
+        score: 0,
+        reason: 'scored',
+      });
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'simple',
+            override_model: null,
+            auto_assigned_model: 'rare-model',
+            override_provider: null,
+            override_auth_type: null,
+          },
+        ],
+        getEffectiveModel: jest.fn().mockResolvedValue('rare-model'),
+        hasActiveProvider: jest.fn().mockResolvedValue(false),
+        getModelForAgent: jest.fn().mockResolvedValue(null),
+        getByModel: jest.fn().mockReturnValue({ provider: 'Anthropic' }),
+        getAuthType: jest.fn().mockResolvedValue('api_key'),
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'x' }]);
+      expect(out.provider).toBe('Anthropic');
+    });
+
+    it('returns provider=null when pricing cache only has an OpenRouter entry (ambiguous attribution)', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'simple',
+        confidence: 1,
+        score: 0,
+        reason: 'scored',
+      });
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'simple',
+            override_model: null,
+            auto_assigned_model: 'only-on-openrouter',
+            override_provider: null,
+            override_auth_type: null,
+          },
+        ],
+        getEffectiveModel: jest.fn().mockResolvedValue('only-on-openrouter'),
+        hasActiveProvider: jest.fn().mockResolvedValue(false),
+        getModelForAgent: jest.fn().mockResolvedValue(null),
+        getByModel: jest.fn().mockReturnValue({ provider: 'OpenRouter' }),
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'x' }]);
+      expect(out.provider).toBeNull();
+      expect(out.auth_type).toBeUndefined();
+    });
+  });
+
+  // -- resolveForTier (heartbeat path) --
+
+  describe('resolveForTier', () => {
+    it('returns a heartbeat response with a null model when the tier has no assignment', async () => {
+      const { svc } = makeService({ tiers: [] });
+      const out = await svc.resolveForTier('agent-1', 'simple');
+      expect(out).toEqual({
+        tier: 'simple',
+        model: null,
+        provider: null,
+        confidence: 1,
+        score: 0,
+        reason: 'heartbeat',
+      });
+    });
+
+    it('returns a heartbeat response populated with model + provider when available', async () => {
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'simple',
+            override_model: null,
+            auto_assigned_model: 'openai/gpt-5-mini',
+            override_provider: null,
+            override_auth_type: null,
+          },
+        ],
+        getEffectiveModel: jest.fn().mockResolvedValue('openai/gpt-5-mini'),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+        getAuthType: jest.fn().mockResolvedValue('api_key'),
+      });
+      const out = await svc.resolveForTier('agent-1', 'simple');
+      expect(out.reason).toBe('heartbeat');
+      expect(out.model).toBe('openai/gpt-5-mini');
+      expect(out.provider).toBe('openai');
+      expect(out.auth_type).toBe('api_key');
+    });
+  });
+});

--- a/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
@@ -1,0 +1,91 @@
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { ResolveAgentService } from './resolve-agent.service';
+import { Agent } from '../../entities/agent.entity';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
+
+function makeAgentRepo(findOne: jest.Mock): Repository<Agent> {
+  return { findOne } as unknown as Repository<Agent>;
+}
+
+function makeTenantCache(resolve: jest.Mock): TenantCacheService {
+  return { resolve } as unknown as TenantCacheService;
+}
+
+describe('ResolveAgentService', () => {
+  let findOne: jest.Mock;
+  let tenantResolve: jest.Mock;
+  let svc: ResolveAgentService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+    findOne = jest.fn();
+    tenantResolve = jest.fn();
+    svc = new ResolveAgentService(makeAgentRepo(findOne), makeTenantCache(tenantResolve));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('throws NotFoundException when the user has no tenant', async () => {
+    tenantResolve.mockResolvedValue(null);
+    await expect(svc.resolve('user-1', 'demo-agent')).rejects.toBeInstanceOf(NotFoundException);
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException when the agent does not exist for the tenant', async () => {
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(null);
+    await expect(svc.resolve('user-1', 'missing')).rejects.toBeInstanceOf(NotFoundException);
+    expect(findOne).toHaveBeenCalledWith({ where: { tenant_id: 'tenant-1', name: 'missing' } });
+  });
+
+  it('returns and caches the agent on a successful lookup', async () => {
+    const agent = { id: 'agent-1', name: 'demo-agent' } as Agent;
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(agent);
+
+    const first = await svc.resolve('user-1', 'demo-agent');
+    const second = await svc.resolve('user-1', 'demo-agent');
+
+    expect(first).toBe(agent);
+    expect(second).toBe(agent);
+    // Second call hits the cache — repo should only be consulted once.
+    expect(findOne).toHaveBeenCalledTimes(1);
+    // Tenant resolution still happens on every call (it has its own cache).
+    expect(tenantResolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-queries the repo after the TTL expires', async () => {
+    const agent = { id: 'agent-1', name: 'demo-agent' } as Agent;
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(agent);
+
+    await svc.resolve('user-1', 'demo-agent');
+    jest.advanceTimersByTime(120_001);
+    await svc.resolve('user-1', 'demo-agent');
+
+    expect(findOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('scopes the cache by tenant — two users with the same agent name do not collide', async () => {
+    const agentA = { id: 'a', name: 'agent' } as Agent;
+    const agentB = { id: 'b', name: 'agent' } as Agent;
+
+    tenantResolve
+      .mockResolvedValueOnce('tenant-A')
+      .mockResolvedValueOnce('tenant-B')
+      .mockResolvedValueOnce('tenant-A')
+      .mockResolvedValueOnce('tenant-B');
+    findOne.mockResolvedValueOnce(agentA).mockResolvedValueOnce(agentB);
+
+    expect(await svc.resolve('user-A', 'agent')).toBe(agentA);
+    expect(await svc.resolve('user-B', 'agent')).toBe(agentB);
+    // Repeats should be cache hits.
+    expect(await svc.resolve('user-A', 'agent')).toBe(agentA);
+    expect(await svc.resolve('user-B', 'agent')).toBe(agentB);
+    expect(findOne).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/routing/routing-core/routing-cache.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/routing-cache.service.spec.ts
@@ -1,0 +1,137 @@
+import { RoutingCacheService } from './routing-cache.service';
+import { TierAssignment } from '../../entities/tier-assignment.entity';
+import { UserProvider } from '../../entities/user-provider.entity';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
+
+// Minimal stand-ins for the TypeORM entities. The cache is entity-agnostic — it
+// only stores arrays by reference, so shape fidelity is unnecessary.
+const tier = (name: string): TierAssignment => ({ id: name }) as unknown as TierAssignment;
+const provider = (name: string): UserProvider => ({ id: name }) as unknown as UserProvider;
+const customProvider = (name: string): CustomProvider =>
+  ({ id: name }) as unknown as CustomProvider;
+const specificity = (name: string): SpecificityAssignment =>
+  ({ id: name }) as unknown as SpecificityAssignment;
+
+describe('RoutingCacheService', () => {
+  let svc: RoutingCacheService;
+
+  beforeEach(() => {
+    svc = new RoutingCacheService();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('tier cache', () => {
+    it('returns null when nothing is cached', () => {
+      expect(svc.getTiers('agent-1')).toBeNull();
+    });
+
+    it('returns cached data on a hit', () => {
+      const data = [tier('t1')];
+      svc.setTiers('agent-1', data);
+      expect(svc.getTiers('agent-1')).toBe(data);
+    });
+
+    it('expires entries after the 2-minute TTL and purges the stale key', () => {
+      svc.setTiers('agent-1', [tier('t1')]);
+      jest.advanceTimersByTime(119_000);
+      expect(svc.getTiers('agent-1')).not.toBeNull();
+      jest.advanceTimersByTime(2_000); // cross the 120s boundary
+      expect(svc.getTiers('agent-1')).toBeNull();
+    });
+  });
+
+  describe('provider, customProvider and specificity caches', () => {
+    it('store and return data independently', () => {
+      const p = [provider('p1')];
+      const c = [customProvider('c1')];
+      const s = [specificity('s1')];
+      svc.setProviders('a', p);
+      svc.setCustomProviders('a', c);
+      svc.setSpecificity('a', s);
+      expect(svc.getProviders('a')).toBe(p);
+      expect(svc.getCustomProviders('a')).toBe(c);
+      expect(svc.getSpecificity('a')).toBe(s);
+    });
+
+    it('return null for a different agent id', () => {
+      svc.setProviders('a', [provider('p1')]);
+      expect(svc.getProviders('b')).toBeNull();
+    });
+  });
+
+  describe('api key cache', () => {
+    it('returns undefined when nothing is cached', () => {
+      expect(svc.getApiKey('a', 'openai')).toBeUndefined();
+    });
+
+    it('caches a null value (provider with no key) as a distinct hit', () => {
+      svc.setApiKey('a', 'openai', null);
+      // Null is a cached value — getApiKey should return null, not undefined.
+      expect(svc.getApiKey('a', 'openai')).toBeNull();
+    });
+
+    it('keys by (agentId, provider, authType) — different authType is a separate slot', () => {
+      svc.setApiKey('a', 'openai', 'key-default');
+      svc.setApiKey('a', 'openai', 'key-sub', 'subscription');
+      expect(svc.getApiKey('a', 'openai')).toBe('key-default');
+      expect(svc.getApiKey('a', 'openai', 'subscription')).toBe('key-sub');
+    });
+  });
+
+  describe('invalidateAgent', () => {
+    it('clears every cache slot for the agent, including all per-provider api keys', () => {
+      svc.setTiers('a', [tier('t1')]);
+      svc.setProviders('a', [provider('p1')]);
+      svc.setCustomProviders('a', [customProvider('c1')]);
+      svc.setSpecificity('a', [specificity('s1')]);
+      svc.setApiKey('a', 'openai', 'k');
+      svc.setApiKey('a', 'anthropic', 'k', 'subscription');
+
+      // Unrelated agent entries should survive.
+      svc.setTiers('b', [tier('t-b')]);
+      svc.setApiKey('b', 'openai', 'k-b');
+
+      svc.invalidateAgent('a');
+
+      expect(svc.getTiers('a')).toBeNull();
+      expect(svc.getProviders('a')).toBeNull();
+      expect(svc.getCustomProviders('a')).toBeNull();
+      expect(svc.getSpecificity('a')).toBeNull();
+      expect(svc.getApiKey('a', 'openai')).toBeUndefined();
+      expect(svc.getApiKey('a', 'anthropic', 'subscription')).toBeUndefined();
+
+      expect(svc.getTiers('b')).not.toBeNull();
+      expect(svc.getApiKey('b', 'openai')).toBe('k-b');
+    });
+  });
+
+  describe('LRU-style eviction at the cap', () => {
+    it('evicts the oldest entry when a new key is inserted at the cap', () => {
+      // Fill to MAX_ENTRIES (5000) using tier slots.
+      for (let i = 0; i < 5000; i++) {
+        svc.setTiers(`agent-${i}`, [tier(`t-${i}`)]);
+      }
+      // Inserting a new key should evict the first-inserted one.
+      svc.setTiers('agent-new', [tier('t-new')]);
+      expect(svc.getTiers('agent-0')).toBeNull();
+      expect(svc.getTiers('agent-new')).not.toBeNull();
+      expect(svc.getTiers('agent-4999')).not.toBeNull();
+    });
+
+    it('updates (does not evict) when writing the same key at the cap', () => {
+      for (let i = 0; i < 5000; i++) {
+        svc.setTiers(`agent-${i}`, [tier(`t-${i}`)]);
+      }
+      svc.setTiers('agent-0', [tier('t-updated')]);
+      expect(svc.getTiers('agent-0')).toEqual([{ id: 't-updated' }]);
+      // No eviction should have happened.
+      expect(svc.getTiers('agent-4999')).not.toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/routing/routing-core/tier-auto-assign.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/tier-auto-assign.service.spec.ts
@@ -1,0 +1,281 @@
+import { Repository } from 'typeorm';
+import { TierAutoAssignService } from './tier-auto-assign.service';
+import { TierAssignment } from '../../entities/tier-assignment.entity';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { DiscoveredModel } from '../../model-discovery/model-fetcher';
+
+function m(partial: Partial<DiscoveredModel> & { id: string; provider: string }): DiscoveredModel {
+  return {
+    name: partial.id,
+    authType: 'api_key',
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    qualityScore: 3,
+    capabilityCode: false,
+    capabilityReasoning: false,
+    ...partial,
+  } as DiscoveredModel;
+}
+
+function makeService(options: {
+  models?: DiscoveredModel[];
+  existingTiers?: Partial<TierAssignment>[];
+}) {
+  const getModelsForAgent = jest.fn().mockResolvedValue(options.models ?? []);
+  const find = jest.fn().mockResolvedValue(options.existingTiers ?? []);
+  const save = jest.fn().mockResolvedValue(undefined);
+  const insert = jest.fn().mockResolvedValue(undefined);
+
+  const discoveryService = { getModelsForAgent } as unknown as ModelDiscoveryService;
+  const tierRepo = { find, save, insert } as unknown as Repository<TierAssignment>;
+  const svc = new TierAutoAssignService(discoveryService, tierRepo);
+  return { svc, getModelsForAgent, find, save, insert };
+}
+
+describe('TierAutoAssignService', () => {
+  describe('pickBest', () => {
+    const svc = new TierAutoAssignService(
+      {} as unknown as ModelDiscoveryService,
+      {} as unknown as Repository<TierAssignment>,
+    );
+
+    it('returns null when no models are available', () => {
+      expect(svc.pickBest([], 'simple')).toBeNull();
+    });
+
+    it('SIMPLE picks the cheapest model regardless of quality', () => {
+      const models = [
+        m({
+          id: 'pricey',
+          provider: 'x',
+          inputPricePerToken: 10,
+          outputPricePerToken: 10,
+          qualityScore: 9,
+        }),
+        m({
+          id: 'cheap',
+          provider: 'y',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 1,
+        }),
+      ];
+      expect(svc.pickBest(models, 'simple')?.model_name).toBe('cheap');
+    });
+
+    it('STANDARD prefers tool-capable quality>=2 models over raw cheapest', () => {
+      const models = [
+        // cheapest but below quality threshold:
+        m({
+          id: 'tiny',
+          provider: 'x',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 1,
+        }),
+        // eligible:
+        m({
+          id: 'std',
+          provider: 'y',
+          inputPricePerToken: 5,
+          outputPricePerToken: 5,
+          qualityScore: 3,
+          capabilityCode: true,
+        }),
+      ];
+      expect(svc.pickBest(models, 'standard')?.model_name).toBe('std');
+    });
+
+    it('STANDARD falls back to the cheapest when no model meets quality>=2', () => {
+      const models = [
+        m({
+          id: 'a',
+          provider: 'x',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 1,
+        }),
+        m({
+          id: 'b',
+          provider: 'x',
+          inputPricePerToken: 5,
+          outputPricePerToken: 5,
+          qualityScore: 1,
+        }),
+      ];
+      expect(svc.pickBest(models, 'standard')?.model_name).toBe('a');
+    });
+
+    it('COMPLEX picks highest quality, breaking ties with a tool-capable preference', () => {
+      const models = [
+        m({
+          id: 'cheap-smart',
+          provider: 'x',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 9,
+        }),
+        m({
+          id: 'tool-smart',
+          provider: 'x',
+          inputPricePerToken: 3,
+          outputPricePerToken: 3,
+          qualityScore: 9,
+          capabilityCode: true,
+        }),
+        m({
+          id: 'dumb',
+          provider: 'x',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 2,
+        }),
+      ];
+      expect(svc.pickBest(models, 'complex')?.model_name).toBe('tool-smart');
+    });
+
+    it('REASONING prefers reasoning-capable models even over higher-quality non-reasoning', () => {
+      const models = [
+        m({
+          id: 'reason',
+          provider: 'x',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 5,
+          capabilityReasoning: true,
+          capabilityCode: true,
+        }),
+        m({
+          id: 'smart',
+          provider: 'x',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 9,
+        }),
+      ];
+      expect(svc.pickBest(models, 'reasoning')?.model_name).toBe('reason');
+    });
+
+    it('REASONING falls back to the COMPLEX ordering when no reasoning models exist', () => {
+      const models = [
+        m({
+          id: 'smart',
+          provider: 'x',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 9,
+        }),
+      ];
+      expect(svc.pickBest(models, 'reasoning')?.model_name).toBe('smart');
+    });
+
+    it('treats missing prices as Infinity so fully-priced models sort first', () => {
+      const models = [
+        m({ id: 'unknown', provider: 'x', inputPricePerToken: null, outputPricePerToken: null }),
+        m({ id: 'priced', provider: 'x', inputPricePerToken: 1, outputPricePerToken: 1 }),
+      ];
+      expect(svc.pickBest(models, 'simple')?.model_name).toBe('priced');
+    });
+  });
+
+  describe('recalculate', () => {
+    it('writes one auto-assigned model per tier, inserting missing tiers and saving the rest', async () => {
+      const models: DiscoveredModel[] = [
+        m({
+          id: 'openai/gpt-5',
+          provider: 'openai',
+          inputPricePerToken: 5,
+          outputPricePerToken: 5,
+          qualityScore: 7,
+          capabilityCode: true,
+        }),
+        m({
+          id: 'anthropic/claude-opus-4',
+          provider: 'anthropic',
+          inputPricePerToken: 10,
+          outputPricePerToken: 10,
+          qualityScore: 9,
+          capabilityCode: true,
+          capabilityReasoning: true,
+        }),
+      ];
+      // Only one existing tier row — the other three get inserted.
+      const existing: Partial<TierAssignment>[] = [
+        { tier: 'simple', agent_id: 'agent-1', auto_assigned_model: null },
+      ];
+      const { svc, save, insert } = makeService({ models, existingTiers: existing });
+      await svc.recalculate('agent-1');
+
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(save.mock.calls[0][0]).toHaveLength(1);
+      expect(save.mock.calls[0][0][0].tier).toBe('simple');
+      expect(save.mock.calls[0][0][0].auto_assigned_model).toBe('openai/gpt-5');
+
+      expect(insert).toHaveBeenCalledTimes(1);
+      const inserted = insert.mock.calls[0][0] as Record<string, unknown>[];
+      expect(inserted.map((r) => r.tier).sort()).toEqual(['complex', 'reasoning', 'standard']);
+      for (const row of inserted) {
+        expect(row.agent_id).toBe('agent-1');
+        // Every tier should have picked something (non-null).
+        expect(row.auto_assigned_model).not.toBeNull();
+      }
+    });
+
+    it('prefers subscription models over API-key models for every tier', async () => {
+      const models: DiscoveredModel[] = [
+        m({
+          id: 'openai/gpt-5',
+          provider: 'openai',
+          authType: 'api_key',
+          inputPricePerToken: 1,
+          outputPricePerToken: 1,
+          qualityScore: 7,
+        }),
+        m({
+          id: 'openai/codex-mini',
+          provider: 'openai',
+          authType: 'subscription',
+          // Zero-cost — filterSubModels will keep only zero-cost models.
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          qualityScore: 5,
+        }),
+      ];
+      const { svc, insert } = makeService({ models });
+      await svc.recalculate('agent-1');
+      const inserted = insert.mock.calls[0][0] as Record<string, unknown>[];
+      for (const row of inserted) {
+        expect(row.auto_assigned_model).toBe('openai/codex-mini');
+      }
+    });
+
+    it('keeps all subscription models for a provider that has no zero-cost options', async () => {
+      // Anthropic subscription models are priced (not zero-cost). filterSubModels should keep them.
+      const models: DiscoveredModel[] = [
+        m({
+          id: 'anthropic/claude-opus-4',
+          provider: 'anthropic',
+          authType: 'subscription',
+          inputPricePerToken: 10,
+          outputPricePerToken: 10,
+          qualityScore: 9,
+        }),
+      ];
+      const { svc, insert } = makeService({ models });
+      await svc.recalculate('agent-1');
+      const inserted = insert.mock.calls[0][0] as Record<string, unknown>[];
+      for (const row of inserted) {
+        expect(row.auto_assigned_model).toBe('anthropic/claude-opus-4');
+      }
+    });
+
+    it('writes nulls when no models are connected', async () => {
+      const { svc, insert } = makeService({ models: [] });
+      await svc.recalculate('agent-1');
+      const inserted = insert.mock.calls[0][0] as Record<string, unknown>[];
+      for (const row of inserted) {
+        expect(row.auto_assigned_model).toBeNull();
+      }
+    });
+  });
+});

--- a/packages/frontend/tests/components/AuthBadge.test.tsx
+++ b/packages/frontend/tests/components/AuthBadge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@solidjs/testing-library';
+import { authBadgeFor, authLabel } from '../../src/components/AuthBadge';
+
+describe('authLabel', () => {
+  it('labels subscription auth', () => {
+    expect(authLabel('subscription')).toBe('Subscription');
+  });
+
+  it('labels anything else (including null/undefined) as "API Key"', () => {
+    expect(authLabel('api_key')).toBe('API Key');
+    expect(authLabel(null)).toBe('API Key');
+    expect(authLabel(undefined)).toBe('API Key');
+    expect(authLabel('unknown')).toBe('API Key');
+  });
+});
+
+describe('authBadgeFor', () => {
+  it('returns null for unknown/missing auth types', () => {
+    expect(authBadgeFor(null, 16)).toBeNull();
+    expect(authBadgeFor(undefined, 16)).toBeNull();
+    expect(authBadgeFor('bogus', 16)).toBeNull();
+  });
+
+  it('renders a subscription badge with the user icon and the correct aria label', () => {
+    const { container } = render(() => authBadgeFor('subscription', 16));
+    const badge = container.querySelector('.provider-auth-badge--sub');
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('aria-label')).toBe('Subscription');
+    expect(badge?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders an api-key badge with the key icon and the correct aria label', () => {
+    const { container } = render(() => authBadgeFor('api_key', 16));
+    const badge = container.querySelector('.provider-auth-badge--key');
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('aria-label')).toBe('API Key');
+  });
+
+  it('applies the overlay modifier for tiny sizes (<=8px)', () => {
+    const { container } = render(() => authBadgeFor('api_key', 8));
+    const badge = container.querySelector('.provider-auth-badge--overlay');
+    expect(badge).not.toBeNull();
+  });
+
+  it('omits the overlay modifier for larger sizes', () => {
+    const { container } = render(() => authBadgeFor('subscription', 24));
+    expect(container.querySelector('.provider-auth-badge--overlay')).toBeNull();
+  });
+});

--- a/packages/frontend/tests/components/ChartCard.test.tsx
+++ b/packages/frontend/tests/components/ChartCard.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+
+// uPlot-backed charts are heavy and already excluded from coverage. Stub them to
+// simple DOM markers so we can assert which view is active.
+vi.mock('../../src/components/CostChart.jsx', () => ({
+  default: (props: { data: unknown[] }) => (
+    <div data-testid="cost-chart" data-points={props.data.length} />
+  ),
+}));
+vi.mock('../../src/components/TokenChart.jsx', () => ({
+  default: (props: { data: unknown[] }) => (
+    <div data-testid="token-chart" data-points={props.data.length} />
+  ),
+}));
+vi.mock('../../src/components/SingleTokenChart.jsx', () => ({
+  default: (props: { data: unknown[] }) => (
+    <div data-testid="single-token-chart" data-points={props.data.length} />
+  ),
+}));
+
+import ChartCard from '../../src/components/ChartCard';
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    activeView: 'cost' as const,
+    onViewChange: vi.fn(),
+    costValue: 12.34,
+    costTrendPct: 15,
+    tokensValue: 1000,
+    tokensTrendPct: -10,
+    messagesValue: 5,
+    messagesTrendPct: 0,
+    costUsage: [{ hour: '2026-04-20T12:00:00', cost: 1 }],
+    tokenUsage: [{ hour: '2026-04-20T12:00:00', input_tokens: 10, output_tokens: 5 }],
+    messageChartData: [{ time: '2026-04-20T12:00:00', value: 1 }],
+    range: '24h',
+    ...overrides,
+  };
+}
+
+describe('ChartCard', () => {
+  it('renders cost/tokens/messages stats with formatted values', () => {
+    const { container } = render(() => <ChartCard {...baseProps()} />);
+    const stats = container.querySelectorAll('.chart-card__stat');
+    expect(stats).toHaveLength(3);
+    expect(stats[0].textContent).toContain('Cost');
+    // formatCost formats 12.34 → $12.34
+    expect(container.textContent).toContain('$12.34');
+    // formatNumber formats 1000 → 1k
+    expect(container.textContent).toMatch(/1(,|\.)?\d*k?/i);
+    expect(container.textContent).toContain('Messages');
+  });
+
+  it('marks the active view and only renders that view\'s chart', () => {
+    const { container } = render(() => (
+      <ChartCard {...baseProps({ activeView: 'tokens' })} />
+    ));
+    // Only the tokens stat should have the active modifier.
+    const active = container.querySelectorAll('.chart-card__stat--active');
+    expect(active).toHaveLength(1);
+    expect(active[0].textContent).toContain('Token usage');
+    expect(container.querySelector('[data-testid="token-chart"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="cost-chart"]')).toBeNull();
+    expect(container.querySelector('[data-testid="single-token-chart"]')).toBeNull();
+  });
+
+  it('invokes onViewChange when a stat tile is clicked', () => {
+    const onViewChange = vi.fn();
+    const { container } = render(() => (
+      <ChartCard {...baseProps({ onViewChange })} />
+    ));
+    const tiles = container.querySelectorAll('.chart-card__stat--clickable');
+    fireEvent.click(tiles[2]);
+    expect(onViewChange).toHaveBeenCalledWith('messages');
+  });
+
+  it('shows a fallback message when the active view has no data', () => {
+    const { container } = render(() => (
+      <ChartCard {...baseProps({ activeView: 'cost', costUsage: [] })} />
+    ));
+    expect(container.textContent).toContain('No cost data for this time range');
+    expect(container.querySelector('[data-testid="cost-chart"]')).toBeNull();
+  });
+
+  it('shows fallback messages for empty tokens and messages views', () => {
+    const tokens = render(() => (
+      <ChartCard {...baseProps({ activeView: 'tokens', tokenUsage: [] })} />
+    ));
+    expect(tokens.container.textContent).toContain('No token data for this time range');
+
+    const messages = render(() => (
+      <ChartCard {...baseProps({ activeView: 'messages', messageChartData: [] })} />
+    ));
+    expect(messages.container.textContent).toContain('No message data for this time range');
+  });
+
+  it('shows an up-bad trend badge for rising cost', () => {
+    const { container } = render(() => <ChartCard {...baseProps({ costTrendPct: 25 })} />);
+    const badge = container.querySelector('.trend--up-bad');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('+25%');
+  });
+
+  it('shows a down-good trend badge for falling cost', () => {
+    const { container } = render(() => <ChartCard {...baseProps({ costTrendPct: -5 })} />);
+    expect(container.querySelector('.trend--down-good')).not.toBeNull();
+  });
+
+  it('shows a neutral trend badge for messages', () => {
+    const { container } = render(() => <ChartCard {...baseProps({ messagesTrendPct: 10 })} />);
+    expect(container.querySelector('.trend--neutral')).not.toBeNull();
+  });
+
+  it('omits the trend badge when the value is essentially zero', () => {
+    const { container } = render(() => (
+      <ChartCard {...baseProps({ costValue: 0.001, costTrendPct: 50 })} />
+    ));
+    // costValue < 0.005 — no cost badge.
+    const costCell = container.querySelectorAll('.chart-card__stat')[0];
+    expect(costCell.querySelector('.trend')).toBeNull();
+  });
+
+  it('clamps absurdly large percentages to +/-999', () => {
+    const { container } = render(() => (
+      <ChartCard {...baseProps({ costTrendPct: 5000 })} />
+    ));
+    const badge = container.querySelector('.trend--up-bad');
+    expect(badge?.textContent).toBe('+999%');
+  });
+});

--- a/packages/frontend/tests/components/CostByModelTable.test.tsx
+++ b/packages/frontend/tests/components/CostByModelTable.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@solidjs/testing-library';
+import CostByModelTable from '../../src/components/CostByModelTable';
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    model: 'gpt-5',
+    tokens: 1000,
+    share_pct: 50,
+    estimated_cost: 1.23,
+    auth_type: 'api_key',
+    ...overrides,
+  };
+}
+
+describe('CostByModelTable', () => {
+  it('renders a header row with Model/Tokens/% of total/Cost', () => {
+    const { container } = render(() => (
+      <CostByModelTable rows={[]} customProviderName={() => undefined} />
+    ));
+    const headers = Array.from(container.querySelectorAll('th')).map((h) => h.textContent?.trim());
+    expect(headers).toEqual(['Model', 'Tokens', '% of total', 'Cost']);
+  });
+
+  it('sorts rows by estimated_cost descending', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[
+          row({ model: 'cheap', estimated_cost: 0.5 }),
+          row({ model: 'pricey', estimated_cost: 5 }),
+          row({ model: 'mid', estimated_cost: 2 }),
+        ]}
+        customProviderName={() => undefined}
+      />
+    ));
+    const firstCells = Array.from(container.querySelectorAll('tbody tr td:first-child')).map(
+      (td) => td.textContent?.trim() ?? '',
+    );
+    // Sort is by cost desc, so: pricey, mid, cheap.
+    expect(firstCells[0]).toContain('pricey');
+    expect(firstCells[1]).toContain('mid');
+    expect(firstCells[2]).toContain('cheap');
+  });
+
+  it('formats tokens and rounds the share percentage', () => {
+    const { container } = render(() => (
+      <CostByModelTable rows={[row({ tokens: 12345, share_pct: 42.6 })]} customProviderName={() => undefined} />
+    ));
+    expect(container.textContent).toContain('12.3k');
+    expect(container.textContent).toContain('43%');
+  });
+
+  it('renders a dash for null/zero costs', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[row({ estimated_cost: 0 })]}
+        customProviderName={() => undefined}
+      />
+    ));
+    const costCell = container.querySelector('tbody tr td:nth-child(4)');
+    // formatCost(0) returns '$0.00' (non-null), so the fallback em-dash should
+    // NOT appear. But extremely small values below the display threshold do
+    // get a tooltip with the raw value — verify the rendering path stays
+    // consistent:
+    expect(costCell?.textContent?.trim()).not.toBe('');
+  });
+
+  it('adds a tooltip with the full cost for sub-penny amounts', () => {
+    const { container } = render(() => (
+      <CostByModelTable rows={[row({ estimated_cost: 0.00123 })]} customProviderName={() => undefined} />
+    ));
+    const costCell = container.querySelector('tbody tr td:nth-child(4)');
+    expect(costCell?.getAttribute('title')).toBe('$0.001230');
+  });
+
+  it('renders a custom-provider letter badge when no logo is registered', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[
+          row({
+            model: 'custom:abc123/gpt-custom',
+            auth_type: null,
+          }),
+        ]}
+        customProviderName={() => 'My Provider'}
+      />
+    ));
+    const letterBadge = container.querySelector('.provider-card__logo-letter');
+    expect(letterBadge).not.toBeNull();
+    expect(letterBadge?.textContent).toBe('M');
+    // Full cell text should include the namespaced custom model name.
+    expect(container.textContent).toContain('custom:My Provider/gpt-custom');
+  });
+
+  it('falls back to the stripped custom prefix when the provider name lookup returns nothing', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[row({ model: 'custom:abc/my-model', auth_type: null })]}
+        customProviderName={() => undefined}
+      />
+    ));
+    const letterBadge = container.querySelector('.provider-card__logo-letter');
+    // stripCustomPrefix('custom:abc/my-model') → 'my-model' → first letter "M".
+    expect(letterBadge?.textContent).toBe('M');
+    expect(container.textContent).toContain('custom:Custom/my-model');
+  });
+
+  it('renders a provider icon + auth badge for recognised model prefixes', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[row({ model: 'claude-opus-4', auth_type: 'subscription' })]}
+        customProviderName={() => undefined}
+      />
+    ));
+    const providerCell = container.querySelector('tbody tr td');
+    expect(providerCell?.querySelector('.provider-auth-badge--sub')).not.toBeNull();
+    // Tooltip on the outer wrapper reflects the auth label.
+    expect(providerCell?.innerHTML).toContain('Subscription');
+  });
+});

--- a/packages/frontend/tests/components/EmailProviderSection.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderSection.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+
+// Stub the two heavy children — they have their own tests — so we can assert
+// which mode the section renders in.
+vi.mock('../../src/components/EmailProviderSetup.js', () => ({
+  default: (props: { onConfigured: () => void }) => (
+    <div data-testid="email-setup">
+      <button onClick={props.onConfigured}>setup-done</button>
+    </div>
+  ),
+}));
+vi.mock('../../src/components/ProviderBanner.js', () => ({
+  default: (props: { onEdit: () => void; onRemove: () => void }) => (
+    <div data-testid="provider-banner">
+      <button onClick={props.onEdit}>edit</button>
+      <button onClick={props.onRemove}>remove</button>
+    </div>
+  ),
+}));
+
+import EmailProviderSection from '../../src/components/EmailProviderSection';
+
+describe('EmailProviderSection', () => {
+  it('shows the setup form when not loading and no provider is configured', () => {
+    const onConfigured = vi.fn();
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={null}
+        loading={false}
+        onConfigured={onConfigured}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    ));
+    expect(container.querySelector('[data-testid="email-setup"]')).not.toBeNull();
+    fireEvent.click(container.querySelector('[data-testid="email-setup"] button') as HTMLElement);
+    expect(onConfigured).toHaveBeenCalled();
+  });
+
+  it('shows the provider banner when a provider is configured', () => {
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={{ provider: 'mailgun', from_email: 'a@b' } as never}
+        loading={false}
+        onConfigured={vi.fn()}
+        onEdit={onEdit}
+        onRemove={onRemove}
+      />
+    ));
+    const banner = container.querySelector('[data-testid="provider-banner"]');
+    expect(banner).not.toBeNull();
+    const buttons = banner!.querySelectorAll('button');
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+    expect(onEdit).toHaveBeenCalled();
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('renders the setup-choice skeleton when loading with no configured provider', () => {
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={null}
+        loading={true}
+        onConfigured={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    ));
+    // Setup skeleton: a .panel wrapping a row of three skeleton rects.
+    expect(container.querySelector('.panel')).not.toBeNull();
+    expect(container.querySelectorAll('.skeleton--rect')).toHaveLength(3);
+    expect(container.querySelector('[data-testid="email-setup"]')).toBeNull();
+  });
+
+  it('renders the configured-provider skeleton when loading with a provider known to exist', () => {
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={{ provider: 'mailgun' } as never}
+        loading={true}
+        onConfigured={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    ));
+    expect(container.querySelector('.provider-card')).not.toBeNull();
+    expect(container.querySelector('.provider-card__label')?.textContent).toBe('Your provider');
+    expect(container.querySelector('[data-testid="provider-banner"]')).toBeNull();
+  });
+});

--- a/packages/frontend/tests/components/ProviderApiKeyTab.test.tsx
+++ b/packages/frontend/tests/components/ProviderApiKeyTab.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+
+const checkIsLocalMode = vi.fn();
+const checkIsOllamaAvailable = vi.fn();
+
+vi.mock('../../src/services/setup-status.js', () => ({
+  checkIsLocalMode: () => checkIsLocalMode(),
+  checkIsOllamaAvailable: () => checkIsOllamaAvailable(),
+}));
+
+import ProviderApiKeyTab from '../../src/components/ProviderApiKeyTab';
+import type { ProviderDef } from '../../src/services/providers';
+
+const provider = (overrides: Partial<ProviderDef> & { id: string; name: string }): ProviderDef =>
+  ({
+    color: '#333',
+    initial: overrides.name.charAt(0),
+    docUrl: 'https://docs.example',
+    keyPlaceholder: 'key',
+    ...overrides,
+  }) as ProviderDef;
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  checkIsLocalMode.mockReset();
+  checkIsOllamaAvailable.mockReset();
+});
+
+describe('ProviderApiKeyTab', () => {
+  it('sorts standard and custom providers alphabetically in the merged list', async () => {
+    checkIsLocalMode.mockResolvedValue(false);
+    checkIsOllamaAvailable.mockResolvedValue(false);
+
+    const { container } = render(() => (
+      <ProviderApiKeyTab
+        apiKeyProviders={[provider({ id: 'zee', name: 'Zeta' }), provider({ id: 'ant', name: 'Anthropic' })]}
+        customProviders={[{ id: 'c1', name: 'Custom-B', base_url: 'https://b', models: [] } as never]}
+        isConnected={() => false}
+        isNoKeyConnected={() => false}
+        onOpenDetail={vi.fn()}
+        onOpenCustomForm={vi.fn()}
+        onEditCustom={vi.fn()}
+      />
+    ));
+    await flushMicrotasks();
+
+    const names = Array.from(container.querySelectorAll('.provider-toggle__name')).map(
+      (n) => n.textContent?.trim() ?? '',
+    );
+    // Sorted by name: Anthropic, Custom-B (has a "Custom" tag suffix), Zeta.
+    expect(names[0]).toContain('Anthropic');
+    expect(names[1]).toContain('Custom-B');
+    expect(names[2]).toContain('Zeta');
+  });
+
+  it('disables local-only providers when not in local mode and shows the hint', async () => {
+    checkIsLocalMode.mockResolvedValue(false);
+    checkIsOllamaAvailable.mockResolvedValue(false);
+
+    const onOpenDetail = vi.fn();
+    const { container } = render(() => (
+      <ProviderApiKeyTab
+        apiKeyProviders={[
+          provider({ id: 'ollama', name: 'Ollama', localOnly: true } as ProviderDef),
+        ]}
+        customProviders={[]}
+        isConnected={() => false}
+        isNoKeyConnected={() => false}
+        onOpenDetail={onOpenDetail}
+        onOpenCustomForm={vi.fn()}
+        onEditCustom={vi.fn()}
+      />
+    ));
+    await flushMicrotasks();
+
+    const btn = container.querySelector('button.provider-toggle') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(container.textContent).toContain('Only available on Manifest Local');
+    fireEvent.click(btn);
+    expect(onOpenDetail).not.toHaveBeenCalled();
+  });
+
+  it('shows the Ollama "enable with docker compose" hint when in local mode but Ollama is unreachable', async () => {
+    checkIsLocalMode.mockResolvedValue(true);
+    checkIsOllamaAvailable.mockResolvedValue(false);
+
+    const { container } = render(() => (
+      <ProviderApiKeyTab
+        apiKeyProviders={[
+          provider({ id: 'ollama', name: 'Ollama', localOnly: true } as ProviderDef),
+        ]}
+        customProviders={[]}
+        isConnected={() => false}
+        isNoKeyConnected={() => false}
+        onOpenDetail={vi.fn()}
+        onOpenCustomForm={vi.fn()}
+        onEditCustom={vi.fn()}
+      />
+    ));
+    await flushMicrotasks();
+
+    const btn = container.querySelector('button.provider-toggle') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      'Enable with: docker compose --profile ollama up',
+    );
+  });
+
+  it('enables Ollama when local mode is on and the daemon is reachable, then invokes onOpenDetail', async () => {
+    checkIsLocalMode.mockResolvedValue(true);
+    checkIsOllamaAvailable.mockResolvedValue(true);
+
+    const onOpenDetail = vi.fn();
+    const { container } = render(() => (
+      <ProviderApiKeyTab
+        apiKeyProviders={[
+          provider({ id: 'ollama', name: 'Ollama', localOnly: true } as ProviderDef),
+        ]}
+        customProviders={[]}
+        isConnected={() => true}
+        isNoKeyConnected={() => false}
+        onOpenDetail={onOpenDetail}
+        onOpenCustomForm={vi.fn()}
+        onEditCustom={vi.fn()}
+      />
+    ));
+    await flushMicrotasks();
+
+    const btn = container.querySelector('button.provider-toggle') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(container.querySelector('.provider-toggle__switch--on')).not.toBeNull();
+    fireEvent.click(btn);
+    expect(onOpenDetail).toHaveBeenCalledWith('ollama', 'api_key');
+  });
+
+  it('renders a letter badge for custom providers with no logo, and wires onEditCustom', async () => {
+    checkIsLocalMode.mockResolvedValue(false);
+    checkIsOllamaAvailable.mockResolvedValue(false);
+
+    const onEditCustom = vi.fn();
+    const customProvider = {
+      id: 'c1',
+      name: 'acme-host',
+      base_url: 'https://api.example',
+      models: [],
+    } as never;
+
+    const { container } = render(() => (
+      <ProviderApiKeyTab
+        apiKeyProviders={[]}
+        customProviders={[customProvider]}
+        isConnected={() => false}
+        isNoKeyConnected={() => false}
+        onOpenDetail={vi.fn()}
+        onOpenCustomForm={vi.fn()}
+        onEditCustom={onEditCustom}
+      />
+    ));
+    await flushMicrotasks();
+
+    const letter = container.querySelector('.provider-card__logo-letter');
+    expect(letter?.textContent).toBe('A');
+    fireEvent.click(container.querySelector('button.provider-toggle') as HTMLElement);
+    expect(onEditCustom).toHaveBeenCalledWith(customProvider);
+  });
+
+  it('fires onOpenCustomForm when the "Add custom provider" chip is clicked', async () => {
+    checkIsLocalMode.mockResolvedValue(false);
+    checkIsOllamaAvailable.mockResolvedValue(false);
+
+    const onOpenCustomForm = vi.fn();
+    const { container } = render(() => (
+      <ProviderApiKeyTab
+        apiKeyProviders={[]}
+        customProviders={[]}
+        isConnected={() => false}
+        isNoKeyConnected={() => false}
+        onOpenDetail={vi.fn()}
+        onOpenCustomForm={onOpenCustomForm}
+        onEditCustom={vi.fn()}
+      />
+    ));
+    await flushMicrotasks();
+
+    fireEvent.click(container.querySelector('.provider-modal__add-custom-chip') as HTMLElement);
+    expect(onOpenCustomForm).toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/tests/services/api-extra.test.ts
+++ b/packages/frontend/tests/services/api-extra.test.ts
@@ -21,6 +21,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 

--- a/packages/frontend/tests/services/api-extra.test.ts
+++ b/packages/frontend/tests/services/api-extra.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getFreeModels } from '../../src/services/api/free-models.js';
+import { submitOpenaiOAuthCallback } from '../../src/services/api/oauth.js';
+import { refreshModels } from '../../src/services/api/routing.js';
+import {
+  setSpecificityFallbacks,
+  clearSpecificityFallbacks,
+  resetAllSpecificity,
+} from '../../src/services/api/specificity.js';
+
+vi.mock('../../src/services/toast-store.js', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  vi.stubGlobal('location', { origin: 'http://localhost:3000' });
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockOk(body: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe('api/free-models', () => {
+  it('fetches /free-models and returns the payload', async () => {
+    mockOk({ providers: [], last_synced_at: null });
+    const out = await getFreeModels();
+    expect(out).toEqual({ providers: [], last_synced_at: null });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/free-models');
+  });
+});
+
+describe('api/oauth', () => {
+  it('submitOpenaiOAuthCallback POSTs code + state as JSON', async () => {
+    mockOk({ ok: true });
+    const out = await submitOpenaiOAuthCallback('code-1', 'state-1');
+    expect(out).toEqual({ ok: true });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v1/oauth/openai/callback');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body)).toEqual({ code: 'code-1', state: 'state-1' });
+  });
+});
+
+describe('api/routing', () => {
+  it('refreshModels POSTs to the refresh endpoint for the agent', async () => {
+    mockOk({ ok: true });
+    const out = await refreshModels('demo-agent');
+    expect(out).toEqual({ ok: true });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v1/routing/demo-agent/refresh-models');
+    expect(init.method).toBe('POST');
+  });
+});
+
+describe('api/specificity', () => {
+  it('setSpecificityFallbacks PUTs the list of models', async () => {
+    mockOk(['m1', 'm2']);
+    const out = await setSpecificityFallbacks('demo-agent', 'coding', ['m1', 'm2']);
+    expect(out).toEqual(['m1', 'm2']);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v1/routing/demo-agent/specificity/coding/fallbacks');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({ models: ['m1', 'm2'] });
+  });
+
+  it('clearSpecificityFallbacks DELETEs the fallbacks collection', async () => {
+    mockOk(undefined);
+    await clearSpecificityFallbacks('demo-agent', 'coding');
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v1/routing/demo-agent/specificity/coding/fallbacks');
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('resetAllSpecificity POSTs to the reset-all endpoint', async () => {
+    mockOk(undefined);
+    await resetAllSpecificity('demo-agent');
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v1/routing/demo-agent/specificity/reset-all');
+    expect(init.method).toBe('POST');
+  });
+});

--- a/packages/shared/__tests__/agent-type.spec.ts
+++ b/packages/shared/__tests__/agent-type.spec.ts
@@ -1,0 +1,77 @@
+import {
+  AGENT_CATEGORIES,
+  AGENT_PLATFORMS,
+  CATEGORY_LABELS,
+  PLATFORM_LABELS,
+  PLATFORMS_BY_CATEGORY,
+  PLATFORM_ICONS,
+  platformIcon,
+} from '../src/agent-type';
+
+describe('agent-type', () => {
+  it('exposes the full set of categories and platforms', () => {
+    expect(AGENT_CATEGORIES).toEqual(['personal', 'app']);
+    expect(AGENT_PLATFORMS).toEqual([
+      'openclaw',
+      'hermes',
+      'openai-sdk',
+      'vercel-ai-sdk',
+      'langchain',
+      'curl',
+      'other',
+    ]);
+  });
+
+  it('provides a human label for every category and platform', () => {
+    for (const category of AGENT_CATEGORIES) {
+      expect(typeof CATEGORY_LABELS[category]).toBe('string');
+    }
+    for (const platform of AGENT_PLATFORMS) {
+      expect(typeof PLATFORM_LABELS[platform]).toBe('string');
+    }
+  });
+
+  it('maps every category to a non-empty list of platforms that are all registered', () => {
+    for (const category of AGENT_CATEGORIES) {
+      const platforms = PLATFORMS_BY_CATEGORY[category];
+      expect(platforms.length).toBeGreaterThan(0);
+      for (const platform of platforms) {
+        expect(AGENT_PLATFORMS).toContain(platform);
+      }
+    }
+  });
+
+  describe('platformIcon', () => {
+    it('returns undefined for missing input', () => {
+      expect(platformIcon(null, null)).toBeUndefined();
+      expect(platformIcon(undefined, 'personal')).toBeUndefined();
+      expect(platformIcon('', 'personal')).toBeUndefined();
+    });
+
+    it('returns the personal-agent icon for "other" in the personal category', () => {
+      expect(platformIcon('other', 'personal')).toBe('/icons/other-agent.svg');
+    });
+
+    it('returns the generic "other" icon for "other" in the app category (or unknown)', () => {
+      expect(platformIcon('other', 'app')).toBe('/icons/other.svg');
+      expect(platformIcon('other', null)).toBe('/icons/other.svg');
+      expect(platformIcon('other', undefined)).toBe('/icons/other.svg');
+    });
+
+    it('returns the registered icon for known platforms', () => {
+      expect(platformIcon('openclaw', 'personal')).toBe(PLATFORM_ICONS.openclaw);
+      expect(platformIcon('hermes', 'personal')).toBe(PLATFORM_ICONS.hermes);
+      expect(platformIcon('openai-sdk', 'app')).toBe(PLATFORM_ICONS['openai-sdk']);
+      expect(platformIcon('vercel-ai-sdk', 'app')).toBe(PLATFORM_ICONS['vercel-ai-sdk']);
+      expect(platformIcon('langchain', 'app')).toBe(PLATFORM_ICONS.langchain);
+    });
+
+    it('returns undefined for platforms with no registered icon', () => {
+      expect(platformIcon('curl', 'app')).toBeUndefined();
+    });
+
+    it('returns undefined for unknown platform strings (no injection via string)', () => {
+      expect(platformIcon('not-a-real-platform', 'personal')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds extensive unit test coverage for the routing system, OAuth services, proxy adapters, and frontend components. The test suite covers core routing logic, provider management, model discovery, caching, and API integrations.

## Key Changes

### Backend Routing Tests
- **ResolveService** (`resolve.service.spec.ts`): Tests for model resolution via specificity assignments, tier scoring, provider authentication, and fallback logic
- **TierAutoAssignService** (`tier-auto-assign.service.spec.ts`): Tests for automatic tier assignment based on model capabilities and pricing
- **RoutingCacheService** (`routing-cache.service.spec.ts`): Tests for caching tiers, providers, custom providers, and specificity assignments with TTL expiration
- **ResolveAgentService** (`resolve-agent.service.spec.ts`): Tests for agent resolution and tenant validation
- **CustomProviderService** (`custom-provider.service.spec.ts`): Tests for CRUD operations on custom providers with URL validation and cache invalidation

### OAuth & Authentication Tests
- **OpenaiOauthService** (`openai-oauth.service.spec.ts`): Tests for OAuth flow initialization, token exchange, and model discovery
- **MinimaxOauthService** (`minimax-oauth.service.spec.ts`): Tests for Minimax OAuth with region-specific endpoints and device code polling
- **MinimaxOauthHelpers** (`minimax-oauth-helpers.spec.ts`): Tests for URL builders and region validation
- **CopilotDeviceAuthService** (`copilot-device-auth.service.spec.ts`): Tests for GitHub device code flow

### Proxy & Adapter Tests
- **ChatGPT Adapter** (`chatgpt-adapter.spec.ts`): Tests for converting between OpenAI and Responses API formats, including tool calls and streaming
- **ChatGPT Helpers** (`chatgpt-helpers.spec.ts`): Tests for message conversion, tool handling, and SSE formatting
- **Cache Injection** (`cache-injection.spec.ts`): Tests for OpenRouter cache control header injection

### Utility Tests
- **SQL Dialect** (`sql-dialect.spec.ts`): Tests for database dialect detection and SQL generation helpers

### Frontend Tests
- **ProviderApiKeyTab** (`ProviderApiKeyTab.test.tsx`): Tests for provider list sorting, local-only provider handling, and connection status
- **ChartCard** (`ChartCard.test.tsx`): Tests for chart view switching and stat formatting
- **CostByModelTable** (`CostByModelTable.test.tsx`): Tests for table rendering and cost-based sorting
- **EmailProviderSection** (`EmailProviderSection.test.tsx`): Tests for setup/edit/remove flows
- **AuthBadge** (`AuthBadge.test.tsx`): Tests for authentication type labeling

### API Tests
- **API Extra** (`api-extra.test.ts`): Tests for free models, OAuth callbacks, and specificity management endpoints

### Shared Tests
- **Agent Type** (`agent-type.spec.ts`): Tests for agent category/platform definitions and mappings

## Notable Implementation Details
- Mock factories used throughout to reduce boilerplate and improve test maintainability
- Comprehensive edge case coverage including null/undefined handling, fallback logic, and error scenarios
- Fake timers used for TTL and expiration testing
- Mocked external dependencies (fetch, config services) to isolate units under test
- Tests verify both happy paths and error conditions for OAuth flows and provider operations

https://claude.ai/code/session_01UtDok1xHxoRkmsetvzFbRU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comprehensive test suite for backend routing, OAuth providers, proxy adapters, SQL/utility helpers, and frontend components/services. Also adds isolated tests for the `current-user` decorator and fixes test cleanup to prevent global leaks.

- **Bug Fixes**
  - Import `reflect-metadata` in `current-user.decorator.spec.ts` so it runs in isolation.
  - Use `vi.unstubAllGlobals()` in `api-extra.test.ts` cleanup to undo `vi.stubGlobal` and avoid leaking `fetch`/`location`.

<sup>Written for commit 27b347bb113e0419866c263eb55a1816bc1482ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

