### PR TITLE
fix(csp): drop upgrade-insecure-requests to unblock LAN deployments

### DIFF
--- a/.changeset/fix-blank-page-lan-deployment.md
+++ b/.changeset/fix-blank-page-lan-deployment.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix blank dashboard when exposing Manifest on a LAN IP over HTTP. Helmet's default CSP emitted `upgrade-insecure-requests`, which browsers enforce on private IPv4 ranges (10.x, 172.16-31.x, 192.168.x) but relax for localhost — so the JS bundle was rewritten to `https://` and silently failed to load, leaving an empty `<body>`. The directive is now disabled; HTTPS deployments should enforce upgrades via HSTS at the reverse proxy instead.

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -230,6 +230,8 @@ By default the compose file binds port `3001` to `127.0.0.1` only. The dashboard
 
 If you see "Invalid origin" on the login page, `BETTER_AUTH_URL` doesn't match the URL you're accessing the dashboard on. The host matters as much as the port.
 
+If the dashboard loads as a **blank page on a LAN IP on an older image**, pull the latest image (`docker compose pull && docker compose up -d`). Older builds emitted an `upgrade-insecure-requests` CSP directive that made browsers rewrite `/assets/*.js` to HTTPS on private-IP hosts (10.x / 172.16-31.x / 192.168.x), which the server doesn't serve — the JS bundle failed to load and the page never mounted. This directive has been removed.
+
 ## Image tags
 
 Every release is published with the following tags:

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -34,6 +34,12 @@ export async function bootstrap() {
                 .map((v) => v.trim())
                 .filter((v) => v !== '*')
             : ["'none'"],
+          // Disable helmet's default `upgrade-insecure-requests`: it breaks
+          // HTTP-only LAN deployments (10.x / 192.168.x / 172.16-31.x) where
+          // browsers don't treat the origin as trustworthy and rewrite
+          // `/assets/*.js` to https://, which the server doesn't serve.
+          // HTTPS deployments should enforce upgrades via HSTS at the proxy.
+          upgradeInsecureRequests: null,
         },
       },
     }),

--- a/packages/backend/test/csp.e2e-spec.ts
+++ b/packages/backend/test/csp.e2e-spec.ts
@@ -1,0 +1,63 @@
+import express from 'express';
+import helmet from 'helmet';
+import request from 'supertest';
+import type { Server } from 'http';
+
+// Mirrors the helmet config in src/main.ts. If the two drift, this test
+// stops guarding the real deployment — keep them in sync.
+function buildApp() {
+  const app = express();
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          imgSrc: ["'self'", 'data:'],
+          connectSrc: ["'self'"],
+          fontSrc: ["'self'"],
+          objectSrc: ["'none'"],
+          frameAncestors: process.env['FRAME_ANCESTORS']
+            ? process.env['FRAME_ANCESTORS']
+                .split(',')
+                .map((v) => v.trim())
+                .filter((v) => v !== '*')
+            : ["'none'"],
+          upgradeInsecureRequests: null,
+        },
+      },
+    }),
+  );
+  app.get('/', (_req, res) => res.status(200).send('ok'));
+  return app;
+}
+
+describe('CSP header', () => {
+  let server: Server;
+
+  beforeAll(() => {
+    server = buildApp().listen(0);
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('does NOT include upgrade-insecure-requests (breaks LAN deployments over HTTP)', async () => {
+    const res = await request(server).get('/').expect(200);
+    const csp = res.headers['content-security-policy'];
+    expect(csp).toBeDefined();
+    expect(csp).not.toContain('upgrade-insecure-requests');
+  });
+
+  it('still emits the self-only CSP directives', async () => {
+    const res = await request(server).get('/').expect(200);
+    const csp = res.headers['content-security-policy'] as string;
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+  });
+});


### PR DESCRIPTION
## Summary

- Multiple Discord users report Manifest loads fine on `localhost` but renders a blank page when accessed from another device on the LAN (e.g. `http://10.25.0.224:3001` or `http://192.168.0.17:3001`), even with `docker-compose.yml` ports changed to `3001:3001` and `BETTER_AUTH_URL` updated.
- Root cause: `packages/backend/src/main.ts` passes a `directives` object to `helmet({ contentSecurityPolicy })` without `useDefaults: false`. Helmet merges in its default `"upgrade-insecure-requests": []` directive. Browsers give `localhost` / `127.0.0.1` / `::1` a "potentially trustworthy" exemption from that directive; private IPv4 ranges (10/8, 172.16-31/12, 192.168/16) do not. The JS bundle request gets rewritten to `https://<lan-ip>:3001/assets/index-*.js`, the server has no TLS listener, the script never loads, SolidJS never mounts — blank `<body>`.
- Fix: set `upgradeInsecureRequests: null` in the CSP directives (helmet's documented opt-out). The rest of the CSP is already strictly `'self'`-only, so there's nothing the directive was meaningfully protecting. HTTPS deployments should enforce upgrades via HSTS at the reverse proxy.

## Test plan

- [x] New regression e2e `packages/backend/test/csp.e2e-spec.ts` asserts the `Content-Security-Policy` response header does **not** contain `upgrade-insecure-requests` and still emits the self-only directives.
- [x] Backend unit tests: 3909/3909 passing.
- [x] Backend e2e tests: 123/123 passing (incl. new CSP spec).
- [x] Frontend tests: 2221/2221 passing.
- [x] TypeScript: both backend and frontend `tsc --noEmit` clean.
- [x] End-to-end LAN verification — bound backend to `0.0.0.0:34078`, accessed `http://192.168.0.17:34078`: HTML + all 9 script/style/font/favicon assets return 200 over HTTP, `/api/v1/setup/status` and `/api/auth/get-session` respond, SPA routes (`/login`, `/setup`, `/agents/demo`, wildcard) all return 200 HTML while `/api/v1/nonexistent` still returns JSON 404.
- [x] Changeset added (`manifest` patch bump).
- [x] `docker/DOCKER_README.md` "Exposing on the LAN" section gets a troubleshooting note for anyone landing on an older image.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blank dashboard on LAN HTTP hosts by disabling the CSP `upgrade-insecure-requests` directive in `helmet`. Asset requests are no longer forced to HTTPS on private IPs, so the app loads correctly; HTTPS upgrades should be handled via HSTS at the reverse proxy.

- **Bug Fixes**
  - Set `upgradeInsecureRequests: null` in the CSP (`helmet` config) to prevent HTTPS rewrites on 10.x/172.16-31.x/192.168.x.
  - Added an e2e test to verify the header omits `upgrade-insecure-requests` and keeps self-only directives.
  - Updated Docker README with a LAN-blank-page note for older images.
  - Added a patch changeset for `manifest`.

<sup>Written for commit 135b9e3bde1b8a9be15a873ab8924994a58962eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

