### PR TITLE
chore: shrink Docker image by 14% via distroless runtime

### DIFF
--- a/.changeset/docker-distroless-runtime.md
+++ b/.changeset/docker-distroless-runtime.md
@@ -1,0 +1,11 @@
+---
+'manifest': patch
+---
+
+Shrink the Docker image by switching the runtime stage to distroless Node 22 (`gcr.io/distroless/nodejs22-debian12:nonroot`):
+
+- Runtime drops the shell, `apk`, and the unused yarn toolchain that `node:22-alpine` bakes in.
+- Production dependencies are now staged on `node:22-slim` so glibc matches the distroless debian12 runtime (all runtime deps are pure JS).
+- Prune `sql.js` from the runtime node_modules — it's an optional TypeORM peer only used by the legacy SQLite local mode, which is never active in Docker.
+- Add `--prefer-offline --no-audit --no-fund` to all npm installs, and pin the two new base images by digest.
+- Result: `423MB → 362MB` on disk (−14.4%), `84.2MB → 71.9MB` compressed pull (−14.6%).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,46 +1,57 @@
-# Stage 1: Install dependencies
-# Base image pinned by digest (multi-arch manifest list). Updated via Dependabot.
+# Runtime is gcr.io/distroless/nodejs22-debian12 (no shell, no package
+# manager, just node). Prod deps are staged on node:22-slim so the glibc
+# binaries match the distroless debian12 runtime. Build/dev stages stay
+# on node:22-alpine — smallest base that still has a shell, which the
+# build (turbo, nest) needs. All base images are pinned by digest.
+
+# Stage 1: Install all dependencies (including dev deps) for the build.
 FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS deps
 WORKDIR /app
 COPY package.json package-lock.json turbo.json ./
 COPY packages/shared/package.json packages/shared/
 COPY packages/frontend/package.json packages/frontend/
 COPY packages/backend/package.json packages/backend/
-RUN --mount=type=cache,target=/root/.npm npm ci
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --prefer-offline --no-audit --no-fund --loglevel=error
 
-# Stage 2: Build the application
+# Stage 2: Build the frontend + backend + shared bundles.
 FROM deps AS build
 COPY packages/shared packages/shared
 COPY packages/frontend packages/frontend
 COPY packages/backend packages/backend
 RUN npx turbo build --filter=manifest-backend --filter=manifest-frontend --filter=manifest-shared
 
-# Stage 3: Production dependencies only
-FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS prod-deps
+# Stage 3: Production dependencies only, installed on glibc to match the
+# distroless debian12 runtime. All runtime deps are pure JS.
+FROM node:22-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS prod-deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY packages/shared/package.json packages/shared/
 COPY packages/frontend/package.json packages/frontend/
 COPY packages/backend/package.json packages/backend/
-RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev --ignore-scripts && \
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev --ignore-scripts \
+           --prefer-offline --no-audit --no-fund --loglevel=error && \
     rm -rf node_modules/typescript node_modules/@types \
            node_modules/ts-node node_modules/acorn \
-           node_modules/create-require node_modules/v8-compile-cache-lib && \
+           node_modules/create-require node_modules/v8-compile-cache-lib \
+           node_modules/sql.js && \
     find . -path "*/node_modules/vitest" -type d -exec rm -rf {} + 2>/dev/null; \
     find . -path "*/node_modules/vite-node" -type d -exec rm -rf {} + 2>/dev/null; \
     find . -path "*/node_modules/rollup" -type d -exec rm -rf {} + 2>/dev/null; \
     find . -path "*/node_modules/@vitest" -type d -exec rm -rf {} + 2>/dev/null; \
     find . -path "*/node_modules/*" \( -name "*.map" -o -name "README*" \
       -o -name "LICENSE*" -o -name "CHANGELOG*" -o -name "*.txt" \
-      -o -name "Makefile" -o -name "*.gyp" -o -name "*.gypi" \
+      -o -name "*.md" -o -name "Makefile" -o -name "*.gyp" -o -name "*.gypi" \
       -o \( -name "*.ts" ! -name "*.d.ts" \) \) -delete 2>/dev/null; \
     find . -path "*/node_modules/*" -type d \( -name "__tests__" -o -name "test" \
       -o -name "tests" -o -name "docs" -o -name "example" \
-      -o -name "examples" \) -exec rm -rf {} + 2>/dev/null; \
+      -o -name "examples" -o -name ".github" \) -exec rm -rf {} + 2>/dev/null; \
     true
 
-# Stage 4: Production runtime
-FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS runtime
+# Stage 4: Distroless runtime. Runs as the built-in `nonroot` user (UID
+# 65532) by default. No shell, no apk/apt, minimal CVE surface.
+FROM gcr.io/distroless/nodejs22-debian12:nonroot@sha256:13593b7570658e8477de39e2f4a1dd25db2f836d68a0ba771251572d23bb4f8e AS runtime
 WORKDIR /app
 
 LABEL org.opencontainers.image.title="Manifest" \
@@ -51,25 +62,28 @@ LABEL org.opencontainers.image.title="Manifest" \
       org.opencontainers.image.vendor="MNFST Inc." \
       org.opencontainers.image.licenses="MIT"
 
-RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
-
 ENV NODE_ENV=production
 ENV BIND_ADDRESS=0.0.0.0
+# Expose the distroless node binary on PATH so `node` in docker-compose
+# healthchecks (and anything else invoked with a bare command name) resolves.
+ENV PATH=/nodejs/bin:$PATH
 
