### PR TITLE
fix(telemetry): include packages/manifest/package.json in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,6 +75,10 @@ COPY --from=build --chown=nonroot:nonroot /app/packages/backend/dist packages/ba
 COPY --from=build --chown=nonroot:nonroot /app/packages/frontend/dist packages/frontend/dist
 COPY --chown=nonroot:nonroot packages/shared/package.json packages/shared/
 COPY --chown=nonroot:nonroot packages/backend/package.json packages/backend/
+# The telemetry sender reads the canonical Manifest version from this
+# file at boot. Without it, readManifestVersion() falls back to "unknown"
+# and the sender ends up posting invalid semver to the ingest endpoint.
+COPY --chown=nonroot:nonroot packages/manifest/package.json packages/manifest/
 
 EXPOSE 2099
 

--- a/packages/backend/src/telemetry/telemetry.config.spec.ts
+++ b/packages/backend/src/telemetry/telemetry.config.spec.ts
@@ -40,6 +40,29 @@ describe('buildTelemetryConfig', () => {
     });
     expect(cfg.endpoint).toBe('http://127.0.0.1:9999/ingest');
   });
+
+  it('is disabled when the Manifest version cannot be read', () => {
+    // Simulates a misconfigured image that ships without
+    // packages/manifest/package.json. readManifestVersion() falls back to
+    // "unknown", which the ingest would reject as invalid semver — better
+    // to stay silent than to spam the endpoint.
+    jest.isolateModules(() => {
+      jest.doMock('fs', () => {
+        const actual = jest.requireActual<typeof import('fs')>('fs');
+        return {
+          ...actual,
+          readFileSync: jest.fn(() => {
+            throw new Error('ENOENT');
+          }),
+        };
+      });
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('./telemetry.config') as typeof import('./telemetry.config');
+      const cfg = mod.buildTelemetryConfig({ NODE_ENV: 'production' });
+      expect(cfg.manifestVersion).toBe('unknown');
+      expect(cfg.enabled).toBe(false);
+    });
+  });
 });
 
 describe('readManifestVersion', () => {

--- a/packages/backend/src/telemetry/telemetry.config.ts
+++ b/packages/backend/src/telemetry/telemetry.config.ts
@@ -13,18 +13,26 @@ export interface TelemetryConfig {
 
 /**
  * Opt-out with `MANIFEST_TELEMETRY_DISABLED=1`. Also auto-silenced outside
- * production so dev instances and test runs never report.
+ * production so dev instances and test runs never report. Also silenced
+ * when the Manifest version can't be read — the ingest validates
+ * `manifest_version` as semver, so a misconfigured image without
+ * `packages/manifest/package.json` would otherwise spam the endpoint
+ * with 400s.
  */
 export function buildTelemetryConfig(env: NodeJS.ProcessEnv = process.env): TelemetryConfig {
   const disabled = env['MANIFEST_TELEMETRY_DISABLED'];
   const isProd = (env['NODE_ENV'] ?? 'development') === 'production';
   const isDisabled = disabled === '1' || disabled === 'true';
+  const manifestVersion = readManifestVersion();
+  const versionReadable = manifestVersion !== UNKNOWN_VERSION;
   return {
-    enabled: isProd && !isDisabled,
+    enabled: isProd && !isDisabled && versionReadable,
     endpoint: env['TELEMETRY_ENDPOINT'] ?? DEFAULT_TELEMETRY_ENDPOINT,
-    manifestVersion: readManifestVersion(),
+    manifestVersion,
   };
 }
+
+export const UNKNOWN_VERSION = 'unknown';
 
 export function readManifestVersion(): string {
   try {
@@ -32,8 +40,8 @@ export function readManifestVersion(): string {
     const raw = readFileSync(path, 'utf8');
     const pkg = JSON.parse(raw) as { version?: unknown };
     if (typeof pkg.version === 'string') return pkg.version;
-    return 'unknown';
+    return UNKNOWN_VERSION;
   } catch {
-    return 'unknown';
+    return UNKNOWN_VERSION;
   }
 }


### PR DESCRIPTION
## The bug

Fresh install from `manifestdotbuild/manifest:5.49.0` (or `:latest`) bootstraps telemetry correctly — singleton row, install_id UUID, jitter — but every time the sender fires it posts `manifest_version: "unknown"` and peacock rejects with 400:

```
{"message":["manifest_version must be a valid semver string"],"error":"Bad Request","statusCode":400}
```

`last_sent_at` never advances, so every hourly tick retries the same bad payload.

## Root cause

`packages/manifest/package.json` is the source of truth for the Manifest version (read at boot by `readManifestVersion()`). The Dockerfile's runtime stage copies `packages/shared/package.json` and `packages/backend/package.json` but not `packages/manifest/package.json`, so inside the container `readManifestVersion()` hits `ENOENT` and falls back to the sentinel `"unknown"`.

## Fix

1. **Dockerfile** — add `COPY --chown=nonroot:nonroot packages/manifest/package.json packages/manifest/` alongside the two existing package.json copies in the runtime stage.
2. **telemetry.config.ts** — defence-in-depth: when `readManifestVersion()` returns `"unknown"`, set `enabled: false`. A misconfigured image should stay quiet rather than spam peacock with invalid payloads.

## Local verification

- Rebuilt the image from this branch
- Fresh install via the published quickstart script, pointed at the local tag
- Force-ticked the sender inside the container → peacock returned 202
- Re-posted the same install_id → 409 `Duplicate report` (confirms the original landed)

Before fix: `manifest_version: "unknown"` → 400
After fix:  `manifest_version: "5.49.1"` → 202

## Test plan

- [x] `npx jest src/telemetry` — 36/36 (+1 new test: config disables telemetry when version can't be read)
- [x] `npx tsc --noEmit` clean
- [x] `docker build` + fresh install + force-tick → 202 + dedup 409 on replay

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes telemetry payloads by including the manifest version in the Docker image and auto-disabling telemetry when the version can’t be read. Prevents 400s and repeated retries from self‑hosted installs.

- **Bug Fixes**
  - Docker: copy `packages/manifest/package.json` into the runtime image so `readManifestVersion()` returns the real version instead of "unknown".
  - Safety: when the version is `unknown`, telemetry is disabled to avoid sending invalid semver.

<sup>Written for commit 4f10bb3db3566a01d1ae162b882101a026aa29c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

