### PR TITLE
feat(proxy): route OpenAI Responses-only models to /v1/responses for API-key users

### DIFF
--- a/.changeset/openai-responses-api.md
+++ b/.changeset/openai-responses-api.md
@@ -1,0 +1,12 @@
+---
+'manifest': patch
+---
+
+**Route OpenAI Codex, `-pro`, `o1-pro`, and deep-research models to `/v1/responses` for API-key users.** Closes #1660.
+
+OpenAI's `gpt-5.3-codex`, `gpt-5-codex`, `gpt-5.1-codex*`, `gpt-5.2-codex`, `gpt-5-pro`, `gpt-5.2-pro`, `o1-pro`, and `o4-mini-deep-research` only accept `api.openai.com/v1/responses` — they return HTTP 400 "not a chat model" on `/v1/chat/completions`. Manifest's subscription path already routed these correctly via the ChatGPT Codex backend, but API-key users always hit `/v1/chat/completions` and failed. Prod telemetry: 31 distinct users attempting Codex on API keys over the last 90 days, 36% error rate, one user stuck in a 1,400-call retry loop at 98% failure.
+
+- New `openai-responses` provider endpoint targeting `api.openai.com/v1/responses`, reusing the existing `chatgpt` format (same `toResponsesRequest` / `convertChatGptResponse` converters used by the subscription path — just with a plain `Authorization: Bearer` header instead of the Codex-CLI masquerade).
+- `ProviderClient.resolveEndpoint` swaps `openai` → `openai-responses` at forward time for any model matching the Responses-only regex. Subscription OAuth still routes to `openai-subscription` as before; custom endpoints are never overridden.
+- Model discovery no longer drops Codex/-pro/o1-pro/deep-research — they're kept so users can select them and the proxy routes them transparently. `gpt-image-*` is moved to the non-chat filter (it was only incidentally caught by the old Responses-only filter; it's image generation, not a chat model).
+- `OPENAI_RESPONSES_ONLY_RE` moved to `common/constants/openai-models.ts` with a shared `stripVendorPrefix` helper, so discovery and the proxy read the same source of truth without cross-module coupling.

--- a/packages/backend/src/common/constants/openai-models.ts
+++ b/packages/backend/src/common/constants/openai-models.ts
@@ -1,0 +1,17 @@
+/**
+ * OpenAI chat-style models that only accept /v1/responses (not /v1/chat/completions).
+ * The proxy swaps the endpoint at forward time; discovery keeps these so users can
+ * select them. Covers: Codex (except codex-mini-latest), GPT-5+ -pro variants,
+ * o1-pro, and deep-research models.
+ *
+ * Shared by model discovery and the routing proxy — kept in `common/constants`
+ * so neither module imports from the other just for this pattern.
+ */
+export const OPENAI_RESPONSES_ONLY_RE =
+  /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$)|^o1-pro|^o4-mini-deep-research)/i;
+
+/** Strip a single leading vendor prefix ("openai/foo" → "foo"). No-op if none. */
+export function stripVendorPrefix(model: string): string {
+  const slashIdx = model.indexOf('/');
+  return slashIdx > 0 ? model.substring(slashIdx + 1) : model;
+}

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -180,7 +180,7 @@ describe('ProviderModelFetcherService', () => {
       expect(result.map((m) => m.id)).toEqual(['gpt-4o', 'gpt-4.1']);
     });
 
