### PR TITLE
chore(docker): pin project name, preserve volume, bump start_period, rotate logs

### DIFF
--- a/.changeset/docker-health-logs-naming.md
+++ b/.changeset/docker-health-logs-naming.md
@@ -1,0 +1,15 @@
+---
+'manifest': patch
+---
+
+Four small Docker-compose quality-of-life fixes, all verified against an existing install without data loss:
+
+- **Project name pinned to `mnfst`.** Docker Compose used to infer the project name from the install directory's basename (typically `manifest`), so two unrelated projects both happening to live in a `manifest/` directory would silently share container namespace — the user who reported this saw a `Found orphan containers` warning from a completely unrelated container. Added `name: mnfst` at the top of `docker/docker-compose.yml`. Container names move from `manifest-manifest-1` / `manifest-postgres-1` to `mnfst-manifest-1` / `mnfst-postgres-1`.
+
+- **`pgdata` volume name pinned to `manifest_pgdata`.** With the project rename, Docker would have created a fresh empty `mnfst_pgdata` volume on next `up`, orphaning every existing self-hoster's database. Pinning `volumes.pgdata.name` to the historical `manifest_pgdata` keeps the new compose file attaching to the existing data. Verified locally: tore down an existing `manifest` stack, booted the new file from a different directory, confirmed the `mnfst-postgres-1` container mounted `manifest_pgdata` with all 51 migrations intact.
+
+- **Healthcheck `start_period` 45s → 90s.** On a cold first pull, Docker was flipping the container to `unhealthy` before the backend had finished pulling images + running migrations + warming the pricing cache. The 90s grace gives real installs room to boot.
+
+- **Log rotation.** Default Docker `json-file` logging is unbounded — a long-running install can silently fill the host disk. Both services now cap at 5 × 10 MB per container (~50 MB ceiling each).
+
+**CI:** added an `install-script` job in `docker-smoke.yml` that runs the actual `docker/install.sh` end-to-end against the PR-built image. Caught the `${p}` healthcheck-escape regression retroactively — and will catch the next one before it ships. The installer now reads its source from `MANIFEST_INSTALLER_SOURCE` (defaults to `main` on GitHub), so the CI job can point it at a local HTTP server serving the branch under test.

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -121,3 +121,84 @@ jobs:
         if: always()
         working-directory: docker
         run: docker compose down -v
+
+  install-script:
+    name: install.sh end-to-end
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Exercises the published one-liner path — docker/install.sh pulled
+    # from HTTP — against the branch-under-test. The default source
+    # (raw.githubusercontent.com/.../main) would always test `main` even
+    # on a PR, so we point the installer at a local HTTP server serving
+    # the PR's docker/ directory via MANIFEST_INSTALLER_SOURCE.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build local image as manifestdotbuild/manifest:latest
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: manifestdotbuild/manifest:latest
+          platforms: linux/amd64
+          cache-from: type=gha,scope=smoke-amd64
+          cache-to: type=gha,mode=max,scope=smoke-amd64
+
+      - name: Serve the PR's docker/ files on a local HTTP port
+        run: |
+          cd docker
+          # `python -m http.server` ships with every ubuntu-latest runner
+          # and serves the cwd verbatim. Install.sh will fetch
+          # docker-compose.yml and .env.example from this origin.
+          nohup python3 -m http.server 38000 >/tmp/http.log 2>&1 &
+          sleep 1
+          curl -sSf http://127.0.0.1:38000/docker-compose.yml -o /dev/null
+          curl -sSf http://127.0.0.1:38000/.env.example -o /dev/null
+
+      - name: Run install.sh against the local source
+        env:
+          MANIFEST_INSTALLER_SOURCE: http://127.0.0.1:38000
+        run: |
+          bash docker/install.sh --dir "$RUNNER_TEMP/install-smoke" --yes
+
+      - name: Verify /api/v1/health responds on the default port
+        run: |
+          curl -sSf http://127.0.0.1:2099/api/v1/health | tee /tmp/health.json
+          grep -q '"status":"healthy"' /tmp/health.json
+
+      - name: Verify install wrote the expected files
+        run: |
+          install_dir="$RUNNER_TEMP/install-smoke"
+          test -f "$install_dir/docker-compose.yml"
+          test -f "$install_dir/.env"
+          # .env must have a real BETTER_AUTH_SECRET written — not the
+          # empty template value.
+          grep -Eq '^BETTER_AUTH_SECRET=[0-9a-f]{64}$' "$install_dir/.env"
+
+      - name: Verify Compose project name is pinned (no dir-basename leak)
+        run: |
+          # `name: mnfst` in docker-compose.yml should win over the
+          # install-directory basename, so we always see `mnfst-*` here.
+          docker ps --format '{{.Names}}' | tee /tmp/containers.txt
+          grep -Eq '^mnfst-manifest-1$' /tmp/containers.txt
+          grep -Eq '^mnfst-postgres-1$' /tmp/containers.txt
+
+      - name: Dump backend logs on failure
+        if: failure()
+        run: |
+          install_dir="$RUNNER_TEMP/install-smoke"
+          (cd "$install_dir" && docker compose logs manifest || true)
+          (cd "$install_dir" && docker compose logs postgres || true)
+          cat /tmp/http.log || true
+
+      - name: Tear down
+        if: always()
+        run: |
+          install_dir="$RUNNER_TEMP/install-smoke"
+          if [ -d "$install_dir" ]; then
+            (cd "$install_dir" && docker compose down -v) || true
+          fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,6 +32,14 @@
 #   Set `PORT=3001` in `.env`. Everything below reads `${PORT:-2099}`, so
 #   the compose file honours it without further edits.
 
