### PR TITLE
chore: retire SQLite / sql.js / local-mode vestiges

### DIFF
--- a/.changeset/retire-sqlite-vestiges.md
+++ b/.changeset/retire-sqlite-vestiges.md
@@ -1,0 +1,15 @@
+---
+'manifest': patch
+---
+
+Retire residual SQLite / sql.js / "local mode" references left behind after the local-mode path was removed:
+
+- Drop the dead `isLocal()` branch in `RoutingInstructionModal` (the `/api/v1/health` endpoint never returns `mode`, so the branch was unreachable) and the test that faked a `mode: "local"` health response to exercise it.
+- Tighten the frontend `NotificationRule.is_active` type from `boolean | number` to `boolean`, and drop the `typeof === 'number' ? !!x : x` coercion in `Limits.tsx` and `LimitRuleTable.tsx` (the integer boolean was a SQLite-era shape; the backend returns real booleans).
+- Remove the dead `connection: { options: { type: 'sqlite' } }` mock in `proxy.controller.spec.ts` — no production code reads `ds.connection.options.type`.
+- Remove the stale `vi.mock("../../src/services/local-mode.js", ...)` in `ProviderSelectModal-opencode-go.test.tsx` (module was deleted long ago).
+- Refresh the `packages/backend/src/common/utils/sql-dialect.ts` header (no dialect switching happens — the file is Postgres-only).
+- Fix comment/test-description rot: "dialect" wording in `query-helpers.ts` + spec, "local mode" in `Sidebar.test.tsx` / `session.guard.spec.ts` / `proxy-rate-limiter.ts`, "PG & sql.js" in `costs.e2e-spec.ts`.
+- Update `CLAUDE.md`: drop references to deleted files (`local-bootstrap.service.ts`, `local-mode.ts`, `LocalAuthGuard`), drop the `MANIFEST_DB_PATH` / `MANIFEST_UPDATE_CHECK_OPTOUT` env vars (no-ops per the v2.x breaking changes), drop the "Local mode database uses sql.js" architecture note, and correct the "Better Auth database" section (Postgres always).
+
+No behaviour change — all four test suites green (backend 4007, frontend 2267, e2e 123) and both packages typecheck clean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Manifest is a smart model router for **personal AI agents**. It sits between an 
 
 ## IMPORTANT: Cloud Mode Always
 
-When starting the app for development or testing (e.g. `/serve`), **always use `MANIFEST_MODE=cloud`** (the default). Never use local/SQLite mode — multiple concurrent Claude instances cause SQLite lock conflicts. Every dev session must use a **fresh PostgreSQL database** via Docker:
+When starting the app for development or testing (e.g. `/serve`), **always use `MANIFEST_MODE=cloud`** (the default). Every dev session must use a **fresh PostgreSQL database** via Docker — multiple concurrent dev instances sharing one DB cause cross-run data pollution and intermittent test failures:
 
 ```bash
 # 1. Ensure the postgres_db container is running
@@ -74,7 +74,6 @@ packages/
 │   │   ├── database/
 │   │   │   ├── database.module.ts           # TypeORM PostgreSQL config
 │   │   │   ├── database-seeder.service.ts   # Seeds demo data (users, agents, security events)
-│   │   │   ├── local-bootstrap.service.ts   # Seeds local mode (SQLite)
 │   │   │   ├── datasource.ts               # CLI DataSource for migration commands
 │   │   │   ├── pricing-sync.service.ts      # OpenRouter pricing data sync
 │   │   │   ├── ollama-sync.service.ts       # Ollama model sync
@@ -91,12 +90,12 @@ packages/
 │   │   │   ├── dto/                         # create-agent, range-query, rename-agent DTOs
 │   │   │   ├── filters/spa-fallback.filter.ts
 │   │   │   ├── interceptors/               # agent-cache, user-cache
-│   │   │   ├── constants/                   # api-key, cache, local-mode, ollama
+│   │   │   ├── constants/                   # api-key, cache, ollama, providers
 │   │   │   ├── services/                    # ingest-event-bus, manifest-runtime, tenant-cache
 │   │   │   ├── utils/range.util.ts
 │   │   │   ├── utils/hash.util.ts           # API key hashing (scrypt KDF)
 │   │   │   ├── utils/crypto.util.ts         # AES-256-GCM encryption
-│   │   │   ├── utils/sql-dialect.ts         # Cross-DB SQL helpers (Postgres/SQLite)
+│   │   │   ├── utils/sql-dialect.ts         # Postgres SQL helpers (column types, bucket/cast expressions)
 │   │   │   ├── utils/slugify.ts             # Name slugification
 │   │   │   ├── utils/url-validation.ts      # URL validation
 │   │   │   ├── utils/provider-inference.ts  # Provider detection from model names
@@ -154,8 +153,7 @@ packages/
 │   │   │   ├── provider-utils.ts            # LLM provider helpers
 │   │   │   ├── routing.ts, routing-utils.ts # Routing config helpers
 │   │   │   ├── theme.ts                     # Theme management
-│   │   │   ├── toast-store.ts               # Toast notification state
-│   │   │   └── local-mode.ts               # Local mode detection
+│   │   │   └── toast-store.ts               # Toast notification state
 │   │   ├── layouts/                         # Layout components
 │   │   └── styles/
 │   └── tests/
@@ -362,8 +360,6 @@ See `packages/backend/.env.example` for all variables. Key ones:
 - `SEED_DATA` — Set `true` to seed demo data on startup.
 - `MANIFEST_MODE` — `selfhosted` or `cloud` (default: `cloud`; auto-`selfhosted` inside Docker via `/.dockerenv`). Self-hosted mode enables loopback auth shortcuts and allows custom-provider URLs with `http://` / private IPs. `local` is accepted as a legacy alias for `selfhosted`.
 - `OLLAMA_HOST` — Ollama endpoint for the built-in tile. Defaults to `http://localhost:11434` outside Docker and `http://host.docker.internal:11434` inside the bundled `docker/docker-compose.yml`.
