### PR TITLE
Reorder chart stats to show Messages first

### DIFF
--- a/packages/frontend/src/components/ChartCard.tsx
+++ b/packages/frontend/src/components/ChartCard.tsx
@@ -52,6 +52,17 @@ const ChartCard: Component<ChartCardProps> = (props) => (
     <div class="chart-card__header">
       <div
         class="chart-card__stat chart-card__stat--clickable"
+        classList={{ 'chart-card__stat--active': props.activeView === 'messages' }}
+        onClick={() => props.onViewChange('messages')}
+      >
+        <span class="chart-card__label">Messages</span>
+        <div class="chart-card__value-row">
+          <span class="chart-card__value">{props.messagesValue}</span>
+          {trendBadge(props.messagesTrendPct, props.messagesValue, 'neutral')}
+        </div>
+      </div>
+      <div
+        class="chart-card__stat chart-card__stat--clickable"
         classList={{ 'chart-card__stat--active': props.activeView === 'cost' }}
         onClick={() => props.onViewChange('cost')}
       >
@@ -73,17 +84,6 @@ const ChartCard: Component<ChartCardProps> = (props) => (
         <div class="chart-card__value-row">
           <span class="chart-card__value">{formatNumber(props.tokensValue)}</span>
           {trendBadge(props.tokensTrendPct, props.tokensValue, 'inverted')}
-        </div>
-      </div>
-      <div
-        class="chart-card__stat chart-card__stat--clickable"
-        classList={{ 'chart-card__stat--active': props.activeView === 'messages' }}
-        onClick={() => props.onViewChange('messages')}
-      >
-        <span class="chart-card__label">Messages</span>
-        <div class="chart-card__value-row">
-          <span class="chart-card__value">{props.messagesValue}</span>
-          {trendBadge(props.messagesTrendPct, props.messagesValue, 'neutral')}
         </div>
       </div>
     </div>

--- a/packages/frontend/src/components/OverviewSkeleton.tsx
+++ b/packages/frontend/src/components/OverviewSkeleton.tsx
@@ -5,6 +5,12 @@ const OverviewSkeleton = () => (
     <div class="chart-card">
       <div class="chart-card__header">
         <div class="chart-card__stat chart-card__stat--active">
+          <span class="chart-card__label">Messages</span>
+          <div class="chart-card__value-row">
+            <div class="skeleton skeleton--text" style="width: 50px; height: 28px;" />
+          </div>
+        </div>
+        <div class="chart-card__stat">
           <span class="chart-card__label">Cost</span>
           <div class="chart-card__value-row">
             <div class="skeleton skeleton--text" style="width: 80px; height: 28px;" />
@@ -14,12 +20,6 @@ const OverviewSkeleton = () => (
           <span class="chart-card__label">Token usage</span>
           <div class="chart-card__value-row">
             <div class="skeleton skeleton--text" style="width: 70px; height: 28px;" />
-          </div>
-        </div>
-        <div class="chart-card__stat">
-          <span class="chart-card__label">Messages</span>
-          <div class="chart-card__value-row">
-            <div class="skeleton skeleton--text" style="width: 50px; height: 28px;" />
           </div>
         </div>
       </div>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -100,7 +100,7 @@ const Overview: Component = () => {
     setUserSelectedRange(true);
     localStorage.setItem(RANGE_STORAGE_KEY, value);
   };
-  const [activeView, setActiveView] = createSignal<'cost' | 'tokens' | 'messages'>('cost');
+  const [activeView, setActiveView] = createSignal<'cost' | 'tokens' | 'messages'>('messages');
   const [setupOpen, setSetupOpen] = createSignal(
     isRecentlyCreated(decodeURIComponent(params.agentName)),
   );

--- a/packages/frontend/tests/components/ChartCard.test.tsx
+++ b/packages/frontend/tests/components/ChartCard.test.tsx
@@ -44,12 +44,13 @@ describe('ChartCard', () => {
     const { container } = render(() => <ChartCard {...baseProps()} />);
     const stats = container.querySelectorAll('.chart-card__stat');
     expect(stats).toHaveLength(3);
-    expect(stats[0].textContent).toContain('Cost');
+    expect(stats[0].textContent).toContain('Messages');
+    expect(stats[1].textContent).toContain('Cost');
+    expect(stats[2].textContent).toContain('Token usage');
     // formatCost formats 12.34 → $12.34
     expect(container.textContent).toContain('$12.34');
     // formatNumber formats 1000 → 1k
     expect(container.textContent).toMatch(/1(,|\.)?\d*k?/i);
-    expect(container.textContent).toContain('Messages');
   });
 
   it('marks the active view and only renders that view\'s chart', () => {
@@ -71,7 +72,7 @@ describe('ChartCard', () => {
       <ChartCard {...baseProps({ onViewChange })} />
     ));
     const tiles = container.querySelectorAll('.chart-card__stat--clickable');
-    fireEvent.click(tiles[2]);
+    fireEvent.click(tiles[0]);
     expect(onViewChange).toHaveBeenCalledWith('messages');
   });
 

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -323,20 +323,20 @@ describe("Overview", () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="single-token-chart"]')).not.toBeNull();
+    });
+
+    // Click cost stat
+    const stats = container.querySelectorAll(".chart-card__stat--clickable");
+    fireEvent.click(stats[1]); // cost
+    await vi.waitFor(() => {
       expect(container.querySelector('[data-testid="cost-chart"]')).not.toBeNull();
     });
 
     // Click tokens stat
-    const stats = container.querySelectorAll(".chart-card__stat--clickable");
-    fireEvent.click(stats[1]); // tokens
+    fireEvent.click(stats[2]); // tokens
     await vi.waitFor(() => {
       expect(container.querySelector('[data-testid="token-chart"]')).not.toBeNull();
-    });
-
-    // Click messages stat
-    fireEvent.click(stats[2]); // messages
-    await vi.waitFor(() => {
-      expect(container.querySelector('[data-testid="single-token-chart"]')).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
Reordered the chart card statistics to display Messages as the primary/first stat, followed by Cost and Token usage. This change also updates the default active view to Messages instead of Cost.

## Key Changes
- **ChartCard.tsx**: Moved the Messages stat block to the beginning of the chart header, making it the first displayed statistic
- **Overview.tsx**: Changed the default active view from 'cost' to 'messages' when the component initializes
- **OverviewSkeleton.tsx**: Updated the skeleton loader to match the new stat order (Messages → Cost → Token usage)
- **Test files**: Updated all test assertions and click indices to reflect the new stat ordering:
  - ChartCard.test.tsx: Updated stat order expectations and adjusted click target from index 2 to 0 for Messages
  - Overview.test.tsx: Updated test comments and expectations to match the new stat positions

## Implementation Details
The reordering is purely a UI/UX change that affects the visual presentation and default behavior. The Messages stat is now the primary focus when users first view the overview page, with Cost and Token usage as secondary metrics. All functionality remains the same; only the order and default selection have changed.

https://claude.ai/code/session_01YHUkQkbeVfRSnRm9FXZGMJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered chart stats to show Messages first, followed by Cost and Token usage, making Messages the primary stat.
Set Messages as the default active view on Overview and updated the skeleton and tests to match the new order.

<sup>Written for commit 9792fe5d5ad5a85eb4a86b1d6516eae2373b1813. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