+# Pin the Compose project name so containers, networks, and volumes have
+# stable, predictable names regardless of the install directory's
+# basename. Without this, the project name would be inherited from the
+# directory (commonly `manifest`) and would silently collide with any
+# other Docker project the user happens to have called `manifest` —
+# including older Manifest installs moved to a different path.
+name: mnfst
+
 services:
   manifest:
     image: manifestdotbuild/manifest:latest
@@ -80,8 +88,20 @@ services:
         - "const p=process.env.PORT||'2099';fetch(`http://127.0.0.1:$${p}/api/v1/health`).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
       interval: 30s
       timeout: 5s
-      start_period: 45s
+      # Cold first-pull with migrations + pricing-cache warmup comfortably
+      # runs past 60s. A 90s grace keeps Docker from flipping the container
+      # to `unhealthy` (and tripping `depends_on: service_healthy`) while
+      # the app is still legitimately booting.
+      start_period: 90s
       retries: 3
+    # Cap container logs at ~50 MB (5 × 10 MB) so a long-running install
+    # can't fill the host disk via Docker's default unbounded json-file
+    # driver. Rotated logs are still retrievable via `docker logs`.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     read_only: true
     tmpfs:
       - /tmp:size=64m
@@ -108,6 +128,11 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     security_opt:
       - no-new-privileges:true
     networks:
@@ -121,4 +146,11 @@ networks:
     driver: bridge
 
 volumes:
+  # Pin the volume name so existing installs (whose project name was
+  # inherited from the `manifest` directory basename) keep seeing their
+  # historical `manifest_pgdata` volume after we set an explicit
+  # `name: mnfst` project name above. Without this pin, renaming the
+  # project would orphan the old volume and the new stack would come up
+  # against a fresh empty DB — i.e. data loss.
   pgdata:
+    name: manifest_pgdata

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -26,7 +26,12 @@
 
 set -euo pipefail
 
-REPO_RAW="https://raw.githubusercontent.com/mnfst/manifest/main/docker"
+# Override via MANIFEST_INSTALLER_SOURCE when you need the installer to
+# pull files from somewhere other than `main` — a fork, a release branch,
+# or a local HTTP server hosting a pre-release copy (this is how the
+# Docker smoke CI exercises the script end-to-end against the branch
+# under test, not the published files on GitHub).
+REPO_RAW="${MANIFEST_INSTALLER_SOURCE:-https://raw.githubusercontent.com/mnfst/manifest/main/docker}"
 # Default to $HOME/manifest so running the one-liner from inside another
 # project (a git worktree, a dotfiles checkout, etc.) doesn't silently
 # litter that directory with `./manifest/`.


### PR DESCRIPTION
Four Docker-compose quality-of-life fixes surfaced during the end-to-end verification I ran last session. All verified against an existing install without data loss.

## 1. Pin Compose project name to \`mnfst\`