-- `MANIFEST_DB_PATH` — SQLite file path for legacy local mode (default: in-memory).
-- `MANIFEST_UPDATE_CHECK_OPTOUT` — Set `1` to disable the legacy local-mode npm version check.
 
 ## Domain Terminology
 
@@ -404,8 +400,7 @@ To add a new font or icon library:
 - **Body parsing**: Disabled at NestJS level (`bodyParser: false`). Better Auth mounted first (needs raw body), then `express.json()` and `express.urlencoded()`.
 - **QueryBuilder API**: Analytics and ingestion services use TypeORM `Repository.createQueryBuilder()` instead of raw SQL. The `addTenantFilter()` helper in `query-helpers.ts` applies multi-tenant WHERE clauses. Only the database seeder and notification cron still use `DataSource.query()` with numbered `$1, $2, ...` placeholders.
 - **PostgreSQL time functions**: `NOW() - CAST(:interval AS interval)`, `to_char(date_trunc('hour', timestamp), ...)`, `timestamp::date`.
-- **Better Auth database**: In cloud mode, uses a `pg.Pool` instance passed directly to `betterAuth({ database: pool })`. In local mode, Better Auth is skipped entirely (`auth = null`) — `LocalAuthGuard` handles auth via loopback IP check, and simple Express handlers serve session data.
-- **Local mode database**: Uses `sql.js` (WASM-based SQLite, zero native deps). TypeORM driver type is `'sqljs'` with `autoSave: true` for file persistence.
+- **Better Auth database**: Uses a `pg.Pool` instance passed directly to `betterAuth({ database: pool })`. See `packages/backend/src/auth/auth.instance.ts`.
 - **PostgreSQL container**: `docker run -d --name postgres_db -e POSTGRES_USER=myuser -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=mydatabase -p 5432:5432 postgres:16`
 - **Validation**: Global `ValidationPipe` with `whitelist: true`, `forbidNonWhitelisted: true`. Explicit `@Type()` decorators on numeric DTO fields.
 - **Agent key auth caching**: `AgentKeyAuthGuard` caches valid API keys in-memory for 5 minutes to avoid repeated DB lookups.

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -206,9 +206,9 @@ describe('selectMessageRowColumns', () => {
     expect(emittedAliases).toEqual([...MESSAGE_ROW_SELECT_ALIASES]);
   });
 
