### PR TITLE
fix(release): detect version bump from pushed SHA, not polluted HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,20 @@ jobs:
         id: detect
         env:
           BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
-          # Read CURR from HEAD (not the working tree) because
-          # changesets/action runs `npm run version-packages` in place and
-          # may have mutated packages/manifest/package.json on disk.
-          CURR=$(git show HEAD:packages/manifest/package.json 2>/dev/null | jq -r .version 2>/dev/null || echo "")
+          # Read both versions from the immutable remote SHAs of the push
+          # event, NOT from `HEAD`. changesets/action@v1 runs
+          # `npm run version-packages` in this same checkout when there are
+          # unconsumed changesets and commits the result locally to push as
+          # a "chore: version packages" side-branch PR. After that runs,
+          # local HEAD points at a commit whose version bump is NOT yet on
+          # main — using it here would falsely report a bump and trigger
+          # downstream publish jobs with main's stale version number,
+          # clobbering an existing Docker tag and a GitHub Release. See the
+          # 5.47.0 re-publish incident during PR #1557 merge for the
+          # failure mode this guards against.
+          CURR=$(git show "${AFTER_SHA}:packages/manifest/package.json" 2>/dev/null | jq -r .version 2>/dev/null || echo "")
           # Compare against the push base so multi-commit pushes are handled
           # correctly. On first push to a branch, BEFORE_SHA is all zeros.
           if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then


### PR DESCRIPTION
## Summary

Fixes a pipeline race in `release.yml` that caused PR #1557 to clobber the Docker tag `manifestdotbuild/manifest:5.47.0` and fail the `github-release` job.

## Background

`release.yml` is the push-to-main pipeline. It runs in three stages:

1. **`release`** — installs, builds, runs `changesets/action@v1`, then a `Detect version bump` step sets `should_publish` based on whether `packages/manifest/package.json` changed.
2. **`github-release`** — creates the GH Release if `should_publish=true`.
3. **`publish-docker`** — builds and pushes the multi-arch image if `should_publish=true`.

Per the docs in `CLAUDE.md`, merging a feature PR should only *open* the "chore: version packages" PR; only merging that PR should publish. The detect step is the gate that enforces this.

## The bug

`Detect version bump` compared `BEFORE_SHA` (the push base, a remote SHA) against local `HEAD`. But when the workflow run also contains unconsumed changesets, `changesets/action@v1` runs `npm run version-packages` in the same checkout, commits the result locally, and pushes it to a side branch for the "chore: version packages" PR. After that step, **local HEAD points at a commit whose version bump is not yet on main** — the side-branch PR is still pending review.

Result:

- Detect reports a false-positive bump (`5.47.0 → 5.47.1` in this case).
- `github-release` and `publish-docker` do fresh `actions/checkout` of remote main and read the *stale* version (`5.47.0`, the version actually on main).
- Docker publishes the new image under the **old** tag, clobbering `manifestdotbuild/manifest:5.47.0` (previously from 2026-04-17).
- GH Release create fails with `HTTP 422: Release.tag_name already exists` because `manifest@5.47.0` was released weeks ago.

Failure from PR #1557 merge: https://github.com/mnfst/manifest/actions/runs/24665774884

## Fix

Read `CURR` from `${{ github.sha }}` — the immutable remote SHA the push event delivered — instead of local HEAD. That matches how `PREV` is already read from `${{ github.event.before }}` and how downstream jobs see the repo after their own checkouts. Every stage now agrees on the version.

## Test plan

- [ ] Merge this PR. `release.yml` will re-run on the merge commit. Since this PR doesn't touch `packages/manifest/package.json`, both `BEFORE_SHA` and `${{ github.sha }}` should resolve to the same version → `should_publish=false` → no downstream publish. (Sanity check that the fix doesn't over-correct.)
- [ ] Once PR #1631 ("chore: version packages" to 5.47.1) is merged, the next pipeline run should legitimately detect `5.47.0 → 5.47.1` from the pushed SHA, publish `manifestdotbuild/manifest:5.47.1`, and create a fresh GH Release — no clobbering, no 422.

## Related

- Incident: `:5.47.0` Docker tag overwritten during #1557 merge.
- Pending follow-up: merge #1631 to republish under the correct version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `release.yml` by reading the version from the pushed SHA instead of local `HEAD`. This stops false bump detection when `changesets/action@v1` mutates the checkout and prevents overwriting Docker tags or failing GitHub Releases.

- **Bug Fixes**
  - Compare `${{ github.event.before }}` to `${{ github.sha }}` and read `packages/manifest/package.json` from those SHAs.
  - Keeps `release`, `github-release`, and `publish-docker` in sync after their own `actions/checkout`.

<sup>Written for commit 8e78331ce252d3375632015475bd0a0590412d9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