The project name used to be inferred from the install directory's basename. When that basename was \`manifest\` (which the installer produces by default), the project silently collided with any other Docker project the user happened to also call \`manifest\`. The symptom during my verification was a \`Found orphan containers ([chatgpt-app-builder])\` warning from completely unrelated containers.

Added \`name: mnfst\` at the top of \`docker-compose.yml\`. Container names move from \`manifest-manifest-1\` / \`manifest-postgres-1\` to \`mnfst-manifest-1\` / \`mnfst-postgres-1\`. The namespace is now deterministic regardless of install location.

## 2. Pin \`pgdata\` volume to \`manifest_pgdata\`

Unpinned, #1 would have orphaned every existing self-hoster's database on next \`up\` — Docker would create a fresh empty \`mnfst_pgdata\` volume, leaving the real data stranded in \`manifest_pgdata\` behind.

Pinning \`volumes.pgdata.name: manifest_pgdata\` makes the new compose file attach to the existing volume.

**Verified locally:** stopped an existing \`manifest\`-named stack, booted the new compose file from a different directory, confirmed \`mnfst-postgres-1\` mounted \`manifest_pgdata\` with all 51 migrations intact (no re-seed, no data loss).

## 3. Healthcheck \`start_period\` 45s → 90s

On a cold first pull (image + Postgres + migrations + pricing-cache warmup), a real boot comfortably crosses 60s. 45s was causing Docker to flip the container to \`unhealthy\` while it was still legitimately booting. 90s covers typical cold paths with margin.

## 4. Log rotation on both services

Docker's default \`json-file\` driver is **unbounded** — a long-running install can silently fill the host disk. Both services now declare:

\`\`\`yaml
logging:
  driver: json-file
  options:
    max-size: \"10m\"
    max-file: \"5\"
\`\`\`

~50 MB ceiling per container. Rotated logs are still retrievable via \`docker logs\`.

## Bonus: CI job that actually runs \`install.sh\`

The existing \`Compose smoke test\` boots \`docker-compose.yml\` directly, bypassing the install script. That's why the \`\${p}\` healthcheck regression Cubic caught in #1649 wasn't blocked by CI first.

This PR adds an \`install-script\` job to \`docker-smoke.yml\` that runs the actual \`docker/install.sh\` end-to-end against the PR-built image. The install script now reads its source URL from \`MANIFEST_INSTALLER_SOURCE\` (default: \`raw.githubusercontent.com/.../main\`), so the CI job points it at a local HTTP server serving the branch under test — the test exercises **the exact published code path** rather than a surrogate.

The new job also asserts the project name is pinned (\`grep -Eq '^mnfst-manifest-1$' containers.txt\`).

## Test plan

- [x] \`docker compose config\` parses the new file cleanly
- [x] Fresh boot against pre-existing \`manifest_pgdata\` volume — container names \`mnfst-*\`, healthcheck green within 3s, 51 migrations preserved
- [x] \`docker inspect\` confirms \`start_period: 1m30s\` and \`LogConfig: {max-size: 10m, max-file: 5}\`
- [x] \`docker inspect mnfst-postgres-1\` shows the mounted volume is \`manifest_pgdata\` (not \`mnfst_pgdata\`)
- [x] CI job on the PR runs install.sh end-to-end (this PR adds that job — it'll self-verify on first run)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Docker Compose project name to `mnfst`, preserves the historical `manifest_pgdata` volume, extends healthcheck grace to 90s, and enables log rotation to keep installs predictable and safe. Adds a CI job that runs the real installer end-to-end using `MANIFEST_INSTALLER_SOURCE`.

- **Bug Fixes**
  - Pin project name via `name: mnfst` to avoid container namespace collisions.
  - Pin `volumes.pgdata.name` to `manifest_pgdata` to reuse existing data.
  - Healthcheck `start_period` 45s → 90s to prevent false “unhealthy” on cold starts.
  - Add `json-file` log rotation (`max-size: "10m"`, `max-file: "5"`) on both services.

- **Refactors**
  - New `install-script` job in `docker-smoke.yml` runs `docker/install.sh` end-to-end against the PR image.
  - Installer reads source from `MANIFEST_INSTALLER_SOURCE` (defaults to GitHub `main`) so CI can test the branch under review.

<sup>Written for commit 19f6b0e5122ec841135a4fecc7a1030e95ce534d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

