### PR TITLE
fix: fall back to next provider when streaming response stalls mid-stream

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
@@ -1,0 +1,132 @@
+import { peekStream, WarmupResult } from '../stream-warmup';
+
+function makeStream(chunks: Uint8Array[], delayMs = 0): ReadableStream<Uint8Array> {
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i++]);
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function emptyStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close();
+    },
+  });
+}
+
+function hangingStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    pull() {
+      // Return a promise that resolves when the stream is cancelled,
+      // preventing the process from hanging after the test.
+      return new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          // Pull is no longer called once the reader is cancelled/released
+          clearInterval(check);
+          resolve();
+        }, 50);
+      });
+    },
+  });
+}
+
+function errorStream(message: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      controller.error(new Error(message));
+    },
+  });
+}
+
+async function collectStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let result = '';
+  let done = false;
+  while (!done) {
+    const read = await reader.read();
+    done = read.done;
+    if (read.value) result += decoder.decode(read.value, { stream: !done });
+  }
+  return result;
+}
+
+describe('peekStream', () => {
+  it('returns success and preserves data for a healthy stream', async () => {
+    const data = new TextEncoder().encode('data: {"content":"hello"}\n\n');
+    const stream = makeStream([data, new TextEncoder().encode('data: [DONE]\n\n')]);
+
+    const result = await peekStream(stream, 5000);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const text = await collectStream(result.stream);
+      expect(text).toContain('hello');
+      expect(text).toContain('[DONE]');
+    }
+  });
+
+  it('returns failure for an empty stream', async () => {
+    const result = await peekStream(emptyStream(), 5000);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('empty');
+    }
+  });
+
+  it('returns failure when stream times out', async () => {
+    const result = await peekStream(hangingStream(), 100);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('timeout');
+    }
+  });
+
+  it('returns failure when stream errors immediately', async () => {
+    const result = await peekStream(errorStream('provider died'), 5000);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('error');
+      expect(result.message).toContain('provider died');
+    }
+  });
+
+  it('replays buffered chunk before remaining data', async () => {
+    const chunk1 = new TextEncoder().encode('chunk1');
+    const chunk2 = new TextEncoder().encode('chunk2');
+    const chunk3 = new TextEncoder().encode('chunk3');
+    const stream = makeStream([chunk1, chunk2, chunk3]);
+
+    const result = await peekStream(stream, 5000);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const text = await collectStream(result.stream);
+      expect(text).toBe('chunk1chunk2chunk3');
+    }
+  });
+
+  it('works with a single-chunk stream', async () => {
+    const data = new TextEncoder().encode('only-chunk');
+    const stream = makeStream([data]);
+
+    const result = await peekStream(stream, 5000);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const text = await collectStream(result.stream);
+      expect(text).toBe('only-chunk');
+    }
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
@@ -129,4 +129,29 @@ describe('peekStream', () => {
       expect(text).toBe('only-chunk');
     }
   });
+
+  it('propagates mid-stream errors after warmup succeeds', async () => {
+    let pullCount = 0;
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount++;
+        if (pullCount === 1) {
+          controller.enqueue(new TextEncoder().encode('first'));
+        } else {
+          controller.error(new Error('upstream died mid-stream'));
+        }
+      },
+    });
+
+    const result = await peekStream(source, 5000);
+    expect(result.ok).toBe(true);
+
+    if (result.ok) {
+      const reader = result.stream.getReader();
+      const first = await reader.read();
+      expect(new TextDecoder().decode(first.value)).toBe('first');
+
+      await expect(reader.read()).rejects.toThrow('upstream died mid-stream');
+    }
+  });
 });

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -22,7 +22,10 @@ import { ProxyRequestOptions, SignatureLookup, ThinkingBlockLookup } from './pro
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
+import { peekStream } from './stream-warmup';
 import type { AuthType } from 'manifest-shared';
+
+const STREAM_WARMUP_MS = 15_000;
 
 type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
 
