### PR TITLE
fix(docker): bump runtime to distroless nodejs22-debian13 to clear 9 CVEs

### DIFF
--- a/.changeset/distroless-debian13-cve-bump.md
+++ b/.changeset/distroless-debian13-cve-bump.md
@@ -1,0 +1,16 @@
+---
+"manifest": patch
+---
+
+Bump Docker runtime to `gcr.io/distroless/nodejs22-debian13:nonroot` to clear 9 CVEs (1 CRITICAL / 8 HIGH) that the published image inherited from the older `nodejs22-debian12` base.
+
+Root cause: Google hasn't rebuilt any tag on `gcr.io/distroless/nodejs22-debian12` since Node 22.22.2 and Debian 12's `openssl 3.0.19-1~deb12u2` shipped. Every `debian12` variant still bakes Node 22.22.0 on top of the vulnerable `openssl 3.0.18-1~deb12u2`, so a digest refresh alone couldn't clear the scan. The `nodejs22-debian13` family already publishes Node v22.22.2 on a newer openssl, so moving the runtime stage to it fixes both CVE sources in a single base-image bump.
+
+The move is safe: the prod-deps stage runs `npm ci --ignore-scripts`, so no native modules are compiled and the runtime's glibc version is invisible to `node_modules`. `node:22-alpine` and `node:22-slim` digest pins were also refreshed for hygiene — those layers don't ship in the final image.
+
+**CVEs cleared:**
+- CVE-2025-55130 (CRITICAL, CVSS 9.1) — Node
+- CVE-2025-55131, CVE-2025-59465, CVE-2025-59466, CVE-2026-21637, CVE-2026-21710 (HIGH) — Node
+- CVE-2026-28388, CVE-2026-28389, CVE-2026-28390 (HIGH) — Debian openssl
+
+**Verification:** Local Trivy scan (`--severity HIGH,CRITICAL --ignore-unfixed`) reports 0 findings post-bump (was 9). `docker compose up -d` passes the healthcheck in ~14s and `/api/v1/health` returns `{"status":"healthy"}`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,13 @@
-# Runtime is gcr.io/distroless/nodejs22-debian12 (no shell, no package
-# manager, just node). Prod deps are staged on node:22-slim so the glibc
-# binaries match the distroless debian12 runtime. Build/dev stages stay
-# on node:22-alpine — smallest base that still has a shell, which the
-# build (turbo, nest) needs. All base images are pinned by digest.
+# Runtime is gcr.io/distroless/nodejs22-debian13 (no shell, no package
+# manager, just node). Prod deps are staged on node:22-slim; the prod
+# install uses --ignore-scripts so no native modules are compiled,
+# which means the runtime's glibc version is invisible to node_modules.
+# Build/dev stages stay on node:22-alpine — smallest base that still has
+# a shell, which the build (turbo, nest) needs. All base images are
+# pinned by digest.
 
 # Stage 1: Install all dependencies (including dev deps) for the build.
-FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS deps
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS deps
 WORKDIR /app
 COPY package.json package-lock.json turbo.json ./
 COPY packages/shared/package.json packages/shared/
@@ -21,9 +23,10 @@ COPY packages/frontend packages/frontend
 COPY packages/backend packages/backend
 RUN npx turbo build --filter=manifest-backend --filter=manifest-frontend --filter=manifest-shared
 
-# Stage 3: Production dependencies only, installed on glibc to match the
-# distroless debian12 runtime. All runtime deps are pure JS.
-FROM node:22-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS prod-deps
+# Stage 3: Production dependencies only. npm ci runs with --ignore-scripts
+# so nothing is compiled — all runtime deps are pure JS, making the glibc
+# of this stage irrelevant to the final image.
+FROM node:22-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c AS prod-deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY packages/shared/package.json packages/shared/
@@ -50,7 +53,7 @@ RUN --mount=type=cache,target=/root/.npm \
 
 # Stage 4: Distroless runtime. Runs as the built-in `nonroot` user (UID
 # 65532) by default. No shell, no apk/apt, minimal CVE surface.