-COPY --from=prod-deps /app/node_modules node_modules
-COPY --from=prod-deps /app/packages/backend/node_modules packages/backend/node_modules
-COPY --from=prod-deps /app/package.json package.json
-COPY --from=build /app/packages/shared/dist packages/shared/dist
-COPY --from=build /app/packages/backend/dist packages/backend/dist
-COPY --from=build /app/packages/frontend/dist packages/frontend/dist
-COPY packages/shared/package.json packages/shared/
-COPY packages/backend/package.json packages/backend/
+COPY --from=prod-deps --chown=nonroot:nonroot /app/node_modules node_modules
+COPY --from=prod-deps --chown=nonroot:nonroot /app/packages/backend/node_modules packages/backend/node_modules
+COPY --from=prod-deps --chown=nonroot:nonroot /app/package.json package.json
+COPY --from=build --chown=nonroot:nonroot /app/packages/shared/dist packages/shared/dist
+COPY --from=build --chown=nonroot:nonroot /app/packages/backend/dist packages/backend/dist
+COPY --from=build --chown=nonroot:nonroot /app/packages/frontend/dist packages/frontend/dist
+COPY --chown=nonroot:nonroot packages/shared/package.json packages/shared/
+COPY --chown=nonroot:nonroot packages/backend/package.json packages/backend/
 
 EXPOSE 3001
 
+# Distroless has no shell; use exec-form and a JS-only check.
+# `node` resolves via the PATH we set above.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:3001/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+  CMD ["node", "-e", "fetch('http://127.0.0.1:3001/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
 
-USER node
-
-CMD ["node", "packages/backend/dist/main.js"]
+# The distroless image's ENTRYPOINT is already ["/nodejs/bin/node"],
+# so CMD only needs the script path.
+CMD ["packages/backend/dist/main.js"]


### PR DESCRIPTION
## Summary

Switch the runtime stage to [distroless Node 22](https://github.com/GoogleContainerTools/distroless) (`gcr.io/distroless/nodejs22-debian12:nonroot`) and stage production dependencies on `node:22-slim` for glibc compatibility. Prune `sql.js` (an optional TypeORM peer only used by the legacy SQLite local mode — never active in Docker) and add fast npm install flags.

## Results

| | Before | After | Delta |
|-|-|-|-|
| **On-disk size** | 423MB | 362MB | **−61MB (−14.4%)** |
| **Compressed (pull) size** | 84.2MB | 71.9MB | **−12.3MB (−14.6%)** |

The compressed number is what matters for `docker pull` time — first-time self-host installs pull ~14.6% less over the wire.

## What changed

- **Runtime → distroless**: no shell, no `apk`/`apt`, no yarn (which `node:22-alpine` bakes in and this project never uses). Rebuilt continuously by Google with a minimal CVE surface.
- **Prod-deps stage → `node:22-slim`**: glibc base matches the distroless debian12 runtime. All runtime dependencies are pure JS, so no native-module recompilation is needed.
- **Prune `sql.js`**: 18MB WASM SQLite driver, listed as an optional TypeORM peer. Docker always runs on PostgreSQL, so it's dead weight.
- **npm install flags**: `--prefer-offline --no-audit --no-fund --loglevel=error` on both the full and prod-only installs. Works with the existing BuildKit cache mounts.
- **Digest-pin** the two new base images (`node:22-slim`, distroless), matching the existing convention on `node:22-alpine`.
- **PATH env** so bare `node` resolves — keeps the existing `docker-compose.yml` healthcheck working without requiring a compose file edit.
- **Healthcheck and CMD in exec form** since distroless has no shell.

## Notes

- Drops the `apk update && apk upgrade` security-patch layer — distroless images are rebuilt weekly by Google from patched source, so this was redundant.
- `USER node` is also gone: the distroless `:nonroot` tag runs as UID 65532 by default, and `--chown=nonroot:nonroot` is applied on every `COPY`.
- Cold builds are ~11s slower because one extra base image (`node:22-slim`) is pulled; subsequent warm builds are the same or faster due to tighter npm install flags.

## Test plan

- [x] `npm test --workspace=packages/backend` — 3982/3982 pass
- [x] `npm run test:e2e --workspace=packages/backend` — 123/123 pass (against a fresh Postgres)
- [x] `npm test --workspace=packages/frontend` — 2261/2261 pass
- [x] `npx tsc --noEmit` in backend and frontend — clean
- [x] `docker build -f docker/Dockerfile .` — builds
- [x] `docker compose up -d` with the new image and the existing `docker-compose.yml` — both containers healthy, `/api/v1/health` returns 200, frontend serves, public API endpoints respond, migrations + external sync jobs run without errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Docker runtime to distroless Node 22 and stage prod deps on `node:22-slim` to shrink the image and reduce the attack surface. Pull size drops from 84.2MB to 71.9MB (−14.6%).

- **Refactors**
  - Runtime uses `gcr.io/distroless/nodejs22-debian12:nonroot`; CMD/HEALTHCHECK in exec form; PATH set so `node` resolves.
  - Prod-only deps installed on `node:22-slim` to match glibc; base images digest-pinned.
  - Pruned `sql.js` and unneeded files; added `--prefer-offline --no-audit --no-fund --loglevel=error` to npm installs.
  - Removed Alpine update layer; runs as non-root (UID 65532) with `--chown` on all COPYs.

<sup>Written for commit 4599c47bbc042829c3c0a4abf656ba2b713a6458. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

