### PR TITLE
chore(docker): add OCI base-image labels for Docker Scout policy evaluation

### DIFF
--- a/.changeset/scout-base-image-labels.md
+++ b/.changeset/scout-base-image-labels.md
@@ -1,0 +1,9 @@
+---
+"manifest": patch
+---
+
+Add `org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest` OCI labels to the Docker image so Docker Scout can evaluate the "No unapproved base images" and "No outdated base images" policies.
+
+The published image already ships SLSA provenance and SPDX SBOM attestations (the build workflow sets `sbom: true` and `provenance: mode=max`), but Scout's base-image policies key off the OCI base-image labels on the image config and buildkit does not auto-generate them. Without the labels, Scout reports "No data" for both policies and the image is stuck at a B health score even when it has no outstanding CVEs.
+
+The labels sit next to the matching `FROM … AS runtime` line so a future base-image bump updates both together. No change to build output size, runtime behavior, or the attestation manifests — pure metadata addition on the image config.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,9 @@ LABEL org.opencontainers.image.title="Manifest" \
       org.opencontainers.image.documentation="https://manifest.build/docs" \
       org.opencontainers.image.source="https://github.com/mnfst/manifest" \
       org.opencontainers.image.vendor="MNFST Inc." \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.base.name="gcr.io/distroless/nodejs22-debian13:nonroot" \
+      org.opencontainers.image.base.digest="sha256:559b13edb698d652d7852597747ebd691569d110f0a76132b870067b290e30bd"
 
 ENV NODE_ENV=production
 ENV BIND_ADDRESS=0.0.0.0


### PR DESCRIPTION
## Summary

Adds `org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest` OCI labels to the runtime stage of `docker/Dockerfile` so Docker Scout can evaluate its "No unapproved base images" and "No outdated base images" policies.

## Why

The published image currently sits at a **B** health score on Docker Scout even with 0 outstanding CVEs, because those two policies report "No data" and drag the score down (5/7 policies compliant). Docker Scout's doc [No base image data](https://docs.docker.com/scout/policy/#no-base-image-data) explains why: it can't determine what base image we used.

Empirically checked against the currently-published `manifestdotbuild/manifest:5`:
- Provenance + SBOM attestations **are** attached to the manifest list (one `attestation-manifest` per arch, with SPDX + SLSA-v1 predicates). The `docker.yml` workflow already sets `sbom: true` and `provenance: mode=max`.
- The image config labels include title/description/source/revision/etc., but **not** `org.opencontainers.image.base.name` / `.base.digest`.
- Buildkit does **not** auto-generate those labels (confirmed against a local build of the current Dockerfile — same labels missing).

The canonical fix per Docker's Scout docs is to declare them as `LABEL` in the Dockerfile. They sit next to the matching `FROM gcr.io/distroless/nodejs22-debian13:nonroot@sha256:559b13ed…` line so a future base-image bump updates both together.

## Effect

- **"No unapproved base images"**: Scout will now know the base is `gcr.io/distroless/nodejs22-debian13:nonroot` (on its approved-sources list) → compliant.
- **"No outdated base images"**: Scout will compare the pinned digest against the current `:nonroot` tag. Currently fresh → compliant. Dependabot already runs weekly on `/docker`, so the next time Google publishes a rebuild of the `:nonroot` tag, Scout will non-compliant → Dependabot bumps → compliant again.
- **Expected outcome**: health score **B → A** once Scout re-evaluates after the next image push (a few hours).

## Verification

Built the updated Dockerfile locally and confirmed the labels land on the image config:

```
org.opencontainers.image.base.digest = sha256:559b13edb698d652d7852597747ebd691569d110f0a76132b870067b290e30bd
org.opencontainers.image.base.name   = gcr.io/distroless/nodejs22-debian13:nonroot
```

Pure metadata addition — no change to runtime behavior, image size, or the attestation manifests. Pre-push local TS checks on backend + frontend + shared all compile with no errors.

## Test plan

- [ ] `docker.yml` multi-arch validate build passes on amd64 + arm64
- [ ] `ci.yml` unit / lint / typecheck / coverage jobs pass
- [ ] After the next changeset-release PR merges and the new image publishes, confirm Scout flips both policies to compliant and the overall grade goes B → A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest` labels to the runtime image so Docker Scout can evaluate base-image policies and improve the score (expected B → A after next push).

- **New Features**
  - Add OCI base-image labels next to the matching FROM line; metadata only, no runtime or size changes.
  - Scout now recognizes base `gcr.io/distroless/nodejs22-debian13:nonroot` and compares the pinned digest to detect outdated bases.

<sup>Written for commit 40e9f9f14ed698ad15251e381d498c75eb4c4445. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

