### PR TITLE
fix(routing): clean deleted custom providers from specificity and fallbacks

### DIFF
--- a/.changeset/fix-deleted-custom-provider-ghost-routing.md
+++ b/.changeset/fix-deleted-custom-provider-ghost-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix deleted custom providers continuing to intercept every request (#1603). Specificity routing now validates that an override model is still available before using it, and deleting a custom provider now also clears orphan references in specificity assignments and fallback-model lists. A one-time migration cleans existing orphaned references from the database so previously affected agents recover automatically.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -69,6 +69,7 @@ import { AddSpecificityCategory1775300000000 } from './migrations/1775300000000-
 import { AddCallerAttribution1775400000000 } from './migrations/1775400000000-AddCallerAttribution';
 import { AddMessageProvider1775500000000 } from './migrations/1775500000000-AddMessageProvider';
 import { AddMessageFeedback1775600000000 } from './migrations/1775600000000-AddMessageFeedback';
+import { CleanupOrphanedCustomProviderRefs1776679833383 } from './migrations/1776679833383-CleanupOrphanedCustomProviderRefs';
 
 const entities = [
   AgentMessage,
@@ -139,6 +140,7 @@ const migrations = [
   AddCallerAttribution1775400000000,
   AddMessageProvider1775500000000,
   AddMessageFeedback1775600000000,
+  CleanupOrphanedCustomProviderRefs1776679833383,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1776679833383-CleanupOrphanedCustomProviderRefs.spec.ts
+++ b/packages/backend/src/database/migrations/1776679833383-CleanupOrphanedCustomProviderRefs.spec.ts
@@ -1,0 +1,248 @@
+import { QueryRunner } from 'typeorm';
+import { CleanupOrphanedCustomProviderRefs1776679833383 } from './1776679833383-CleanupOrphanedCustomProviderRefs';
+
+type Row = {
+  id: string;
+  override_model: string | null;
+  override_provider: string | null;
+  fallback_models: string | null;
+};
+
+function makeQueryRunner(options: {
+  existingCustomIds: string[];
+  tierRows?: Row[];
+  specificityRows?: Row[];
+}) {
+  const updates: { table: string; sql: string; params: unknown[] }[] = [];
+  const query = jest.fn(async (sql: string, params?: unknown[]) => {
+    const trimmed = sql.trim();
+    if (trimmed.startsWith('SELECT id FROM custom_providers')) {
+      return options.existingCustomIds.map((id) => ({ id }));
+    }
+    if (trimmed.startsWith('SELECT id, override_model')) {
+      if (sql.includes('tier_assignments')) return options.tierRows ?? [];
+      if (sql.includes('specificity_assignments')) return options.specificityRows ?? [];
+    }
+    if (trimmed.startsWith('UPDATE')) {
+      const table = sql.includes('tier_assignments')
+        ? 'tier_assignments'
+        : 'specificity_assignments';
+      updates.push({ table, sql, params: params ?? [] });
+    }
+    return undefined;
+  });
+  return { query, updates };
+}
+
+describe('CleanupOrphanedCustomProviderRefs1776679833383', () => {
+  let migration: CleanupOrphanedCustomProviderRefs1776679833383;
+
+  beforeEach(() => {
+    migration = new CleanupOrphanedCustomProviderRefs1776679833383();
+  });
+
+  it('clears tier overrides whose custom provider no longer exists', async () => {
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: ['still-here'],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: 'custom:gone/gemini',
+          override_provider: 'custom:gone',
+          fallback_models: null,
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    const tierUpdates = updates.filter((u) => u.table === 'tier_assignments');
+    expect(tierUpdates).toHaveLength(1);
+    expect(tierUpdates[0].params.slice(0, 3)).toEqual([null, null, null]);
+  });
+
+  it('clears specificity overrides whose custom provider no longer exists', async () => {
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: [],
+      specificityRows: [
+        {
+          id: 'spec-1',
+          override_model: 'custom:gone/gemini',
+          override_provider: 'custom:gone',
+          fallback_models: null,
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    const specUpdates = updates.filter((u) => u.table === 'specificity_assignments');
+    expect(specUpdates).toHaveLength(1);
+  });
+
+  it('leaves overrides alone when the custom provider still exists', async () => {
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: ['alive'],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: 'custom:alive/gemini',
+          override_provider: 'custom:alive',
+          fallback_models: null,
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('filters fallback_models entries pointing to deleted custom providers', async () => {
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: ['alive'],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: null,
+          override_provider: null,
+          fallback_models: JSON.stringify(['custom:gone/a', 'custom:alive/b', 'openai/gpt-4o']),
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    const tierUpdates = updates.filter((u) => u.table === 'tier_assignments');
+    expect(tierUpdates).toHaveLength(1);
+    const updated = JSON.parse(tierUpdates[0].params[0] as string);
+    expect(updated).toEqual(['custom:alive/b', 'openai/gpt-4o']);
+  });
+
+  it('sets fallback_models to null when all entries are orphaned', async () => {
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: [],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: null,
+          override_provider: null,
+          fallback_models: JSON.stringify(['custom:gone/a']),
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    const tierUpdates = updates.filter((u) => u.table === 'tier_assignments');
+    expect(tierUpdates[0].params[0]).toBeNull();
+  });
+
+  it('ignores malformed fallback_models JSON without crashing', async () => {
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: [],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: null,
+          override_provider: null,
+          fallback_models: 'not json',
+        },
+      ],
+    });
+
+    await expect(migration.up({ query } as unknown as QueryRunner)).resolves.toBeUndefined();
+    expect(updates).toHaveLength(0);
+  });
+
+  it('keeps non-string entries in fallback_models untouched', async () => {
+    // Guards against a fallback_models payload that somehow contains objects / numbers;
+    // we should pass them through instead of filtering them out or crashing.
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: [],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: null,
+          override_provider: null,
+          fallback_models: JSON.stringify([{ weird: true }, 42, 'custom:gone/a']),
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    const tierUpdates = updates.filter((u) => u.table === 'tier_assignments');
+    expect(tierUpdates).toHaveLength(1);
+    const updated = JSON.parse(tierUpdates[0].params[0] as string);
+    expect(updated).toEqual([{ weird: true }, 42]);
+  });
+
+  it('leaves overrides with non-custom providers untouched (extractCustomIdFromProvider short-circuit)', async () => {
+    // override_provider = "anthropic" does NOT start with "custom:" — nothing to clear.
+    // This row only lands in the SELECT because its fallback_models contains 'custom:...'.
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: ['alive'],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: 'anthropic/claude-opus-4',
+          override_provider: 'anthropic',
+          fallback_models: JSON.stringify(['custom:alive/b']),
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    // override stays intact; fallback_models unchanged (all entries still point to live providers)
+    expect(updates).toHaveLength(0);
+  });
+
+  it('treats "custom:" with empty id as not-a-custom-ref and leaves the row alone', async () => {
+    // Defensive: extractCustomIdFromProvider/Model both return null when the id portion
+    // is empty. Such a row should not be touched even if existingIds is empty.
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: [],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: 'custom:',
+          override_provider: 'custom:',
+          fallback_models: null,
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('extracts custom id from a bare "custom:<id>" model string (no slash)', async () => {
+    // Covers extractCustomIdFromModel's no-slash branch: entry is just "custom:uuid"
+    // without a trailing "/<model>". Such an entry must still be detected and filtered.
+    const { query, updates } = makeQueryRunner({
+      existingCustomIds: [],
+      tierRows: [
+        {
+          id: 'tier-1',
+          override_model: null,
+          override_provider: null,
+          fallback_models: JSON.stringify(['custom:gone', 'openai/gpt-4o']),
+        },
+      ],
+    });
+
+    await migration.up({ query } as unknown as QueryRunner);
+
+    const tierUpdates = updates.filter((u) => u.table === 'tier_assignments');
+    expect(tierUpdates).toHaveLength(1);
+    const updated = JSON.parse(tierUpdates[0].params[0] as string);
+    expect(updated).toEqual(['openai/gpt-4o']);
+  });
+
+  it('down() is a no-op', async () => {
+    await expect(migration.down()).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend/src/database/migrations/1776679833383-CleanupOrphanedCustomProviderRefs.ts
+++ b/packages/backend/src/database/migrations/1776679833383-CleanupOrphanedCustomProviderRefs.ts
@@ -1,0 +1,125 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const CUSTOM_PROVIDER_PREFIX = 'custom:';
+
+/**
+ * Backfill cleanup for #1603.
+ *
+ * `tier_assignments` and `specificity_assignments` store custom provider
+ * references as plain varchar / JSON text (no FK). Deleting a custom provider
+ * used to leave behind orphan references — most visibly in specificity
+ * assignments, where resolve() bypassed availability checks and pinned every
+ * matching request to the dead provider. This migration finds all such
+ * orphan references and clears them so existing affected agents recover
+ * without manual DB intervention.
+ */
+export class CleanupOrphanedCustomProviderRefs1776679833383 implements MigrationInterface {
+  name = 'CleanupOrphanedCustomProviderRefs1776679833383';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const existing: { id: string }[] = await queryRunner.query('SELECT id FROM custom_providers');
+    const existingIds = new Set(existing.map((row) => row.id));
+
+    await this.cleanTable(queryRunner, 'tier_assignments', existingIds);
+    await this.cleanTable(queryRunner, 'specificity_assignments', existingIds);
+  }
+
+  public async down(): Promise<void> {
+    // No-op: cleared references cannot be reconstructed.
+  }
+
+  private async cleanTable(
+    queryRunner: QueryRunner,
+    table: string,
+    existingIds: Set<string>,
+  ): Promise<void> {
+    const rows: {
+      id: string;
+      override_model: string | null;
+      override_provider: string | null;
+      fallback_models: string | null;
+    }[] = await queryRunner.query(
+      `SELECT id, override_model, override_provider, fallback_models
+         FROM "${table}"
+        WHERE override_provider LIKE $1
+           OR override_model LIKE $1
+           OR fallback_models LIKE $2`,
+      [`${CUSTOM_PROVIDER_PREFIX}%`, `%${CUSTOM_PROVIDER_PREFIX}%`],
+    );
+
+    for (const row of rows) {
+      let overrideModel = row.override_model;
+      let overrideProvider = row.override_provider;
+      let fallbackModels = row.fallback_models;
+      let clearOverrideAuth = false;
+      let changed = false;
+
+      const overrideCustomId =
+        extractCustomIdFromProvider(overrideProvider) ?? extractCustomIdFromModel(overrideModel);
+      if (overrideCustomId && !existingIds.has(overrideCustomId)) {
+        overrideModel = null;
+        overrideProvider = null;
+        clearOverrideAuth = true;
+        changed = true;
+      }
+
+      if (fallbackModels) {
+        try {
+          const parsed = JSON.parse(fallbackModels);
+          if (Array.isArray(parsed)) {
+            const filtered = parsed.filter((entry) => {
+              if (typeof entry !== 'string') return true;
+              const id = extractCustomIdFromModel(entry);
+              return !id || existingIds.has(id);
+            });
+            if (filtered.length !== parsed.length) {
+              fallbackModels = filtered.length > 0 ? JSON.stringify(filtered) : null;
+              changed = true;
+            }
+          }
+        } catch {
+          // Leave malformed JSON untouched; log-only behavior isn't worth a crash here.
+        }
+      }
+
+      if (!changed) continue;
+
+      if (clearOverrideAuth) {
+        await queryRunner.query(
+          `UPDATE "${table}"
+              SET override_model = $1,
+                  override_provider = $2,
+                  override_auth_type = NULL,
+                  fallback_models = $3,
+                  updated_at = NOW()
+            WHERE id = $4`,
+          [overrideModel, overrideProvider, fallbackModels, row.id],
+        );
+      } else {
+        await queryRunner.query(
+          `UPDATE "${table}"
+              SET fallback_models = $1,
+                  updated_at = NOW()
+            WHERE id = $2`,
+          [fallbackModels, row.id],
+        );
+      }
+    }
+  }
+}
+
+function extractCustomIdFromProvider(value: string | null): string | null {
+  if (!value) return null;
+  if (!value.startsWith(CUSTOM_PROVIDER_PREFIX)) return null;
+  const id = value.slice(CUSTOM_PROVIDER_PREFIX.length);
+  return id.length > 0 ? id : null;
+}
+
+function extractCustomIdFromModel(value: string | null): string | null {
+  if (!value) return null;
+  if (!value.startsWith(CUSTOM_PROVIDER_PREFIX)) return null;
+  const rest = value.slice(CUSTOM_PROVIDER_PREFIX.length);
+  const slash = rest.indexOf('/');
+  const id = slash === -1 ? rest : rest.slice(0, slash);
+  return id.length > 0 ? id : null;
+}

--- a/packages/backend/src/routing/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve.service.spec.ts
@@ -26,6 +26,7 @@ describe('ResolveService', () => {
       getEffectiveModel: jest.fn(),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       hasActiveProvider: jest.fn().mockResolvedValue(true),
+      isModelAvailable: jest.fn().mockResolvedValue(true),
     };
     mockSpecificityService = {
       getActiveAssignments: jest.fn().mockResolvedValue([]),

--- a/packages/backend/src/routing/resolve/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.spec.ts
@@ -18,6 +18,7 @@ function makeService(overrides: {
   getEffectiveModel?: jest.Mock;
   getAuthType?: jest.Mock;
   hasActiveProvider?: jest.Mock;
+  isModelAvailable?: jest.Mock;
   activeSpecificity?: unknown[];
   getModelForAgent?: jest.Mock;
   getByModel?: jest.Mock;
@@ -30,6 +31,7 @@ function makeService(overrides: {
     getEffectiveModel: overrides.getEffectiveModel ?? jest.fn().mockResolvedValue(null),
     getAuthType: overrides.getAuthType ?? jest.fn().mockResolvedValue('api_key'),
     hasActiveProvider: overrides.hasActiveProvider ?? jest.fn().mockResolvedValue(false),
+    isModelAvailable: overrides.isModelAvailable ?? jest.fn().mockResolvedValue(true),
   } as unknown as ProviderKeyService;
 
   const specificityService: SpecificityService = {
@@ -129,6 +131,119 @@ describe('ResolveService', () => {
       });
       const out = await svc.resolve('agent-1', [{ role: 'user', content: 'hi' }]);
       expect(out.reason).toBe('scored');
+    });
+
+    it('falls through to tier routing when the specificity override points to an unavailable model (#1603)', async () => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'simple',
+        confidence: 1,
+        score: 0,
+        reason: 'scored',
+      });
+      scoring.scanMessages.mockReturnValue({ category: 'coding', confidence: 0.9 });
+      const isModelAvailable = jest.fn().mockResolvedValue(false);
+      const { svc } = makeService({
+        activeSpecificity: [
+          {
+            category: 'coding',
+            override_model: 'custom:deleted-uuid/gemini-2.5-flash-lite',
+            override_provider: 'custom:deleted-uuid',
+            auto_assigned_model: null,
+          },
+        ],
+        tiers: [
+          {
+            tier: 'simple',
+            override_model: null,
+            auto_assigned_model: 'openai/gpt-5-mini',
+            override_provider: null,
+            override_auth_type: null,
+          },
+        ],
+        isModelAvailable,
+        getEffectiveModel: jest.fn().mockResolvedValue('openai/gpt-5-mini'),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'write code' }]);
+      expect(isModelAvailable).toHaveBeenCalledWith(
+        'agent-1',
+        'custom:deleted-uuid/gemini-2.5-flash-lite',
+      );
+      expect(out.reason).toBe('scored');
+      expect(out.model).toBe('openai/gpt-5-mini');
+      expect(out.provider).toBe('openai');
+    });
+
+    it('uses auto_assigned_model when override_model is null on a specificity assignment', async () => {
+      scoring.scanMessages.mockReturnValue({ category: 'coding', confidence: 0.8 });
+      const { svc } = makeService({
+        activeSpecificity: [
+          {
+            category: 'coding',
+            override_model: null,
+            auto_assigned_model: 'openai/gpt-5',
+            override_provider: null,
+          },
+        ],
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'code' }]);
+      expect(out.reason).toBe('specificity');
+      expect(out.model).toBe('openai/gpt-5');
+    });
+
+    it('returns a specificity response with provider=null and no auth_type when the model cannot be attributed to any provider', async () => {
+      // Exercises the `provider ? ... : undefined` branch in resolveSpecificity where
+      // resolveProvider returns null — the call still surfaces the specificity category
+      // + model, but auth_type is omitted because there's no provider to look it up for.
+      scoring.scanMessages.mockReturnValue({ category: 'coding', confidence: 0.9 });
+      const getAuthType = jest.fn().mockResolvedValue('api_key');
+      const { svc } = makeService({
+        activeSpecificity: [
+          {
+            category: 'coding',
+            override_model: 'unresolvable-model',
+            auto_assigned_model: null,
+            override_provider: null,
+            override_auth_type: null,
+          },
+        ],
+        // no prefix match, no discovered model, no pricing entry → provider resolves to null
+        hasActiveProvider: jest.fn().mockResolvedValue(false),
+        getModelForAgent: jest.fn().mockResolvedValue(null),
+        getByModel: jest.fn().mockReturnValue(null),
+        getAuthType,
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'code' }]);
+      expect(out.reason).toBe('specificity');
+      expect(out.model).toBe('unresolvable-model');
+      expect(out.provider).toBeNull();
+      expect(out.auth_type).toBeUndefined();
+      expect(getAuthType).not.toHaveBeenCalled();
+    });
+
+    it('uses override_auth_type directly when the specificity assignment pins one (skips getAuthType)', async () => {
+      scoring.scanMessages.mockReturnValue({ category: 'coding', confidence: 0.9 });
+      const hasActiveProvider = jest.fn().mockResolvedValue(true);
+      const getAuthType = jest.fn().mockResolvedValue('api_key');
+      const { svc } = makeService({
+        activeSpecificity: [
+          {
+            category: 'coding',
+            override_model: 'anthropic/claude-opus-4',
+            auto_assigned_model: null,
+            override_provider: null,
+            override_auth_type: 'subscription',
+          },
+        ],
+        hasActiveProvider,
+        getAuthType,
+      });
+      const out = await svc.resolve('agent-1', [{ role: 'user', content: 'write some code' }]);
+      expect(out.reason).toBe('specificity');
+      expect(out.auth_type).toBe('subscription');
+      // getAuthType must not be called when override_auth_type is set
+      expect(getAuthType).not.toHaveBeenCalled();
     });
 
     it('returns the specificity response with provider + auth type when a match hits', async () => {

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -137,7 +137,7 @@ export class ResolveService {
     const assignment = active.find((a) => a.category === detected.category);
     if (!assignment) return null;
 
-    const model = assignment.override_model ?? assignment.auto_assigned_model;
+    const model = await this.resolveSpecificityModel(agentId, assignment);
     if (!model) return null;
 
     const provider = await this.resolveProvider(
@@ -164,6 +164,29 @@ export class ResolveService {
       specificity_category: detected.category,
       fallback_models: assignment.fallback_models ?? null,
     };
+  }
+
+  /**
+   * Validates the specificity override points to an available model before
+   * using it. An orphaned override (e.g. a deleted custom provider) returns
+   * null so resolve() falls through to tier-based routing instead of pinning
+   * every matching request to a dead provider (#1603).
+   */
+  private async resolveSpecificityModel(
+    agentId: string,
+    assignment: { override_model: string | null; auto_assigned_model: string | null },
+  ): Promise<string | null> {
+    if (assignment.override_model !== null) {
+      if (await this.providerKeyService.isModelAvailable(agentId, assignment.override_model)) {
+        return assignment.override_model;
+      }
+      this.logger.warn(
+        `Specificity override ${assignment.override_model} is unavailable ` +
+          `for agent=${agentId}; falling through to tier routing`,
+      );
+      return null;
+    }
+    return assignment.auto_assigned_model;
   }
 
   /**

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -165,7 +165,7 @@ export class ProviderKeyService {
     return null;
   }
 
-  private async isModelAvailable(agentId: string, model: string): Promise<boolean> {
+  async isModelAvailable(agentId: string, model: string): Promise<boolean> {
     // Check discovered models first
     const discovered = await this.discoveryService.getModelForAgent(agentId, model);
     if (discovered) return true;

--- a/packages/backend/src/routing/routing-core/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.spec.ts
@@ -5,6 +5,7 @@ import { RoutingCacheService } from './routing-cache.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 
 jest.mock('../../common/utils/crypto.util', () => ({
   encrypt: jest.fn().mockReturnValue('encrypted-value'),
@@ -67,6 +68,7 @@ describe('ProviderService', () => {
   let service: ProviderService;
   let providerRepo: ReturnType<typeof makeMockRepo>;
   let tierRepo: ReturnType<typeof makeMockRepo>;
+  let specificityRepo: ReturnType<typeof makeMockRepo>;
   let autoAssign: { recalculate: jest.Mock };
   let routingCache: {
     invalidateAgent: jest.Mock;
@@ -79,6 +81,7 @@ describe('ProviderService', () => {
     jest.clearAllMocks();
     providerRepo = makeMockRepo();
     tierRepo = makeMockRepo();
+    specificityRepo = makeMockRepo();
     autoAssign = { recalculate: jest.fn().mockResolvedValue(undefined) };
     routingCache = {
       invalidateAgent: jest.fn(),
@@ -90,6 +93,7 @@ describe('ProviderService', () => {
     service = new ProviderService(
       providerRepo as unknown as any,
       tierRepo as unknown as any,
+      specificityRepo as unknown as any,
       autoAssign as unknown as TierAutoAssignService,
       pricingCache as unknown as ModelPricingCacheService,
       routingCache as unknown as RoutingCacheService,
@@ -525,7 +529,7 @@ describe('ProviderService', () => {
       // First find (cleanup) returns the unsupported provider
       providerRepo.find.mockResolvedValueOnce([unsupported]);
 
-      // clearTierAssignmentsForProviders returns hadTierAssignments: true
+      // cleanupProviderReferences returns hadTierAssignments: true
       const existingTier = makeTier({ agent_id: 'agent-1', override_model: null });
       tierRepo.find
         .mockResolvedValueOnce([]) // overrides (Not IsNull)
@@ -541,9 +545,9 @@ describe('ProviderService', () => {
     });
   });
 
-  /* ── clearTierAssignmentsForProviders (private, tested via removeProvider) ── */
+  /* ── cleanupProviderReferences (private, tested via removeProvider) ── */
 
-  describe('clearTierAssignmentsForProviders (via removeProvider)', () => {
+  describe('cleanupProviderReferences (via removeProvider)', () => {
     it('should clear override when pricing provider matches', async () => {
       const existing = makeProvider({ is_active: true });
       providerRepo.findOne.mockResolvedValue(existing);
@@ -687,6 +691,175 @@ describe('ProviderService', () => {
       expect(tierRepo.save).toHaveBeenCalledWith([
         expect.objectContaining({ fallback_models: ['unknown-model'] }),
       ]);
+    });
+  });
+
+  /* ── cleanupProviderReferences: custom provider + specificity (#1603) ── */
+
+  describe('cleanupProviderReferences — custom provider + specificity', () => {
+    function makeSpecificity(
+      overrides: Partial<SpecificityAssignment> = {},
+    ): SpecificityAssignment {
+      return Object.assign(new SpecificityAssignment(), {
+        id: 'spec-1',
+        user_id: 'user-1',
+        agent_id: 'agent-1',
+        category: 'coding',
+        is_active: true,
+        override_model: null,
+        override_provider: null,
+        override_auth_type: null,
+        auto_assigned_model: null,
+        fallback_models: null,
+        updated_at: '2025-01-01T00:00:00Z',
+        ...overrides,
+      });
+    }
+
+    it('clears specificity overrides pointing to the deleted custom provider', async () => {
+      const existing = makeProvider({ provider: 'custom:abc-123', is_active: true });
+      providerRepo.findOne.mockResolvedValue(existing);
+      providerRepo.find.mockResolvedValue([]);
+      tierRepo.find.mockResolvedValue([]);
+
+      const orphanSpec = makeSpecificity({
+        override_model: 'custom:abc-123/gemini-2.5-flash',
+        override_provider: 'custom:abc-123',
+        override_auth_type: 'api_key',
+      });
+      specificityRepo.find.mockResolvedValue([orphanSpec]);
+
+      await service.removeProvider('agent-1', 'custom:abc-123');
+
+      expect(specificityRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'spec-1',
+          override_model: null,
+          override_provider: null,
+          override_auth_type: null,
+        }),
+      ]);
+    });
+
+    it('clears specificity override when model uses custom prefix but override_provider is null', async () => {
+      const existing = makeProvider({ provider: 'custom:abc-123', is_active: true });
+      providerRepo.findOne.mockResolvedValue(existing);
+      providerRepo.find.mockResolvedValue([]);
+      tierRepo.find.mockResolvedValue([]);
+
+      const orphanSpec = makeSpecificity({
+        override_model: 'custom:abc-123/gemini-2.5-flash',
+        override_provider: null,
+      });
+      specificityRepo.find.mockResolvedValue([orphanSpec]);
+
+      await service.removeProvider('agent-1', 'custom:abc-123');
+
+      expect(specificityRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'spec-1', override_model: null }),
+      ]);
+    });
+
+    it('removes custom-prefixed entries from specificity fallback_models', async () => {
+      const existing = makeProvider({ provider: 'custom:abc-123', is_active: true });
+      providerRepo.findOne.mockResolvedValue(existing);
+      providerRepo.find.mockResolvedValue([]);
+      tierRepo.find.mockResolvedValue([]);
+
+      const spec = makeSpecificity({
+        override_model: null,
+        fallback_models: ['custom:abc-123/gemini-2.5-flash', 'anthropic/claude-opus-4'],
+      });
+      specificityRepo.find.mockResolvedValue([spec]);
+
+      await service.removeProvider('agent-1', 'custom:abc-123');
+
+      expect(specificityRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({ fallback_models: ['anthropic/claude-opus-4'] }),
+      ]);
+    });
+
+    it('removes custom-prefixed entries from tier fallback_models (pricing cache would miss them)', async () => {
+      const existing = makeProvider({ provider: 'custom:abc-123', is_active: true });
+      providerRepo.findOne.mockResolvedValue(existing);
+      providerRepo.find.mockResolvedValue([]);
+
+      const tier = makeTier({
+        override_model: null,
+        fallback_models: ['custom:abc-123/gemini-2.5-flash', 'gpt-4o'],
+      });
+      tierRepo.find.mockResolvedValueOnce([]).mockResolvedValueOnce([tier]);
+      pricingCache.getByModel.mockImplementation((model: string) => {
+        if (model === 'gpt-4o') return { provider: 'OpenAI' };
+        return undefined;
+      });
+
+      await service.removeProvider('agent-1', 'custom:abc-123');
+
+      expect(tierRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({ fallback_models: ['gpt-4o'] }),
+      ]);
+    });
+
+    it('clears tier override when only override_model carries the custom prefix', async () => {
+      const existing = makeProvider({ provider: 'custom:abc-123', is_active: true });
+      providerRepo.findOne.mockResolvedValue(existing);
+      providerRepo.find.mockResolvedValue([]);
+
+      const orphanTier = makeTier({
+        tier: 'standard',
+        override_model: 'custom:abc-123/gemini-2.5-flash',
+        override_provider: null,
+      });
+      tierRepo.find
+        .mockResolvedValueOnce([orphanTier])
+        .mockResolvedValueOnce([orphanTier])
+        .mockResolvedValueOnce([makeTier({ tier: 'standard', override_model: null })]);
+
+      const result = await service.removeProvider('agent-1', 'custom:abc-123');
+
+      expect(tierRepo.save).toHaveBeenCalled();
+      expect(result.notifications).toHaveLength(1);
+    });
+
+    it('sets specificity fallback_models to null when every entry belongs to the deleted custom provider', async () => {
+      // Regression for #1603: specificity fallback list containing only orphan entries
+      // should be nulled out (not kept as an empty array) so resolve() has no leftover
+      // references to silently forward to the dead provider.
+      const existing = makeProvider({ provider: 'custom:abc-123', is_active: true });
+      providerRepo.findOne.mockResolvedValue(existing);
+      providerRepo.find.mockResolvedValue([]);
+      tierRepo.find.mockResolvedValue([]);
+
+      const spec = makeSpecificity({
+        override_model: null,
+        fallback_models: ['custom:abc-123/gemini-2.5-flash', 'custom:abc-123/gemini-2.5-pro'],
+      });
+      specificityRepo.find.mockResolvedValue([spec]);
+
+      await service.removeProvider('agent-1', 'custom:abc-123');
+
+      expect(specificityRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({ fallback_models: null }),
+      ]);
+    });
+
+    it('leaves specificity rows untouched when they reference a different provider', async () => {
+      const existing = makeProvider({ provider: 'custom:abc-123', is_active: true });
+      providerRepo.findOne.mockResolvedValue(existing);
+      providerRepo.find.mockResolvedValue([]);
+      tierRepo.find.mockResolvedValue([]);
+
+      const unrelated = makeSpecificity({
+        override_model: 'anthropic/claude-opus-4',
+        override_provider: 'anthropic',
+        fallback_models: ['anthropic/claude-sonnet-4'],
+      });
+      specificityRepo.find.mockResolvedValue([unrelated]);
+
+      await service.removeProvider('agent-1', 'custom:abc-123');
+
+      expect(specificityRepo.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Not, IsNull, Repository, In } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { TierAutoAssignService } from './tier-auto-assign.service';
 import { RoutingCacheService } from './routing-cache.service';
@@ -24,6 +25,8 @@ export class ProviderService {
     private readonly providerRepo: Repository<UserProvider>,
     @InjectRepository(TierAssignment)
     private readonly tierRepo: Repository<TierAssignment>,
+    @InjectRepository(SpecificityAssignment)
+    private readonly specificityRepo: Repository<SpecificityAssignment>,
     private readonly autoAssign: TierAutoAssignService,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly routingCache: RoutingCacheService,
@@ -225,7 +228,7 @@ export class ProviderService {
       return { notifications: [] };
     }
 
-    const { invalidated } = await this.clearTierAssignmentsForProviders(agentId, [provider]);
+    const { invalidated } = await this.cleanupProviderReferences(agentId, [provider]);
     await this.autoAssign.recalculate(agentId);
     this.routingCache.invalidateAgent(agentId);
 
@@ -301,7 +304,7 @@ export class ProviderService {
     );
 
     if (removedProviders.length > 0) {
-      const { hadTierAssignments } = await this.clearTierAssignmentsForProviders(
+      const { hadTierAssignments } = await this.cleanupProviderReferences(
         agentId,
         removedProviders,
       );
@@ -311,27 +314,44 @@ export class ProviderService {
     }
     this.routingCache.invalidateAgent(agentId);
   }
-  private async clearTierAssignmentsForProviders(
+
+  /**
+   * Clears overrides and fallback entries on both tier_assignments and
+   * specificity_assignments that reference any of the given provider keys.
+   *
+   * A row matches when any of these hold for its override_model/fallback entry:
+   *   - the assignment's override_provider equals the provider key (case-insensitive)
+   *   - the model/entry string starts with `<providerKey>/` (covers custom:<uuid>/... entries
+   *     that don't carry an explicit override_provider, and any fallback_models list where
+   *     provider metadata isn't stored alongside the string)
+   *   - the pricing cache infers the entry belongs to this provider (well-known models)
+   */
+  private async cleanupProviderReferences(
     agentId: string,
     providers: string[],
   ): Promise<{ invalidated: { tier: string; modelName: string }[]; hadTierAssignments: boolean }> {
     if (providers.length === 0) return { invalidated: [], hadTierAssignments: false };
 
     const providerNames = new Set(providers.map((provider) => provider.toLowerCase()));
-    const overrides = await this.tierRepo.find({
-      where: { agent_id: agentId, override_model: Not(IsNull()) },
-    });
+    const prefixKeys = providers.map((provider) => `${provider.toLowerCase()}/`);
+    const modelBelongs = (model: string): boolean => {
+      const lower = model.toLowerCase();
+      if (prefixKeys.some((prefix) => lower.startsWith(prefix))) return true;
+      const pricing = this.pricingCache.getByModel(model)?.provider.toLowerCase();
+      return !!pricing && providerNames.has(pricing);
+    };
 
     const invalidated: { tier: string; modelName: string }[] = [];
+
+    const tierOverrides = await this.tierRepo.find({
+      where: { agent_id: agentId, override_model: Not(IsNull()) },
+    });
     const tiersToSave: TierAssignment[] = [];
-    for (const tier of overrides) {
+    for (const tier of tierOverrides) {
       const overrideProvider = tier.override_provider?.toLowerCase();
-      const pricingProvider = this.pricingCache
-        .getByModel(tier.override_model!)
-        ?.provider.toLowerCase();
       if (
         (overrideProvider && providerNames.has(overrideProvider)) ||
-        (pricingProvider && providerNames.has(pricingProvider))
+        modelBelongs(tier.override_model!)
       ) {
         invalidated.push({ tier: tier.tier, modelName: tier.override_model! });
         tier.override_model = null;
@@ -344,21 +364,47 @@ export class ProviderService {
 
     const allTiers = await this.tierRepo.find({ where: { agent_id: agentId } });
     const hadTierAssignments = allTiers.length > 0;
-    const savedIds = new Set(tiersToSave.map((tier) => tier.id));
+    const savedTierIds = new Set(tiersToSave.map((tier) => tier.id));
     for (const tier of allTiers) {
       if (!tier.fallback_models || tier.fallback_models.length === 0) continue;
-      const filtered = tier.fallback_models.filter((model) => {
-        const pricing = this.pricingCache.getByModel(model);
-        return !pricing || !providerNames.has(pricing.provider.toLowerCase());
-      });
+      const filtered = tier.fallback_models.filter((model) => !modelBelongs(model));
       if (filtered.length !== tier.fallback_models.length) {
         tier.fallback_models = filtered.length > 0 ? filtered : null;
         tier.updated_at = new Date().toISOString();
-        if (!savedIds.has(tier.id)) tiersToSave.push(tier);
+        if (!savedTierIds.has(tier.id)) tiersToSave.push(tier);
       }
     }
 
     if (tiersToSave.length > 0) await this.tierRepo.save(tiersToSave);
+
+    const specificityRows = await this.specificityRepo.find({ where: { agent_id: agentId } });
+    const specToSave: SpecificityAssignment[] = [];
+    for (const row of specificityRows) {
+      let changed = false;
+      const overrideProvider = row.override_provider?.toLowerCase();
+      if (
+        row.override_model !== null &&
+        ((overrideProvider && providerNames.has(overrideProvider)) ||
+          modelBelongs(row.override_model))
+      ) {
+        row.override_model = null;
+        row.override_provider = null;
+        row.override_auth_type = null;
+        changed = true;
+      }
+      if (row.fallback_models && row.fallback_models.length > 0) {
+        const filtered = row.fallback_models.filter((model) => !modelBelongs(model));
+        if (filtered.length !== row.fallback_models.length) {
+          row.fallback_models = filtered.length > 0 ? filtered : null;
+          changed = true;
+        }
+      }
+      if (changed) {
+        row.updated_at = new Date().toISOString();
+        specToSave.push(row);
+      }
+    }
+    if (specToSave.length > 0) await this.specificityRepo.save(specToSave);
 
     return { invalidated, hadTierAssignments };
   }


### PR DESCRIPTION
## Summary

Fixes #1603 — a deleted custom provider kept intercepting every API request even after deletion and even after routing was updated to point elsewhere.

**Root cause:** `ProviderService.removeProvider` only swept \`tier_assignments\`; it never touched \`specificity_assignments\`. Because \`ResolveService.resolveSpecificity\` runs before tier resolution and returned \`override_model\` without any availability check (unlike the tier path, which goes through \`getEffectiveModel\` → \`isModelAvailable\`), an orphan specificity override pinned every matching request to the dead provider. The \`fallback_models\` cleanup also missed \`custom:<uuid>/*\` entries because its predicate relied on the pricing cache.

**Fix:**
- `resolveSpecificityModel` in `resolve.service.ts` validates overrides via `ProviderKeyService.isModelAvailable` and falls through to tier-based routing when the model is gone.
- `isModelAvailable` was made public to enable that call.
- `clearTierAssignmentsForProviders` → renamed to `cleanupProviderReferences`, now sweeps both \`tier_assignments\` AND \`specificity_assignments\`, and its `modelBelongs` predicate also matches \`override_model.startsWith("<key>/")\` so custom-prefixed entries with a null `override_provider` are caught.
- A backfill migration (`1776679833383-CleanupOrphanedCustomProviderRefs`) clears existing orphan references from both tables so already-affected agents recover on boot — including the reporter's `custom:400ebd9f-...`.
- No DB-level FK added: `override_provider` is a free-form varchar shared across custom + well-known providers, so application-level cleanup is the right layer.

## Test plan

- [x] Backend unit suite (3886 tests) — all pass, added 11 new tests targeting the fix
- [x] Backend e2e suite (115 tests) — all pass
- [x] `tsc --noEmit` clean on backend and frontend
- [x] Frontend (2221) + shared (83) test suites — all pass
- [x] 100% line coverage on all new/modified source lines (`resolve.service.ts`, `cleanupProviderReferences` in `provider.service.ts`, the new migration)
- [ ] Manual repro on a fresh dev DB: create custom provider A, set specificity override to `custom:A/…`, delete A, create custom provider B, send a coding-flavored request → request must not route to `custom:A` (will verify post-merge on a clean environment)

## Files

- Source: `resolve/resolve.service.ts`, `routing-core/provider.service.ts`, `routing-core/provider-key.service.ts`
- Migration: `database/migrations/1776679833383-CleanupOrphanedCustomProviderRefs.ts` + spec + wiring in `database.module.ts`
- Tests: `resolve/resolve.service.spec.ts`, `resolve.service.spec.ts`, `routing-core/provider.service.spec.ts`
- Changeset under \`.changeset/\`