@@ -163,6 +166,56 @@ export class ProxyService {
         resolved,
         primaryModel,
         forward,
+        body,
+        stream,
+        sessionKey,
+        signal,
+        signatureLookup,
+        thinkingLookup,
+      });
+      if (fallbackResult) return fallbackResult;
+    }
+
+    // Stream warm-up: for streaming 200 responses, verify the provider
+    // actually starts delivering data before committing to the client.
+    // If the stream stalls or dies, we can still try fallback providers.
+    if (forward.response.ok && stream && forward.response.body) {
+      const warmup = await peekStream(forward.response.body, STREAM_WARMUP_MS);
+      if (warmup.ok) {
+        const peeked: ForwardResult = {
+          response: new Response(warmup.stream, {
+            status: forward.response.status,
+            statusText: forward.response.statusText,
+            headers: forward.response.headers,
+          }),
+          isGoogle: forward.isGoogle,
+          isAnthropic: forward.isAnthropic,
+          isChatGpt: forward.isChatGpt,
+        };
+        this.recordTierIfScoring(sessionKey, resolved.tier);
+        this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
+        return { forward: peeked, meta: this.buildBaseMeta(resolved, primaryModel) };
+      }
+
+      this.logger.warn(
+        `Stream warmup failed: provider=${resolved.provider} model=${primaryModel} reason=${warmup.reason} message=${warmup.message}`,
+      );
+
+      const syntheticForward: ForwardResult = {
+        response: new Response(
+          JSON.stringify({ error: { message: `Stream warmup failed: ${warmup.message}` } }),
+          { status: 502, headers: { 'content-type': 'application/json' } },
+        ),
+        isGoogle: forward.isGoogle,
+        isAnthropic: forward.isAnthropic,
+        isChatGpt: forward.isChatGpt,
+      };
+      const fallbackResult = await this.tryFallbackChain({
+        agentId,
+        userId,
+        resolved,
+        primaryModel,
+        forward: syntheticForward,
         body,
         stream,
         sessionKey,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -230,13 +230,21 @@ export class ProxyService {
         primaryModel,
         forward: syntheticForward,
         body,
+        chatBody,
         stream,
         sessionKey,
         signal,
         signatureLookup,
         thinkingLookup,
+        apiMode,
       });
       if (fallbackResult) return fallbackResult;
+
+      // Warmup failed and no fallbacks available: return the synthetic 502
+      // instead of the original forward (whose body was consumed by peekStream).
+      this.recordTierIfScoring(sessionKey, resolved.tier);
+      this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
+      return { forward: syntheticForward, meta: this.buildBaseMeta(resolved, primaryModel) };
     }
 
     this.recordTierIfScoring(sessionKey, resolved.tier);

--- a/packages/backend/src/routing/proxy/stream-warmup.ts
+++ b/packages/backend/src/routing/proxy/stream-warmup.ts
@@ -73,9 +73,9 @@ export async function peekStream(
           } else if (nextValue) {
             controller.enqueue(nextValue);
           }
-        } catch {
-          controller.close();
+        } catch (err) {
           reader.releaseLock();
+          controller.error(err);
         }
       },
       cancel() {

--- a/packages/backend/src/routing/proxy/stream-warmup.ts
+++ b/packages/backend/src/routing/proxy/stream-warmup.ts
@@ -1,0 +1,94 @@
+/**
+ * Stream warm-up: peek at the first bytes of a streaming response before
+ * committing it to the client.  If the provider returned HTTP 200 but the
+ * stream stalls or dies before producing any data, we can still fall back
+ * to another provider instead of sending the client a truncated response.
+ *
+ * @see https://github.com/mnfst/manifest/issues/1656
+ */
+
+const DEFAULT_WARMUP_MS = 15_000;
+
+export interface WarmupSuccess {
+  ok: true;
+  /** A new ReadableStream that yields the buffered chunk first, then the rest. */
+  stream: ReadableStream<Uint8Array>;
+}
+
+export interface WarmupFailure {
+  ok: false;
+  reason: 'timeout' | 'error' | 'empty';
+  message: string;
+}
+
+export type WarmupResult = WarmupSuccess | WarmupFailure;
+
+/**
+ * Read the first chunk from `source`.  If data arrives within `timeoutMs`,
+ * return a new stream that replays the buffered chunk followed by the
+ * remaining data.  If the stream stalls, errors, or ends with no data,
+ * return a failure so the caller can try a fallback.
+ */
+export async function peekStream(
+  source: ReadableStream<Uint8Array>,
+  timeoutMs: number = DEFAULT_WARMUP_MS,
+): Promise<WarmupResult> {
+  const reader = source.getReader();
+
+  try {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const first = await Promise.race([
+      reader.read(),
+      new Promise<{ timedOut: true }>((resolve) => {
+        timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+      }),
+    ]);
+    clearTimeout(timer);
+
+    if ('timedOut' in first) {
+      reader.cancel().catch(() => {});
+      reader.releaseLock();
+      return { ok: false, reason: 'timeout', message: `No data within ${timeoutMs}ms` };
+    }
+
+    const { done, value } = first as ReadableStreamReadResult<Uint8Array>;
+
+    if (done || !value || value.length === 0) {
+      reader.releaseLock();
+      return { ok: false, reason: 'empty', message: 'Stream ended with no data' };
+    }
+
+    // Build a new stream: buffered chunk first, then pipe the rest.
+    const buffered = value;
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(buffered);
+      },
+      async pull(controller) {
+        try {
+          const { done: nextDone, value: nextValue } = await reader.read();
+          if (nextDone) {
+            controller.close();
+            reader.releaseLock();
+          } else if (nextValue) {
+            controller.enqueue(nextValue);
+          }
+        } catch {
+          controller.close();
+          reader.releaseLock();
+        }
+      },
+      cancel() {
+        reader.cancel().catch(() => {});
+        reader.releaseLock();
+      },
+    });
+
+    return { ok: true, stream };
+  } catch (err) {
+    reader.cancel().catch(() => {});
+    reader.releaseLock();
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: 'error', message };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a stream warm-up step to `ProxyService.proxyRequest()` that peeks at the first chunk of a streaming response before committing headers to the client
- If the provider returns HTTP 200 but the stream stalls (no data within 15s), errors, or ends empty, the response is cancelled and the fallback chain is tried instead
- New `peekStream()` utility in `stream-warmup.ts` handles the buffered read and reconstructs a stream that replays the peeked chunk followed by remaining data

