### PR TITLE
security(routing): scrub provider secrets from persisted error bodies

### DIFF
--- a/packages/backend/src/common/utils/secret-scrub.spec.ts
+++ b/packages/backend/src/common/utils/secret-scrub.spec.ts
@@ -1,0 +1,136 @@
+import { scrubSecrets } from './secret-scrub';
+
+describe('scrubSecrets', () => {
+  it('returns empty string for null', () => {
+    expect(scrubSecrets(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(scrubSecrets(undefined)).toBe('');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(scrubSecrets('')).toBe('');
+  });
+
+  it('redacts bare Anthropic sk-ant- keys', () => {
+    const out = scrubSecrets('auth failed for sk-ant-api03-abcdefghijklmnop');
+    expect(out).not.toContain('abcdefghijklmnop');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts OpenAI project keys (sk-proj-)', () => {
+    const out = scrubSecrets('key sk-proj-abcdefghijklmnop is invalid');
+    expect(out).not.toContain('abcdefghijklmnop');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts generic OpenAI sk- keys', () => {
+    const out = scrubSecrets('sk-abcdefghijklmnopqrstuv rejected');
+    expect(out).not.toContain('abcdefghijklmnopqrstuv');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts Groq gsk_ keys', () => {
+    const out = scrubSecrets('token gsk_abcdefghij123456');
+    expect(out).not.toContain('abcdefghij123456');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts xAI xai- keys', () => {
+    const out = scrubSecrets('got xai-abcdefghij12345');
+    expect(out).not.toContain('abcdefghij12345');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts Manifest mnfst_ keys', () => {
+    const out = scrubSecrets('bad token mnfst_abcdefghij12345');
+    expect(out).not.toContain('abcdefghij12345');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts Google AIza- keys', () => {
+    const out = scrubSecrets('AIzaSyAbcdefghij12345678');
+    expect(out).not.toContain('Abcdefghij12345678');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts Bearer tokens', () => {
+    const out = scrubSecrets('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+    expect(out).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+    expect(out).toContain('Bearer [REDACTED]');
+  });
+
+  it('redacts ?key= query parameters (Google-style)', () => {
+    const out = scrubSecrets('GET /v1/models?key=AIzaSyAbcdefg&alt=json');
+    expect(out).not.toContain('AIzaSyAbcdefg');
+    expect(out).toContain('?key=[REDACTED]');
+  });
+
+  it('redacts &key= query parameters', () => {
+    const out = scrubSecrets('url?foo=bar&key=secretvalue123');
+    expect(out).not.toContain('secretvalue123');
+    expect(out).toContain('&key=[REDACTED]');
+  });
+
+  it('redacts x-api-key header (case-insensitive)', () => {
+    expect(scrubSecrets('X-API-Key: somesecretvalue')).toContain('X-API-Key: [REDACTED]');
+    expect(scrubSecrets('x-api-key: abc123xyz')).toContain('x-api-key: [REDACTED]');
+  });
+
+  it('redacts authorization header with a non-Bearer scheme', () => {
+    const out = scrubSecrets('Authorization: Basic dXNlcjpwYXNz');
+    expect(out).not.toContain('dXNlcjpwYXNz');
+    expect(out).toContain('Authorization:');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts api-key header form', () => {
+    const out = scrubSecrets('api-key: myplainkey123');
+    expect(out).not.toContain('myplainkey123');
+    expect(out).toContain('api-key: [REDACTED]');
+  });
+
+  it('redacts quoted header values', () => {
+    const out = scrubSecrets('"x-api-key": "sk-liveabcdefghij"');
+    expect(out).not.toContain('sk-liveabcdefghij');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('leaves short strings untouched (no false positives)', () => {
+    expect(scrubSecrets('skiing is fun')).toBe('skiing is fun');
+    expect(scrubSecrets('task-manager')).toBe('task-manager');
+    expect(scrubSecrets('Bearer x')).toBe('Bearer x');
+  });
+
+  it('leaves benign prose untouched', () => {
+    const input = 'Rate limit exceeded. Please retry after 10 seconds.';
+    expect(scrubSecrets(input)).toBe(input);
+  });
+
+  it('redacts multiple secrets in one string', () => {
+    const out = scrubSecrets('got sk-abcdefghij12345 and gsk_abcdefghij67890 in one body');
+    expect(out).not.toContain('abcdefghij12345');
+    expect(out).not.toContain('abcdefghij67890');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('is idempotent on already-scrubbed text', () => {
+    const once = scrubSecrets('token sk-abcdefghij12345 rejected');
+    const twice = scrubSecrets(once);
+    expect(twice).toBe(once);
+  });
+
+  it('redacts a realistic Anthropic 401 body', () => {
+    const body = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'authentication_error',
+        message: 'Invalid x-api-key: sk-ant-api03-SECRETKEYVALUE12345',
+      },
+    });
+    const out = scrubSecrets(body);
+    expect(out).not.toContain('SECRETKEYVALUE12345');
+    expect(out).toContain('[REDACTED]');
+  });
+});

--- a/packages/backend/src/common/utils/secret-scrub.spec.ts
+++ b/packages/backend/src/common/utils/secret-scrub.spec.ts
@@ -61,6 +61,16 @@ describe('scrubSecrets', () => {
     expect(out).toContain('Bearer [REDACTED]');
   });
 
+  it('redacts Bearer tokens regardless of scheme casing', () => {
+    // HTTP is nominally case-insensitive; some servers/clients emit "bearer"
+    // or "BEARER". All should scrub.
+    for (const scheme of ['bearer', 'BEARER', 'BeArEr']) {
+      const out = scrubSecrets(`${scheme} eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9`);
+      expect(out).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+      expect(out).toContain('[REDACTED]');
+    }
+  });
+
   it('redacts ?key= query parameters (Google-style)', () => {
     const out = scrubSecrets('GET /v1/models?key=AIzaSyAbcdefg&alt=json');
     expect(out).not.toContain('AIzaSyAbcdefg');

--- a/packages/backend/src/common/utils/secret-scrub.ts
+++ b/packages/backend/src/common/utils/secret-scrub.ts
@@ -1,0 +1,45 @@
+// Best-effort redaction of provider credentials that may appear in upstream
+// error bodies before we persist them to agent_messages.error_message. Some
+// providers (notably Anthropic 401s) echo the offending Authorization or
+// x-api-key header back in the error body; without scrubbing, a single 401
+// can pin a user's API key to our database.
+//
+// This is not a defense-in-depth security boundary — it's a reduction-of-
+// blast-radius control. Key hygiene still relies on upstream correctness.
+
+type Pattern = { re: RegExp; replacement: string };
+
+// Ordered: header-style matches and Bearer run FIRST so the whole
+// "<header>: <value>" or "Bearer <token>" span is collapsed before vendor
+// regexes get a chance to try (and before any raw-key regex can leave a
+// dangling prefix for the header regex to double-redact). Vendor-specific
+// patterns then catch bare keys that weren't wrapped in a header.
+const PATTERNS: Pattern[] = [
+  // Matches "x-api-key": "value" (JSON), X-API-Key: rest-of-line, etc.
+  // Group 1: optional surrounding quote for the header name (JSON form).
+  // Group 4: optional surrounding quote for the value. The value char class
+  // permits spaces so multi-word auth schemes (e.g. "Basic dXNlcjpwYXNz") are
+  // captured in full, stopping only at quotes, commas, braces, or EOL.
+  {
+    re: /(["']?)(x-api-key|authorization|api-key)\1(\s*[:=]\s*)(["']?)[^"',}\r\n]+\4/gi,
+    replacement: '$1$2$1$3$4[REDACTED]$4',
+  },
+  { re: /Bearer\s+[A-Za-z0-9_\-.=+/]{8,}/g, replacement: 'Bearer [REDACTED]' },
+  { re: /([?&])key=[^&\s"']+/g, replacement: '$1key=[REDACTED]' },
+  { re: /\bsk-ant-[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
+  { re: /\bsk-proj-[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
+  { re: /\bsk-[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
+  { re: /\bgsk_[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
+  { re: /\bxai-[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
+  { re: /\bmnfst_[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
+  { re: /\bAIza[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
+];
+
+export function scrubSecrets(text: string | null | undefined): string {
+  if (text == null) return '';
+  let out = text;
+  for (const { re, replacement } of PATTERNS) {
+    out = out.replace(re, replacement);
+  }
+  return out;
+}

--- a/packages/backend/src/common/utils/secret-scrub.ts
+++ b/packages/backend/src/common/utils/secret-scrub.ts
@@ -24,7 +24,7 @@ const PATTERNS: Pattern[] = [
     re: /(["']?)(x-api-key|authorization|api-key)\1(\s*[:=]\s*)(["']?)[^"',}\r\n]+\4/gi,
     replacement: '$1$2$1$3$4[REDACTED]$4',
   },
-  { re: /Bearer\s+[A-Za-z0-9_\-.=+/]{8,}/g, replacement: 'Bearer [REDACTED]' },
+  { re: /Bearer\s+[A-Za-z0-9_\-.=+/]{8,}/gi, replacement: 'Bearer [REDACTED]' },
   { re: /([?&])key=[^&\s"']+/g, replacement: '$1key=[REDACTED]' },
   { re: /\bsk-ant-[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },
   { re: /\bsk-proj-[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -291,6 +291,16 @@ describe('ProxyMessageRecorder', () => {
       });
       expect(insertMock.mock.calls[0][0].provider).toBeNull();
     });
+
+    it('scrubs provider secrets from the persisted error_message', async () => {
+      const leaky = JSON.stringify({
+        error: { message: 'Invalid x-api-key: sk-ant-api03-SECRETKEYVALUE12345' },
+      });
+      await recorder.recordProviderError(ctx, 401, leaky, { model: 'claude-3' });
+      const stored: string = insertMock.mock.calls[0][0].error_message;
+      expect(stored).not.toContain('SECRETKEYVALUE12345');
+      expect(stored).toContain('[REDACTED]');
+    });
   });
 
   describe('recordFailedFallbacks', () => {
@@ -443,6 +453,32 @@ describe('ProxyMessageRecorder', () => {
       });
       // baseTimeMs + (1 - 0) * 100 = 100ms past the base.
       expect(insertMock.mock.calls[0][0].timestamp).toBe('2025-01-01T00:00:00.100Z');
+    });
+
+    it('scrubs provider secrets from each persisted fallback error_message', async () => {
+      const failures = [
+        {
+          model: 'gpt-4o',
+          provider: 'openai',
+          status: 401,
+          errorBody: 'Authorization: Bearer sk-proj-LEAKEDKEY1234567890',
+          fallbackIndex: 0,
+        },
+        {
+          model: 'claude-3',
+          provider: 'anthropic',
+          status: 401,
+          errorBody: 'x-api-key: sk-ant-api03-LEAKEDKEY0987654321',
+          fallbackIndex: 1,
+        },
+      ];
+      await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
+      const first: string = insertMock.mock.calls[0][0].error_message;
+      const second: string = insertMock.mock.calls[1][0].error_message;
+      expect(first).not.toContain('LEAKEDKEY1234567890');
+      expect(first).toContain('[REDACTED]');
+      expect(second).not.toContain('LEAKEDKEY0987654321');
+      expect(second).toContain('[REDACTED]');
     });
   });
 

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -10,6 +10,7 @@ import { FailedFallback } from './proxy-fallback.service';
 import { StreamUsage } from './stream-writer';
 import { ProxyMessageDedup } from './proxy-message-dedup';
 import { computeTokenCost } from '../../common/utils/cost-calculator';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
 import { CallerAttribution } from './caller-classifier';
 
 export interface ProviderErrorOpts {
@@ -110,7 +111,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       trace_id: traceId ?? null,
       timestamp: new Date().toISOString(),
       status: messageStatus,
-      error_message: errorMessage.slice(0, 2000),
+      error_message: scrubSecrets(errorMessage).slice(0, 2000),
       error_http_status: httpStatus,
       agent_name: ctx.agentName,
       model: model ?? null,
@@ -171,7 +172,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         trace_id: traceId ?? null,
         timestamp: ts,
         status,
-        error_message: f.errorBody.slice(0, 2000),
+        error_message: scrubSecrets(f.errorBody).slice(0, 2000),
         error_http_status: f.status,
         agent_name: ctx.agentName,
         model: f.model,


### PR DESCRIPTION
## Summary

- New `scrubSecrets()` utility at `packages/backend/src/common/utils/secret-scrub.ts` that redacts common provider credential shapes — `sk-ant-`, `sk-proj-`, `sk-`, `gsk_`, `xai-`, `mnfst_`, `AIza-`, `Bearer` tokens, `?key=` URL params, and `x-api-key` / `authorization` / `api-key` headers in both JSON and raw forms.
- Wired into `proxy-message-recorder.ts` ahead of the existing `.slice(0, 2000)` in `recordProviderError` and `recordFailedFallbacks` so upstream error bodies get scrubbed *before* the slice (avoids severing a token mid-match and then storing the fragments).

## Why

Upstream providers — notably Anthropic on 401 responses — sometimes echo the offending `Authorization` or `x-api-key` header back in the error body. The recorder persists the first 2 KB of that body to `agent_messages.error_message`. Without scrubbing, a single failed request can pin a user's API key to our database, where it's visible to anyone with DB access (support, future compromise, backups).

This is a blast-radius control, not a security boundary: the scrub runs only on persistence paths, upstream key hygiene is still assumed correct, and the 2000-char slice still applies.

Follow-up to the HTTPS-only custom provider URL change on `claude/review-llm-security-j5DRa` (merged). Both fixes come from a vulnerability review of **arXiv:2604.08407 — "Your Agent Is Mine"**, which enumerates passive secret exfiltration as one of four attack classes against LLM routers that terminate TLS in the middle.

## Test plan

- [x] `npx jest src/common/utils/secret-scrub.spec.ts` — 22 tests covering every pattern, idempotency, null/undefined input, false-positive resistance (`skiing`, `task-manager`, short Bearer), and a realistic Anthropic 401 body. **100% line / branch / function coverage** on the new file.
- [x] `npx jest src/routing/proxy/__tests__/proxy-message-recorder.spec.ts` — existing 44 tests plus two new ones asserting end-to-end scrub on both error paths. All 46 pass.
- [ ] Manual smoke: trigger a 401 from Anthropic with an invalid key, confirm the persisted `error_message` contains `[REDACTED]` and does not contain the key.

https://claude.ai/code/session_01KmmN1uvaiDDaE9uacycseY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs provider secrets from persisted upstream error bodies to prevent leaking API keys. Adds a `scrubSecrets` utility and applies it in the recorder before the 2 KB slice, with case-insensitive Bearer token handling.

- **Bug Fixes**
  - Redacts `sk-ant-`, `sk-proj-`, `sk-`, `gsk_`, `xai-`, `mnfst_`, `AIza` keys; `Bearer` tokens (any casing); `?key=` query params; and `x-api-key` / `authorization` / `api-key` headers (raw and JSON).
  - Adds tests for all patterns and recorder paths; validates idempotency, avoids false positives, and covers Bearer casing variants.
  - Mitigation runs only on persistence paths; runtime behavior otherwise unchanged.

<sup>Written for commit d4ffd26815379288971483a30c78a403dc3a0363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

