### PR TITLE
fix(proxy): forward multi-segment custom-provider model IDs unchanged

### DIFF
--- a/.changeset/fix-custom-provider-multi-segment-model-id.md
+++ b/.changeset/fix-custom-provider-multi-segment-model-id.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix custom providers mangling upstream model IDs that contain `/` characters (#1591, #1615). Multi-segment model names like `MiniMaxAI/MiniMax-2.7` or `accounts/fireworks/routers/kimi-k2p5-turbo` are now forwarded to the upstream API unchanged instead of having a legitimate slash segment stripped.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1667,6 +1667,62 @@ describe('ProviderClient', () => {
       expect(fetchOptions.headers['Authorization']).toBe('Bearer test-key');
       expect(fetchOptions.headers['X-Custom']).toBe('value');
     });
+
+    // Regression: #1591 — MiniMax endpoint rejects bare model name because the
+    // second "/" segment was being eaten before reaching the provider.
+    it('preserves multi-segment upstream model ids with a vendor/model shape (#1591)', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const customEndpoint = {
+        baseUrl: 'https://api.minimax.io/v1',
+        buildHeaders: (key: string) => ({
+          Authorization: `Bearer ${key}`,
+          'Content-Type': 'application/json',
+        }),
+        buildPath: () => '/chat/completions',
+        format: 'openai' as const,
+      };
+
+      await client.forward({
+        provider: 'custom:minimax-cp',
+        apiKey: 'test-key',
+        model: 'MiniMaxAI/MiniMax-2.7',
+        body,
+        stream: false,
+        customEndpoint,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('MiniMaxAI/MiniMax-2.7');
+    });
+
+    // Regression: #1615 — Fireworks Fire Pass rejects truncated model name
+    // because earlier code stripped the "accounts/" segment off the wire payload.
+    it('preserves deeply slashed upstream model ids (#1615)', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const customEndpoint = {
+        baseUrl: 'https://api.fireworks.ai/inference/v1',
+        buildHeaders: (key: string) => ({
+          Authorization: `Bearer ${key}`,
+          'Content-Type': 'application/json',
+        }),
+        buildPath: () => '/chat/completions',
+        format: 'openai' as const,
+      };
+
+      await client.forward({
+        provider: 'custom:fireworks-cp',
+        apiKey: 'test-key',
+        model: 'accounts/fireworks/routers/kimi-k2p5-turbo',
+        body,
+        stream: false,
+        customEndpoint,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('accounts/fireworks/routers/kimi-k2p5-turbo');
+    });
   });
 
   describe('Error handling', () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -38,6 +38,11 @@ const PROVIDER_TIMEOUT_MS = 180_000;
 function stripModelPrefix(model: string, endpointKey: string): string {
   // OpenRouter accepts and expects vendor prefixes
   if (endpointKey === 'openrouter') return model;
+  // Custom providers: CustomProviderService.rawModelName already stripped the
+  // internal "custom:<id>/" prefix upstream. Stripping again would eat a
+  // legitimate slash segment from the upstream model id
+  // (e.g. "MiniMaxAI/MiniMax-2.7" or "accounts/fireworks/routers/...").
+  if (endpointKey === 'custom') return model;
   const slashIdx = model.indexOf('/');
   return slashIdx > 0 ? model.substring(slashIdx + 1) : model;
 }


### PR DESCRIPTION
## Summary
- Custom-provider model IDs whose upstream name contains a `/` were being mangled on the way to the provider, because `provider-client.ts` ran `stripModelPrefix` on top of the `CustomProviderService.rawModelName` strip that already happens in `proxy-fallback.service.ts`.
- Symptoms: `MiniMaxAI/MiniMax-2.7` arrived at MiniMax as `MiniMax-2.7` ("not hosted"), and `accounts/fireworks/routers/kimi-k2p5-turbo` arrived at Fireworks as `fireworks/routers/kimi-k2p5-turbo` (`NOT_FOUND`).
- Fix is scoped to the custom-provider path: skip `stripModelPrefix` when `endpointKey === 'custom'`, mirroring the existing `openrouter` skip. Built-in providers keep their vendor-prefix strip (e.g. `anthropic/claude-sonnet-4` → `claude-sonnet-4`), and other custom providers whose real upstream IDs legitimately contain slashes (the concern raised in #1615's follow-up comment) are now forwarded verbatim.

Closes #1591.
Closes #1615.

## Why not a global "strip custom prefix" regex
The #1615 reporter warned specifically against a blanket prefix rewrite because their other custom provider relies on slashed upstream IDs. The `stripModelPrefix` second pass was effectively that kind of blanket rule. Removing the second pass preserves the existing one-strip-at-the-boundary pattern (`rawModelName`), which is the only place that actually knows a `custom:<id>/` prefix was synthesized.

## Test plan
- [x] `npx jest src/routing/proxy/__tests__/provider-client.spec.ts` — 90 passed (includes two new regression cases covering #1591 and #1615).
- [x] `npx jest src/routing/proxy` — 1070 passed.
- [x] `npm test --workspace=packages/backend` — 3936 passed.
- [x] `npm run test:e2e --workspace=packages/backend` — 123 passed.
- [x] `npx tsc --noEmit` (backend + frontend) — clean.
- [x] Shared + frontend tests — 83 + 2221 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom-provider requests that mangled model IDs with slashes by forwarding upstream IDs unchanged. This resolves failures for models like `MiniMaxAI/MiniMax-2.7` and `accounts/fireworks/routers/kimi-k2p5-turbo`.

- **Bug Fixes**
  - Skip `stripModelPrefix` when `endpointKey` is `custom`, avoiding a second prefix strip after `rawModelName`. Built-in providers still strip vendor prefixes; `openrouter` behavior unchanged.
  - Added regression tests for MiniMax and Fireworks custom providers.

<sup>Written for commit d5b23dc0382a6590d947459374947f1f5f4efff4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