Fixes #1656

## Problem

When a provider returns HTTP 200 and begins streaming (SSE), the fallback chain is never triggered if the stream subsequently stalls or dies. The check at `proxy.service.ts:141` (`!forward.response.ok`) passes because the status is 200, SSE headers are committed to the client via `res.flushHeaders()`, and there's no way to retry on a different provider. The client receives a truncated or empty response.

## How it works

```
Provider returns 200 OK
  → peekStream reads first chunk (15s timeout)
    → Data arrives: reconstruct stream (buffered chunk + rest), return to caller
    → Timeout/error/empty: build synthetic 502 response, enter tryFallbackChain()
```

For healthy providers this adds zero perceptible latency — the first chunk typically arrives in milliseconds, so the peek resolves immediately.

## Test plan

- [x] 6 unit tests for `peekStream` (healthy stream, empty, timeout, error, replay, single-chunk)
- [x] All 85 existing `proxy.service.spec.ts` tests pass
- [x] All 29 existing `proxy-fallback.service.spec.ts` tests pass
- [x] Lint + prettier clean (pre-commit hooks pass)
- [ ] E2E: configure a provider that returns 200 then stalls, verify fallback kicks in

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a stream warm-up to verify streaming responses before sending headers and fall back if the stream stalls, errors, or is empty. Mid-stream errors now propagate; the fallback call passes `apiMode` and `chatBody`, and if no fallbacks remain we return a synthetic 502, fixing #1656.

- Bug Fixes
  - Warm-up in `ProxyService.proxyRequest()` peeks the first chunk within 15s before committing headers.
  - On timeout/error/empty, cancel the stream, pass `apiMode`/`chatBody` to `tryFallbackChain()`, and return a synthetic 502 JSON response when no fallbacks remain.
  - `peekStream()` rebuilds the stream (replays the first chunk, then the rest) and uses `controller.error(...)` to surface mid-stream failures.
  - Added unit tests for healthy, empty, timeout, immediate error, replay/single-chunk, and mid-stream error cases.

<sup>Written for commit 0309c813da5b3363144b7eecab612d6df6661388. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1657?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