-    it('should filter out v1/responses-only models', async () => {
+    it('should keep Responses-only chat models (Codex/-pro/o1-pro/deep-research) so the proxy can route them to /v1/responses', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -206,8 +206,41 @@ describe('ProviderModelFetcherService', () => {
       });
 
       const result = await service.fetch('openai', 'sk-test');
-      // chat-latest, codex-mini-latest, and o3 should pass; codex, pro, image, and deep-research filtered
-      expect(result.map((m) => m.id)).toEqual(['gpt-5-chat-latest', 'codex-mini-latest', 'o3']);
+      // Image-gen is not chat and stays filtered; everything else passes through
+      // so the proxy can swap to openai-responses at forward time.
+      expect(result.map((m) => m.id)).toEqual([
+        'gpt-5-chat-latest',
+        'gpt-5-codex',
+        'gpt-5-pro',
+        'gpt-5.1-codex',
+        'gpt-5.1-codex-mini',
+        'gpt-5.2-codex',
+        'gpt-5.2-pro',
+        'gpt-5.4-pro',
+        'gpt-5.3-codex',
+        'codex-mini-latest',
+        'o1-pro',
+        'o4-mini-deep-research',
+        'o3',
+      ]);
+    });
+
+    it('should drop image-generation models from discovery (not chat-compatible)', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-image-1' },
+            { id: 'gpt-image-1-mini' },
+            { id: 'gpt-image-1.5' },
+            { id: 'gpt-image-2' },
+            { id: 'gpt-4o' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
     });
 
     it('should not filter non-OpenAI providers with similar model names', async () => {
@@ -223,7 +256,7 @@ describe('ProviderModelFetcherService', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('should keep codex-mini-latest (chat-compatible codex model)', async () => {
+    it('should keep both codex-mini-latest (chat-compatible) and Responses-only Codex variants (routed at proxy time)', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -232,7 +265,7 @@ describe('ProviderModelFetcherService', () => {
       });
 
       const result = await service.fetch('openai', 'sk-test');
-      expect(result.map((m) => m.id)).toEqual(['codex-mini-latest']);
+      expect(result.map((m) => m.id)).toEqual(['codex-mini-latest', 'gpt-5-codex']);
     });
 
     it('should deduplicate dated snapshots when alias exists', async () => {
@@ -1606,7 +1639,7 @@ describe('ProviderModelFetcherService', () => {
       expect(result[0].id).toBe('o3');
     });
 
-    it('should keep codex-mini-latest but filter other codex models', async () => {
+    it('should keep all Codex variants in discovery (proxy routes them to /v1/responses)', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1620,10 +1653,15 @@ describe('ProviderModelFetcherService', () => {
       });
 
       const result = await service.fetch('openai', 'sk-test');
-      expect(result.map((m) => m.id)).toEqual(['codex-mini-latest']);
+      expect(result.map((m) => m.id)).toEqual([
+        'codex-mini-latest',
+        'gpt-5-codex',
+        'gpt-5.1-codex',
+        'gpt-5.2-codex',
+      ]);
     });
 
-    it('should filter out gpt-5-pro but keep gpt-5-chat-latest', async () => {
+    it('should keep gpt-5 -pro variants alongside gpt-5-chat-latest (proxy routes -pro to /v1/responses)', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1637,7 +1675,12 @@ describe('ProviderModelFetcherService', () => {
       });
 
       const result = await service.fetch('openai', 'sk-test');
-      expect(result.map((m) => m.id)).toEqual(['gpt-5-chat-latest', 'gpt-5']);
+      expect(result.map((m) => m.id)).toEqual([
+        'gpt-5-pro',
+        'gpt-5.2-pro',
+        'gpt-5-chat-latest',
+        'gpt-5',
+      ]);
     });
 
     it('should filter out audio models', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -72,21 +72,12 @@ const parseOpenAI = createModelParser<OpenAIModelEntry>({
 /** Date-suffixed snapshots returned by OpenAI (e.g. gpt-4o-mini-2024-07-18). */
 const OPENAI_DATE_SUFFIX_RE = /-\d{4}-\d{2}-\d{2}$/;
 
-/**
- * OpenAI models only supported in v1/responses (not v1/chat/completions).
- * Codex models (except codex-mini-latest), -pro variants of GPT-5+,
- * image generation models, o1-pro, and deep-research models.
- */
-const OPENAI_RESPONSES_ONLY_RE =
-  /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$)|^gpt-image-|^o1-pro|^o4-mini-deep-research)/i;
-
 function parseOpenAIDeduped(body: unknown, provider: string): DiscoveredModel[] {
-  const filtered = parseOpenAI(body, provider).filter((m) => !OPENAI_RESPONSES_ONLY_RE.test(m.id));
-
+  const parsed = parseOpenAI(body, provider);
   // Deduplicate: if both an alias (gpt-4o-mini) and a dated snapshot
   // (gpt-4o-mini-2024-07-18) exist, keep only the alias.
-  const ids = new Set(filtered.map((m) => m.id));
-  return filtered.filter((m) => {
+  const ids = new Set(parsed.map((m) => m.id));
+  return parsed.filter((m) => {
     if (!OPENAI_DATE_SUFFIX_RE.test(m.id)) return true;
     const alias = m.id.replace(OPENAI_DATE_SUFFIX_RE, '');
     return !ids.has(alias);
@@ -109,9 +100,9 @@ export const UNIVERSAL_NON_CHAT_RE =
  */
 export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
   openai:
-    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image|search-api)/i,
+    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image|^gpt-image-|search-api)/i,
   'openai-subscription':
-    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio|^chatgpt-image)/i,
+    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio|^chatgpt-image|^gpt-image-)/i,
   gemini:
     /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview|robotics)/i,
   mistral:

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -486,6 +486,213 @@ describe('ProviderClient', () => {
     });
   });
 
+  describe('resolveEndpoint - OpenAI Responses-only routing', () => {
+    // When a user authenticates with a normal OpenAI API key but requests
+    // a Codex / -pro / o1-pro / deep-research model, OpenAI rejects the call
+    // on /v1/chat/completions. The proxy transparently swaps to /v1/responses.
+    const responsesOnlyModels = [
+      'gpt-5.3-codex',
+      'gpt-5-codex',
+      'gpt-5.1-codex-mini',
+      'gpt-5.2-codex',
+    ];
+
+    it.each(responsesOnlyModels)(
+      'routes api_key + Codex model %s to /v1/responses with chatgpt format',
+      async (model) => {
+        mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        const result = await client.forward({
+          provider: 'openai',
+          apiKey: 'sk-test',
+          model,
+          body,
+          stream: false,
+        });
+
+        const url = mockFetch.mock.calls[0][0] as string;
+        expect(url).toBe('https://api.openai.com/v1/responses');
+        expect(result.isChatGpt).toBe(true);
+        expect(result.isAnthropic).toBe(false);
+        expect(result.isGoogle).toBe(false);
+
+        // Plain openaiHeaders — Bearer + Content-Type only, no Codex CLI spoof.
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBe('Bearer sk-test');
+        expect(headers['Content-Type']).toBe('application/json');
+        expect(headers['originator']).toBeUndefined();
+
+        // Body is Responses-API shape (input/store/instructions), not Chat Completions.
+        const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(Array.isArray(sentBody.input)).toBe(true);
+        expect(sentBody.store).toBe(false);
+        expect(sentBody.instructions).toBeDefined();
+        expect(sentBody.messages).toBeUndefined();
+        expect(sentBody.model).toBe(model);
+      },
+    );
+
+    const proModels = ['gpt-5-pro', 'gpt-5.2-pro', 'gpt-5.4-pro'];
+
+    it.each(proModels)('routes api_key + %s to /v1/responses', async (model) => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model,
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.openai.com/v1/responses');
+      expect(result.isChatGpt).toBe(true);
+    });
+
+    it('routes api_key + o1-pro to /v1/responses', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'o1-pro',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.openai.com/v1/responses');
+      expect(result.isChatGpt).toBe(true);
+    });
+
+    it('routes api_key + o4-mini-deep-research to /v1/responses', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'o4-mini-deep-research',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.openai.com/v1/responses');
+      expect(result.isChatGpt).toBe(true);
+    });
+
+    it('detects Responses-only models after stripping an OpenRouter-style vendor prefix', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'openai/gpt-5.3-codex',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.openai.com/v1/responses');
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // Vendor prefix is stripped before being sent to OpenAI.
+      expect(sentBody.model).toBe('gpt-5.3-codex');
+    });
+
+    // Regression guard: models that DO support /v1/chat/completions must stay
+    // on the default OpenAI endpoint — we must not over-match the regex.
+    const chatCompatibleModels = [
+      'gpt-5',
+      'gpt-4o',
+      'gpt-4o-mini',
+      'gpt-5-chat-latest',
+      'codex-mini-latest',
+    ];
+
+    it.each(chatCompatibleModels)('leaves api_key + %s on /v1/chat/completions', async (model) => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model,
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.openai.com/v1/chat/completions');
+      expect(result.isChatGpt).toBe(false);
+
+      // Body is Chat Completions shape (messages array, not input array).
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toBeDefined();
+      expect(sentBody.input).toBeUndefined();
+      expect(sentBody.store).toBeUndefined();
+    });
+
+    it('keeps subscription + Codex on the Codex backend (subscription override wins)', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'oauth-token',
+        model: 'gpt-5.3-codex',
+        body,
+        stream: false,
+        authType: 'subscription',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      // Must stay on chatgpt.com/backend-api (subscription), NOT swap to api.openai.com.
+      expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
+      expect(url).not.toContain('api.openai.com');
+      expect(result.isChatGpt).toBe(true);
+
+      // Subscription spoofs the Codex CLI user agent; the api_key responses
+      // path does not. This confirms we hit the subscription endpoint.
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers['originator']).toBe('codex_cli_rs');
+    });
+
+    it('does not override custom endpoints when a Codex model is used through a custom provider', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const customEndpoint = {
+        baseUrl: 'https://proxy.example.com/v1',
+        buildHeaders: (key: string) => ({
+          Authorization: `Bearer ${key}`,
+          'Content-Type': 'application/json',
+        }),
+        buildPath: () => '/chat/completions',
+        format: 'openai' as const,
+      };
+
+      const result = await client.forward({
+        provider: 'custom:some-uuid',
+        apiKey: 'sk-custom',
+        model: 'gpt-5.3-codex',
+        body,
+        stream: false,
+        customEndpoint,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      // customEndpoint short-circuits resolveEndpoint — the Responses-only
+      // branch must not fire and rewrite the URL to api.openai.com.
+      expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+      expect(url).not.toContain('api.openai.com');
+      expect(result.isChatGpt).toBe(false);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // Still Chat Completions shape — the custom endpoint is openai format.
+      expect(sentBody.messages).toBeDefined();
+      expect(sentBody.input).toBeUndefined();
+    });
+  });
+
   describe('Z.ai subscription provider', () => {
     it('routes to Coding Plan endpoint with subscription authType', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -91,6 +91,74 @@ describe('chatgpt-adapter', () => {
         { type: 'function', name: 'add', parameters: { type: 'object' } },
       ]);
     });
+
+    // Integration-style check for the api.openai.com/v1/responses branch:
+    // Codex-family models (e.g. gpt-5.3-codex) route through this adapter
+    // when hit with an API key. The output must be a valid Responses API
+    // request body, not leak any Chat Completions-only fields.
+    it('produces a valid Responses API body for a Codex model with tools', () => {
+      const chatCompletionsBody = {
+        model: 'gpt-4o', // Should be overridden by the argument
+        messages: [{ role: 'user', content: 'Write a hello world in Python.' }],
+        stream: false,
+        max_tokens: 1024,
+        temperature: 0.5,
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'run_code',
+              description: 'Execute code in a sandbox',
+              parameters: {
+                type: 'object',
+                properties: { code: { type: 'string' } },
+                required: ['code'],
+              },
+            },
+          },
+        ],
+      };
+
+      const req = toResponsesRequest(chatCompletionsBody, 'gpt-5.3-codex');
+
+      // Required Responses API fields.
+      expect(req.model).toBe('gpt-5.3-codex');
+      expect(req.store).toBe(false);
+      expect(req.stream).toBe(false);
+      expect(req).toHaveProperty('instructions');
+      expect(typeof req.instructions).toBe('string');
+
+      // input is an array of { role, content } items, NOT a `messages` array.
+      expect(Array.isArray(req.input)).toBe(true);
+      const input = req.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(1);
+      expect(input[0].role).toBe('user');
+      expect(Array.isArray(input[0].content)).toBe(true);
+      const content = input[0].content as Array<Record<string, unknown>>;
+      expect(content[0]).toMatchObject({
+        type: 'input_text',
+        text: 'Write a hello world in Python.',
+      });
+
+      // Tools are flattened — no nested `function` wrapper.
+      expect(req.tools).toEqual([
+        {
+          type: 'function',
+          name: 'run_code',
+          description: 'Execute code in a sandbox',
+          parameters: {
+            type: 'object',
+            properties: { code: { type: 'string' } },
+            required: ['code'],
+          },
+        },
+      ]);
+
+      // None of the Chat Completions-only fields must leak into the body
+      // — OpenAI's /v1/responses endpoint rejects or ignores them.
+      expect(req).not.toHaveProperty('messages');
+      expect(req).not.toHaveProperty('max_tokens');
+    });
   });
 
   describe('fromResponsesResponse', () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './provider-endpoints';
 import { resolveSubscriptionEndpointKey } from './provider-hooks';
 import { injectOpenRouterCacheControl } from './cache-injection';
@@ -51,8 +52,7 @@ function stripModelPrefix(model: string, endpointKey: string): string {
   // legitimate slash segment from the upstream model id
   // (e.g. "MiniMaxAI/MiniMax-2.7" or "accounts/fireworks/routers/...").
   if (endpointKey === 'custom') return model;
-  const slashIdx = model.indexOf('/');
-  return slashIdx > 0 ? model.substring(slashIdx + 1) : model;
+  return stripVendorPrefix(model);
 }
 
 @Injectable()
@@ -124,12 +124,14 @@ export class ProviderClient {
       const override = resolveSubscriptionEndpointKey(resolved);
       if (override) resolved = override;
     }
+    // OpenAI rejects these models on /v1/chat/completions; forward to /v1/responses.
+    if (resolved === 'openai' && OPENAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
+      resolved = 'openai-responses';
+    }
     if (resolved === 'opencode-go') {
       // OpenCode Go uses two different API formats depending on the model:
       // MiniMax models use Anthropic /v1/messages, all others use OpenAI /v1/chat/completions.
-      const slashIdx = model.indexOf('/');
-      const bare = slashIdx > 0 ? model.substring(slashIdx + 1) : model;
-      if (bare.toLowerCase().startsWith('minimax-')) {
+      if (stripVendorPrefix(model).toLowerCase().startsWith('minimax-')) {
         resolved = 'opencode-go-anthropic';
       }
     }

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -76,6 +76,14 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: () => '/codex/responses',
     format: 'chatgpt',
   },
+  // Standard OpenAI API key against api.openai.com/v1/responses — used for
+  // Codex, -pro, o1-pro, and deep-research models that reject /v1/chat/completions.
+  'openai-responses': {
+    baseUrl: 'https://api.openai.com',
+    buildHeaders: openaiHeaders,
+    buildPath: () => '/v1/responses',
+    format: 'chatgpt',
+  },
   anthropic: {
     baseUrl: 'https://api.anthropic.com',
     buildHeaders: anthropicHeaders,


### PR DESCRIPTION
## Summary

- Adds an `openai-responses` endpoint so `api.openai.com/v1/responses` is reachable for standard OpenAI API keys. Reuses the existing Responses adapter (`toResponsesRequest` / `convertChatGptResponse`) that previously only ran for ChatGPT subscription OAuth.
- `ProviderClient.resolveEndpoint` swaps `openai` → `openai-responses` at forward time when the model is Responses-only (`gpt-*-codex`, `gpt-5*-pro`, `o1-pro`, `o4-mini-deep-research`). Subscription OAuth and custom endpoints are untouched.
- Stops filtering those models out of discovery — keep them available, route them transparently. `gpt-image-*` moves to the non-chat filter (it was only incidentally caught by the old drop-list; it's image generation, not a chat model).
- Hoists `OPENAI_RESPONSES_ONLY_RE` and a small `stripVendorPrefix` helper to `common/constants/openai-models.ts` so discovery and the proxy read the same source of truth without cross-module imports.

Closes #1660.

## Why this matters

OpenAI rejects Codex models on `/v1/chat/completions` with HTTP 400 `"not a chat model"`. The subscription path already handled them; API-key users always hit chat completions and failed silently.

Prod telemetry (90d):
- **31 distinct API-key users** attempted Codex models (`gpt-5.3-codex`, `gpt-5.1-codex-max`, etc.).
- **2,240 attempts** with a **36% error rate**.
- One user stuck in a **1,400-call retry loop at 98% failure**.
- API-key is **~31% of the OpenAI user base**, so this is not a niche.

The one user who worked around it via a custom provider pointing at a Responses-capable gateway ran at **0.9% error rate** — confirming the fix is correct once the endpoint is right.

## Test plan

- [x] `npm test --workspace=packages/backend` — 4,026 unit tests pass
- [x] `npm run test:e2e --workspace=packages/backend` — 125 e2e tests pass
- [x] `npm test --workspace=packages/frontend` — 2,267 vitest tests pass
- [x] `npm test --workspace=packages/shared` — 83 tests pass
- [x] `npx tsc --noEmit` clean in backend and frontend
- [x] Patch coverage: 100% line coverage on all four changed/new source files (`openai-models.ts`, `provider-client.ts`, `provider-endpoints.ts`, `provider-model-fetcher.service.ts`)
- [x] Prettier clean
- [x] Manual verification against live `api.openai.com`: `gpt-5.3-codex` returns HTTP 400 on `/v1/chat/completions` (`"This is not a chat model"`) and HTTP 200 on `/v1/responses` with the exact same API key and body transform
- [x] Changeset added (`patch`)

## Risk & rollback

- Subscription path unchanged (explicit regression test asserts `originator: codex_cli_rs` header + chatgpt.com URL are preserved).
- Custom endpoints never overridden (explicit regression test).
- Chat-compatible models (`gpt-5`, `gpt-4o`, `gpt-4o-mini`, `gpt-5-chat-latest`, `codex-mini-latest`) stay on `/v1/chat/completions` (regression test).
- Revert-safe: single commit, no data migrations, no schema changes. Reverting restores the discovery filter as-is.

## Follow-ups (not in this PR)

- Verify OpenRouter pricing cache has per-token prices for Codex variants — otherwise dashboard costs and alert budgets silently report $0.
- Make sure `TierAutoAssignService` doesn't promote Codex into the generic `reasoning`/`complex` tier (Codex is premium; it should be the `coding` specificity target, not the default reasoning pick).
- Reach out to the API-key user with 1,435 failing Codex-max calls — their setup will start working on deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route OpenAI Responses-only models to /v1/responses for API-key users to stop 400 “not a chat model” errors and make Codex, -pro, o1-pro, and deep-research models work transparently. Closes #1660.

- **New Features**
  - Added `openai-responses` endpoint pointing to api.openai.com/v1/responses using the existing ChatGPT adapter.
  - `ProviderClient.resolveEndpoint` swaps `openai` → `openai-responses` for models matching `OPENAI_RESPONSES_ONLY_RE`; subscription OAuth and custom endpoints are not overridden.
  - Kept Responses-only models in discovery so users can select them; moved `gpt-image-*` to the non-chat filter.
  - Hoisted `OPENAI_RESPONSES_ONLY_RE` and `stripVendorPrefix` to `common/constants/openai-models.ts` to share one source of truth across discovery and the proxy.

<sup>Written for commit 321a6447e24d70a9a754412bae4a09f9e53ca196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