-FROM gcr.io/distroless/nodejs22-debian12:nonroot@sha256:13593b7570658e8477de39e2f4a1dd25db2f836d68a0ba771251572d23bb4f8e AS runtime
+FROM gcr.io/distroless/nodejs22-debian13:nonroot@sha256:559b13edb698d652d7852597747ebd691569d110f0a76132b870067b290e30bd AS runtime
 WORKDIR /app
 
 LABEL org.opencontainers.image.title="Manifest" \


### PR DESCRIPTION
## Summary

Bumps the Docker runtime stage from `gcr.io/distroless/nodejs22-debian12:nonroot` to `gcr.io/distroless/nodejs22-debian13:nonroot` to clear 9 CVEs (1 CRITICAL / 8 HIGH) flagged against the published image. Also refreshes the `node:22-alpine` and `node:22-slim` digest pins used by the build-only stages for hygiene.

## Root cause

Google has not rebuilt any tag on `gcr.io/distroless/nodejs22-debian12` since Node 22.22.2 and Debian 12's `openssl 3.0.19-1~deb12u2` shipped. Every variant (`:nonroot`, `:latest`, `:debug-nonroot`) still bakes **Node 22.22.0** on top of the vulnerable **openssl 3.0.18-1~deb12u2**, so a digest refresh on `debian12` cannot clear the scan. The `nodejs22-debian13` family already publishes Node v22.22.2 on a newer openssl, so moving the runtime stage to it fixes both CVE sources in one base bump.

## Why the base-OS bump is safe

- The prod-deps stage (`packages` install) runs `npm ci --ignore-scripts`, so **no native modules are compiled**. Everything copied into the runtime is pure JS, which means the runtime's glibc version is invisible to `node_modules`.
- Distroless family and contract (no shell, no apt, `nonroot` UID 65532, OCI index pinned by SHA256) are unchanged.
- `node:22-alpine` (build stage) and `node:22-slim` (prod-deps stage) digests are also refreshed but only for hygiene — those layers don't ship in the final image.

## CVEs cleared

| Severity | CVE | Source | Current | Fix |
|---|---|---|---|---|
| CRITICAL (9.1) | CVE-2025-55130 | Node | 22.22.0 | 22.22.2 |
| HIGH (7.5) | CVE-2025-55131, CVE-2025-59465, CVE-2025-59466, CVE-2026-21637, CVE-2026-21710 | Node | 22.22.0 | 22.22.2 |
| HIGH (7.5) | CVE-2026-28388, CVE-2026-28389, CVE-2026-28390 | Debian openssl | 3.0.18-1~deb12u2 | 3.0.19-1~deb12u2 (debian12) / bypassed entirely by moving to debian13 |

## Verification

Against the locally built image:

- `docker run --entrypoint /nodejs/bin/node manifest:cve-check --version` → **`v22.22.2`**
- `trivy image --severity HIGH,CRITICAL --ignore-unfixed manifest:cve-check` → **0 findings** (was 9)
- `docker compose up -d` healthy within ~14s; `curl /api/v1/health` → `{"status":"healthy","uptime_seconds":14}`
- Backend NestJS bootstrap logs show all routes mapped, migrations/pricing caches warm

Pre-push local checks all green:
- backend Jest: 4064/4064 passing
- frontend Vitest: 2267/2267 passing
- shared Jest: 83/83 passing
- TypeScript: backend + frontend + shared all compile with no errors

## Test plan

- [ ] `docker.yml` CI validates the multi-arch build on amd64 + arm64 (no push)
- [ ] `ci.yml` jobs pass (tests, lint, typecheck, coverage)
- [ ] After merge of the `chore: version packages` PR, confirm the new image on Docker Hub reports 0 of the 9 CVEs in a fresh scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Docker runtime to `gcr.io/distroless/nodejs22-debian13:nonroot` to remove 9 CVEs (1 CRITICAL, 8 HIGH). Final image runs Node v22.22.2 and Trivy reports 0 HIGH/CRITICAL.

- **Dependencies**
  - Runtime: `gcr.io/distroless/nodejs22-debian12:nonroot` → `gcr.io/distroless/nodejs22-debian13:nonroot` (Node v22.22.2 on newer OpenSSL).
  - Build-only: refreshed `node:22-alpine` and `node:22-slim` digests; prod deps use `npm ci --ignore-scripts` so no native modules, making the glibc change safe.

<sup>Written for commit fec55cf6884efaf5ebc783f7a84649c5d058b7e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

