### PR TITLE
feat(proxy): advertise honest context window for manifest/auto

### DIFF
--- a/.changeset/advertise-honest-context-window.md
+++ b/.changeset/advertise-honest-context-window.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Advertise an honest context window for `manifest/auto` via a new OpenAI-compatible `GET /v1/models` endpoint. The `context_length` returned is the minimum across every model the agent could be routed to (tier primaries, fallbacks, specificity overrides) — any routed model is guaranteed to accept at least that many tokens, so clients that compact against this value stop overflowing the routed model. Adds a per-agent **Context window** card in Settings to override the computed floor, and a helper endpoint `GET /api/v1/routing/:agentName/context-window` for the dashboard. Addresses #1617, #1612, and #1450.

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -19,6 +19,8 @@ describe('AgentsController', () => {
   let mockConfigGet: jest.Mock;
   let mockDeleteAgent: jest.Mock;
   let mockRenameAgent: jest.Mock;
+  let mockUpdateAgentType: jest.Mock;
+  let mockUpdateContextFloorOverride: jest.Mock;
   let mockTenantResolve: jest.Mock;
 
   beforeEach(async () => {
@@ -31,6 +33,8 @@ describe('AgentsController', () => {
     mockConfigGet = jest.fn().mockReturnValue('');
     mockDeleteAgent = jest.fn().mockResolvedValue(undefined);
     mockRenameAgent = jest.fn().mockResolvedValue(undefined);
+    mockUpdateAgentType = jest.fn().mockResolvedValue(undefined);
+    mockUpdateContextFloorOverride = jest.fn().mockResolvedValue(undefined);
     mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
 
     const module: TestingModule = await Test.createTestingModule({
@@ -46,7 +50,8 @@ describe('AgentsController', () => {
           useValue: {
             deleteAgent: mockDeleteAgent,
             renameAgent: mockRenameAgent,
-            updateAgentType: jest.fn(),
+            updateAgentType: mockUpdateAgentType,
+            updateContextFloorOverride: mockUpdateContextFloorOverride,
           },
         },
         {
@@ -255,7 +260,6 @@ describe('AgentsController', () => {
   });
 
   it('passes category/platform to updateAgentType on PATCH', async () => {
-    const mockUpdateType = jest.fn().mockResolvedValue(undefined);
     const user = { id: 'u1' };
     const result = await controller.updateAgent(user as never, 'bot-1', {
       agent_category: 'app',
@@ -266,6 +270,57 @@ describe('AgentsController', () => {
       agent_category: 'app',
       agent_platform: 'openai-sdk',
     });
+  });
+
+  /**
+   * context_floor_override PATCH cases — the UI "Custom context window" card
+   * writes through this path. Defends issues #1617 / #1612 by making sure a
+   * user-entered override is actually persisted (not swallowed by the
+   * controller ignoring the field because the DTO treats it as optional).
+   */
+  it('calls updateContextFloorOverride with a numeric value on PATCH', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.updateAgent(user as never, 'bot-1', {
+      context_floor_override: 50_000,
+    } as never);
+
+    expect(mockUpdateContextFloorOverride).toHaveBeenCalledWith('u1', 'bot-1', 50_000);
+    expect(result).toEqual({ context_floor_override: 50_000 });
+  });
+
+  it('calls updateContextFloorOverride with null to clear the override', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.updateAgent(user as never, 'bot-1', {
+      context_floor_override: null,
+    } as never);
+
+    expect(mockUpdateContextFloorOverride).toHaveBeenCalledWith('u1', 'bot-1', null);
+    expect(result).toEqual({ context_floor_override: null });
+  });
+
+  it('does not call updateContextFloorOverride when the field is omitted', async () => {
+    // The field is optional — PATCH { agent_category: 'app' } must not wipe
+    // any existing override.
+    const user = { id: 'u1' };
+    await controller.updateAgent(user as never, 'bot-1', {
+      agent_category: 'app',
+    } as never);
+
+    expect(mockUpdateContextFloorOverride).not.toHaveBeenCalled();
+  });
+
+  it('routes context_floor_override to the NEW slug when renaming in the same PATCH', async () => {
+    // Rename-and-set-override in one PATCH is a real path in the Settings
+    // page. After renaming to `new-slug`, the lifecycle call has to target
+    // the new name, not the original.
+    const user = { id: 'u1' };
+    await controller.updateAgent(user as never, 'bot-1', {
+      name: 'New Slug',
+      context_floor_override: 64_000,
+    } as never);
+
+    expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'new-slug', 'New Slug');
+    expect(mockUpdateContextFloorOverride).toHaveBeenCalledWith('u1', 'new-slug', 64_000);
   });
 
   it('invalidates agent list cache after successful createAgent', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -128,6 +128,15 @@ export class AgentsController {
       if (body.agent_platform !== undefined) result['agent_platform'] = body.agent_platform;
     }
 
+    if (body.context_floor_override !== undefined) {
+      await this.lifecycle.updateContextFloorOverride(
+        user.id,
+        body.name ? slugify(body.name)! : agentName,
+        body.context_floor_override,
+      );
+      result['context_floor_override'] = body.context_floor_override;
+    }
+
     await this.cacheManager.del(this.agentListCacheKey(user.id));
     return result;
   }

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -154,6 +154,75 @@ describe('AgentLifecycleService', () => {
     });
   });
 
+  describe('updateContextFloorOverride', () => {
+    it('writes the override value on the agents row when the agent exists', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'agent-id-1', name: 'my-agent' });
+
+      const mockExecute = jest.fn().mockResolvedValue({});
+      const mockUpdateQb = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: mockExecute,
+      };
+
+      mockAgentCreateQueryBuilder
+        .mockReturnValueOnce({
+          select: jest.fn().mockReturnThis(),
+          leftJoin: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getOne: mockAgentGetOne,
+          getMany: jest.fn().mockResolvedValue([]),
+        })
+        .mockReturnValueOnce(mockUpdateQb);
+
+      await service.updateContextFloorOverride('test-user', 'my-agent', 50_000);
+
+      expect(mockUpdateQb.update).toHaveBeenCalledWith('agents');
+      expect(mockUpdateQb.set).toHaveBeenCalledWith({ context_floor_override: 50_000 });
+      expect(mockUpdateQb.where).toHaveBeenCalledWith('id = :id', { id: 'agent-id-1' });
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes null when clearing the override', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'agent-id-1', name: 'my-agent' });
+
+      const mockExecute = jest.fn().mockResolvedValue({});
+      const mockUpdateQb = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: mockExecute,
+      };
+
+      mockAgentCreateQueryBuilder
+        .mockReturnValueOnce({
+          select: jest.fn().mockReturnThis(),
+          leftJoin: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getOne: mockAgentGetOne,
+          getMany: jest.fn().mockResolvedValue([]),
+        })
+        .mockReturnValueOnce(mockUpdateQb);
+
+      await service.updateContextFloorOverride('test-user', 'my-agent', null);
+
+      expect(mockUpdateQb.set).toHaveBeenCalledWith({ context_floor_override: null });
+    });
+
+    it('throws NotFoundException when the agent does not belong to the user', async () => {
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.updateContextFloorOverride('test-user', 'nonexistent', 50_000),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
   describe('renameAgent', () => {
     it('should throw NotFoundException when agent not found', async () => {
       mockAgentGetOne.mockResolvedValueOnce(null);

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -55,6 +55,22 @@ export class AgentLifecycleService {
       .execute();
   }
 
+  async updateContextFloorOverride(
+    userId: string,
+    agentName: string,
+    value: number | null,
+  ): Promise<void> {
+    const agent = await this.findAgentByUser(userId, agentName);
+    if (!agent) throw new NotFoundException(`Agent "${agentName}" not found`);
+
+    await this.agentRepo
+      .createQueryBuilder()
+      .update('agents')
+      .set({ context_floor_override: value })
+      .where('id = :id', { id: agent.id })
+      .execute();
+  }
+
   async renameAgent(
     userId: string,
     currentName: string,

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -356,5 +356,35 @@ describe('TimeseriesQueriesService', () => {
       expect(result[0].total_cost).toBe(0);
       expect(result[0].sparkline).toEqual([]);
     });
+
+    /**
+     * The Settings page loads the current override from GET /api/v1/agents
+     * (to prefill the Auto/Custom radio). If this projection ever drops the
+     * field, the Settings page silently reverts to "Auto" every reload.
+     */
+    it('surfaces a configured context_floor_override on each agent row', async () => {
+      mockGetMany.mockResolvedValueOnce([
+        {
+          name: 'custom-bot',
+          display_name: null,
+          created_at: '2026-02-16',
+          context_floor_override: 50_000,
+        },
+      ]);
+      mockGetRawMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.getAgentList('u1');
+      expect(result[0].context_floor_override).toBe(50_000);
+    });
+
+    it('defaults context_floor_override to null when the agent row has no override', async () => {
+      mockGetMany.mockResolvedValueOnce([
+        { name: 'auto-bot', display_name: null, created_at: '2026-02-16' },
+      ]);
+      mockGetRawMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.getAgentList('u1');
+      expect(result[0].context_floor_override).toBeNull();
+    });
   });
 });

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -230,6 +230,7 @@ export class TimeseriesQueriesService {
         display_name: a.display_name ?? name,
         agent_category: a.agent_category ?? null,
         agent_platform: a.agent_platform ?? null,
+        context_floor_override: a.context_floor_override ?? null,
         message_count: Number(stats?.['message_count'] ?? 0),
         last_active: String(stats?.['last_active'] ?? a.created_at ?? ''),
         total_cost: Number(stats?.['total_cost'] ?? 0),

--- a/packages/backend/src/common/dto/rename-agent.dto.spec.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.spec.ts
@@ -1,7 +1,11 @@
 import 'reflect-metadata';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { RenameAgentDto } from './rename-agent.dto';
+import {
+  RenameAgentDto,
+  MIN_CONTEXT_FLOOR_OVERRIDE,
+  MAX_CONTEXT_FLOOR_OVERRIDE,
+} from './rename-agent.dto';
 
 describe('RenameAgentDto', () => {
   it('accepts valid agent names', async () => {
@@ -64,5 +68,81 @@ describe('RenameAgentDto', () => {
     const dto = plainToInstance(RenameAgentDto, { agent_platform: 'invalid' });
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * context_floor_override cases — the per-agent lever for the honest
+   * GET /v1/models advertisement. Defends the bounds that keep users from
+   * advertising absurd values (0, 10 billion) that re-introduce the same
+   * overflow/over-compaction bugs the feature exists to fix.
+   */
+  describe('context_floor_override', () => {
+    it('accepts null (explicitly clears the override)', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: null });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('is optional (DTO is valid when the field is omitted entirely)', async () => {
+      const dto = plainToInstance(RenameAgentDto, {});
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts the documented minimum (1024)', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MIN_CONTEXT_FLOOR_OVERRIDE,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts the documented maximum (10_000_000)', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MAX_CONTEXT_FLOOR_OVERRIDE,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts a typical value inside the range', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: 128_000 });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects values below the minimum', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MIN_CONTEXT_FLOOR_OVERRIDE - 1,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects zero (clearing should be null, not 0)', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: 0 });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects negative values', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: -1 });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects values above the maximum', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MAX_CONTEXT_FLOOR_OVERRIDE + 1,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects non-integer floats', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: 128_000.5 });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/backend/src/common/dto/rename-agent.dto.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.ts
@@ -6,8 +6,16 @@ import {
   Matches,
   IsOptional,
   IsIn,
+  IsInt,
+  Min,
+  Max,
+  ValidateIf,
 } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { AGENT_CATEGORIES, AGENT_PLATFORMS } from 'manifest-shared';
+
+export const MIN_CONTEXT_FLOOR_OVERRIDE = 1024;
+export const MAX_CONTEXT_FLOOR_OVERRIDE = 10_000_000;
 
 export class RenameAgentDto {
   @IsOptional()
@@ -29,4 +37,18 @@ export class RenameAgentDto {
   @IsString()
   @IsIn([...AGENT_PLATFORMS])
   agent_platform?: string;
+
+  /**
+   * Overrides the `context_length` advertised on GET /v1/models. `null`
+   * clears the override and restores the computed floor. Validation range
+   * gives users room to experiment without letting them advertise absurd
+   * values to their agents.
+   */
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @Transform(({ value }) => (value === null ? null : value))
+  @IsInt()
+  @Min(MIN_CONTEXT_FLOOR_OVERRIDE)
+  @Max(MAX_CONTEXT_FLOOR_OVERRIDE)
+  context_floor_override?: number | null;
 }

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -70,6 +70,7 @@ import { AddMessageFeedback1775600000000 } from './migrations/1775600000000-AddM
 import { CleanupOrphanedCustomProviderRefs1776679833383 } from './migrations/1776679833383-CleanupOrphanedCustomProviderRefs';
 import { AddMessageRequestHeaders1776700000000 } from './migrations/1776700000000-AddMessageRequestHeaders';
 import { AddSpecificityMiscategorized1777000000000 } from './migrations/1777000000000-AddSpecificityMiscategorized';
+import { AddAgentContextFloorOverride1777100000000 } from './migrations/1777100000000-AddAgentContextFloorOverride';
 
 const entities = [
   AgentMessage,
@@ -141,6 +142,7 @@ const migrations = [
   CleanupOrphanedCustomProviderRefs1776679833383,
   AddMessageRequestHeaders1776700000000,
   AddSpecificityMiscategorized1777000000000,
+  AddAgentContextFloorOverride1777100000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.spec.ts
+++ b/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.spec.ts
@@ -1,0 +1,35 @@
+import { QueryRunner } from 'typeorm';
+import { AddAgentContextFloorOverride1777100000000 } from './1777100000000-AddAgentContextFloorOverride';
+
+describe('AddAgentContextFloorOverride1777100000000', () => {
+  let migration: AddAgentContextFloorOverride1777100000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new AddAgentContextFloorOverride1777100000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('adds context_floor_override column to agents', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('"context_floor_override"'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(expect.stringContaining('"agents"'));
+    });
+  });
+
+  describe('down', () => {
+    it('drops context_floor_override column', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('DROP COLUMN "context_floor_override"'),
+      );
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.ts
+++ b/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a per-agent override for the context window advertised by
+ * GET /v1/models. When NULL, the proxy computes the honest floor from the
+ * agent's currently-routed models. Users with unusual setups (pinned tiers,
+ * known client quirks) can override it from the Settings page — see
+ * discussions #1450, #1612 and issue #1617.
+ */
+export class AddAgentContextFloorOverride1777100000000 implements MigrationInterface {
+  name = 'AddAgentContextFloorOverride1777100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agents" ADD COLUMN "context_floor_override" integer`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agents" DROP COLUMN "context_floor_override"`);
+  }
+}

--- a/packages/backend/src/entities/agent.entity.ts
+++ b/packages/backend/src/entities/agent.entity.ts
@@ -27,6 +27,9 @@ export class Agent {
   @Column('boolean', { default: true })
   is_active!: boolean;
 
+  @Column('int', { nullable: true })
+  context_floor_override!: number | null;
+
   @ManyToOne(() => Tenant, (t) => t.agents, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'tenant_id' })
   tenant!: Tenant;

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -35,6 +35,7 @@ describe('ModelController', () => {
   let mockResolveAgent: Record<string, jest.Mock>;
   let mockCustomProviderService: Record<string, jest.Mock>;
   let mockPricingSync: Record<string, jest.Mock>;
+  let mockGetEffectiveContext: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -60,6 +61,10 @@ describe('ModelController', () => {
       refreshCache: jest.fn().mockResolvedValue(42),
     };
 
+    mockGetEffectiveContext = jest
+      .fn()
+      .mockResolvedValue({ contextLength: 128000, overridden: false });
+
     controller = new ModelController(
       mockProviderService as unknown as ProviderService,
       mockDiscoveryService as unknown as ModelDiscoveryService,
@@ -67,6 +72,7 @@ describe('ModelController', () => {
       mockResolveAgent as unknown as ResolveAgentService,
       mockCustomProviderService as unknown as CustomProviderService,
       mockPricingSync as unknown as PricingSyncService,
+      { getEffectiveContext: mockGetEffectiveContext } as never,
     );
   });
 
@@ -146,6 +152,33 @@ describe('ModelController', () => {
       expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'test-agent');
       expect(mockDiscoveryService.discoverAllForAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
       expect(result).toEqual({ ok: true });
+    });
+  });
+
+  /* ── getContextWindow ── */
+
+  /**
+   * The Settings page's "Advertised context window" card calls this endpoint
+   * to render the live "Auto (N tokens)" label. The `overridden` flag also
+   * drives whether the UI starts in Custom mode on load.
+   */
+  describe('getContextWindow', () => {
+    it('returns the computed floor and overridden=false in auto mode', async () => {
+      mockGetEffectiveContext.mockResolvedValue({ contextLength: 128_000, overridden: false });
+
+      const result = await controller.getContextWindow(mockUser, mockAgentName);
+
+      expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'test-agent');
+      expect(mockGetEffectiveContext).toHaveBeenCalledWith(TEST_AGENT_ID);
+      expect(result).toEqual({ context_length: 128_000, overridden: false });
+    });
+
+    it('returns the override and overridden=true when the user set one', async () => {
+      mockGetEffectiveContext.mockResolvedValue({ contextLength: 50_000, overridden: true });
+
+      const result = await controller.getContextWindow(mockUser, mockAgentName);
+
+      expect(result).toEqual({ context_length: 50_000, overridden: true });
     });
   });
 

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -8,6 +8,7 @@ import { ModelDiscoveryService } from '../model-discovery/model-discovery.servic
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { AgentNameParamDto } from './dto/routing.dto';
+import { ContextAdvertisementService } from './proxy/context-advertisement.service';
 
 @Controller('api/v1/routing')
 export class ModelController {
@@ -18,6 +19,7 @@ export class ModelController {
     private readonly resolveAgentService: ResolveAgentService,
     private readonly customProviderService: CustomProviderService,
     private readonly pricingSync: PricingSyncService,
+    private readonly contextAdvertisement: ContextAdvertisementService,
   ) {}
 
   @Get('pricing-health')
@@ -49,6 +51,16 @@ export class ModelController {
   @Post('ollama/sync')
   async syncOllama() {
     return this.ollamaSync.sync();
+  }
+
+  @Get(':agentName/context-window')
+  async getContextWindow(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
+    const effective = await this.contextAdvertisement.getEffectiveContext(agent.id);
+    return {
+      context_length: effective.contextLength,
+      overridden: effective.overridden,
+    };
   }
 
   @Get(':agentName/available-models')

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -91,6 +91,7 @@ describe('ProxyController', () => {
   };
   let mockPricingCache: { getByModel: jest.Mock };
   let recorder: ProxyMessageRecorder;
+  let mockGetEffectiveContext: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -130,6 +131,9 @@ describe('ProxyController', () => {
       new ProxyMessageDedup(),
       { emit: jest.fn() } as unknown as IngestEventBusService,
     );
+    mockGetEffectiveContext = jest
+      .fn()
+      .mockResolvedValue({ contextLength: 128000, overridden: false });
     controller = new ProxyController(
       proxyService as never,
       rateLimiter as never,
@@ -137,6 +141,7 @@ describe('ProxyController', () => {
       recorder,
       new ThoughtSignatureCache(),
       new ThinkingBlockCache(),
+      { getEffectiveContext: mockGetEffectiveContext } as never,
     );
   });
 
@@ -2751,5 +2756,50 @@ describe('ProxyController', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(headers['X-Manifest-Fallback-Exhausted']).toBeUndefined();
+  });
+
+  /**
+   * GET /v1/models — OpenAI-compatible listing. The payload shape is what
+   * OpenClaw / OpenAI SDK / LangChain etc. read when they probe the endpoint
+   * to decide how aggressively to compact. Any change here can silently
+   * re-introduce issues #1617 / #1612 / #1450 in every client that trusts
+   * the response.
+   */
+  describe('listModels (GET /v1/models)', () => {
+    it('returns the OpenAI-compatible envelope with the honest context floor', async () => {
+      mockGetEffectiveContext.mockResolvedValue({
+        contextLength: 128000,
+        overridden: false,
+      });
+
+      const req = mockRequest({});
+      const result = await controller.listModels(req as never);
+
+      expect(mockGetEffectiveContext).toHaveBeenCalledWith('agent-1');
+      expect(result.object).toBe('list');
+      expect(result.data).toHaveLength(1);
+      const [model] = result.data;
+      expect(model.id).toBe('auto');
+      expect(model.object).toBe('model');
+      expect(model.owned_by).toBe('manifest');
+      expect(model.context_length).toBe(128000);
+      // `created` is a Unix timestamp in seconds — assert the field exists
+      // and is a positive integer, don't pin the exact value.
+      expect(typeof model.created).toBe('number');
+      expect(Number.isInteger(model.created)).toBe(true);
+      expect(model.created).toBeGreaterThan(0);
+    });
+
+    it('advertises the override when a user-set floor is in effect', async () => {
+      mockGetEffectiveContext.mockResolvedValue({
+        contextLength: 50_000,
+        overridden: true,
+      });
+
+      const req = mockRequest({});
+      const result = await controller.listModels(req as never);
+
+      expect(result.data[0].context_length).toBe(50_000);
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
@@ -41,7 +41,7 @@ interface ContextSvcDeps {
   findOne?: jest.Mock;
   getTiers?: jest.Mock;
   getActiveAssignments?: jest.Mock;
-  getModelForAgent?: jest.Mock;
+  getModelsForAgent?: jest.Mock;
 }
 
 async function makeService(overrides: ContextSvcDeps = {}): Promise<{
@@ -49,12 +49,12 @@ async function makeService(overrides: ContextSvcDeps = {}): Promise<{
   findOne: jest.Mock;
   getTiers: jest.Mock;
   getActiveAssignments: jest.Mock;
-  getModelForAgent: jest.Mock;
+  getModelsForAgent: jest.Mock;
 }> {
   const findOne = overrides.findOne ?? jest.fn().mockResolvedValue(null);
   const getTiers = overrides.getTiers ?? jest.fn().mockResolvedValue([]);
   const getActiveAssignments = overrides.getActiveAssignments ?? jest.fn().mockResolvedValue([]);
-  const getModelForAgent = overrides.getModelForAgent ?? jest.fn().mockResolvedValue(null);
+  const getModelsForAgent = overrides.getModelsForAgent ?? jest.fn().mockResolvedValue([]);
 
   const module: TestingModule = await Test.createTestingModule({
     providers: [
@@ -65,7 +65,7 @@ async function makeService(overrides: ContextSvcDeps = {}): Promise<{
       },
       { provide: TierService, useValue: { getTiers } },
       { provide: SpecificityService, useValue: { getActiveAssignments } },
-      { provide: ModelDiscoveryService, useValue: { getModelForAgent } },
+      { provide: ModelDiscoveryService, useValue: { getModelsForAgent } },
     ],
   }).compile();
 
@@ -74,14 +74,14 @@ async function makeService(overrides: ContextSvcDeps = {}): Promise<{
     findOne,
     getTiers,
     getActiveAssignments,
-    getModelForAgent,
+    getModelsForAgent,
   };
 }
 
 describe('ContextAdvertisementService', () => {
   describe('agent override', () => {
     it('returns the override verbatim when agent.context_floor_override is set', async () => {
-      const { service, findOne, getTiers, getModelForAgent } = await makeService({
+      const { service, findOne, getTiers, getModelsForAgent } = await makeService({
         findOne: jest.fn().mockResolvedValue({ context_floor_override: 50_000 }),
       });
 
@@ -91,7 +91,7 @@ describe('ContextAdvertisementService', () => {
       expect(findOne).toHaveBeenCalledWith({ where: { id: 'agent-1' } });
       // Override short-circuits discovery — don't pay for it.
       expect(getTiers).not.toHaveBeenCalled();
-      expect(getModelForAgent).not.toHaveBeenCalled();
+      expect(getModelsForAgent).not.toHaveBeenCalled();
     });
 
     it('ignores a zero override (falsy) and computes from models instead', async () => {
@@ -165,7 +165,7 @@ describe('ContextAdvertisementService', () => {
           .mockResolvedValue([
             { auto_assigned_model: 'ghost-model', override_model: null, fallback_models: null },
           ]),
-        getModelForAgent: jest.fn().mockResolvedValue(undefined),
+        getModelsForAgent: jest.fn().mockResolvedValue([]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -187,11 +187,9 @@ describe('ContextAdvertisementService', () => {
             fallback_models: ['also-broken'],
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'broken') return Promise.resolve(mkModel('broken', 0));
-          if (modelId === 'also-broken') return Promise.resolve(mkModel('also-broken', -1));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([mkModel('broken', 0), mkModel('also-broken', -1)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -216,12 +214,12 @@ describe('ContextAdvertisementService', () => {
             fallback_models: ['gpt-4o-mini'],
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'claude-opus-4-6')
-            return Promise.resolve(mkModel('claude-opus-4-6', 200_000));
-          if (modelId === 'gpt-4o-mini') return Promise.resolve(mkModel('gpt-4o-mini', 128_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            mkModel('claude-opus-4-6', 200_000),
+            mkModel('gpt-4o-mini', 128_000),
+          ]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -232,7 +230,10 @@ describe('ContextAdvertisementService', () => {
     it('prefers override_model over auto_assigned_model when both are set', async () => {
       // Matches the `tier.override_model ?? tier.auto_assigned_model` rule:
       // a user pinned a different model, so that's the one we have to honour.
-      const { service, getModelForAgent } = await makeService({
+      // We check the collected candidate set via the internal bookkeeping —
+      // if `auto-model` ever made it into the candidates, a discovery entry
+      // for it with a smaller window would win and break this test.
+      const { service } = await makeService({
         getTiers: jest.fn().mockResolvedValue([
           {
             auto_assigned_model: 'auto-model',
@@ -240,19 +241,17 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'pinned-model') return Promise.resolve(mkModel('pinned-model', 64_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest.fn().mockResolvedValue([
+          mkModel('pinned-model', 64_000),
+          // If the impl mistakenly used auto-model, this 8K entry would drag
+          // the advertised floor down and fail the assertion below.
+          mkModel('auto-model', 8_000),
+        ]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
 
       expect(result.contextLength).toBe(64_000);
-      // We must never look up the auto-assigned one when an override exists.
-      const lookedUp = getModelForAgent.mock.calls.map((c) => c[1]);
-      expect(lookedUp).toContain('pinned-model');
-      expect(lookedUp).not.toContain('auto-model');
     });
 
     it('includes specificity assignments in the candidate set', async () => {
@@ -275,14 +274,13 @@ describe('ContextAdvertisementService', () => {
             fallback_models: ['medium-fallback'],
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'big-model') return Promise.resolve(mkModel('big-model', 1_000_000));
-          if (modelId === 'small-coding-model')
-            return Promise.resolve(mkModel('small-coding-model', 32_000));
-          if (modelId === 'medium-fallback')
-            return Promise.resolve(mkModel('medium-fallback', 128_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            mkModel('big-model', 1_000_000),
+            mkModel('small-coding-model', 32_000),
+            mkModel('medium-fallback', 128_000),
+          ]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -301,10 +299,7 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'pinned-spec') return Promise.resolve(mkModel('pinned-spec', 96_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest.fn().mockResolvedValue([mkModel('pinned-spec', 96_000)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -312,33 +307,35 @@ describe('ContextAdvertisementService', () => {
       expect(result.contextLength).toBe(96_000);
     });
 
-    it('dedupes identical model ids across tiers and specificity so they only cost one lookup', async () => {
-      // Same model appears as both a tier primary and a specificity
-      // fallback. The internal Set must collapse it — we don't want to
-      // query the discovery service twice per request for the same model.
-      const getModelForAgent = jest.fn().mockResolvedValue(mkModel('gpt-4o', 128_000));
+    it('fetches the discovery index only once regardless of how many candidates the agent has', async () => {
+      // Before this optimisation the service looped `getModelForAgent` which
+      // internally scanned the full provider list on each call, turning N
+      // candidates into N full fetches. Guard against regressing that.
+      const getModelsForAgent = jest
+        .fn()
+        .mockResolvedValue([mkModel('gpt-4o', 128_000), mkModel('claude-opus-4-6', 200_000)]);
       const { service } = await makeService({
         getTiers: jest.fn().mockResolvedValue([
           {
             auto_assigned_model: 'gpt-4o',
             override_model: null,
-            fallback_models: ['gpt-4o'],
+            fallback_models: ['claude-opus-4-6'],
           },
         ]),
         getActiveAssignments: jest.fn().mockResolvedValue([
           {
             auto_assigned_model: 'gpt-4o',
             override_model: null,
-            fallback_models: ['gpt-4o'],
+            fallback_models: ['claude-opus-4-6'],
           },
         ]),
-        getModelForAgent,
+        getModelsForAgent,
       });
 
       await service.getEffectiveContext('agent-1');
 
-      expect(getModelForAgent).toHaveBeenCalledTimes(1);
-      expect(getModelForAgent).toHaveBeenCalledWith('agent-1', 'gpt-4o');
+      expect(getModelsForAgent).toHaveBeenCalledTimes(1);
+      expect(getModelsForAgent).toHaveBeenCalledWith('agent-1');
     });
 
     it('skips tiers whose primary is null and has no fallbacks', async () => {
@@ -358,7 +355,7 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockResolvedValue(mkModel('only-real', 42_000)),
+        getModelsForAgent: jest.fn().mockResolvedValue([mkModel('only-real', 42_000)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -383,7 +380,7 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockResolvedValue(mkModel('spec-real', 70_000)),
+        getModelsForAgent: jest.fn().mockResolvedValue([mkModel('spec-real', 70_000)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');

--- a/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
@@ -1,0 +1,394 @@
+/**
+ * Why these tests exist:
+ *
+ * Issues #1617 / #1612 / #1450 all trace back to clients hard-coding a
+ * context window that didn't match whichever model manifest/auto actually
+ * routed to — either too small (aggressive compaction wasted tokens) or too
+ * large (requests overflowed the routed model). Phase 1 advertises the
+ * **minimum** context window across every model the agent can be routed to.
+ * These tests defend that invariant: if ContextAdvertisementService ever
+ * returns the max, the sum, or "whatever the first tier says", the three
+ * bugs we fixed come back. Every test here checks a real code path that
+ * guards one of those three failure modes.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  ContextAdvertisementService,
+  DEFAULT_ADVERTISED_CONTEXT,
+} from './context-advertisement.service';
+import { Agent } from '../../entities/agent.entity';
+import { TierService } from '../routing-core/tier.service';
+import { SpecificityService } from '../routing-core/specificity.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { DiscoveredModel } from '../../model-discovery/model-fetcher';
+
+function mkModel(id: string, contextWindow: number): DiscoveredModel {
+  return {
+    id,
+    displayName: id,
+    provider: 'openai',
+    contextWindow,
+    inputPricePerToken: 0,
+    outputPricePerToken: 0,
+    capabilityReasoning: false,
+    capabilityCode: true,
+    qualityScore: 3,
+  };
+}
+
+interface ContextSvcDeps {
+  findOne?: jest.Mock;
+  getTiers?: jest.Mock;
+  getActiveAssignments?: jest.Mock;
+  getModelForAgent?: jest.Mock;
+}
+
+async function makeService(overrides: ContextSvcDeps = {}): Promise<{
+  service: ContextAdvertisementService;
+  findOne: jest.Mock;
+  getTiers: jest.Mock;
+  getActiveAssignments: jest.Mock;
+  getModelForAgent: jest.Mock;
+}> {
+  const findOne = overrides.findOne ?? jest.fn().mockResolvedValue(null);
+  const getTiers = overrides.getTiers ?? jest.fn().mockResolvedValue([]);
+  const getActiveAssignments = overrides.getActiveAssignments ?? jest.fn().mockResolvedValue([]);
+  const getModelForAgent = overrides.getModelForAgent ?? jest.fn().mockResolvedValue(null);
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      ContextAdvertisementService,
+      {
+        provide: getRepositoryToken(Agent),
+        useValue: { findOne },
+      },
+      { provide: TierService, useValue: { getTiers } },
+      { provide: SpecificityService, useValue: { getActiveAssignments } },
+      { provide: ModelDiscoveryService, useValue: { getModelForAgent } },
+    ],
+  }).compile();
+
+  return {
+    service: module.get<ContextAdvertisementService>(ContextAdvertisementService),
+    findOne,
+    getTiers,
+    getActiveAssignments,
+    getModelForAgent,
+  };
+}
+
+describe('ContextAdvertisementService', () => {
+  describe('agent override', () => {
+    it('returns the override verbatim when agent.context_floor_override is set', async () => {
+      const { service, findOne, getTiers, getModelForAgent } = await makeService({
+        findOne: jest.fn().mockResolvedValue({ context_floor_override: 50_000 }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({ contextLength: 50_000, overridden: true });
+      expect(findOne).toHaveBeenCalledWith({ where: { id: 'agent-1' } });
+      // Override short-circuits discovery — don't pay for it.
+      expect(getTiers).not.toHaveBeenCalled();
+      expect(getModelForAgent).not.toHaveBeenCalled();
+    });
+
+    it('ignores a zero override (falsy) and computes from models instead', async () => {
+      // context_floor_override is typed as `number | null`; 0 is in range for
+      // `integer` so it is worth confirming the guard treats 0/null the same
+      // way: fall through to the computed floor.
+      const { service, getTiers } = await makeService({
+        findOne: jest.fn().mockResolvedValue({ context_floor_override: 0 }),
+        getTiers: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+      expect(getTiers).toHaveBeenCalled();
+    });
+
+    it('treats a null override as "use the computed floor"', async () => {
+      const { service } = await makeService({
+        findOne: jest.fn().mockResolvedValue({ context_floor_override: null }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.overridden).toBe(false);
+    });
+
+    it('treats a missing agent row the same as no override', async () => {
+      // Covers the `agent?.context_floor_override` optional-chain path when
+      // findOne returns null.
+      const { service } = await makeService({
+        findOne: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await service.getEffectiveContext('ghost');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+  });
+
+  describe('empty-candidate fallback', () => {
+    it('falls back to DEFAULT_ADVERTISED_CONTEXT when no tiers and no specificity are configured', async () => {
+      // This is the onboarding state: user just created the agent, no
+      // providers connected yet. Advertising 128K keeps OpenClaw etc. from
+      // compacting to the hard-coded 16K floor they fell back to before.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([]),
+        getActiveAssignments: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.getEffectiveContext('new-agent');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+
+    it('falls back to DEFAULT_ADVERTISED_CONTEXT when discovery returns nothing for every candidate', async () => {
+      // Stale tier assignments pointing at models the discovery cache no
+      // longer knows about. We don't want to return `Math.min()` === Infinity.
+      const { service } = await makeService({
+        getTiers: jest
+          .fn()
+          .mockResolvedValue([
+            { auto_assigned_model: 'ghost-model', override_model: null, fallback_models: null },
+          ]),
+        getModelForAgent: jest.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+
+    it('ignores models whose contextWindow is zero or negative', async () => {
+      // Guard against bad data in cached_models. A model with contextWindow=0
+      // must never drag the advertised floor down to 0.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'broken',
+            override_model: null,
+            fallback_models: ['also-broken'],
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'broken') return Promise.resolve(mkModel('broken', 0));
+          if (modelId === 'also-broken') return Promise.resolve(mkModel('also-broken', -1));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+  });
+
+  describe('minimum-context behaviour (the whole point of the feature)', () => {
+    it('returns the smallest context_window across tier primaries and fallbacks', async () => {
+      // This is the core defense against #1617: when a tier primary has a
+      // 200K window but the fallback only has 128K, we must advertise 128K
+      // so the client never overflows the fallback on a failover.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'claude-opus-4-6',
+            override_model: null,
+            fallback_models: ['gpt-4o-mini'],
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'claude-opus-4-6')
+            return Promise.resolve(mkModel('claude-opus-4-6', 200_000));
+          if (modelId === 'gpt-4o-mini') return Promise.resolve(mkModel('gpt-4o-mini', 128_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({ contextLength: 128_000, overridden: false });
+    });
+
+    it('prefers override_model over auto_assigned_model when both are set', async () => {
+      // Matches the `tier.override_model ?? tier.auto_assigned_model` rule:
+      // a user pinned a different model, so that's the one we have to honour.
+      const { service, getModelForAgent } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'auto-model',
+            override_model: 'pinned-model',
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'pinned-model') return Promise.resolve(mkModel('pinned-model', 64_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(64_000);
+      // We must never look up the auto-assigned one when an override exists.
+      const lookedUp = getModelForAgent.mock.calls.map((c) => c[1]);
+      expect(lookedUp).toContain('pinned-model');
+      expect(lookedUp).not.toContain('auto-model');
+    });
+
+    it('includes specificity assignments in the candidate set', async () => {
+      // Bug class from #1612: when the agent is routed via specificity to a
+      // smaller-window model (e.g. a coding-specific one), the advertised
+      // floor had to account for it. If we ignored specificity we'd over-
+      // advertise and OpenClaw would overflow the coding model.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'big-model',
+            override_model: null,
+            fallback_models: null,
+          },
+        ]),
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'small-coding-model',
+            override_model: null,
+            fallback_models: ['medium-fallback'],
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'big-model') return Promise.resolve(mkModel('big-model', 1_000_000));
+          if (modelId === 'small-coding-model')
+            return Promise.resolve(mkModel('small-coding-model', 32_000));
+          if (modelId === 'medium-fallback')
+            return Promise.resolve(mkModel('medium-fallback', 128_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({ contextLength: 32_000, overridden: false });
+    });
+
+    it('uses override_model for specificity assignments when set', async () => {
+      // Same override-wins rule, on the specificity side. Exercises the
+      // `assignment.override_model ?? assignment.auto_assigned_model` line.
+      const { service } = await makeService({
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'auto-spec',
+            override_model: 'pinned-spec',
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'pinned-spec') return Promise.resolve(mkModel('pinned-spec', 96_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(96_000);
+    });
+
+    it('dedupes identical model ids across tiers and specificity so they only cost one lookup', async () => {
+      // Same model appears as both a tier primary and a specificity
+      // fallback. The internal Set must collapse it — we don't want to
+      // query the discovery service twice per request for the same model.
+      const getModelForAgent = jest.fn().mockResolvedValue(mkModel('gpt-4o', 128_000));
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'gpt-4o',
+            override_model: null,
+            fallback_models: ['gpt-4o'],
+          },
+        ]),
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'gpt-4o',
+            override_model: null,
+            fallback_models: ['gpt-4o'],
+          },
+        ]),
+        getModelForAgent,
+      });
+
+      await service.getEffectiveContext('agent-1');
+
+      expect(getModelForAgent).toHaveBeenCalledTimes(1);
+      expect(getModelForAgent).toHaveBeenCalledWith('agent-1', 'gpt-4o');
+    });
+
+    it('skips tiers whose primary is null and has no fallbacks', async () => {
+      // Covers the `if (primary) models.add(primary)` and the null-safety on
+      // fallback_models together — an unconfigured tier should contribute
+      // zero candidates, not crash.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: null,
+            override_model: null,
+            fallback_models: null,
+          },
+          {
+            auto_assigned_model: 'only-real',
+            override_model: null,
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockResolvedValue(mkModel('only-real', 42_000)),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(42_000);
+    });
+
+    it('skips specificity assignments whose primary is null and fallbacks are null', async () => {
+      // Mirrors the tier test but on the specificity branch so the
+      // equivalent `if (primary)` / `if (assignment.fallback_models)` guards
+      // are both covered.
+      const { service } = await makeService({
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: null,
+            override_model: null,
+            fallback_models: null,
+          },
+          {
+            auto_assigned_model: 'spec-real',
+            override_model: null,
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockResolvedValue(mkModel('spec-real', 70_000)),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(70_000);
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/context-advertisement.service.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Agent } from '../../entities/agent.entity';
+import { TierService } from '../routing-core/tier.service';
+import { SpecificityService } from '../routing-core/specificity.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+
+/**
+ * Floor returned when the agent has no routable models yet. Matches the
+ * default used by `ProviderModelFetcherService` so clients see a consistent
+ * value whether they call us during onboarding or after connecting providers.
+ */
+export const DEFAULT_ADVERTISED_CONTEXT = 128_000;
+
+export interface EffectiveContext {
+  contextLength: number;
+  /** True when the value came from the per-agent override. */
+  overridden: boolean;
+}
+
+/**
+ * Computes the honest `context_length` advertised on `GET /v1/models` for
+ * `manifest/auto`. The number is the **minimum** `context_window` across
+ * every model the agent could actually be routed to (tier primaries,
+ * fallbacks, and active specificity overrides). Any model Manifest picks is
+ * guaranteed to accept at least this many tokens, so clients that compact to
+ * the advertised floor never overflow the routed model.
+ *
+ * Why minimum instead of maximum or average: issues #1617 / #1612 / #1450 all
+ * trace back to clients assuming a larger window than the routed model
+ * actually offers. The floor is the only value that's safe to advertise
+ * without knowing which model this particular request will land on.
+ */
+@Injectable()
+export class ContextAdvertisementService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
+    private readonly tierService: TierService,
+    private readonly specificityService: SpecificityService,
+    private readonly discoveryService: ModelDiscoveryService,
+  ) {}
+
+  async getEffectiveContext(agentId: string): Promise<EffectiveContext> {
+    const agent = await this.agentRepo.findOne({ where: { id: agentId } });
+    if (agent?.context_floor_override) {
+      return { contextLength: agent.context_floor_override, overridden: true };
+    }
+
+    const candidates = await this.collectCandidateModels(agentId);
+    if (candidates.size === 0) {
+      return { contextLength: DEFAULT_ADVERTISED_CONTEXT, overridden: false };
+    }
+
+    const contexts: number[] = [];
+    for (const modelId of candidates) {
+      const discovered = await this.discoveryService.getModelForAgent(agentId, modelId);
+      if (discovered && discovered.contextWindow > 0) {
+        contexts.push(discovered.contextWindow);
+      }
+    }
+
+    if (contexts.length === 0) {
+      return { contextLength: DEFAULT_ADVERTISED_CONTEXT, overridden: false };
+    }
+
+    return { contextLength: Math.min(...contexts), overridden: false };
+  }
+
+  private async collectCandidateModels(agentId: string): Promise<Set<string>> {
+    const models = new Set<string>();
+
+    const tiers = await this.tierService.getTiers(agentId);
+    for (const tier of tiers) {
+      const primary = tier.override_model ?? tier.auto_assigned_model;
+      if (primary) models.add(primary);
+      if (tier.fallback_models) {
+        for (const fallback of tier.fallback_models) models.add(fallback);
+      }
+    }
+
+    const active = await this.specificityService.getActiveAssignments(agentId);
+    for (const assignment of active) {
+      const primary = assignment.override_model ?? assignment.auto_assigned_model;
+      if (primary) models.add(primary);
+      if (assignment.fallback_models) {
+        for (const fallback of assignment.fallback_models) models.add(fallback);
+      }
+    }
+
+    return models;
+  }
+}

--- a/packages/backend/src/routing/proxy/context-advertisement.service.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.ts
@@ -53,12 +53,16 @@ export class ContextAdvertisementService {
       return { contextLength: DEFAULT_ADVERTISED_CONTEXT, overridden: false };
     }
 
+    // Single fetch — getModelForAgent internally calls getModelsForAgent on
+    // every invocation, so looping it would re-scan the full provider list
+    // once per candidate. Build the index once and look candidates up in it.
+    const discovered = await this.discoveryService.getModelsForAgent(agentId);
+    const byId = new Map(discovered.map((m) => [m.id, m]));
+
     const contexts: number[] = [];
     for (const modelId of candidates) {
-      const discovered = await this.discoveryService.getModelForAgent(agentId, modelId);
-      if (discovered && discovered.contextWindow > 0) {
-        contexts.push(discovered.contextWindow);
-      }
+      const model = byId.get(modelId);
+      if (model && model.contextWindow > 0) contexts.push(model.contextWindow);
     }
 
     if (contexts.length === 0) {

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Get,
   Post,
   Req,
   Res,
@@ -31,6 +32,7 @@ import {
 } from './proxy-response-handler';
 import { ProxyExceptionFilter, isChatRenderingClient } from './proxy-exception.filter';
 import { sendFriendlyResponse } from './proxy-friendly-response';
+import { ContextAdvertisementService } from './context-advertisement.service';
 
 const MAX_SEEN_USERS = 10_000;
 const SEEN_USER_TTL_MS = 24 * 60 * 60 * 1000;
@@ -51,7 +53,34 @@ export class ProxyController {
     private readonly recorder: ProxyMessageRecorder,
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
+    private readonly contextAdvertisement: ContextAdvertisementService,
   ) {}
+
+  /**
+   * OpenAI-compatible model listing. Advertises `manifest/auto` with a
+   * dynamic `context_length` equal to the smallest context window across the
+   * agent's currently-routed models — the honest floor any request is
+   * guaranteed to fit in. Clients that compact against this value (OpenClaw,
+   * OpenRouter SDKs, etc.) stop overflowing routed models. See issues #1617,
+   * #1612 and #1450.
+   */
+  @Get('models')
+  async listModels(@Req() req: Request & { ingestionContext: IngestionContext }) {
+    const { agentId } = req.ingestionContext;
+    const { contextLength } = await this.contextAdvertisement.getEffectiveContext(agentId);
+    return {
+      object: 'list',
+      data: [
+        {
+          id: 'auto',
+          object: 'model',
+          created: Math.floor(Date.now() / 1000),
+          owned_by: 'manifest',
+          context_length: contextLength,
+        },
+      ],
+    };
+  }
 
   @Post('chat/completions')
   async chatCompletions(

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
+import { Agent } from '../../entities/agent.entity';
 import { RoutingCoreModule } from '../routing-core/routing-core.module';
 import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { ModelDiscoveryModule } from '../../model-discovery/model-discovery.module';
@@ -21,10 +22,11 @@ import { CopilotTokenService } from './copilot-token.service';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
+import { ContextAdvertisementService } from './context-advertisement.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AgentMessage, CustomProvider]),
+    TypeOrmModule.forFeature([AgentMessage, CustomProvider, Agent]),
     RoutingCoreModule,
     ModelPricesModule,
     ModelDiscoveryModule,
@@ -46,6 +48,8 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
     ThoughtSignatureCache,
     ThinkingBlockCache,
     ProxyExceptionFilter,
+    ContextAdvertisementService,
   ],
+  exports: [ContextAdvertisementService],
 })
 export class ProxyModule {}

--- a/packages/backend/test/context-advertisement.e2e-spec.ts
+++ b/packages/backend/test/context-advertisement.e2e-spec.ts
@@ -1,0 +1,163 @@
+/**
+ * End-to-end coverage for the Phase 1 "honest context window advertisement"
+ * feature (issues #1617, #1612, #1450). These tests exercise the full
+ * request path — bearer-token auth → ContextAdvertisementService → response
+ * shape — that clients like OpenClaw, OpenAI SDK, LangChain etc. actually
+ * touch when they probe GET /v1/models.
+ */
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import {
+  createTestApp,
+  TEST_AGENT_ID,
+  TEST_API_KEY,
+  TEST_OTLP_KEY,
+} from './helpers';
+import { PricingSyncService } from '../src/database/pricing-sync.service';
+import { ModelPricingCacheService } from '../src/model-prices/model-pricing-cache.service';
+import { TierAutoAssignService } from '../src/routing/routing-core/tier-auto-assign.service';
+import { RoutingCacheService } from '../src/routing/routing-core/routing-cache.service';
+
+let app: INestApplication;
+
+const api = () => request(app.getHttpServer());
+const bearer = (r: request.Test) => r.set('Authorization', `Bearer ${TEST_OTLP_KEY}`);
+
+beforeAll(async () => {
+  app = await createTestApp();
+
+  // Seed the OpenRouter pricing cache with two differently-sized models so
+  // the min() across routed models is observable from the outside.
+  const pricingSync = app.get(PricingSyncService);
+  const orCache = pricingSync.getAll() as Map<
+    string,
+    { input: number; output: number; contextWindow?: number }
+  >;
+  orCache.set('openai/gpt-4o-mini', {
+    input: 0.00000015,
+    output: 0.0000006,
+    contextWindow: 128_000,
+  });
+  orCache.set('anthropic/claude-opus-4-6', {
+    input: 0.000015,
+    output: 0.000075,
+    contextWindow: 200_000,
+  });
+  await app.get(ModelPricingCacheService).reload();
+
+  // Connect openai + anthropic providers and seed discovered models so tier
+  // auto-assign actually has something to route to.
+  await api()
+    .post('/api/v1/routing/test-agent/providers')
+    .set('x-api-key', TEST_API_KEY)
+    .send({ provider: 'openai', apiKey: 'sk-fake-openai' })
+    .expect(201);
+  await api()
+    .post('/api/v1/routing/test-agent/providers')
+    .set('x-api-key', TEST_API_KEY)
+    .send({ provider: 'anthropic', apiKey: 'sk-fake-anthropic' })
+    .expect(201);
+
+  const ds = app.get(DataSource);
+  const openaiModels = JSON.stringify([
+    {
+      id: 'gpt-4o-mini',
+      displayName: 'gpt-4o-mini',
+      provider: 'openai',
+      contextWindow: 128_000,
+      inputPricePerToken: 0.00000015,
+      outputPricePerToken: 0.0000006,
+      capabilityReasoning: false,
+      capabilityCode: true,
+      qualityScore: 2,
+    },
+  ]);
+  const anthropicModels = JSON.stringify([
+    {
+      id: 'claude-opus-4-6',
+      displayName: 'claude-opus-4-6',
+      provider: 'anthropic',
+      contextWindow: 200_000,
+      inputPricePerToken: 0.000015,
+      outputPricePerToken: 0.000075,
+      capabilityReasoning: true,
+      capabilityCode: true,
+      qualityScore: 5,
+    },
+  ]);
+  await ds.query(
+    `UPDATE user_providers SET cached_models = $1 WHERE agent_id = $2 AND provider = $3`,
+    [openaiModels, TEST_AGENT_ID, 'openai'],
+  );
+  await ds.query(
+    `UPDATE user_providers SET cached_models = $1 WHERE agent_id = $2 AND provider = $3`,
+    [anthropicModels, TEST_AGENT_ID, 'anthropic'],
+  );
+
+  // Run tier auto-assign so at least one tier points at each model — this
+  // is what makes both 200K and 128K land in the candidate set.
+  const autoAssign = app.get(TierAutoAssignService);
+  await autoAssign.recalculate(TEST_AGENT_ID);
+}, 30000);
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('GET /v1/models — honest context window advertisement', () => {
+  it('rejects unauthenticated requests with HTTP 401', async () => {
+    // Same guard as /v1/chat/completions — clients that forget the bearer
+    // must not get a stale / default value.
+    const res = await api().get('/v1/models').expect(401);
+    expect(res.body.error.type).toBe('auth_error');
+  });
+
+  it('returns the minimum context window across all tier primaries and fallbacks', async () => {
+    // After auto-assign the tiers include both gpt-4o-mini (128K) and
+    // claude-opus-4-6 (200K). The floor is 128K — that's the invariant
+    // the feature protects.
+    const res = await bearer(api().get('/v1/models')).expect(200);
+
+    expect(res.body.object).toBe('list');
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+
+    const [model] = res.body.data;
+    expect(model.id).toBe('auto');
+    expect(model.object).toBe('model');
+    expect(model.owned_by).toBe('manifest');
+    expect(Number.isInteger(model.context_length)).toBe(true);
+    expect(model.context_length).toBeGreaterThan(0);
+    expect(model.context_length).toBe(128_000);
+    // `created` is a Unix timestamp (seconds). Don't pin the exact number —
+    // just verify the shape clients depend on.
+    expect(typeof model.created).toBe('number');
+    expect(Number.isInteger(model.created)).toBe(true);
+    expect(model.created).toBeGreaterThan(0);
+  });
+
+  it('honours context_floor_override when the user sets one', async () => {
+    // Bypass the DTO/controller so we can pin the column value to something
+    // that wouldn't otherwise be computed (50_000 isn't any model's window).
+    const ds = app.get(DataSource);
+    await ds.query(`UPDATE agents SET context_floor_override = $1 WHERE id = $2`, [
+      50_000,
+      TEST_AGENT_ID,
+    ]);
+    // The advertisement service reads tiers via an in-memory cache — flush
+    // it so the update takes effect immediately.
+    app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
+
+    try {
+      const res = await bearer(api().get('/v1/models')).expect(200);
+
+      expect(res.body.data[0].context_length).toBe(50_000);
+    } finally {
+      await ds.query(`UPDATE agents SET context_floor_override = NULL WHERE id = $1`, [
+        TEST_AGENT_ID,
+      ]);
+      app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
+    }
+  });
+});

--- a/packages/frontend/src/components/OpenClawSetup.tsx
+++ b/packages/frontend/src/components/OpenClawSetup.tsx
@@ -73,6 +73,13 @@ const OpenClawSetup: Component<Props> = (props) => {
         Register Manifest in your OpenClaw config to route each request to the best provider using
         the model <code class="setup-model-hint__code">manifest/auto</code>
       </p>
+      <p class="setup-step__desc" style="font-size: var(--font-size-sm);">
+        OpenClaw reads the context window from <code>GET /v1/models</code> automatically, so the
+        snippet below intentionally doesn't hardcode <code>contextWindow</code>. If an older
+        Manifest guide told you to paste <code>contextWindow: 2000000</code> or similar, remove that
+        line — it prevents OpenClaw from compacting and will cause requests to overflow smaller
+        routed models.
+      </p>
 
       <div
         class="setup-segment setup-segment--full"

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,6 +1,13 @@
 import { Meta, Title } from '@solidjs/meta';
 import { useLocation, useNavigate, useParams } from '@solidjs/router';
-import { createResource, createSignal, ErrorBoundary, Show, type Component } from 'solid-js';
+import {
+  createEffect,
+  createResource,
+  createSignal,
+  ErrorBoundary,
+  Show,
+  type Component,
+} from 'solid-js';
 import CopyButton from '../components/CopyButton.jsx';
 import ErrorState from '../components/ErrorState.jsx';
 import AgentTypeGrid from '../components/AgentTypeGrid.jsx';
@@ -11,6 +18,7 @@ import {
   deleteAgent,
   getAgentInfo,
   getAgentKey,
+  getContextWindow,
   renameAgent,
   rotateAgentKey,
   updateAgent,
@@ -50,6 +58,51 @@ const Settings: Component = () => {
 
   const [agentInfo, { refetch: refetchInfo }] = createResource(() => agentName(), getAgentInfo);
   const [apiKeyData, { refetch: refetchKey }] = createResource(() => agentName(), getAgentKey);
+  const [contextWindow, { refetch: refetchContext }] = createResource(
+    () => agentName(),
+    getContextWindow,
+  );
+
+  const [ctxMode, setCtxMode] = createSignal<'auto' | 'custom'>('auto');
+  const [ctxValue, setCtxValue] = createSignal('');
+  const [ctxSaving, setCtxSaving] = createSignal(false);
+
+  createEffect(() => {
+    const info = agentInfo();
+    if (!info) return;
+    const override = info.context_floor_override ?? null;
+    if (override === null) {
+      setCtxMode('auto');
+      setCtxValue('');
+    } else {
+      setCtxMode('custom');
+      setCtxValue(String(override));
+    }
+  });
+
+  const handleSaveContext = async () => {
+    setCtxSaving(true);
+    try {
+      let override: number | null = null;
+      if (ctxMode() === 'custom') {
+        const parsed = Number(ctxValue());
+        if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1024) {
+          toast.error('Context window must be an integer of at least 1,024 tokens');
+          setCtxSaving(false);
+          return;
+        }
+        override = parsed;
+      }
+      await updateAgent(agentName(), { context_floor_override: override });
+      await refetchInfo();
+      await refetchContext();
+      toast.success('Context window updated');
+    } catch {
+      /* toast handled by fetchMutate */
+    } finally {
+      setCtxSaving(false);
+    }
+  };
 
   const currentCategory = () => (agentInfo()?.agent_category as AgentCategory) ?? null;
   const currentPlatform = () => (agentInfo()?.agent_platform as AgentPlatform) ?? null;
@@ -215,6 +268,85 @@ const Settings: Component = () => {
               Change
             </button>
           </div>
+        </div>
+      </div>
+
+      {/* -- Context window ----------------------------- */}
+      <h3 class="settings-section__title">Context window</h3>
+      <div class="settings-card">
+        <div class="settings-card__row">
+          <div class="settings-card__label">
+            <span class="settings-card__label-title">Advertised context window</span>
+            <span class="settings-card__label-desc">
+              The <code>context_length</code> your agent sees on <code>GET /v1/models</code>. In{' '}
+              <strong>Auto</strong> mode, Manifest advertises the smallest context among the models
+              this agent can be routed to — the honest floor any routed request will fit in. Use{' '}
+              <strong>Custom</strong> only if your client needs a specific value.
+            </span>
+          </div>
+          <div class="settings-card__control" style="flex-direction: column; gap: 8px;">
+            <div
+              role="radiogroup"
+              aria-label="Context window mode"
+              style="display: flex; gap: 12px;"
+            >
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input
+                  type="radio"
+                  name="ctx-mode"
+                  value="auto"
+                  checked={ctxMode() === 'auto'}
+                  onChange={() => setCtxMode('auto')}
+                />
+                <span>
+                  Auto{' '}
+                  <Show when={contextWindow()}>
+                    <span class="settings-card__label-desc">
+                      ({contextWindow()!.context_length.toLocaleString()} tokens)
+                    </span>
+                  </Show>
+                </span>
+              </label>
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input
+                  type="radio"
+                  name="ctx-mode"
+                  value="custom"
+                  checked={ctxMode() === 'custom'}
+                  onChange={() => setCtxMode('custom')}
+                />
+                <span>Custom</span>
+              </label>
+            </div>
+            <Show when={ctxMode() === 'custom'}>
+              <input
+                class="settings-card__input"
+                type="number"
+                min={1024}
+                step={1024}
+                aria-label="Custom context window in tokens"
+                placeholder="e.g. 128000"
+                value={ctxValue()}
+                onInput={(e) => setCtxValue(e.currentTarget.value)}
+              />
+            </Show>
+          </div>
+        </div>
+        <div class="settings-card__footer">
+          <button
+            class="btn btn--primary btn--sm"
+            onClick={handleSaveContext}
+            disabled={ctxSaving()}
+          >
+            {ctxSaving() ? (
+              <>
+                <span class="spinner" />
+                <span class="sr-only">Saving...</span>
+              </>
+            ) : (
+              'Save'
+            )}
+          </button>
         </div>
       </div>
 

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -9,6 +9,7 @@ export interface AgentInfo {
   display_name: string;
   agent_category: string | null;
   agent_platform: string | null;
+  context_floor_override: number | null;
 }
 
 export function getAgentInfo(agentName: string): Promise<AgentInfo | null> {
@@ -35,6 +36,7 @@ export function updateAgent(
     name?: string;
     agent_category?: string;
     agent_platform?: string;
+    context_floor_override?: number | null;
   },
 ) {
   return fetchMutate<Record<string, unknown>>(`/agents/${encodeURIComponent(currentName)}`, {

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -185,6 +185,15 @@ export function refreshModels(agentName: string) {
   });
 }
 
+export interface ContextWindowInfo {
+  context_length: number;
+  overridden: boolean;
+}
+
+export function getContextWindow(agentName: string) {
+  return fetchJson<ContextWindowInfo>(routingPath(agentName, 'context-window'));
+}
+
 /* -- Routing: Pricing cache health -- */
 
 export interface PricingHealth {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -20,6 +20,7 @@ const mockDeleteAgent = vi.fn();
 const mockRenameAgent = vi.fn();
 const mockRotateAgentKey = vi.fn();
 const mockUpdateAgent = vi.fn();
+const mockGetContextWindow = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getAgentKey: (...args: unknown[]) => mockGetAgentKey(...args),
   getAgentInfo: (...args: unknown[]) => mockGetAgentInfo(...args),
@@ -27,10 +28,18 @@ vi.mock("../../src/services/api.js", () => ({
   renameAgent: (...args: unknown[]) => mockRenameAgent(...args),
   rotateAgentKey: (...args: unknown[]) => mockRotateAgentKey(...args),
   updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),
+  getContextWindow: (...args: unknown[]) => mockGetContextWindow(...args),
 }));
 
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+
 vi.mock("../../src/services/toast-store.js", () => ({
-  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    warning: vi.fn(),
+  },
 }));
 
 vi.mock("../../src/components/ErrorState.jsx", () => ({
@@ -126,11 +135,17 @@ describe("Settings", () => {
     mockAgentName = "test-agent";
     mockSetupThrows = false;
     mockGetAgentKey.mockResolvedValue({ keyPrefix: "mnfst_abc" });
-    mockGetAgentInfo.mockResolvedValue({ agent_name: "test-agent", agent_category: "personal", agent_platform: "openclaw" });
+    mockGetAgentInfo.mockResolvedValue({
+      agent_name: "test-agent",
+      agent_category: "personal",
+      agent_platform: "openclaw",
+      context_floor_override: null,
+    });
     mockDeleteAgent.mockResolvedValue(undefined);
     mockRenameAgent.mockResolvedValue({ renamed: true, name: "new-name" });
     mockRotateAgentKey.mockResolvedValue({ apiKey: "new-key" });
     mockUpdateAgent.mockResolvedValue({});
+    mockGetContextWindow.mockResolvedValue({ context_length: 128000, overridden: false });
   });
 
   it("renders Settings heading", () => {
@@ -246,10 +261,14 @@ describe("Settings", () => {
   });
 
   it("save button enables when agent name changes", () => {
-    render(() => <Settings />);
+    const { container } = render(() => <Settings />);
     const input = screen.getByLabelText("Agent name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-name" } });
-    const saveBtn = screen.getByText("Save") as HTMLButtonElement;
+    // With the new Context window card there are multiple Save buttons; grab
+    // the one in the Agent name card (first Save in document order).
+    const saveBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Save",
+    ) as HTMLButtonElement;
     expect(saveBtn.disabled).toBe(false);
   });
 
@@ -257,9 +276,12 @@ describe("Settings", () => {
     const replaceFn = vi.fn();
     const originalLocation = window.location;
     Object.defineProperty(window, "location", { value: { ...originalLocation, replace: replaceFn }, writable: true, configurable: true });
-    render(() => <Settings />);
+    const { container } = render(() => <Settings />);
     fireEvent.input(screen.getByLabelText("Agent name"), { target: { value: "new-name" } });
-    fireEvent.click(screen.getByText("Save"));
+    const saveBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Save",
+    ) as HTMLButtonElement;
+    fireEvent.click(saveBtn);
     await vi.waitFor(() => { expect(mockRenameAgent).toHaveBeenCalledWith("test-agent", "new-name"); });
     await vi.waitFor(() => { expect(replaceFn).toHaveBeenCalledWith("/agents/new-name/settings"); });
     Object.defineProperty(window, "location", { value: originalLocation, writable: true, configurable: true });
@@ -267,10 +289,13 @@ describe("Settings", () => {
 
   it("resets name on rename error", async () => {
     mockRenameAgent.mockRejectedValueOnce(new Error("Conflict"));
-    render(() => <Settings />);
+    const { container } = render(() => <Settings />);
     const input = screen.getByLabelText("Agent name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "bad-name" } });
-    fireEvent.click(screen.getByText("Save"));
+    const saveBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Save",
+    ) as HTMLButtonElement;
+    fireEvent.click(saveBtn);
     await vi.waitFor(() => { expect(input.value).toBe("test-agent"); });
   });
 
@@ -521,6 +546,293 @@ describe("Settings", () => {
     const { container } = render(() => <Settings />);
     await vi.waitFor(() => {
       expect(container.textContent).toContain("mnfst_xyz...");
+    });
+  });
+
+  /**
+   * "Advertised context window" card — the UI lever for issues
+   * #1617 / #1612 / #1450. These tests defend the three behaviours a user
+   * actually goes through: prefill from /v1/models, save a custom override,
+   * and roll back to auto. If the input validation regresses we start
+   * sending `0` or `500` through PATCH again.
+   */
+  describe("context window card", () => {
+    it("renders the Auto option with the live context_length from getContextWindow", async () => {
+      mockGetContextWindow.mockResolvedValue({ context_length: 128000, overridden: false });
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("128,000 tokens");
+      });
+    });
+
+    it("starts in Custom mode with the current override when agentInfo.context_floor_override is set", async () => {
+      mockGetAgentInfo.mockResolvedValue({
+        agent_name: "test-agent",
+        agent_category: "personal",
+        agent_platform: "openclaw",
+        context_floor_override: 64000,
+      });
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        const customInput = container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement | null;
+        expect(customInput).not.toBeNull();
+        expect(customInput!.value).toBe("64000");
+      });
+    });
+
+    it("reveals the numeric input only when the Custom radio is selected", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+      // No override → Auto by default → numeric input should not be in DOM.
+      expect(
+        container.querySelector('input[aria-label="Custom context window in tokens"]'),
+      ).toBeNull();
+
+      const customRadio = container.querySelector(
+        'input[name="ctx-mode"][value="custom"]',
+      ) as HTMLInputElement;
+      expect(customRadio).not.toBeNull();
+      fireEvent.click(customRadio);
+
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+    });
+
+    it("saves a valid custom value by PATCH-ing context_floor_override as a number", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      const numericInput = container.querySelector(
+        'input[aria-label="Custom context window in tokens"]',
+      ) as HTMLInputElement;
+      fireEvent.input(numericInput, { target: { value: "64000" } });
+
+      // The Save button lives inside the Context window card — identify it by
+      // finding the card that owns the radiogroup and grabbing the Save button
+      // in its footer.
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalledWith("test-agent", {
+          context_floor_override: 64000,
+        });
+      });
+    });
+
+    it("saves Auto mode by PATCH-ing context_floor_override: null", async () => {
+      // Start in Custom so we can toggle back to Auto and prove the reset
+      // writes null (not the previous numeric value).
+      mockGetAgentInfo.mockResolvedValue({
+        agent_name: "test-agent",
+        agent_category: "personal",
+        agent_platform: "openclaw",
+        context_floor_override: 64000,
+      });
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        const customInput = container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement | null;
+        expect(customInput).not.toBeNull();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="auto"]') as HTMLInputElement,
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalledWith("test-agent", {
+          context_floor_override: null,
+        });
+      });
+    });
+
+    it("rejects a value below 1024 with a toast and does NOT call updateAgent", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "500" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith(
+          expect.stringContaining("1,024"),
+        );
+      });
+      expect(mockUpdateAgent).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-integer value with a toast and does NOT call updateAgent", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "abc" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockToastError).toHaveBeenCalled();
+      });
+      expect(mockUpdateAgent).not.toHaveBeenCalled();
+    });
+
+    it("shows a success toast when the override saves", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "128000" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          expect.stringContaining("Context window"),
+        );
+      });
+    });
+
+    it("swallows updateAgent errors (toast is handled by fetchMutate)", async () => {
+      mockUpdateAgent.mockRejectedValueOnce(new Error("network"));
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "128000" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalled();
+      });
+      // Save button must re-enable even though the PATCH rejected.
+      await vi.waitFor(() => {
+        expect(saveBtn.hasAttribute("disabled")).toBe(false);
+      });
     });
   });
 

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -46,6 +46,7 @@ import {
   clearFallbacks,
   getPricingHealth,
   refreshPricing,
+  getContextWindow,
   setMessageFeedback,
   clearMessageFeedback,
   getMessageDetails,
@@ -447,6 +448,52 @@ describe('updateAgent', () => {
 
     await expect(updateAgent('my-agent', { agent_category: 'bad' })).rejects.toThrow('Invalid category');
     expect(toast.error).toHaveBeenCalledWith('Invalid category');
+  });
+
+  // context_floor_override is the Phase 1 lever that drives GET /v1/models —
+  // make sure the PATCH body serialises numeric and null values as-is so the
+  // backend's class-validator DTO sees the right types.
+  it('serialises context_floor_override as a number in the PATCH body', async () => {
+    mockMutateOk({ context_floor_override: 50000 });
+
+    await updateAgent('my-agent', { context_floor_override: 50000 });
+
+    const call = mockFetch.mock.calls[0];
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({
+      context_floor_override: 50000,
+    });
+  });
+
+  it('serialises context_floor_override: null to clear the override', async () => {
+    mockMutateOk({ context_floor_override: null });
+
+    await updateAgent('my-agent', { context_floor_override: null });
+
+    const call = mockFetch.mock.calls[0];
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({
+      context_floor_override: null,
+    });
+  });
+});
+
+describe('getContextWindow', () => {
+  it('fetches /routing/:agentName/context-window and returns the floor', async () => {
+    const payload = { context_length: 128000, overridden: false };
+    mockOk(payload);
+
+    const result = await getContextWindow('my-agent');
+    expect(result).toEqual(payload);
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain('/api/v1/routing/my-agent/context-window');
+  });
+
+  it('URL-encodes the agent name', async () => {
+    mockOk({ context_length: 128000, overridden: false });
+
+    await getContextWindow('agent/with slash');
+
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain('/agent%2Fwith%20slash/context-window');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/models` (OpenAI-compatible) to the proxy so agents can discover the effective context window instead of hardcoding `contextWindow: 2000000` or `16000` in their configs.
- `context_length` is computed as the **minimum** across every model the agent could be routed to (tier primaries, tier fallbacks, active specificity assignments). Any routed model is guaranteed to accept at least this many tokens — so clients that compact to the advertised floor stop overflowing the routed model.
- New "Context window" card on the Settings page lets users override the computed floor per agent, with Auto/Custom modes and input validation (1024–10,000,000 tokens).

## Why

Today `manifest/auto` is a router with no `GET /v1/models` endpoint. Users pick a `contextWindow` number for their OpenClaw / Hermes / OpenAI SDK config out of thin air:

- **Too low** (`16000`) → client compacts aggressively, history falls out, the agent hallucinates (#1450).
- **Too high** (`2000000`) → client never compacts, request overflows the smallest routed model, system prompt gets silently truncated ("personality collapse" — #1617, also #1612).

Neither failure mode is visible to the user until it's already happening. This PR lets the client ask the router what the honest floor is.

Addresses #1617, #1612, #1450.

## Changes

**Backend**

- New `ContextAdvertisementService` — collects candidate models (tier primaries + fallbacks + active specificity overrides), looks up each `context_window` from the discovery cache, returns `min(...)`. Short-circuits on per-agent override. Falls back to `DEFAULT_ADVERTISED_CONTEXT = 128_000` when no providers are connected.
- `ProxyController.listModels` — `@Get('models')` handler returning the OpenAI-compatible envelope.
- `ModelController.getContextWindow` — `GET /api/v1/routing/:agentName/context-window` dashboard helper so Settings can render the live "Auto (N tokens)" label.
- Migration `1777100000000-AddAgentContextFloorOverride` adds nullable `context_floor_override INTEGER` to `agents`.
- DTO validation (`MIN_CONTEXT_FLOOR_OVERRIDE = 1024`, `MAX_CONTEXT_FLOOR_OVERRIDE = 10_000_000`); `AgentLifecycleService.updateContextFloorOverride` + PATCH routing in `AgentsController`.
- `getAgentList` projects the new column.

**Frontend**

- New Settings "Context window" card (Auto/Custom radios, numeric input, toast feedback, validation).
- `getContextWindow(agentName)` API helper; `updateAgent` accepts `context_floor_override`.
- Note in OpenClaw setup telling users to remove any manually-pasted `contextWindow: 2000000` from their OpenClaw config.

## Out of scope (explicitly deferred)

- **Phase 2** — context-aware routing within tier (token estimator + filter tier models by size + escalate). Tracked in #1646.
- **Phase 3** — OpenRouter-style middle-out compaction as opt-in last-resort fallback. Carries data-loss risk; separate PR.

## Test plan

- [x] Backend unit tests (4046 passing, 212 suites)
- [x] Backend E2E tests (128 passing, 17 suites) — new `context-advertisement.e2e-spec.ts` covers min() across 200K + 128K models, override precedence, 401 on unauth.
- [x] Frontend tests (2280 passing, 113 files) — new Settings card coverage + `getContextWindow` serialization.
- [x] `npx tsc --noEmit` clean on both backend and frontend.
- [x] Manual smoke on fresh PostgreSQL: seed agent → `/v1/models` returns 128000 (default floor, no providers); set `context_floor_override = 50000` → returns 50000; clear → returns 128000 again.
- [x] Migration up/down round-trip verified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAI‑compatible GET `/v1/models` that advertises an honest context window for `manifest/auto`, computed as the minimum across routed models, with a per‑agent override in Settings. Also reduces discovery overhead by fetching the model index once per request. Addresses #1617, #1612, #1450.

- **New Features**
  - Proxy: `GET /v1/models` returns `auto` with `context_length` = min across tier primaries, fallbacks, and active specificity; defaults to 128,000 when no providers are connected.
  - Dashboard API: `GET /api/v1/routing/:agentName/context-window` returns the live floor and `overridden` for the Settings label.
  - Agents PATCH: accept `context_floor_override` to set or clear the override; validated 1,024–10,000,000 tokens and included in `getAgentList`.
  - Settings UI: new “Context window” card (Auto/Custom + numeric input). OpenClaw setup note removes any hardcoded `contextWindow`.

- **Migration**
  - Adds nullable `context_floor_override INTEGER` to `agents`.
  - Run database migrations; no other steps required.

<sup>Written for commit c6a6cdf8996ca5da67388ee0f11feecfb0d020a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