-  it('uses the caller-supplied cost expression so dialect handling stays at the call site', () => {
+  it('uses the caller-supplied cost expression verbatim', () => {
     const { qb, addSelectCalls } = makeMockQb();
-    const costExpr = 'SOME_DIALECT_SPECIFIC_CAST(at.cost_usd)';
+    const costExpr = 'CAST(CASE WHEN at.cost_usd >= 0 THEN at.cost_usd ELSE NULL END AS FLOAT)';
     selectMessageRowColumns(qb, costExpr);
 
     const costCall = addSelectCalls.find(([, alias]) => alias === 'cost');

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -63,9 +63,9 @@ export function addTenantFilter<T extends ObjectLiteral>(
  * is the downstream contract — every field it declares must be selected here so
  * the shared badge/provider rendering works identically across every call site.
  *
- * Assumes the query builder aliases `agent_messages` as `at`. Callers pass a
- * dialect-specific `costExpr` (e.g. `sqlCastFloat(sqlSanitizeCost('at.cost_usd'), dialect)`)
- * so per-service dialect handling stays at the call site.
+ * Assumes the query builder aliases `agent_messages` as `at`. Callers pass the
+ * `costExpr` (e.g. `sqlCastFloat(sqlSanitizeCost('at.cost_usd'))`) so the
+ * shared helper stays agnostic to how each call site sanitises cost.
  */
 export const MESSAGE_ROW_SELECT_ALIASES = [
   'id',

--- a/packages/backend/src/auth/session.guard.spec.ts
+++ b/packages/backend/src/auth/session.guard.spec.ts
@@ -86,7 +86,7 @@ describe('SessionGuard', () => {
     expect(request['authMethod']).toBe('session');
   });
 
-  it('returns true even when no session found (non-local mode)', async () => {
+  it('returns true even when no session found (anonymous passthrough)', async () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
     (auth.api.getSession as jest.Mock).mockResolvedValue(null);
     const { context, request } = createMockContext({ ip: '203.0.113.1' });

--- a/packages/backend/src/common/utils/sql-dialect.ts
+++ b/packages/backend/src/common/utils/sql-dialect.ts
@@ -1,7 +1,7 @@
 /**
- * Postgres SQL helpers. Manifest is Postgres-only, so these emit Postgres SQL
- * directly — no dialect switching. The module name is historical; the
- * `DbDialect` abstraction was removed once SQLite was retired.
+ * Postgres SQL helpers: TypeORM column type factories + hand-rolled SQL
+ * expressions (bucketing, casts, interval math) used by analytics and
+ * entity definitions.
  */
 
 /**

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -81,7 +81,6 @@ describe('ProxyController', () => {
     transaction: jest.Mock;
     getRepository: jest.Mock;
     query: jest.Mock;
-    connection: { options: { type: string } };
   };
   let mockMessageRepo: {
     insert: jest.Mock;
@@ -115,7 +114,6 @@ describe('ProxyController', () => {
       ),
       getRepository: jest.fn(),
       query: jest.fn().mockResolvedValue([]),
-      connection: { options: { type: 'sqlite' } },
     };
     mockMessageRepo = {
       insert: jest.fn().mockResolvedValue({}),

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -56,7 +56,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
 
   /**
    * Check if the IP is over the per-IP rate limit and increment the counter.
-   * This catches abuse even when all requests share a userId (e.g. dev/local mode).
+   * This catches abuse even when many requests share a single userId (e.g. dev).
    */
   checkIpLimit(ip: string): void {
     const now = Date.now();

--- a/packages/backend/test/costs.e2e-spec.ts
+++ b/packages/backend/test/costs.e2e-spec.ts
@@ -27,7 +27,8 @@ beforeAll(async () => {
   await app.get(ModelPricingCacheService).reload();
 
   // Seed agent_messages directly (with pre-calculated cost_usd) using the same
-  // timestamp format as sqlNow() so that date comparisons work in both PG & sql.js.
+  // timestamp format as sqlNow() so that date comparisons line up with the
+  // Postgres `timestamp without time zone` columns the analytics queries read.
   const costUsd1 = 5000 * 0.0000025 + 2000 * 0.00001; // 0.0325
   const costUsd2 = 3000 * 0.0000025 + 1000 * 0.00001; // 0.0175
   await ds.query(

--- a/packages/frontend/src/components/LimitRuleTable.tsx
+++ b/packages/frontend/src/components/LimitRuleTable.tsx
@@ -22,9 +22,6 @@ interface LimitRuleTableProps {
   onToggleMenu: (ruleId: string, e: MouseEvent) => void;
 }
 
-const isActive = (rule: NotificationRule) =>
-  typeof rule.is_active === 'number' ? !!rule.is_active : rule.is_active;
-
 const hasEmailAction = (action: string) => action === 'notify' || action === 'both';
 const hasBlockAction = (action: string) => action === 'block' || action === 'both';
 
@@ -87,7 +84,7 @@ const LimitRuleTable: Component<LimitRuleTableProps> = (props) => (
           <tbody>
             <For each={props.rules}>
               {(rule) => (
-                <tr classList={{ 'notif-table__row--disabled': !isActive(rule) }}>
+                <tr classList={{ 'notif-table__row--disabled': !rule.is_active }}>
                   <td>
                     <div class="limit-type-icons">
                       <Show when={hasEmailAction(rule.action ?? 'notify')}>
@@ -136,7 +133,13 @@ const LimitRuleTable: Component<LimitRuleTableProps> = (props) => (
                         onClick={(e) => props.onToggleMenu(rule.id, e)}
                         aria-label="Rule options"
                       >
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <svg
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
                           <circle cx="12" cy="5" r="2" />
                           <circle cx="12" cy="12" r="2" />
                           <circle cx="12" cy="19" r="2" />

--- a/packages/frontend/src/components/RoutingInstructionModal.tsx
+++ b/packages/frontend/src/components/RoutingInstructionModal.tsx
@@ -3,7 +3,7 @@ import CopyButton from './CopyButton.jsx';
 import ModelSelectDropdown from './ModelSelectDropdown.jsx';
 import SetupStepAddProvider from './SetupStepAddProvider.jsx';
 import { PROVIDERS } from '../services/providers.js';
-import { getAgentKey, getHealth } from '../services/api.js';
+import { getAgentKey } from '../services/api.js';
 import { agentPlatform } from '../services/agent-platform-store.js';
 
 interface Props {
@@ -25,15 +25,12 @@ const RoutingInstructionModal: Component<Props> = (props) => {
   const title = () => (isEnable() ? 'Activate routing' : 'Deactivate routing');
   const modelOrPlaceholder = () => selectedModel() ?? '<provider/model>';
 
-  const [healthData] = createResource(() => (props.open ? true : null), getHealth);
-  const isLocal = () => (healthData() as { mode?: string })?.mode === 'local';
   const [apiKeyData] = createResource(
     () => (props.open && isEnable() ? props.agentName : null),
     (n) => getAgentKey(n),
   );
 
   const baseUrl = () => {
-    if (isLocal()) return `${window.location.origin}/v1`;
     const host = window.location.hostname;
     if (host === 'app.manifest.build') return 'https://app.manifest.build/v1';
     return `${window.location.origin}/v1`;

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -116,7 +116,7 @@ const Limits: Component = () => {
     return r.some(
       (rule) =>
         (rule.action === 'block' || rule.action === 'both') &&
-        (typeof rule.is_active === 'number' ? !!rule.is_active : rule.is_active) &&
+        rule.is_active &&
         Number(rule.trigger_count) > 0,
     );
   };

--- a/packages/frontend/src/services/api/notifications.ts
+++ b/packages/frontend/src/services/api/notifications.ts
@@ -7,7 +7,7 @@ export interface NotificationRule {
   threshold: number;
   period: 'hour' | 'day' | 'week' | 'month';
   action: 'notify' | 'block' | 'both';
-  is_active: boolean | number;
+  is_active: boolean;
   trigger_count: number;
   created_at: string;
 }

--- a/packages/frontend/tests/components/ProviderSelectModal-opencode-go.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-opencode-go.test.tsx
@@ -25,11 +25,6 @@ vi.mock("../../src/components/ProviderIcon.js", () => ({
   customProviderLogo: () => null,
 }));
 
-vi.mock("../../src/services/local-mode.js", () => ({
-  isLocalMode: () => false,
-  checkLocalMode: () => Promise.resolve(false),
-}));
-
 // Only mock opencode-go so the subscription tab has a single entry to click.
 vi.mock("../../src/services/providers.js", () => {
   const opencodeGoProvider = {

--- a/packages/frontend/tests/components/RoutingInstructionModal.test.tsx
+++ b/packages/frontend/tests/components/RoutingInstructionModal.test.tsx
@@ -7,11 +7,9 @@ vi.stubGlobal("navigator", {
 
 const mockGetModelPrices = vi.fn();
 const mockGetAgentKey = vi.fn();
-const mockGetHealth = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getModelPrices: () => mockGetModelPrices(),
   getAgentKey: (n: string) => mockGetAgentKey(n),
-  getHealth: () => mockGetHealth(),
 }));
 
 vi.mock("../../src/services/agent-platform-store.js", () => ({
@@ -42,7 +40,6 @@ describe("RoutingInstructionModal", () => {
   beforeEach(() => {
     mockGetModelPrices.mockResolvedValue(testModels);
     mockGetAgentKey.mockResolvedValue({ keyPrefix: "mnfst_abc", apiKey: "mnfst_abc123" });
-    mockGetHealth.mockResolvedValue({ mode: "cloud" });
   });
 
   it("renders nothing when open is false", () => {
@@ -299,18 +296,6 @@ describe("RoutingInstructionModal", () => {
       const el = container.querySelector('[data-testid="setup-add-provider"]');
       expect(el).not.toBeNull();
       expect(el!.getAttribute("data-api-key")).toBe("mnfst_abc123full");
-    });
-  });
-
-  it("uses origin/v1 as baseUrl in local mode", async () => {
-    mockGetHealth.mockResolvedValue({ mode: "local" });
-    const { container } = render(() => (
-      <RoutingInstructionModal open={true} mode="enable" agentName="test-agent" onClose={() => {}} />
-    ));
-    await vi.waitFor(() => {
-      const el = container.querySelector('[data-testid="setup-add-provider"]');
-      expect(el).not.toBeNull();
-      expect(el!.getAttribute("data-base-url")).toContain("/v1");
     });
   });
 

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -51,12 +51,7 @@ describe("Sidebar with agent", () => {
     expect(screen.getByText("MANAGE")).toBeDefined();
   });
 
-  it("shows Settings link in local mode", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Settings")).toBeDefined();
-  });
-
-  it("renders Settings link in cloud mode", () => {
+  it("renders Settings link", () => {
     render(() => <Sidebar />);
     expect(screen.getByText("Settings")).toBeDefined();
   });
@@ -199,13 +194,13 @@ describe("Sidebar active states for sub-paths", () => {
   });
 });
 
-describe("Sidebar in local mode", () => {
+describe("Sidebar with no agent selected", () => {
   beforeAll(() => {
     mockAgentName = null;
     mockPathname = "/";
   });
 
-  it("shows Agents link in local mode when no agent selected", () => {
+  it("shows Agents link when no agent is selected", () => {
     render(() => <Sidebar />);
     expect(screen.getByText("Agents")).toBeDefined();
   });

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -230,11 +230,11 @@ describe("Limits page", () => {
     });
   });
 
-  it("shows disabled row style for inactive rules (is_active=0)", async () => {
+  it("shows disabled row style for inactive rules", async () => {
     mockRules = [{
       id: "r1", agent_name: "test-agent", metric_type: "tokens",
       threshold: 50000, period: "day", action: "notify",
-      is_active: 0, trigger_count: 0, created_at: "2026-01-01",
+      is_active: false, trigger_count: 0, created_at: "2026-01-01",
     }];
     const { container } = render(() => <Limits />);
     await vi.waitFor(() => {
@@ -242,11 +242,11 @@ describe("Limits page", () => {
     });
   });
 
-  it("does not show disabled row for active rules (is_active=1, sql.js local mode)", async () => {
+  it("does not show disabled row for active rules", async () => {
     mockRules = [{
       id: "r1", agent_name: "test-agent", metric_type: "tokens",
       threshold: 50000, period: "day", action: "notify",
-      is_active: 1, trigger_count: 0, created_at: "2026-01-01",
+      is_active: true, trigger_count: 0, created_at: "2026-01-01",
     }];
     const { container } = render(() => <Limits />);
     await vi.waitFor(() => {


### PR DESCRIPTION
## Summary

Source, test, and doc cleanup for references the project still carries around from the pre-Postgres-only days. No behaviour change. Follow-up to #1644 (Docker image shrink) which flagged `sql.js` as dead-weight in the runtime tree.

## What's gone

### Dead code
- `RoutingInstructionModal.tsx` — unreachable `isLocal()` branch. `getHealth()` returns `{ status, uptime_seconds }` only (verified in `health.controller.spec.ts`), so the `mode === 'local'` check was always false. The two remaining `baseUrl` branches already produced the correct URL. Removed along with the now-unused `getHealth` import and the `createResource` call.
- `Limits.tsx` / `LimitRuleTable.tsx` — dropped the `typeof rule.is_active === 'number' ? !!rule.is_active : rule.is_active` coercion. Postgres returns a real boolean; the integer-boolean case was a SQLite-era shape that can no longer happen.
- `services/api/notifications.ts` — `NotificationRule.is_active: boolean | number` → `boolean`. The DTO is `@IsBoolean()`, the entity is `@Column('boolean')`, and no raw SQL path could leak a number.
- `proxy.controller.spec.ts` — removed the `connection: { options: { type: 'sqlite' } }` mock field. No production code reads `ds.connection.options.type`; grep across `src/` returns zero hits.

### Stale test scaffolding
- `ProviderSelectModal-opencode-go.test.tsx` — `vi.mock("../../src/services/local-mode.js", …)` for a module deleted long ago. Vitest tolerated it silently.
- `RoutingInstructionModal.test.tsx` — dropped the \"uses origin/v1 as baseUrl in local mode\" test that faked `{ mode: 'local' }` to exercise the dead branch above. Removed the `mockGetHealth` plumbing.
- `Limits.test.tsx` — the `is_active: 0` / `is_active: 1` tests now use `false` / `true`.
- `Sidebar.test.tsx` — merged near-duplicate \"Settings link in local mode\" + \"Settings link in cloud mode\" cases into one; renamed the \"Sidebar in local mode\" describe block to \"Sidebar with no agent selected\" (which is what it actually tests).

### Stale docs
- `CLAUDE.md`: removed references to `database/local-bootstrap.service.ts`, `services/local-mode.ts`, and `LocalAuthGuard` (none exist), the \"Local mode database uses sql.js\" architecture note, the `MANIFEST_DB_PATH` / `MANIFEST_UPDATE_CHECK_OPTOUT` env-var lines (documented as no-ops in `packages/manifest/CHANGELOG.md`), and the \"Cross-DB SQL helpers (Postgres/SQLite)\" label on `sql-dialect.ts`. Rewrote the \"Never use local/SQLite mode\" rationale around the actual reason we use fresh PG DBs in dev (cross-run data pollution, not SQLite lock conflicts).

### Rotted wording
- `sql-dialect.ts` header: previous comment explained why the file is named poorly. Replaced with a plain description of what it does. The rename itself is deferred (23 files import it).
- `query-helpers.ts` + spec: dropped \"dialect-specific\" wording.
- `proxy-rate-limiter.ts` comment: \"dev/local mode\" → \"dev\".
- `costs.e2e-spec.ts` comment: \"PG & sql.js\" → actual Postgres explanation.
- `session.guard.spec.ts`: \"non-local mode\" test description → \"anonymous passthrough\".

## Not in scope
- **Rename `sql-dialect.ts`** — 23 import sites. Separate janitorial PR.
- **Stub `sql.js` out of the dep tree** — TypeORM declares it as an optional peer; npm installs it anyway. The Docker runtime prune in #1644 already takes care of the 18MB cost; overriding the peer would add fragility for no real benefit.
- **Orphan compiled assets under `packages/openclaw-plugins/manifest/public/assets/`** — surfaced by the code-quality-reviewer agent; outside this PR's scope.

## Test plan

- [x] `npm test --workspace=packages/backend` — 4007/4007 pass
- [x] `npm run test:e2e --workspace=packages/backend` — 123/123 pass (fresh PG database)
- [x] `npm test --workspace=packages/frontend` — 2267/2267 pass (2 tests removed as part of the cleanup — dead-branch test and redundant near-duplicate)
- [x] `npx tsc --noEmit` in backend and frontend — clean
- [x] `code-quality-reviewer` agent audit — green, flagged the follow-ups now folded in

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires leftover SQLite/`sql.js`/“local mode” code and wording now that the app is Postgres-only. No behavior change; simplifies frontend types, tests, and docs.

- **Refactors**
  - Frontend: removed dead `isLocal()` path and `getHealth` usage in `RoutingInstructionModal`; base URL logic unchanged.
  - Tightened `NotificationRule.is_active` to `boolean`; removed number-to-boolean coercions in `Limits.tsx` and `LimitRuleTable.tsx`; tests now use true/false.
  - Backend/tests: dropped unused `connection.options.type: 'sqlite'` mock; refreshed `sql-dialect.ts` header and “dialect-specific” wording; clarified rate limiter and analytics comments.
  - Test scaffolding: deleted stale `vi.mock('../../src/services/local-mode.js')`; removed dead-branch modal test; merged redundant Sidebar tests.
  - Docs: cleaned `CLAUDE.md` of local-mode files, env vars, and `sql.js` notes; clarified Postgres-only setup and Better Auth usage.

<sup>Written for commit bb3dc2949b186b4031ac38e98353e054ba080c47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

