### PR TITLE
feat(proxy): context-aware routing — skip tier models that can't fit

### DIFF
--- a/.changeset/advertise-honest-context-window.md
+++ b/.changeset/advertise-honest-context-window.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Advertise an honest context window for `manifest/auto` via a new OpenAI-compatible `GET /v1/models` endpoint. The `context_length` returned is the minimum across every model the agent could be routed to (tier primaries, fallbacks, specificity overrides) — any routed model is guaranteed to accept at least that many tokens, so clients that compact against this value stop overflowing the routed model. Adds a per-agent **Context window** card in Settings to override the computed floor, and a helper endpoint `GET /api/v1/routing/:agentName/context-window` for the dashboard. Addresses #1617, #1612, and #1450.

--- a/.changeset/context-aware-routing.md
+++ b/.changeset/context-aware-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Context-aware routing: the proxy now estimates token counts up front (js-tiktoken cl100k_base + 10% safety margin) and filters tier candidates by whether their context window can fit `estimatedTokens + max_tokens`. When no model in the scored tier fits, the router escalates upward (simple → standard → complex → reasoning) instead of silently routing to a too-small model. When no model in any tier can fit, the user gets an actionable error that breaks out input vs reserved-output rather than an opaque 400. Emits `X-Manifest-Context-Estimated`, `X-Manifest-Context-Used`, and `X-Manifest-Context-Escalated: <fromTier>-><toTier>` response headers so agents can adapt per-response. Addresses the #1617 RFC (context window awareness for agentic integrations) end-to-end.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,8 @@ All analytics queries filter by user via `addTenantFilter(qb, userId)` from `que
 | POST | `/api/v1/routing/:agentName/ollama/sync` | Session/API Key | Sync Ollama models |
 | POST | `/api/v1/routing/resolve` | Bearer (mnfst_*) | Model resolution |
 | POST | `/v1/chat/completions` | Bearer (mnfst_*) | LLM proxy (OpenAI-compatible) |
+| GET | `/v1/models` | Bearer (mnfst_*) | OpenAI-compatible model listing; advertises `manifest/auto` with the honest `context_length` floor for the agent (Phase 1, #1617) |
+| GET | `/api/v1/routing/:agentName/context-window` | Session/API Key | Effective advertised context window + whether the user set an override (drives the Settings "Context window" card) |
 | GET | `/api/v1/events` | Session | SSE real-time events |
 | GET | `/api/v1/github/stars` | Public | GitHub star count |
 
@@ -363,7 +365,7 @@ See `packages/backend/.env.example` for all variables. Key ones:
 
 ## Domain Terminology
 
-- **Message**: The primary entity in the system. Every row in `agent_messages` is a Message. The UI labels them "Messages" everywhere. Key routing columns: `routing_tier` (complexity tier used), `routing_reason` (why — `scored`, `specificity`, `heartbeat`, etc.), `specificity_category` (which task-type category, null if complexity-routed).
+- **Message**: The primary entity in the system. Every row in `agent_messages` is a Message. The UI labels them "Messages" everywhere. Key routing columns: `routing_tier` (complexity tier used), `routing_reason` (why — `scored`, `specificity`, `heartbeat`, `size_escalated`, `context_window_exceeded`, …), `specificity_category` (which task-type category, null if complexity-routed).
 - **Tenant**: A user's data boundary. Created from `user.id` on first agent creation.
 - **Agent**: An AI agent owned by a tenant. Has a unique OTLP ingest key.
 
@@ -410,7 +412,9 @@ To add a new font or icon library:
 - **LLM Routing**: Two-layer routing system with provider key management (AES-256-GCM encrypted) and OpenAI-compatible proxy at `/v1/chat/completions`:
   - **Complexity tiers** (always active): 4 tiers (simple/standard/complex/reasoning) based on request content scoring with 23 weighted keyword dimensions.
   - **Specificity routing** (opt-in): 9 task-type categories (coding, web_browsing, data_analysis, image_generation, video_generation, social_media, email_management, calendar_management, trading). When enabled, overrides complexity tiers. Detection uses keyword analysis on the last user message + tool name heuristics. Categories defined in `shared/src/specificity.ts`, keywords in `scoring/keywords.ts`, detection in `scoring/specificity-detector.ts`.
-  - **Resolution order**: specificity check (if any category active) → complexity scoring → tier assignment → provider/model resolution → proxy forward.
+  - **Context-aware size check** (Phase 2 — always active): before forwarding, the proxy estimates tokens for the full request via `routing/proxy/token-estimate.ts` (js-tiktoken `cl100k_base` + 1.1× safety multiplier). `ResolveService.resolveWithSizeCheck` then walks the scored tier's `(primary, ...fallbacks)` in order and picks the first candidate whose `contextWindow >= estimated + reservedOutput` (reservedOutput = `body.max_tokens ?? 4096`). If no model in the scored tier fits, escalate upward (`simple → standard → complex → reasoning`). If *nothing* fits in any tier, ResolveService returns `reason: 'context_window_exceeded'` and ProxyService surfaces a friendly chat-completion response with the estimated token count, largest available window, and a link to the Routing page — no silent truncation. Size-aware candidate filtering is the pure function `findFittingCandidate` in `routing/resolve/context-fit.ts`.
+  - **Resolution order**: specificity check (if any category active) → complexity scoring → tier assignment → **size-aware candidate pick within tier** → **tier escalation if no candidate fits** → provider/model resolution → proxy forward.
+  - **Size signals on the wire**: successful proxy responses emit `X-Manifest-Context-Estimated` and `X-Manifest-Context-Used`; when the size check bumped the tier, an additional `X-Manifest-Context-Escalated: <fromTier>-><toTier>` is emitted. Agents use these to adapt per-response without a second round trip (#1617). Header values are ASCII-only — Node's http layer silently drops headers containing Latin-1-incompatible characters.
 
 ## Providers & Models
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9022,6 +9022,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
@@ -13334,6 +13343,7 @@
         "compression": "^1.8.1",
         "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
+        "js-tiktoken": "^1.0.21",
         "manifest-shared": "*",
         "pg": "^8.13.0",
         "react": "^19.2.4",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,7 +18,6 @@
     "migration:create": "typeorm-ts-node-commonjs migration:create"
   },
   "dependencies": {
-    "manifest-shared": "*",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",
@@ -38,6 +37,8 @@
     "compression": "^1.8.1",
     "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
+    "js-tiktoken": "^1.0.21",
+    "manifest-shared": "*",
     "pg": "^8.13.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -19,6 +19,8 @@ describe('AgentsController', () => {
   let mockConfigGet: jest.Mock;
   let mockDeleteAgent: jest.Mock;
   let mockRenameAgent: jest.Mock;
+  let mockUpdateAgentType: jest.Mock;
+  let mockUpdateContextFloorOverride: jest.Mock;
   let mockTenantResolve: jest.Mock;
 
   beforeEach(async () => {
@@ -31,6 +33,8 @@ describe('AgentsController', () => {
     mockConfigGet = jest.fn().mockReturnValue('');
     mockDeleteAgent = jest.fn().mockResolvedValue(undefined);
     mockRenameAgent = jest.fn().mockResolvedValue(undefined);
+    mockUpdateAgentType = jest.fn().mockResolvedValue(undefined);
+    mockUpdateContextFloorOverride = jest.fn().mockResolvedValue(undefined);
     mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
 
     const module: TestingModule = await Test.createTestingModule({
@@ -46,7 +50,8 @@ describe('AgentsController', () => {
           useValue: {
             deleteAgent: mockDeleteAgent,
             renameAgent: mockRenameAgent,
-            updateAgentType: jest.fn(),
+            updateAgentType: mockUpdateAgentType,
+            updateContextFloorOverride: mockUpdateContextFloorOverride,
           },
         },
         {
@@ -255,7 +260,6 @@ describe('AgentsController', () => {
   });
 
   it('passes category/platform to updateAgentType on PATCH', async () => {
-    const mockUpdateType = jest.fn().mockResolvedValue(undefined);
     const user = { id: 'u1' };
     const result = await controller.updateAgent(user as never, 'bot-1', {
       agent_category: 'app',
@@ -266,6 +270,57 @@ describe('AgentsController', () => {
       agent_category: 'app',
       agent_platform: 'openai-sdk',
     });
+  });
+
+  /**
+   * context_floor_override PATCH cases — the UI "Custom context window" card
+   * writes through this path. Defends issues #1617 / #1612 by making sure a
+   * user-entered override is actually persisted (not swallowed by the
+   * controller ignoring the field because the DTO treats it as optional).
+   */
+  it('calls updateContextFloorOverride with a numeric value on PATCH', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.updateAgent(user as never, 'bot-1', {
+      context_floor_override: 50_000,
+    } as never);
+
+    expect(mockUpdateContextFloorOverride).toHaveBeenCalledWith('u1', 'bot-1', 50_000);
+    expect(result).toEqual({ context_floor_override: 50_000 });
+  });
+
+  it('calls updateContextFloorOverride with null to clear the override', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.updateAgent(user as never, 'bot-1', {
+      context_floor_override: null,
+    } as never);
+
+    expect(mockUpdateContextFloorOverride).toHaveBeenCalledWith('u1', 'bot-1', null);
+    expect(result).toEqual({ context_floor_override: null });
+  });
+
+  it('does not call updateContextFloorOverride when the field is omitted', async () => {
+    // The field is optional — PATCH { agent_category: 'app' } must not wipe
+    // any existing override.
+    const user = { id: 'u1' };
+    await controller.updateAgent(user as never, 'bot-1', {
+      agent_category: 'app',
+    } as never);
+
+    expect(mockUpdateContextFloorOverride).not.toHaveBeenCalled();
+  });
+
+  it('routes context_floor_override to the NEW slug when renaming in the same PATCH', async () => {
+    // Rename-and-set-override in one PATCH is a real path in the Settings
+    // page. After renaming to `new-slug`, the lifecycle call has to target
+    // the new name, not the original.
+    const user = { id: 'u1' };
+    await controller.updateAgent(user as never, 'bot-1', {
+      name: 'New Slug',
+      context_floor_override: 64_000,
+    } as never);
+
+    expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'new-slug', 'New Slug');
+    expect(mockUpdateContextFloorOverride).toHaveBeenCalledWith('u1', 'new-slug', 64_000);
   });
 
   it('invalidates agent list cache after successful createAgent', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -128,6 +128,15 @@ export class AgentsController {
       if (body.agent_platform !== undefined) result['agent_platform'] = body.agent_platform;
     }
 
+    if (body.context_floor_override !== undefined) {
+      await this.lifecycle.updateContextFloorOverride(
+        user.id,
+        body.name ? slugify(body.name)! : agentName,
+        body.context_floor_override,
+      );
+      result['context_floor_override'] = body.context_floor_override;
+    }
+
     await this.cacheManager.del(this.agentListCacheKey(user.id));
     return result;
   }

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -154,6 +154,75 @@ describe('AgentLifecycleService', () => {
     });
   });
 
+  describe('updateContextFloorOverride', () => {
+    it('writes the override value on the agents row when the agent exists', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'agent-id-1', name: 'my-agent' });
+
+      const mockExecute = jest.fn().mockResolvedValue({});
+      const mockUpdateQb = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: mockExecute,
+      };
+
+      mockAgentCreateQueryBuilder
+        .mockReturnValueOnce({
+          select: jest.fn().mockReturnThis(),
+          leftJoin: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getOne: mockAgentGetOne,
+          getMany: jest.fn().mockResolvedValue([]),
+        })
+        .mockReturnValueOnce(mockUpdateQb);
+
+      await service.updateContextFloorOverride('test-user', 'my-agent', 50_000);
+
+      expect(mockUpdateQb.update).toHaveBeenCalledWith('agents');
+      expect(mockUpdateQb.set).toHaveBeenCalledWith({ context_floor_override: 50_000 });
+      expect(mockUpdateQb.where).toHaveBeenCalledWith('id = :id', { id: 'agent-id-1' });
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes null when clearing the override', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'agent-id-1', name: 'my-agent' });
+
+      const mockExecute = jest.fn().mockResolvedValue({});
+      const mockUpdateQb = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: mockExecute,
+      };
+
+      mockAgentCreateQueryBuilder
+        .mockReturnValueOnce({
+          select: jest.fn().mockReturnThis(),
+          leftJoin: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getOne: mockAgentGetOne,
+          getMany: jest.fn().mockResolvedValue([]),
+        })
+        .mockReturnValueOnce(mockUpdateQb);
+
+      await service.updateContextFloorOverride('test-user', 'my-agent', null);
+
+      expect(mockUpdateQb.set).toHaveBeenCalledWith({ context_floor_override: null });
+    });
+
+    it('throws NotFoundException when the agent does not belong to the user', async () => {
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.updateContextFloorOverride('test-user', 'nonexistent', 50_000),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
   describe('renameAgent', () => {
     it('should throw NotFoundException when agent not found', async () => {
       mockAgentGetOne.mockResolvedValueOnce(null);

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -55,6 +55,22 @@ export class AgentLifecycleService {
       .execute();
   }
 
+  async updateContextFloorOverride(
+    userId: string,
+    agentName: string,
+    value: number | null,
+  ): Promise<void> {
+    const agent = await this.findAgentByUser(userId, agentName);
+    if (!agent) throw new NotFoundException(`Agent "${agentName}" not found`);
+
+    await this.agentRepo
+      .createQueryBuilder()
+      .update('agents')
+      .set({ context_floor_override: value })
+      .where('id = :id', { id: agent.id })
+      .execute();
+  }
+
   async renameAgent(
     userId: string,
     currentName: string,

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -356,5 +356,35 @@ describe('TimeseriesQueriesService', () => {
       expect(result[0].total_cost).toBe(0);
       expect(result[0].sparkline).toEqual([]);
     });
+
+    /**
+     * The Settings page loads the current override from GET /api/v1/agents
+     * (to prefill the Auto/Custom radio). If this projection ever drops the
+     * field, the Settings page silently reverts to "Auto" every reload.
+     */
+    it('surfaces a configured context_floor_override on each agent row', async () => {
+      mockGetMany.mockResolvedValueOnce([
+        {
+          name: 'custom-bot',
+          display_name: null,
+          created_at: '2026-02-16',
+          context_floor_override: 50_000,
+        },
+      ]);
+      mockGetRawMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.getAgentList('u1');
+      expect(result[0].context_floor_override).toBe(50_000);
+    });
+
+    it('defaults context_floor_override to null when the agent row has no override', async () => {
+      mockGetMany.mockResolvedValueOnce([
+        { name: 'auto-bot', display_name: null, created_at: '2026-02-16' },
+      ]);
+      mockGetRawMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.getAgentList('u1');
+      expect(result[0].context_floor_override).toBeNull();
+    });
   });
 });

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -230,6 +230,7 @@ export class TimeseriesQueriesService {
         display_name: a.display_name ?? name,
         agent_category: a.agent_category ?? null,
         agent_platform: a.agent_platform ?? null,
+        context_floor_override: a.context_floor_override ?? null,
         message_count: Number(stats?.['message_count'] ?? 0),
         last_active: String(stats?.['last_active'] ?? a.created_at ?? ''),
         total_cost: Number(stats?.['total_cost'] ?? 0),

--- a/packages/backend/src/common/dto/rename-agent.dto.spec.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.spec.ts
@@ -1,7 +1,11 @@
 import 'reflect-metadata';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { RenameAgentDto } from './rename-agent.dto';
+import {
+  RenameAgentDto,
+  MIN_CONTEXT_FLOOR_OVERRIDE,
+  MAX_CONTEXT_FLOOR_OVERRIDE,
+} from './rename-agent.dto';
 
 describe('RenameAgentDto', () => {
   it('accepts valid agent names', async () => {
@@ -64,5 +68,81 @@ describe('RenameAgentDto', () => {
     const dto = plainToInstance(RenameAgentDto, { agent_platform: 'invalid' });
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * context_floor_override cases — the per-agent lever for the honest
+   * GET /v1/models advertisement. Defends the bounds that keep users from
+   * advertising absurd values (0, 10 billion) that re-introduce the same
+   * overflow/over-compaction bugs the feature exists to fix.
+   */
+  describe('context_floor_override', () => {
+    it('accepts null (explicitly clears the override)', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: null });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('is optional (DTO is valid when the field is omitted entirely)', async () => {
+      const dto = plainToInstance(RenameAgentDto, {});
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts the documented minimum (1024)', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MIN_CONTEXT_FLOOR_OVERRIDE,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts the documented maximum (10_000_000)', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MAX_CONTEXT_FLOOR_OVERRIDE,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts a typical value inside the range', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: 128_000 });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects values below the minimum', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MIN_CONTEXT_FLOOR_OVERRIDE - 1,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects zero (clearing should be null, not 0)', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: 0 });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects negative values', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: -1 });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects values above the maximum', async () => {
+      const dto = plainToInstance(RenameAgentDto, {
+        context_floor_override: MAX_CONTEXT_FLOOR_OVERRIDE + 1,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects non-integer floats', async () => {
+      const dto = plainToInstance(RenameAgentDto, { context_floor_override: 128_000.5 });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/backend/src/common/dto/rename-agent.dto.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.ts
@@ -6,8 +6,16 @@ import {
   Matches,
   IsOptional,
   IsIn,
+  IsInt,
+  Min,
+  Max,
+  ValidateIf,
 } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { AGENT_CATEGORIES, AGENT_PLATFORMS } from 'manifest-shared';
+
+export const MIN_CONTEXT_FLOOR_OVERRIDE = 1024;
+export const MAX_CONTEXT_FLOOR_OVERRIDE = 10_000_000;
 
 export class RenameAgentDto {
   @IsOptional()
@@ -29,4 +37,18 @@ export class RenameAgentDto {
   @IsString()
   @IsIn([...AGENT_PLATFORMS])
   agent_platform?: string;
+
+  /**
+   * Overrides the `context_length` advertised on GET /v1/models. `null`
+   * clears the override and restores the computed floor. Validation range
+   * gives users room to experiment without letting them advertise absurd
+   * values to their agents.
+   */
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @Transform(({ value }) => (value === null ? null : value))
+  @IsInt()
+  @Min(MIN_CONTEXT_FLOOR_OVERRIDE)
+  @Max(MAX_CONTEXT_FLOOR_OVERRIDE)
+  context_floor_override?: number | null;
 }

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -70,6 +70,7 @@ import { AddMessageFeedback1775600000000 } from './migrations/1775600000000-AddM
 import { CleanupOrphanedCustomProviderRefs1776679833383 } from './migrations/1776679833383-CleanupOrphanedCustomProviderRefs';
 import { AddMessageRequestHeaders1776700000000 } from './migrations/1776700000000-AddMessageRequestHeaders';
 import { AddSpecificityMiscategorized1777000000000 } from './migrations/1777000000000-AddSpecificityMiscategorized';
+import { AddAgentContextFloorOverride1777100000000 } from './migrations/1777100000000-AddAgentContextFloorOverride';
 
 const entities = [
   AgentMessage,
@@ -141,6 +142,7 @@ const migrations = [
   CleanupOrphanedCustomProviderRefs1776679833383,
   AddMessageRequestHeaders1776700000000,
   AddSpecificityMiscategorized1777000000000,
+  AddAgentContextFloorOverride1777100000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.spec.ts
+++ b/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.spec.ts
@@ -1,0 +1,35 @@
+import { QueryRunner } from 'typeorm';
+import { AddAgentContextFloorOverride1777100000000 } from './1777100000000-AddAgentContextFloorOverride';
+
+describe('AddAgentContextFloorOverride1777100000000', () => {
+  let migration: AddAgentContextFloorOverride1777100000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new AddAgentContextFloorOverride1777100000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('adds context_floor_override column to agents', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('"context_floor_override"'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(expect.stringContaining('"agents"'));
+    });
+  });
+
+  describe('down', () => {
+    it('drops context_floor_override column', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('DROP COLUMN "context_floor_override"'),
+      );
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.ts
+++ b/packages/backend/src/database/migrations/1777100000000-AddAgentContextFloorOverride.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a per-agent override for the context window advertised by
+ * GET /v1/models. When NULL, the proxy computes the honest floor from the
+ * agent's currently-routed models. Users with unusual setups (pinned tiers,
+ * known client quirks) can override it from the Settings page — see
+ * discussions #1450, #1612 and issue #1617.
+ */
+export class AddAgentContextFloorOverride1777100000000 implements MigrationInterface {
+  name = 'AddAgentContextFloorOverride1777100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agents" ADD COLUMN "context_floor_override" integer`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agents" DROP COLUMN "context_floor_override"`);
+  }
+}

--- a/packages/backend/src/entities/agent.entity.ts
+++ b/packages/backend/src/entities/agent.entity.ts
@@ -27,6 +27,9 @@ export class Agent {
   @Column('boolean', { default: true })
   is_active!: boolean;
 
+  @Column('int', { nullable: true })
+  context_floor_override!: number | null;
+
   @ManyToOne(() => Tenant, (t) => t.agents, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'tenant_id' })
   tenant!: Tenant;

--- a/packages/backend/src/routing/dto/resolve-response.ts
+++ b/packages/backend/src/routing/dto/resolve-response.ts
@@ -3,14 +3,51 @@ import type { AuthType, SpecificityCategory } from 'manifest-shared';
 
 export type { AuthType } from 'manifest-shared';
 
+/**
+ * Reason literals produced by the size-awareness layer (Phase 2). Kept
+ * distinct from `ScoringReason` because these are *routing* outcomes — the
+ * scorer itself never produces them. Any new size-related reason added by
+ * Phase 3+ should live here rather than polluting the scoring vocabulary.
+ */
+export const REASON_SIZE_ESCALATED = 'size_escalated';
+export const REASON_CONTEXT_WINDOW_EXCEEDED = 'context_window_exceeded';
+
+export type SizeAwareReason = typeof REASON_SIZE_ESCALATED | typeof REASON_CONTEXT_WINDOW_EXCEEDED;
+
+/** Superset of reasons the resolver can surface — scoring + size-awareness. */
+export type ResolveReason = ScoringReason | SizeAwareReason;
+
 export interface ResolveResponse {
   tier: Tier;
   model: string | null;
   provider: string | null;
   confidence: number;
   score: number;
-  reason: ScoringReason;
+  reason: ResolveReason;
   auth_type?: AuthType;
   specificity_category?: SpecificityCategory;
   fallback_models?: string[] | null;
+  /** Estimated token count of the incoming request (undefined when size-unaware). */
+  estimated_tokens?: number;
+  /**
+   * Output budget reserved when computing the fit: `body.max_tokens` or
+   * the default output reserve. Populated on size-aware resolutions so the
+   * proxy can produce an honest error message when the blocker is the
+   * `max_tokens` parameter rather than the input size.
+   */
+  reserved_output_tokens?: number;
+  /** Context window of the chosen model. Populated for size-aware resolutions. */
+  used_context_window?: number;
+  /**
+   * Present when the size check escalated the request out of its
+   * scored tier (e.g. `complex → reasoning`). Lets the proxy surface this
+   * to clients via a response header and log it for later analysis.
+   */
+  size_escalated_from?: Tier;
+  /**
+   * Largest context window available on any candidate we could have
+   * routed to. Populated only for `REASON_CONTEXT_WINDOW_EXCEEDED` so the
+   * error body can tell the user by how much they overshot.
+   */
+  largest_available_context?: number;
 }

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -35,6 +35,7 @@ describe('ModelController', () => {
   let mockResolveAgent: Record<string, jest.Mock>;
   let mockCustomProviderService: Record<string, jest.Mock>;
   let mockPricingSync: Record<string, jest.Mock>;
+  let mockGetEffectiveContext: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -60,6 +61,10 @@ describe('ModelController', () => {
       refreshCache: jest.fn().mockResolvedValue(42),
     };
 
+    mockGetEffectiveContext = jest
+      .fn()
+      .mockResolvedValue({ contextLength: 128000, overridden: false });
+
     controller = new ModelController(
       mockProviderService as unknown as ProviderService,
       mockDiscoveryService as unknown as ModelDiscoveryService,
@@ -67,6 +72,7 @@ describe('ModelController', () => {
       mockResolveAgent as unknown as ResolveAgentService,
       mockCustomProviderService as unknown as CustomProviderService,
       mockPricingSync as unknown as PricingSyncService,
+      { getEffectiveContext: mockGetEffectiveContext } as never,
     );
   });
 
@@ -146,6 +152,33 @@ describe('ModelController', () => {
       expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'test-agent');
       expect(mockDiscoveryService.discoverAllForAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
       expect(result).toEqual({ ok: true });
+    });
+  });
+
+  /* ── getContextWindow ── */
+
+  /**
+   * The Settings page's "Advertised context window" card calls this endpoint
+   * to render the live "Auto (N tokens)" label. The `overridden` flag also
+   * drives whether the UI starts in Custom mode on load.
+   */
+  describe('getContextWindow', () => {
+    it('returns the computed floor and overridden=false in auto mode', async () => {
+      mockGetEffectiveContext.mockResolvedValue({ contextLength: 128_000, overridden: false });
+
+      const result = await controller.getContextWindow(mockUser, mockAgentName);
+
+      expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'test-agent');
+      expect(mockGetEffectiveContext).toHaveBeenCalledWith(TEST_AGENT_ID);
+      expect(result).toEqual({ context_length: 128_000, overridden: false });
+    });
+
+    it('returns the override and overridden=true when the user set one', async () => {
+      mockGetEffectiveContext.mockResolvedValue({ contextLength: 50_000, overridden: true });
+
+      const result = await controller.getContextWindow(mockUser, mockAgentName);
+
+      expect(result).toEqual({ context_length: 50_000, overridden: true });
     });
   });
 

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -8,6 +8,7 @@ import { ModelDiscoveryService } from '../model-discovery/model-discovery.servic
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { AgentNameParamDto } from './dto/routing.dto';
+import { ContextAdvertisementService } from './proxy/context-advertisement.service';
 
 @Controller('api/v1/routing')
 export class ModelController {
@@ -18,6 +19,7 @@ export class ModelController {
     private readonly resolveAgentService: ResolveAgentService,
     private readonly customProviderService: CustomProviderService,
     private readonly pricingSync: PricingSyncService,
+    private readonly contextAdvertisement: ContextAdvertisementService,
   ) {}
 
   @Get('pricing-health')
@@ -49,6 +51,16 @@ export class ModelController {
   @Post('ollama/sync')
   async syncOllama() {
     return this.ollamaSync.sync();
+  }
+
+  @Get(':agentName/context-window')
+  async getContextWindow(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
+    const effective = await this.contextAdvertisement.getEffectiveContext(agent.id);
+    return {
+      context_length: effective.contextLength,
+      overridden: effective.overridden,
+    };
   }
 
   @Get(':agentName/available-models')

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -108,6 +108,70 @@ describe('proxy-response-handler', () => {
 
       expect(headers).not.toHaveProperty('X-Manifest-Specificity');
     });
+
+    // Phase 2: size-awareness signals. Tests here defend the contract
+    // called out in issue #1617 (EthanFrostpro) — agents must be able to
+    // learn the routed model's context window from a response header.
+
+    it('emits X-Manifest-Context-Estimated when the resolver measured the request', () => {
+      const meta = makeMeta({ estimatedTokens: 145_000 });
+      const headers = buildMetaHeaders(meta);
+
+      expect(headers['X-Manifest-Context-Estimated']).toBe('145000');
+    });
+
+    it('emits X-Manifest-Context-Used with the routed model context window', () => {
+      const meta = makeMeta({ usedContextWindow: 200_000 });
+      const headers = buildMetaHeaders(meta);
+
+      expect(headers['X-Manifest-Context-Used']).toBe('200000');
+    });
+
+    it('emits X-Manifest-Context-Escalated when the size check bumped the tier', () => {
+      const meta = makeMeta({
+        tier: 'complex',
+        sizeEscalatedFrom: 'standard',
+      });
+      const headers = buildMetaHeaders(meta);
+
+      expect(headers['X-Manifest-Context-Escalated']).toBe('standard->complex');
+    });
+
+    it('encodes the escalation header with an ASCII arrow so Node does not drop it silently', () => {
+      // Node's http layer silently drops headers containing
+      // Latin-1-incompatible characters — a Unicode arrow here would
+      // disappear from the response. Verified by manual smoke on
+      // 2026-04-22. Future-me: the arrow must stay ASCII `->`.
+      const meta = makeMeta({
+        tier: 'complex',
+        sizeEscalatedFrom: 'standard',
+      });
+      const headers = buildMetaHeaders(meta);
+
+      expect(headers['X-Manifest-Context-Escalated']).toBe('standard->complex');
+      expect(headers['X-Manifest-Context-Escalated']).toContain('->');
+      expect(headers['X-Manifest-Context-Escalated']).not.toContain('→');
+      // Belt and braces — verify every byte is 7-bit ASCII so the
+      // regression cannot recur with any other non-latin-1 glyph either.
+      for (const ch of headers['X-Manifest-Context-Escalated']!) {
+        expect(ch.charCodeAt(0)).toBeLessThan(128);
+      }
+    });
+
+    it('omits the escalation header when the scored tier fit on its own', () => {
+      // A happy-path request that fit in the scored tier should not leak
+      // a misleading "escalated" signal to clients. Estimated+used are
+      // still useful and present; Escalated is only for the rescue case.
+      const meta = makeMeta({
+        estimatedTokens: 10_000,
+        usedContextWindow: 128_000,
+      });
+      const headers = buildMetaHeaders(meta);
+
+      expect(headers).not.toHaveProperty('X-Manifest-Context-Escalated');
+      expect(headers['X-Manifest-Context-Estimated']).toBe('10000');
+      expect(headers['X-Manifest-Context-Used']).toBe('128000');
+    });
   });
 
   /* ── handleProviderError ── */

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -91,6 +91,7 @@ describe('ProxyController', () => {
   };
   let mockPricingCache: { getByModel: jest.Mock };
   let recorder: ProxyMessageRecorder;
+  let mockGetEffectiveContext: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -130,6 +131,9 @@ describe('ProxyController', () => {
       new ProxyMessageDedup(),
       { emit: jest.fn() } as unknown as IngestEventBusService,
     );
+    mockGetEffectiveContext = jest
+      .fn()
+      .mockResolvedValue({ contextLength: 128000, overridden: false });
     controller = new ProxyController(
       proxyService as never,
       rateLimiter as never,
@@ -137,6 +141,7 @@ describe('ProxyController', () => {
       recorder,
       new ThoughtSignatureCache(),
       new ThinkingBlockCache(),
+      { getEffectiveContext: mockGetEffectiveContext } as never,
     );
   });
 
@@ -2751,5 +2756,50 @@ describe('ProxyController', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(headers['X-Manifest-Fallback-Exhausted']).toBeUndefined();
+  });
+
+  /**
+   * GET /v1/models — OpenAI-compatible listing. The payload shape is what
+   * OpenClaw / OpenAI SDK / LangChain etc. read when they probe the endpoint
+   * to decide how aggressively to compact. Any change here can silently
+   * re-introduce issues #1617 / #1612 / #1450 in every client that trusts
+   * the response.
+   */
+  describe('listModels (GET /v1/models)', () => {
+    it('returns the OpenAI-compatible envelope with the honest context floor', async () => {
+      mockGetEffectiveContext.mockResolvedValue({
+        contextLength: 128000,
+        overridden: false,
+      });
+
+      const req = mockRequest({});
+      const result = await controller.listModels(req as never);
+
+      expect(mockGetEffectiveContext).toHaveBeenCalledWith('agent-1');
+      expect(result.object).toBe('list');
+      expect(result.data).toHaveLength(1);
+      const [model] = result.data;
+      expect(model.id).toBe('auto');
+      expect(model.object).toBe('model');
+      expect(model.owned_by).toBe('manifest');
+      expect(model.context_length).toBe(128000);
+      // `created` is a Unix timestamp in seconds — assert the field exists
+      // and is a positive integer, don't pin the exact value.
+      expect(typeof model.created).toBe('number');
+      expect(Number.isInteger(model.created)).toBe(true);
+      expect(model.created).toBeGreaterThan(0);
+    });
+
+    it('advertises the override when a user-set floor is in effect', async () => {
+      mockGetEffectiveContext.mockResolvedValue({
+        contextLength: 50_000,
+        overridden: true,
+      });
+
+      const req = mockRequest({});
+      const result = await controller.listModels(req as never);
+
+      expect(result.data[0].context_length).toBe(50_000);
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1000,6 +1000,47 @@ describe('ProxyService', () => {
       expect(resolveService.resolve).toHaveBeenCalled();
     });
 
+    it('falls through to size-aware routing when a tiny HEARTBEAT_OK prompt has a huge max_tokens (#1678 cubic P1 follow-up)', async () => {
+      // Second half of the heartbeat-gate bug: even with tiny input (a
+      // legitimate heartbeat-shaped body), a max_tokens reserve that
+      // would overflow the simple tier must still go through size-aware
+      // routing. Before the follow-up fix, gating only considered input
+      // size, so `{content: 'HEARTBEAT_OK', max_tokens: 500_000}` hit
+      // the simple tier and overflowed.
+      const tinyHeartbeatHugeMaxTokens = {
+        messages: [{ role: 'user', content: 'HEARTBEAT_OK' }],
+        max_tokens: 500_000,
+        stream: false,
+      };
+
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      resolveService.resolveForTier = jest.fn();
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body: tinyHeartbeatHugeMaxTokens,
+        sessionKey: 'sess-tiny-huge',
+      });
+
+      expect(resolveService.resolve).toHaveBeenCalled();
+      expect(resolveService.resolveForTier).not.toHaveBeenCalled();
+    });
+
     it('falls through to size-aware routing when a large payload contains HEARTBEAT_OK as substring (#1678 cubic P1)', async () => {
       // The heartbeat sentinel is matched via `.includes(...)`. Before the
       // fix, a legitimate large user message that happened to mention

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -556,6 +556,7 @@ describe('ProxyService', () => {
       ['complex', 'complex'],
       undefined,
       undefined,
+      expect.any(Number),
     );
   });
 
@@ -638,6 +639,7 @@ describe('ProxyService', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Number),
     );
 
     // But the full body (with tools) should be forwarded to the provider
@@ -1300,6 +1302,7 @@ describe('ProxyService', () => {
         undefined,
         undefined,
         undefined,
+        expect.any(Number),
       );
     });
   });
@@ -3357,6 +3360,41 @@ describe('ProxyService', () => {
       const lookup = callArgs.signatureLookup as (id: string) => string | null;
       expect(lookup('tc-42')).toBe('cached-sig-value');
       expect(lookup('nonexistent')).toBeNull();
+    });
+
+    it('returns the context-window-exceeded friendly response when ResolveService reports it', async () => {
+      // Phase 2: no tier contained a model that could fit the request.
+      // The proxy must produce a friendly-but-specific message so the user
+      // understands why the request didn't go out, and surface the numbers
+      // needed to act (estimated tokens, largest available window, URL).
+      resolveService.resolve.mockResolvedValue({
+        tier: 'reasoning',
+        model: null,
+        provider: null,
+        confidence: 1,
+        score: 0,
+        reason: 'context_window_exceeded',
+        estimated_tokens: 1_500_000,
+        largest_available_context: 200_000,
+      });
+
+      const result = await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'default',
+        agentName: 'my-agent',
+      });
+
+      expect(result.forward.response.ok).toBe(true);
+      expect(result.meta.reason).toBe('context_window_exceeded');
+      const json = (await result.forward.response.json()) as Record<string, unknown>;
+      const choices = json.choices as { message: { content: string } }[];
+      expect(choices[0].message.content).toContain('1,500,000 tokens');
+      expect(choices[0].message.content).toContain('200,000');
+      expect(choices[0].message.content).toContain('/agents/my-agent/routing');
+      // Ensure we don't fall through to the no-provider message.
+      expect(choices[0].message.content).not.toContain('no providers are set up yet');
     });
 
     it('ignores invalid MiniMax resource URLs when forwarding subscription requests', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -999,6 +999,58 @@ describe('ProxyService', () => {
 
       expect(resolveService.resolve).toHaveBeenCalled();
     });
+
+    it('falls through to size-aware routing when a large payload contains HEARTBEAT_OK as substring (#1678 cubic P1)', async () => {
+      // The heartbeat sentinel is matched via `.includes(...)`. Before the
+      // fix, a legitimate large user message that happened to mention
+      // HEARTBEAT_OK (e.g. a prompt asking "should I include HEARTBEAT_OK
+      // in my cron output?") would skip size-aware routing and fire at
+      // the `simple` tier, overflowing any small model pinned there.
+      // Gate: the heartbeat fast-path only applies when estimated tokens
+      // are under the real-heartbeat ceiling.
+      const largeContentWithSentinel = {
+        messages: [
+          {
+            role: 'user',
+            // Long enough to push estimated tokens past HEARTBEAT_TOKEN_CEILING (1000).
+            content: (
+              'Explain how heartbeat polling works in distributed systems. ' +
+              'Should I literally include HEARTBEAT_OK in the response body? '
+            ).repeat(200),
+          },
+        ],
+        stream: false,
+      };
+
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      resolveService.resolveForTier = jest.fn();
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body: largeContentWithSentinel,
+        sessionKey: 'sess-gated',
+      });
+
+      // The size-aware path (resolve) must be used — NOT the heartbeat
+      // fast-path (resolveForTier). Exactly the regression #1678 flagged.
+      expect(resolveService.resolve).toHaveBeenCalled();
+      expect(resolveService.resolveForTier).not.toHaveBeenCalled();
+    });
   });
 
   describe('system prompt stripping', () => {

--- a/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
@@ -41,7 +41,7 @@ interface ContextSvcDeps {
   findOne?: jest.Mock;
   getTiers?: jest.Mock;
   getActiveAssignments?: jest.Mock;
-  getModelForAgent?: jest.Mock;
+  getModelsForAgent?: jest.Mock;
 }
 
 async function makeService(overrides: ContextSvcDeps = {}): Promise<{
@@ -49,12 +49,12 @@ async function makeService(overrides: ContextSvcDeps = {}): Promise<{
   findOne: jest.Mock;
   getTiers: jest.Mock;
   getActiveAssignments: jest.Mock;
-  getModelForAgent: jest.Mock;
+  getModelsForAgent: jest.Mock;
 }> {
   const findOne = overrides.findOne ?? jest.fn().mockResolvedValue(null);
   const getTiers = overrides.getTiers ?? jest.fn().mockResolvedValue([]);
   const getActiveAssignments = overrides.getActiveAssignments ?? jest.fn().mockResolvedValue([]);
-  const getModelForAgent = overrides.getModelForAgent ?? jest.fn().mockResolvedValue(null);
+  const getModelsForAgent = overrides.getModelsForAgent ?? jest.fn().mockResolvedValue([]);
 
   const module: TestingModule = await Test.createTestingModule({
     providers: [
@@ -65,7 +65,7 @@ async function makeService(overrides: ContextSvcDeps = {}): Promise<{
       },
       { provide: TierService, useValue: { getTiers } },
       { provide: SpecificityService, useValue: { getActiveAssignments } },
-      { provide: ModelDiscoveryService, useValue: { getModelForAgent } },
+      { provide: ModelDiscoveryService, useValue: { getModelsForAgent } },
     ],
   }).compile();
 
@@ -74,14 +74,14 @@ async function makeService(overrides: ContextSvcDeps = {}): Promise<{
     findOne,
     getTiers,
     getActiveAssignments,
-    getModelForAgent,
+    getModelsForAgent,
   };
 }
 
 describe('ContextAdvertisementService', () => {
   describe('agent override', () => {
     it('returns the override verbatim when agent.context_floor_override is set', async () => {
-      const { service, findOne, getTiers, getModelForAgent } = await makeService({
+      const { service, findOne, getTiers, getModelsForAgent } = await makeService({
         findOne: jest.fn().mockResolvedValue({ context_floor_override: 50_000 }),
       });
 
@@ -91,7 +91,7 @@ describe('ContextAdvertisementService', () => {
       expect(findOne).toHaveBeenCalledWith({ where: { id: 'agent-1' } });
       // Override short-circuits discovery — don't pay for it.
       expect(getTiers).not.toHaveBeenCalled();
-      expect(getModelForAgent).not.toHaveBeenCalled();
+      expect(getModelsForAgent).not.toHaveBeenCalled();
     });
 
     it('ignores a zero override (falsy) and computes from models instead', async () => {
@@ -165,7 +165,7 @@ describe('ContextAdvertisementService', () => {
           .mockResolvedValue([
             { auto_assigned_model: 'ghost-model', override_model: null, fallback_models: null },
           ]),
-        getModelForAgent: jest.fn().mockResolvedValue(undefined),
+        getModelsForAgent: jest.fn().mockResolvedValue([]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -187,11 +187,9 @@ describe('ContextAdvertisementService', () => {
             fallback_models: ['also-broken'],
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'broken') return Promise.resolve(mkModel('broken', 0));
-          if (modelId === 'also-broken') return Promise.resolve(mkModel('also-broken', -1));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([mkModel('broken', 0), mkModel('also-broken', -1)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -216,12 +214,12 @@ describe('ContextAdvertisementService', () => {
             fallback_models: ['gpt-4o-mini'],
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'claude-opus-4-6')
-            return Promise.resolve(mkModel('claude-opus-4-6', 200_000));
-          if (modelId === 'gpt-4o-mini') return Promise.resolve(mkModel('gpt-4o-mini', 128_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            mkModel('claude-opus-4-6', 200_000),
+            mkModel('gpt-4o-mini', 128_000),
+          ]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -232,7 +230,10 @@ describe('ContextAdvertisementService', () => {
     it('prefers override_model over auto_assigned_model when both are set', async () => {
       // Matches the `tier.override_model ?? tier.auto_assigned_model` rule:
       // a user pinned a different model, so that's the one we have to honour.
-      const { service, getModelForAgent } = await makeService({
+      // We check the collected candidate set via the internal bookkeeping —
+      // if `auto-model` ever made it into the candidates, a discovery entry
+      // for it with a smaller window would win and break this test.
+      const { service } = await makeService({
         getTiers: jest.fn().mockResolvedValue([
           {
             auto_assigned_model: 'auto-model',
@@ -240,19 +241,17 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'pinned-model') return Promise.resolve(mkModel('pinned-model', 64_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest.fn().mockResolvedValue([
+          mkModel('pinned-model', 64_000),
+          // If the impl mistakenly used auto-model, this 8K entry would drag
+          // the advertised floor down and fail the assertion below.
+          mkModel('auto-model', 8_000),
+        ]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
 
       expect(result.contextLength).toBe(64_000);
-      // We must never look up the auto-assigned one when an override exists.
-      const lookedUp = getModelForAgent.mock.calls.map((c) => c[1]);
-      expect(lookedUp).toContain('pinned-model');
-      expect(lookedUp).not.toContain('auto-model');
     });
 
     it('includes specificity assignments in the candidate set', async () => {
@@ -275,14 +274,13 @@ describe('ContextAdvertisementService', () => {
             fallback_models: ['medium-fallback'],
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'big-model') return Promise.resolve(mkModel('big-model', 1_000_000));
-          if (modelId === 'small-coding-model')
-            return Promise.resolve(mkModel('small-coding-model', 32_000));
-          if (modelId === 'medium-fallback')
-            return Promise.resolve(mkModel('medium-fallback', 128_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            mkModel('big-model', 1_000_000),
+            mkModel('small-coding-model', 32_000),
+            mkModel('medium-fallback', 128_000),
+          ]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -301,10 +299,7 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
-          if (modelId === 'pinned-spec') return Promise.resolve(mkModel('pinned-spec', 96_000));
-          return Promise.resolve(null);
-        }),
+        getModelsForAgent: jest.fn().mockResolvedValue([mkModel('pinned-spec', 96_000)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -312,33 +307,35 @@ describe('ContextAdvertisementService', () => {
       expect(result.contextLength).toBe(96_000);
     });
 
-    it('dedupes identical model ids across tiers and specificity so they only cost one lookup', async () => {
-      // Same model appears as both a tier primary and a specificity
-      // fallback. The internal Set must collapse it — we don't want to
-      // query the discovery service twice per request for the same model.
-      const getModelForAgent = jest.fn().mockResolvedValue(mkModel('gpt-4o', 128_000));
+    it('fetches the discovery index only once regardless of how many candidates the agent has', async () => {
+      // Before this optimisation the service looped `getModelForAgent` which
+      // internally scanned the full provider list on each call, turning N
+      // candidates into N full fetches. Guard against regressing that.
+      const getModelsForAgent = jest
+        .fn()
+        .mockResolvedValue([mkModel('gpt-4o', 128_000), mkModel('claude-opus-4-6', 200_000)]);
       const { service } = await makeService({
         getTiers: jest.fn().mockResolvedValue([
           {
             auto_assigned_model: 'gpt-4o',
             override_model: null,
-            fallback_models: ['gpt-4o'],
+            fallback_models: ['claude-opus-4-6'],
           },
         ]),
         getActiveAssignments: jest.fn().mockResolvedValue([
           {
             auto_assigned_model: 'gpt-4o',
             override_model: null,
-            fallback_models: ['gpt-4o'],
+            fallback_models: ['claude-opus-4-6'],
           },
         ]),
-        getModelForAgent,
+        getModelsForAgent,
       });
 
       await service.getEffectiveContext('agent-1');
 
-      expect(getModelForAgent).toHaveBeenCalledTimes(1);
-      expect(getModelForAgent).toHaveBeenCalledWith('agent-1', 'gpt-4o');
+      expect(getModelsForAgent).toHaveBeenCalledTimes(1);
+      expect(getModelsForAgent).toHaveBeenCalledWith('agent-1');
     });
 
     it('skips tiers whose primary is null and has no fallbacks', async () => {
@@ -358,7 +355,7 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockResolvedValue(mkModel('only-real', 42_000)),
+        getModelsForAgent: jest.fn().mockResolvedValue([mkModel('only-real', 42_000)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');
@@ -383,7 +380,7 @@ describe('ContextAdvertisementService', () => {
             fallback_models: null,
           },
         ]),
-        getModelForAgent: jest.fn().mockResolvedValue(mkModel('spec-real', 70_000)),
+        getModelsForAgent: jest.fn().mockResolvedValue([mkModel('spec-real', 70_000)]),
       });
 
       const result = await service.getEffectiveContext('agent-1');

--- a/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.spec.ts
@@ -1,0 +1,394 @@
+/**
+ * Why these tests exist:
+ *
+ * Issues #1617 / #1612 / #1450 all trace back to clients hard-coding a
+ * context window that didn't match whichever model manifest/auto actually
+ * routed to — either too small (aggressive compaction wasted tokens) or too
+ * large (requests overflowed the routed model). Phase 1 advertises the
+ * **minimum** context window across every model the agent can be routed to.
+ * These tests defend that invariant: if ContextAdvertisementService ever
+ * returns the max, the sum, or "whatever the first tier says", the three
+ * bugs we fixed come back. Every test here checks a real code path that
+ * guards one of those three failure modes.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  ContextAdvertisementService,
+  DEFAULT_ADVERTISED_CONTEXT,
+} from './context-advertisement.service';
+import { Agent } from '../../entities/agent.entity';
+import { TierService } from '../routing-core/tier.service';
+import { SpecificityService } from '../routing-core/specificity.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { DiscoveredModel } from '../../model-discovery/model-fetcher';
+
+function mkModel(id: string, contextWindow: number): DiscoveredModel {
+  return {
+    id,
+    displayName: id,
+    provider: 'openai',
+    contextWindow,
+    inputPricePerToken: 0,
+    outputPricePerToken: 0,
+    capabilityReasoning: false,
+    capabilityCode: true,
+    qualityScore: 3,
+  };
+}
+
+interface ContextSvcDeps {
+  findOne?: jest.Mock;
+  getTiers?: jest.Mock;
+  getActiveAssignments?: jest.Mock;
+  getModelForAgent?: jest.Mock;
+}
+
+async function makeService(overrides: ContextSvcDeps = {}): Promise<{
+  service: ContextAdvertisementService;
+  findOne: jest.Mock;
+  getTiers: jest.Mock;
+  getActiveAssignments: jest.Mock;
+  getModelForAgent: jest.Mock;
+}> {
+  const findOne = overrides.findOne ?? jest.fn().mockResolvedValue(null);
+  const getTiers = overrides.getTiers ?? jest.fn().mockResolvedValue([]);
+  const getActiveAssignments = overrides.getActiveAssignments ?? jest.fn().mockResolvedValue([]);
+  const getModelForAgent = overrides.getModelForAgent ?? jest.fn().mockResolvedValue(null);
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      ContextAdvertisementService,
+      {
+        provide: getRepositoryToken(Agent),
+        useValue: { findOne },
+      },
+      { provide: TierService, useValue: { getTiers } },
+      { provide: SpecificityService, useValue: { getActiveAssignments } },
+      { provide: ModelDiscoveryService, useValue: { getModelForAgent } },
+    ],
+  }).compile();
+
+  return {
+    service: module.get<ContextAdvertisementService>(ContextAdvertisementService),
+    findOne,
+    getTiers,
+    getActiveAssignments,
+    getModelForAgent,
+  };
+}
+
+describe('ContextAdvertisementService', () => {
+  describe('agent override', () => {
+    it('returns the override verbatim when agent.context_floor_override is set', async () => {
+      const { service, findOne, getTiers, getModelForAgent } = await makeService({
+        findOne: jest.fn().mockResolvedValue({ context_floor_override: 50_000 }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({ contextLength: 50_000, overridden: true });
+      expect(findOne).toHaveBeenCalledWith({ where: { id: 'agent-1' } });
+      // Override short-circuits discovery — don't pay for it.
+      expect(getTiers).not.toHaveBeenCalled();
+      expect(getModelForAgent).not.toHaveBeenCalled();
+    });
+
+    it('ignores a zero override (falsy) and computes from models instead', async () => {
+      // context_floor_override is typed as `number | null`; 0 is in range for
+      // `integer` so it is worth confirming the guard treats 0/null the same
+      // way: fall through to the computed floor.
+      const { service, getTiers } = await makeService({
+        findOne: jest.fn().mockResolvedValue({ context_floor_override: 0 }),
+        getTiers: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+      expect(getTiers).toHaveBeenCalled();
+    });
+
+    it('treats a null override as "use the computed floor"', async () => {
+      const { service } = await makeService({
+        findOne: jest.fn().mockResolvedValue({ context_floor_override: null }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.overridden).toBe(false);
+    });
+
+    it('treats a missing agent row the same as no override', async () => {
+      // Covers the `agent?.context_floor_override` optional-chain path when
+      // findOne returns null.
+      const { service } = await makeService({
+        findOne: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await service.getEffectiveContext('ghost');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+  });
+
+  describe('empty-candidate fallback', () => {
+    it('falls back to DEFAULT_ADVERTISED_CONTEXT when no tiers and no specificity are configured', async () => {
+      // This is the onboarding state: user just created the agent, no
+      // providers connected yet. Advertising 128K keeps OpenClaw etc. from
+      // compacting to the hard-coded 16K floor they fell back to before.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([]),
+        getActiveAssignments: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.getEffectiveContext('new-agent');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+
+    it('falls back to DEFAULT_ADVERTISED_CONTEXT when discovery returns nothing for every candidate', async () => {
+      // Stale tier assignments pointing at models the discovery cache no
+      // longer knows about. We don't want to return `Math.min()` === Infinity.
+      const { service } = await makeService({
+        getTiers: jest
+          .fn()
+          .mockResolvedValue([
+            { auto_assigned_model: 'ghost-model', override_model: null, fallback_models: null },
+          ]),
+        getModelForAgent: jest.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+
+    it('ignores models whose contextWindow is zero or negative', async () => {
+      // Guard against bad data in cached_models. A model with contextWindow=0
+      // must never drag the advertised floor down to 0.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'broken',
+            override_model: null,
+            fallback_models: ['also-broken'],
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'broken') return Promise.resolve(mkModel('broken', 0));
+          if (modelId === 'also-broken') return Promise.resolve(mkModel('also-broken', -1));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({
+        contextLength: DEFAULT_ADVERTISED_CONTEXT,
+        overridden: false,
+      });
+    });
+  });
+
+  describe('minimum-context behaviour (the whole point of the feature)', () => {
+    it('returns the smallest context_window across tier primaries and fallbacks', async () => {
+      // This is the core defense against #1617: when a tier primary has a
+      // 200K window but the fallback only has 128K, we must advertise 128K
+      // so the client never overflows the fallback on a failover.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'claude-opus-4-6',
+            override_model: null,
+            fallback_models: ['gpt-4o-mini'],
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'claude-opus-4-6')
+            return Promise.resolve(mkModel('claude-opus-4-6', 200_000));
+          if (modelId === 'gpt-4o-mini') return Promise.resolve(mkModel('gpt-4o-mini', 128_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({ contextLength: 128_000, overridden: false });
+    });
+
+    it('prefers override_model over auto_assigned_model when both are set', async () => {
+      // Matches the `tier.override_model ?? tier.auto_assigned_model` rule:
+      // a user pinned a different model, so that's the one we have to honour.
+      const { service, getModelForAgent } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'auto-model',
+            override_model: 'pinned-model',
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'pinned-model') return Promise.resolve(mkModel('pinned-model', 64_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(64_000);
+      // We must never look up the auto-assigned one when an override exists.
+      const lookedUp = getModelForAgent.mock.calls.map((c) => c[1]);
+      expect(lookedUp).toContain('pinned-model');
+      expect(lookedUp).not.toContain('auto-model');
+    });
+
+    it('includes specificity assignments in the candidate set', async () => {
+      // Bug class from #1612: when the agent is routed via specificity to a
+      // smaller-window model (e.g. a coding-specific one), the advertised
+      // floor had to account for it. If we ignored specificity we'd over-
+      // advertise and OpenClaw would overflow the coding model.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'big-model',
+            override_model: null,
+            fallback_models: null,
+          },
+        ]),
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'small-coding-model',
+            override_model: null,
+            fallback_models: ['medium-fallback'],
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'big-model') return Promise.resolve(mkModel('big-model', 1_000_000));
+          if (modelId === 'small-coding-model')
+            return Promise.resolve(mkModel('small-coding-model', 32_000));
+          if (modelId === 'medium-fallback')
+            return Promise.resolve(mkModel('medium-fallback', 128_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result).toEqual({ contextLength: 32_000, overridden: false });
+    });
+
+    it('uses override_model for specificity assignments when set', async () => {
+      // Same override-wins rule, on the specificity side. Exercises the
+      // `assignment.override_model ?? assignment.auto_assigned_model` line.
+      const { service } = await makeService({
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'auto-spec',
+            override_model: 'pinned-spec',
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockImplementation((_agentId, modelId) => {
+          if (modelId === 'pinned-spec') return Promise.resolve(mkModel('pinned-spec', 96_000));
+          return Promise.resolve(null);
+        }),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(96_000);
+    });
+
+    it('dedupes identical model ids across tiers and specificity so they only cost one lookup', async () => {
+      // Same model appears as both a tier primary and a specificity
+      // fallback. The internal Set must collapse it — we don't want to
+      // query the discovery service twice per request for the same model.
+      const getModelForAgent = jest.fn().mockResolvedValue(mkModel('gpt-4o', 128_000));
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'gpt-4o',
+            override_model: null,
+            fallback_models: ['gpt-4o'],
+          },
+        ]),
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: 'gpt-4o',
+            override_model: null,
+            fallback_models: ['gpt-4o'],
+          },
+        ]),
+        getModelForAgent,
+      });
+
+      await service.getEffectiveContext('agent-1');
+
+      expect(getModelForAgent).toHaveBeenCalledTimes(1);
+      expect(getModelForAgent).toHaveBeenCalledWith('agent-1', 'gpt-4o');
+    });
+
+    it('skips tiers whose primary is null and has no fallbacks', async () => {
+      // Covers the `if (primary) models.add(primary)` and the null-safety on
+      // fallback_models together — an unconfigured tier should contribute
+      // zero candidates, not crash.
+      const { service } = await makeService({
+        getTiers: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: null,
+            override_model: null,
+            fallback_models: null,
+          },
+          {
+            auto_assigned_model: 'only-real',
+            override_model: null,
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockResolvedValue(mkModel('only-real', 42_000)),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(42_000);
+    });
+
+    it('skips specificity assignments whose primary is null and fallbacks are null', async () => {
+      // Mirrors the tier test but on the specificity branch so the
+      // equivalent `if (primary)` / `if (assignment.fallback_models)` guards
+      // are both covered.
+      const { service } = await makeService({
+        getActiveAssignments: jest.fn().mockResolvedValue([
+          {
+            auto_assigned_model: null,
+            override_model: null,
+            fallback_models: null,
+          },
+          {
+            auto_assigned_model: 'spec-real',
+            override_model: null,
+            fallback_models: null,
+          },
+        ]),
+        getModelForAgent: jest.fn().mockResolvedValue(mkModel('spec-real', 70_000)),
+      });
+
+      const result = await service.getEffectiveContext('agent-1');
+
+      expect(result.contextLength).toBe(70_000);
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/context-advertisement.service.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Agent } from '../../entities/agent.entity';
+import { TierService } from '../routing-core/tier.service';
+import { SpecificityService } from '../routing-core/specificity.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+
+/**
+ * Floor returned when the agent has no routable models yet. Matches the
+ * default used by `ProviderModelFetcherService` so clients see a consistent
+ * value whether they call us during onboarding or after connecting providers.
+ */
+export const DEFAULT_ADVERTISED_CONTEXT = 128_000;
+
+export interface EffectiveContext {
+  contextLength: number;
+  /** True when the value came from the per-agent override. */
+  overridden: boolean;
+}
+
+/**
+ * Computes the honest `context_length` advertised on `GET /v1/models` for
+ * `manifest/auto`. The number is the **minimum** `context_window` across
+ * every model the agent could actually be routed to (tier primaries,
+ * fallbacks, and active specificity overrides). Any model Manifest picks is
+ * guaranteed to accept at least this many tokens, so clients that compact to
+ * the advertised floor never overflow the routed model.
+ *
+ * Why minimum instead of maximum or average: issues #1617 / #1612 / #1450 all
+ * trace back to clients assuming a larger window than the routed model
+ * actually offers. The floor is the only value that's safe to advertise
+ * without knowing which model this particular request will land on.
+ */
+@Injectable()
+export class ContextAdvertisementService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
+    private readonly tierService: TierService,
+    private readonly specificityService: SpecificityService,
+    private readonly discoveryService: ModelDiscoveryService,
+  ) {}
+
+  async getEffectiveContext(agentId: string): Promise<EffectiveContext> {
+    const agent = await this.agentRepo.findOne({ where: { id: agentId } });
+    if (agent?.context_floor_override) {
+      return { contextLength: agent.context_floor_override, overridden: true };
+    }
+
+    const candidates = await this.collectCandidateModels(agentId);
+    if (candidates.size === 0) {
+      return { contextLength: DEFAULT_ADVERTISED_CONTEXT, overridden: false };
+    }
+
+    const contexts: number[] = [];
+    for (const modelId of candidates) {
+      const discovered = await this.discoveryService.getModelForAgent(agentId, modelId);
+      if (discovered && discovered.contextWindow > 0) {
+        contexts.push(discovered.contextWindow);
+      }
+    }
+
+    if (contexts.length === 0) {
+      return { contextLength: DEFAULT_ADVERTISED_CONTEXT, overridden: false };
+    }
+
+    return { contextLength: Math.min(...contexts), overridden: false };
+  }
+
+  private async collectCandidateModels(agentId: string): Promise<Set<string>> {
+    const models = new Set<string>();
+
+    const tiers = await this.tierService.getTiers(agentId);
+    for (const tier of tiers) {
+      const primary = tier.override_model ?? tier.auto_assigned_model;
+      if (primary) models.add(primary);
+      if (tier.fallback_models) {
+        for (const fallback of tier.fallback_models) models.add(fallback);
+      }
+    }
+
+    const active = await this.specificityService.getActiveAssignments(agentId);
+    for (const assignment of active) {
+      const primary = assignment.override_model ?? assignment.auto_assigned_model;
+      if (primary) models.add(primary);
+      if (assignment.fallback_models) {
+        for (const fallback of assignment.fallback_models) models.add(fallback);
+      }
+    }
+
+    return models;
+  }
+}

--- a/packages/backend/src/routing/proxy/context-advertisement.service.ts
+++ b/packages/backend/src/routing/proxy/context-advertisement.service.ts
@@ -53,12 +53,16 @@ export class ContextAdvertisementService {
       return { contextLength: DEFAULT_ADVERTISED_CONTEXT, overridden: false };
     }
 
+    // Single fetch — getModelForAgent internally calls getModelsForAgent on
+    // every invocation, so looping it would re-scan the full provider list
+    // once per candidate. Build the index once and look candidates up in it.
+    const discovered = await this.discoveryService.getModelsForAgent(agentId);
+    const byId = new Map(discovered.map((m) => [m.id, m]));
+
     const contexts: number[] = [];
     for (const modelId of candidates) {
-      const discovered = await this.discoveryService.getModelForAgent(agentId, modelId);
-      if (discovered && discovered.contextWindow > 0) {
-        contexts.push(discovered.contextWindow);
-      }
+      const model = byId.get(modelId);
+      if (model && model.contextWindow > 0) contexts.push(model.contextWindow);
     }
 
     if (contexts.length === 0) {

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -35,6 +35,21 @@ export function buildMetaHeaders(meta: RoutingMeta): Record<string, string> {
     headers['X-Manifest-Fallback-From'] = meta.fallbackFromModel;
     headers['X-Manifest-Fallback-Index'] = String(meta.fallbackIndex ?? 0);
   }
+  // Phase 2 size-awareness signals. Agents use these to adapt compaction
+  // per-response without a second round trip — see EthanFrostpro's ask on
+  // issue #1617.
+  if (meta.estimatedTokens !== undefined) {
+    headers['X-Manifest-Context-Estimated'] = String(meta.estimatedTokens);
+  }
+  if (meta.usedContextWindow !== undefined) {
+    headers['X-Manifest-Context-Used'] = String(meta.usedContextWindow);
+  }
+  if (meta.sizeEscalatedFrom) {
+    // ASCII-only value. Node's http layer drops headers containing
+    // characters outside the Latin-1 range — a unicode arrow (→) would
+    // silently disappear from the response.
+    headers['X-Manifest-Context-Escalated'] = `${meta.sizeEscalatedFrom}->${meta.tier}`;
+  }
   return headers;
 }
 

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Get,
   Post,
   Req,
   Res,
@@ -31,6 +32,7 @@ import {
 } from './proxy-response-handler';
 import { ProxyExceptionFilter, isChatRenderingClient } from './proxy-exception.filter';
 import { sendFriendlyResponse } from './proxy-friendly-response';
+import { ContextAdvertisementService } from './context-advertisement.service';
 
 const MAX_SEEN_USERS = 10_000;
 const SEEN_USER_TTL_MS = 24 * 60 * 60 * 1000;
@@ -51,7 +53,34 @@ export class ProxyController {
     private readonly recorder: ProxyMessageRecorder,
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
+    private readonly contextAdvertisement: ContextAdvertisementService,
   ) {}
+
+  /**
+   * OpenAI-compatible model listing. Advertises `manifest/auto` with a
+   * dynamic `context_length` equal to the smallest context window across the
+   * agent's currently-routed models — the honest floor any request is
+   * guaranteed to fit in. Clients that compact against this value (OpenClaw,
+   * OpenRouter SDKs, etc.) stop overflowing routed models. See issues #1617,
+   * #1612 and #1450.
+   */
+  @Get('models')
+  async listModels(@Req() req: Request & { ingestionContext: IngestionContext }) {
+    const { agentId } = req.ingestionContext;
+    const { contextLength } = await this.contextAdvertisement.getEffectiveContext(agentId);
+    return {
+      object: 'list',
+      data: [
+        {
+          id: 'auto',
+          object: 'model',
+          created: Math.floor(Date.now() / 1000),
+          owned_by: 'manifest',
+          context_length: contextLength,
+        },
+      ],
+    };
+  }
 
   @Post('chat/completions')
   async chatCompletions(

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
+import { Agent } from '../../entities/agent.entity';
 import { RoutingCoreModule } from '../routing-core/routing-core.module';
 import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { ModelDiscoveryModule } from '../../model-discovery/model-discovery.module';
@@ -21,10 +22,11 @@ import { CopilotTokenService } from './copilot-token.service';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
+import { ContextAdvertisementService } from './context-advertisement.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AgentMessage, CustomProvider]),
+    TypeOrmModule.forFeature([AgentMessage, CustomProvider, Agent]),
     RoutingCoreModule,
     ModelPricesModule,
     ModelDiscoveryModule,
@@ -46,6 +48,8 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
     ThoughtSignatureCache,
     ThinkingBlockCache,
     ProxyExceptionFilter,
+    ContextAdvertisementService,
   ],
+  exports: [ContextAdvertisementService],
 })
 export class ProxyModule {}

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -218,11 +218,16 @@ export class ProxyService {
     // uses `.includes('HEARTBEAT_OK')` so a legitimate user message that
     // happens to mention the sentinel in a large payload would otherwise
     // bypass size-aware routing and fire at the `simple` tier regardless
-    // of whether it can fit. Gate the heartbeat fast-path on the estimate
-    // staying below a safe ceiling — real heartbeats are tens of tokens.
+    // of whether it can fit. Gate on the full request budget (estimated
+    // input + max_tokens reserve) so a tiny prompt with huge max_tokens
+    // can't slip through either — real heartbeats never request a large
+    // output.
     const estimatedTokens = estimateTokens(messages, scoringTools);
+    const reservedOutput =
+      typeof body.max_tokens === 'number' && body.max_tokens > 0 ? body.max_tokens : 0;
     const isHeartbeat =
-      this.detectHeartbeat(scoringMessages) && estimatedTokens <= HEARTBEAT_TOKEN_CEILING;
+      this.detectHeartbeat(scoringMessages) &&
+      estimatedTokens + reservedOutput <= HEARTBEAT_TOKEN_CEILING;
     if (isHeartbeat) return this.resolveService.resolveForTier(agentId, 'simple');
 
     return this.resolveService.resolve(

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -22,6 +22,8 @@ import { ProxyRequestOptions, SignatureLookup, ThinkingBlockLookup } from './pro
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
+import { estimateTokens } from './token-estimate';
+import { REASON_CONTEXT_WINDOW_EXCEEDED } from '../dto/resolve-response';
 import type { AuthType } from 'manifest-shared';
 
 type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
@@ -56,6 +58,16 @@ export interface RoutingMeta {
    * failure row to the correct vendor.
    */
   primaryProvider?: string;
+  /** Estimated tokens for the request. Surfaced in response headers. */
+  estimatedTokens?: number;
+  /** Context window of the chosen model. Surfaced in response headers. */
+  usedContextWindow?: number;
+  /**
+   * Set when Phase 2 size check escalated the request out of its scored
+   * tier because no model in the tier could fit. Carries the original
+   * tier so the client can log what actually happened.
+   */
+  sizeEscalatedFrom?: Tier;
 }
 
 export interface ProxyResult {
@@ -93,6 +105,9 @@ export class ProxyService {
     }
 
     const resolved = await this.resolveRouting(agentId, body, sessionKey, specificityOverride);
+    if (resolved.reason === REASON_CONTEXT_WINDOW_EXCEEDED) {
+      return this.buildContextExceededResult(resolved, body.stream === true, agentName);
+    }
     if (!resolved.model || !resolved.provider) {
       this.logger.warn(
         `No model available for agent=${agentId}: ` +
@@ -189,18 +204,27 @@ export class ProxyService {
     const recentTiers = this.momentum.getRecentTiers(sessionKey);
     const recentCategories = this.momentum.getRecentCategories(sessionKey);
 
-    return isHeartbeat
-      ? this.resolveService.resolveForTier(agentId, 'simple')
-      : this.resolveService.resolve(
-          agentId,
-          scoringMessages,
-          scoringTools,
-          body.tool_choice,
-          body.max_tokens as number | undefined,
-          recentTiers,
-          specificityOverride,
-          recentCategories,
-        );
+    // Heartbeat traffic bypasses the size check by design: heartbeats are
+    // tiny by construction and must route to `simple` cheaply, so the
+    // extra tokenization round-trip would be pure overhead.
+    if (isHeartbeat) return this.resolveService.resolveForTier(agentId, 'simple');
+
+    // Estimate against the full message array and tool list — the scoring
+    // window is a subset of the payload, but the *fit* check must reflect
+    // what will actually be forwarded to the provider.
+    const estimatedTokens = estimateTokens(messages, scoringTools);
+
+    return this.resolveService.resolve(
+      agentId,
+      scoringMessages,
+      scoringTools,
+      body.tool_choice,
+      body.max_tokens as number | undefined,
+      recentTiers,
+      specificityOverride,
+      recentCategories,
+      estimatedTokens,
+    );
   }
 
   private async resolveCredentials(
@@ -316,6 +340,9 @@ export class ProxyService {
       auth_type?: string;
       specificity_category?: string;
       provider?: string | null;
+      estimated_tokens?: number;
+      used_context_window?: number;
+      size_escalated_from?: Tier;
     },
     model: string,
     overrides: Partial<RoutingMeta> = {},
@@ -328,6 +355,9 @@ export class ProxyService {
       reason: resolved.reason,
       auth_type: resolved.auth_type,
       specificity_category: resolved.specificity_category,
+      estimatedTokens: resolved.estimated_tokens,
+      usedContextWindow: resolved.used_context_window,
+      sizeEscalatedFrom: resolved.size_escalated_from,
       ...overrides,
     };
   }
@@ -377,6 +407,34 @@ export class ProxyService {
     const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
     const content = `[🦚 Manifest] You're connected, but no providers are set up yet. Add one here: ${dashboardUrl}`;
     return buildFriendlyResponse(content, stream, 'no_provider');
+  }
+
+  /**
+   * Phase 2: no model in any connected tier can fit this request. Tell
+   * the user exactly what the budget looked like — breaking out input
+   * vs reserved output matters because they're independently actionable:
+   * "shorten the conversation" fixes input overshoot, "lower max_tokens"
+   * fixes reserve overshoot. Lumping them together made the message
+   * nonsensical when the reserve was the real blocker.
+   */
+  private buildContextExceededResult(
+    resolved: ResolvedRouting,
+    stream: boolean,
+    agentName?: string,
+  ): ProxyResult {
+    const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
+    const estimated = resolved.estimated_tokens ?? 0;
+    const reserved = resolved.reserved_output_tokens ?? 0;
+    const total = estimated + reserved;
+    const largest = resolved.largest_available_context ?? 0;
+    const reservedSuffix =
+      reserved > 0 ? ` + ${reserved.toLocaleString()} reserved for output` : '';
+    const content =
+      `[🦚 Manifest] Request needs ~${total.toLocaleString()} tokens ` +
+      `(${estimated.toLocaleString()} input${reservedSuffix}), ` +
+      `but the largest connected model's context window is ${largest.toLocaleString()}. ` +
+      `Shorten the conversation, lower \`max_tokens\`, or connect a larger-context provider: ${dashboardUrl}`;
+    return buildFriendlyResponse(content, stream, REASON_CONTEXT_WINDOW_EXCEEDED);
   }
 }
 

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -39,6 +39,15 @@ const SCORING_EXCLUDED_ROLES = new Set(['system', 'developer']);
 const SCORING_RECENT_MESSAGES = 10;
 const MAX_MESSAGES_PER_REQUEST = 1000;
 
+/**
+ * Maximum estimated token count for a request to still be treated as a
+ * heartbeat. Real heartbeats are tens of tokens at most; this ceiling is
+ * generous (1000) but low enough to stop an adversarial/oversized payload
+ * that happens to contain the `HEARTBEAT_OK` substring from bypassing
+ * size-aware routing.
+ */
+const HEARTBEAT_TOKEN_CEILING = 1_000;
+
 export interface RoutingMeta {
   tier: Tier;
   model: string;
@@ -200,19 +209,21 @@ export class ProxyService {
     const messages = body.messages as ScorerMessage[];
     const scoringMessages = this.filterScoringMessages(messages);
     const scoringTools = Array.isArray(body.tools) ? body.tools : undefined;
-    const isHeartbeat = this.detectHeartbeat(scoringMessages);
     const recentTiers = this.momentum.getRecentTiers(sessionKey);
     const recentCategories = this.momentum.getRecentCategories(sessionKey);
 
-    // Heartbeat traffic bypasses the size check by design: heartbeats are
-    // tiny by construction and must route to `simple` cheaply, so the
-    // extra tokenization round-trip would be pure overhead.
-    if (isHeartbeat) return this.resolveService.resolveForTier(agentId, 'simple');
-
     // Estimate against the full message array and tool list — the scoring
     // window is a subset of the payload, but the *fit* check must reflect
-    // what will actually be forwarded to the provider.
+    // what will actually be forwarded to the provider. Heartbeat detection
+    // uses `.includes('HEARTBEAT_OK')` so a legitimate user message that
+    // happens to mention the sentinel in a large payload would otherwise
+    // bypass size-aware routing and fire at the `simple` tier regardless
+    // of whether it can fit. Gate the heartbeat fast-path on the estimate
+    // staying below a safe ceiling — real heartbeats are tens of tokens.
     const estimatedTokens = estimateTokens(messages, scoringTools);
+    const isHeartbeat =
+      this.detectHeartbeat(scoringMessages) && estimatedTokens <= HEARTBEAT_TOKEN_CEILING;
+    if (isHeartbeat) return this.resolveService.resolveForTier(agentId, 'simple');
 
     return this.resolveService.resolve(
       agentId,

--- a/packages/backend/src/routing/proxy/token-estimate.spec.ts
+++ b/packages/backend/src/routing/proxy/token-estimate.spec.ts
@@ -28,6 +28,14 @@ describe('estimateTokens', () => {
     expect(long).toBeGreaterThan(medium);
   });
 
+  it('safety multiplier is set high enough to cover the documented CJK undercount (#1678 cubic P1)', () => {
+    // Regression guard: cl100k_base under-counts Chinese / Japanese by
+    // ~15% in published benchmarks. If the multiplier drops below ~1.15,
+    // CJK-heavy requests slip past the fit check and overflow the routed
+    // model. 1.2 is the minimum we're willing to ship.
+    expect(TOKEN_ESTIMATE_SAFETY_MULTIPLIER).toBeGreaterThanOrEqual(1.2);
+  });
+
   it('applies the safety multiplier so we bias toward over-estimation', () => {
     // With 100 messages of known text we can show the output is larger than
     // the raw tokenization would be — without depending on the exact raw
@@ -39,7 +47,7 @@ describe('estimateTokens', () => {
     const estimate = estimateTokens(messages);
 
     // A pure cl100k_base count would be ~900 tokens for this input. We
-    // expect ≥10% more because of the safety multiplier.
+    // expect ≥20% more because of the safety multiplier.
     expect(estimate).toBeGreaterThan(900);
     expect(TOKEN_ESTIMATE_SAFETY_MULTIPLIER).toBeGreaterThan(1);
   });

--- a/packages/backend/src/routing/proxy/token-estimate.spec.ts
+++ b/packages/backend/src/routing/proxy/token-estimate.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * The estimator is a routing safety check, not a billing oracle. These
+ * tests defend the invariants that matter for routing:
+ *   1. Longer input ⇒ larger estimate (monotonic).
+ *   2. Safety multiplier biases up, never down (undercounting overflows).
+ *   3. Empty input returns 0 so heartbeats skip the size check cleanly.
+ *   4. Tool definitions contribute to the count (JSON-heavy payloads are
+ *      the bug class from #1617; a char-based heuristic would under-
+ *      count them).
+ */
+import { estimateTokens, TOKEN_ESTIMATE_SAFETY_MULTIPLIER } from './token-estimate';
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty input so heartbeats skip the size check', () => {
+    expect(estimateTokens(undefined)).toBe(0);
+    expect(estimateTokens([])).toBe(2); // JSON.stringify([]) = "[]", two tokens
+  });
+
+  it('returns 0 when messages and tools are both undefined', () => {
+    expect(estimateTokens(undefined, undefined)).toBe(0);
+  });
+
+  it('scales monotonically with input length', () => {
+    const short = estimateTokens([{ role: 'user', content: 'Hi' }]);
+    const medium = estimateTokens([{ role: 'user', content: 'Hello there friend' }]);
+    const long = estimateTokens([{ role: 'user', content: 'Hello there friend'.repeat(50) }]);
+    expect(medium).toBeGreaterThan(short);
+    expect(long).toBeGreaterThan(medium);
+  });
+
+  it('applies the safety multiplier so we bias toward over-estimation', () => {
+    // With 100 messages of known text we can show the output is larger than
+    // the raw tokenization would be — without depending on the exact raw
+    // value which varies by encoder version.
+    const messages = Array.from({ length: 100 }, () => ({
+      role: 'user',
+      content: 'The quick brown fox jumps over the lazy dog.',
+    }));
+    const estimate = estimateTokens(messages);
+
+    // A pure cl100k_base count would be ~900 tokens for this input. We
+    // expect ≥10% more because of the safety multiplier.
+    expect(estimate).toBeGreaterThan(900);
+    expect(TOKEN_ESTIMATE_SAFETY_MULTIPLIER).toBeGreaterThan(1);
+  });
+
+  it('counts tool definitions — a char heuristic misses these on OpenClaw payloads', () => {
+    // The tool registry in OpenClaw requests is ~8K chars of JSON. If we
+    // only looked at `messages`, we'd under-count every tool-use request.
+    const messages = [{ role: 'user', content: 'Hi' }];
+    const fatTool = {
+      type: 'function',
+      function: {
+        name: 'search_web',
+        description: 'search the web for a query'.repeat(200),
+        parameters: { type: 'object', properties: { q: { type: 'string' } } },
+      },
+    };
+
+    const withoutTools = estimateTokens(messages);
+    const withTools = estimateTokens(messages, [fatTool]);
+
+    expect(withTools).toBeGreaterThan(withoutTools * 5);
+  });
+
+  it('counts realistic OpenClaw-style tool-registry + conversation payloads above the 2K floor', () => {
+    // Real OpenClaw traffic arrives as ~10 tool definitions with multi-property
+    // JSON-schema parameters, plus a 20-turn conversation. A char-based
+    // heuristic (the naïve "content.length / 4" pre-#1617 approach) would
+    // undercount these and let oversized requests slip through the size
+    // check — #1617 fuzhyperblue's exact failure mode.
+    const tools = Array.from({ length: 10 }, (_, i) => ({
+      type: 'function',
+      function: {
+        name: `tool_${i}`,
+        description:
+          'Perform a specific action against an external service. ' +
+          'Returns a JSON payload describing the action outcome.',
+        parameters: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Natural-language query for the action' },
+            limit: { type: 'integer', description: 'Maximum results to return (default 10)' },
+            filter: {
+              type: 'object',
+              description: 'Structured filter constraints',
+              properties: {
+                tag: { type: 'string' },
+                since: { type: 'string', format: 'date-time' },
+              },
+            },
+            flags: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Optional behaviour flags',
+            },
+            context_id: { type: 'string', description: 'Session-scoped context identifier' },
+          },
+          required: ['query'],
+        },
+      },
+    }));
+    const messages = Array.from({ length: 20 }, (_, i) => ({
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content:
+        `Turn ${i}: ` + 'I need you to analyse this output and suggest the next action. '.repeat(4),
+    }));
+
+    const estimate = estimateTokens(messages, tools);
+    expect(estimate).toBeGreaterThanOrEqual(2000);
+  });
+
+  it('charges non-trivial tokens for multilingual (CJK + code) content so non-English payloads are not wildly undercounted', () => {
+    // cl100k_base under-counts CJK relative to pure-English, which is why we
+    // apply the safety multiplier. This test locks in the minimum: a Chinese
+    // message + fenced code block must still count as *some* tokens, and
+    // adding more of the same content must increase the estimate. A naive
+    // ASCII-only heuristic would badly undercount this and let Chinese
+    // OpenClaw sessions overflow silently (reported in #1450 discussion).
+    const singleTurn = estimateTokens([
+      {
+        role: 'user',
+        content:
+          '请帮我分析下面这段 Python 代码的时间复杂度:\n' +
+          '```python\ndef foo(xs):\n    return sorted(set(xs))\n```',
+      },
+    ]);
+    const doubleTurn = estimateTokens([
+      {
+        role: 'user',
+        content:
+          '请帮我分析下面这段 Python 代码的时间复杂度:\n' +
+          '```python\ndef foo(xs):\n    return sorted(set(xs))\n```',
+      },
+      {
+        role: 'assistant',
+        content: '这段代码的时间复杂度是 O(n log n),因为 sorted() 主导了整体耗时。',
+      },
+    ]);
+    const emptyBaseline = estimateTokens(['']);
+
+    expect(singleTurn).toBeGreaterThan(0);
+    // Each additional CJK-heavy turn must count for at least a few tokens.
+    expect(doubleTurn).toBeGreaterThan(singleTurn + 5);
+    // Sanity: the CJK payload must beat the empty-string baseline by a
+    // comfortable margin — anything under 10 would mean CJK is effectively
+    // invisible to the estimator.
+    expect(singleTurn).toBeGreaterThan(emptyBaseline + 10);
+  });
+
+  it('reuses the encoder across calls so successive estimates stay cheap', () => {
+    // No direct hook into the encoder; we assert behaviour by running a
+    // batch of calls and verifying the total wall time is well below the
+    // 1-MB-vocab load cost (~100ms in practice). 200 calls × 5ms would be
+    // the worst-case cold fetch.
+    const start = Date.now();
+    for (let i = 0; i < 200; i++) {
+      estimateTokens([{ role: 'user', content: 'x' }]);
+    }
+    const elapsed = Date.now() - start;
+    // Very loose bound — this is defending against accidental re-loading,
+    // not asserting a performance SLO.
+    expect(elapsed).toBeLessThan(2000);
+  });
+});

--- a/packages/backend/src/routing/proxy/token-estimate.ts
+++ b/packages/backend/src/routing/proxy/token-estimate.ts
@@ -1,0 +1,58 @@
+/**
+ * Token estimation for routing decisions.
+ *
+ * Used by the pre-call size check in ResolveService to skip tier models
+ * whose context window can't fit the incoming request. Accuracy matters
+ * less than direction: under-counting means overflow, over-counting means
+ * an unnecessary escalation to a larger model. We bias toward the latter
+ * via a safety multiplier because a few cents > a failed request.
+ *
+ * We use js-tiktoken's `cl100k_base` encoder as a universal estimator.
+ * It isn't perfect for Claude/Gemini/Qwen (each provider has its own BPE)
+ * but it's consistently better than char-based heuristics on code- and
+ * JSON-heavy payloads, which is where OpenClaw / Hermes / tool-use
+ * requests live. Per-model tokenizers are a future upgrade if we see
+ * wrong routing decisions in the field.
+ */
+
+import { getEncoding, type Tiktoken } from 'js-tiktoken';
+
+/**
+ * Safety margin on the estimate. A 1.1× multiplier means we treat a
+ * 100K-estimated request as 110K when deciding fit. Picked deliberately:
+ * - cl100k_base under-counts Chinese / Japanese by ~15%
+ * - JSON-heavy tool definitions vary ±10% between encoders
+ * This absorbs both without making every request escalate.
+ */
+export const TOKEN_ESTIMATE_SAFETY_MULTIPLIER = 1.1;
+
+let encoderSingleton: Tiktoken | null = null;
+
+function getEncoder(): Tiktoken {
+  if (!encoderSingleton) {
+    encoderSingleton = getEncoding('cl100k_base');
+  }
+  return encoderSingleton;
+}
+
+/**
+ * Estimate the token count of a chat-completions request payload.
+ *
+ * The estimator is intentionally simple: we serialize both messages and
+ * tool definitions to JSON and tokenize the concatenation. This slightly
+ * over-counts (JSON quotes/braces add tokens that don't exist in the
+ * provider's internal representation) which is fine — see the safety
+ * multiplier above.
+ *
+ * Empty input returns 0, not `NaN` or a minimum floor — callers rely on
+ * this to skip the size check for heartbeats.
+ */
+export function estimateTokens(messages: unknown, tools?: unknown): number {
+  const messagesPart = messages ? JSON.stringify(messages) : '';
+  const toolsPart = tools ? JSON.stringify(tools) : '';
+  if (!messagesPart && !toolsPart) return 0;
+
+  const encoder = getEncoder();
+  const raw = encoder.encode(messagesPart + toolsPart).length;
+  return Math.ceil(raw * TOKEN_ESTIMATE_SAFETY_MULTIPLIER);
+}

--- a/packages/backend/src/routing/proxy/token-estimate.ts
+++ b/packages/backend/src/routing/proxy/token-estimate.ts
@@ -18,13 +18,18 @@
 import { getEncoding, type Tiktoken } from 'js-tiktoken';
 
 /**
- * Safety margin on the estimate. A 1.1× multiplier means we treat a
- * 100K-estimated request as 110K when deciding fit. Picked deliberately:
- * - cl100k_base under-counts Chinese / Japanese by ~15%
- * - JSON-heavy tool definitions vary ±10% between encoders
- * This absorbs both without making every request escalate.
+ * Safety margin on the estimate. A 1.2× multiplier means we treat a
+ * 100K-estimated request as 120K when deciding fit. Picked deliberately:
+ * - cl100k_base under-counts Chinese / Japanese by ~15% in published
+ *   benchmarks — anything below 1.15 would let those requests slip past
+ *   the fit check and overflow the routed model.
+ * - JSON-heavy tool definitions vary ±10% between encoders.
+ * Rounded up to 1.2 so a single buffer covers both the CJK worst-case
+ * and a little headroom for provider-specific tokenizer differences.
+ * The cost of an unnecessary escalation is a few cents; the cost of an
+ * overflow is a failed request.
  */
-export const TOKEN_ESTIMATE_SAFETY_MULTIPLIER = 1.1;
+export const TOKEN_ESTIMATE_SAFETY_MULTIPLIER = 1.2;
 
 let encoderSingleton: Tiktoken | null = null;
 

--- a/packages/backend/src/routing/resolve/context-fit.spec.ts
+++ b/packages/backend/src/routing/resolve/context-fit.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * The whole purpose of this helper is to keep the filter-and-escalate
+ * rules out of ResolveService so they can be exhaustively tested as pure
+ * logic. Each test here maps to a real failure mode from #1617 / #1612.
+ */
+import {
+  findFittingCandidate,
+  DEFAULT_RESERVED_OUTPUT_TOKENS,
+  type FitCandidate,
+} from './context-fit';
+
+function c(model: string, contextWindow: number): FitCandidate {
+  return { model, contextWindow };
+}
+
+describe('findFittingCandidate', () => {
+  it('returns the first candidate when it fits', () => {
+    // Preserves cost preference: primary model wins if it can handle the
+    // request, same as today. No regression for the common-size case.
+    const result = findFittingCandidate(
+      [c('gpt-4o-mini', 128_000), c('claude-opus-4-6', 200_000)],
+      50_000,
+    );
+    expect(result?.model).toBe('gpt-4o-mini');
+  });
+
+  it('skips too-small candidates and picks the next one that fits', () => {
+    // The bug class fuzhyperblue reported: primary is 128K, request is
+    // 150K, fallback is 200K. We must pick the fallback, not the primary.
+    const result = findFittingCandidate(
+      [c('gpt-4o-mini', 128_000), c('claude-opus-4-6', 200_000)],
+      150_000,
+    );
+    expect(result?.model).toBe('claude-opus-4-6');
+  });
+
+  it('returns null when nothing fits — caller will escalate or 413', () => {
+    // Nothing can accept a 500K request with a 128K-reserved budget.
+    const result = findFittingCandidate([c('gpt-4o-mini', 128_000)], 500_000);
+    expect(result).toBeNull();
+  });
+
+  it('subtracts the output reserve from each candidate', () => {
+    // 120K estimated + 4K reserved = 124K. A 128K model fits with 4K to
+    // spare; drop the reserve to 10K and it no longer fits.
+    const candidates = [c('gpt-4o-mini', 128_000)];
+    expect(findFittingCandidate(candidates, 120_000, 4_096)?.model).toBe('gpt-4o-mini');
+    expect(findFittingCandidate(candidates, 120_000, 10_000)).toBeNull();
+  });
+
+  it('uses a default output reserve when none is supplied', () => {
+    // Callers outside the proxy (tests, future REPL tooling) get a safe
+    // default instead of zero, so 0-arity calls never accidentally pass
+    // oversized payloads through.
+    expect(DEFAULT_RESERVED_OUTPUT_TOKENS).toBeGreaterThan(0);
+    const result = findFittingCandidate([c('gpt-4o-mini', 128_000)], 128_000);
+    // 128000 + 4096 > 128000, so we should not fit.
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an empty candidate list', () => {
+    // Agent with no routable models — upstream code must handle this, but
+    // the helper should never crash on the empty case.
+    expect(findFittingCandidate([], 10_000)).toBeNull();
+  });
+
+  it('respects caller cost order when multiple candidates fit — both 128K and 200K can handle a 50K request, pick the cheaper one (#1617)', () => {
+    // Invariant anchor: users expect Manifest to pick the cheapest model that
+    // fits, not the largest. If the helper ever starts sorting by context
+    // window (largest-first) this breaks the cost guarantee in the router's
+    // pitch ("cheapest model that can handle it"). Request fits both, the
+    // 128K primary wins because it appears first in the cost-ordered list.
+    const result = findFittingCandidate(
+      [c('gpt-4o-mini', 128_000), c('claude-opus-4-6', 200_000)],
+      50_000,
+    );
+    expect(result?.model).toBe('gpt-4o-mini');
+    expect(result?.contextWindow).toBe(128_000);
+  });
+});

--- a/packages/backend/src/routing/resolve/context-fit.ts
+++ b/packages/backend/src/routing/resolve/context-fit.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helpers for picking the first tier candidate whose context window
+ * can fit the incoming request. Kept separate from ResolveService so the
+ * filter-and-escalate algorithm is independently testable without having
+ * to stub the entire resolution pipeline.
+ */
+
+export interface FitCandidate {
+  model: string;
+  contextWindow: number;
+}
+
+/**
+ * Default output budget reserved from the context window when the caller
+ * didn't specify `max_tokens`. Enough for the typical assistant reply,
+ * small enough that long-history requests still fit common 128K models.
+ */
+export const DEFAULT_RESERVED_OUTPUT_TOKENS = 4096;
+
+/**
+ * Returns the first candidate whose `contextWindow` is at least
+ * `estimatedTokens + reservedOutput`. Preserves input order so the
+ * caller's cost preference (primary first, then fallbacks) is respected.
+ *
+ * Returns `null` when no candidate fits — caller should escalate to the
+ * next tier or surface a structured "context_window_exceeded" error.
+ */
+export function findFittingCandidate(
+  candidates: readonly FitCandidate[],
+  estimatedTokens: number,
+  reservedOutput: number = DEFAULT_RESERVED_OUTPUT_TOKENS,
+): FitCandidate | null {
+  const required = estimatedTokens + reservedOutput;
+  for (const candidate of candidates) {
+    if (candidate.contextWindow >= required) return candidate;
+  }
+  return null;
+}

--- a/packages/backend/src/routing/resolve/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.spec.ts
@@ -861,6 +861,47 @@ describe('ResolveService', () => {
       expect(getModelsForAgent).toHaveBeenCalledTimes(1);
     });
 
+    it('falls through to auto_assigned_model when override_model is stale (#1678 cubic P1)', async () => {
+      // Before this fix, a tier whose `override_model` pointed at a
+      // model that isn't in the discovery cache (e.g. the provider got
+      // disconnected after the override was pinned) would contribute
+      // zero candidates to the size-aware walk, even though the
+      // auto-assigned model is perfectly serviceable. That matches how
+      // ProviderKeyService.getEffectiveModel resilience works — we must
+      // not regress it.
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'standard',
+            override_model: 'stale-override',
+            auto_assigned_model: 'gpt-4o-mini',
+            override_provider: null,
+            override_auth_type: null,
+            fallback_models: null,
+          },
+        ],
+        // Only the auto-assigned model exists in discovery.
+        getModelsForAgent: jest.fn().mockResolvedValue([discoveredModel('gpt-4o-mini', 128_000)]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      // Stale override was silently skipped; the auto-assigned model
+      // carried the request instead of the tier being dropped entirely.
+      expect(out.model).toBe('gpt-4o-mini');
+    });
+
     it('skips discovered models with a non-positive contextWindow — misconfigured providers', async () => {
       // Defensive: a provider whose cached_models row has contextWindow=0
       // should be treated as invisible, not as a model that "fits anything

--- a/packages/backend/src/routing/resolve/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.spec.ts
@@ -22,6 +22,7 @@ function makeService(overrides: {
   isModelAvailable?: jest.Mock;
   activeSpecificity?: unknown[];
   getModelForAgent?: jest.Mock;
+  getModelsForAgent?: jest.Mock;
   getByModel?: jest.Mock;
 }) {
   const tierService: TierService = {
@@ -41,6 +42,7 @@ function makeService(overrides: {
 
   const discoveryService: ModelDiscoveryService = {
     getModelForAgent: overrides.getModelForAgent ?? jest.fn().mockResolvedValue(null),
+    getModelsForAgent: overrides.getModelsForAgent ?? jest.fn().mockResolvedValue([]),
   } as unknown as ModelDiscoveryService;
 
   const pricingCache: ModelPricingCacheService = {
@@ -587,6 +589,369 @@ describe('ResolveService', () => {
       expect(out.model).toBe('openai/gpt-5-mini');
       expect(out.provider).toBe('openai');
       expect(out.auth_type).toBe('api_key');
+    });
+  });
+
+  /**
+   * Phase 2 — size-aware resolution. The scored tier might contain models
+   * too small for the incoming request; we filter by context window,
+   * escalate one tier up if nothing in the scored tier fits, and return a
+   * structured `context_window_exceeded` response when no tier can
+   * handle the payload. See #1617 / #1612 / #1450.
+   */
+  describe('size-aware resolution', () => {
+    const tierWith = (tier: string, primary: string, fallbacks: string[] = []) => ({
+      tier,
+      override_model: null,
+      auto_assigned_model: primary,
+      override_provider: null,
+      override_auth_type: null,
+      fallback_models: fallbacks.length > 0 ? fallbacks : null,
+    });
+    const discoveredModel = (id: string, contextWindow: number) => ({
+      id,
+      displayName: id,
+      provider: 'openai',
+      contextWindow,
+      inputPricePerToken: 0,
+      outputPricePerToken: 0,
+      capabilityReasoning: false,
+      capabilityCode: true,
+      qualityScore: 3,
+    });
+
+    beforeEach(() => {
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'standard',
+        confidence: 0.8,
+        score: 20,
+        reason: 'scored',
+      });
+      scoring.scanMessages.mockReturnValue(null);
+    });
+
+    it('keeps the scored-tier primary when it fits — the happy path for normal-size requests', async () => {
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'gpt-4o-mini', ['claude-opus-4-6'])],
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            discoveredModel('gpt-4o-mini', 128_000),
+            discoveredModel('claude-opus-4-6', 200_000),
+          ]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      expect(out.model).toBe('gpt-4o-mini');
+      expect(out.tier).toBe('standard');
+      expect(out.reason).toBe('scored');
+      expect(out.size_escalated_from).toBeUndefined();
+      expect(out.estimated_tokens).toBe(50_000);
+      expect(out.used_context_window).toBe(128_000);
+    });
+
+    it('skips a too-small primary and picks the fallback within the same tier — #1617 fuzhyperblue', async () => {
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'gpt-4o-mini', ['claude-opus-4-6'])],
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            discoveredModel('gpt-4o-mini', 128_000),
+            discoveredModel('claude-opus-4-6', 200_000),
+          ]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'big' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        150_000,
+      );
+
+      expect(out.model).toBe('claude-opus-4-6');
+      expect(out.tier).toBe('standard'); // same tier, just walked the fallback chain
+      expect(out.used_context_window).toBe(200_000);
+    });
+
+    it('escalates to the next tier when no model in the scored tier fits', async () => {
+      const { svc } = makeService({
+        tiers: [
+          tierWith('standard', 'gpt-4o-mini'),
+          tierWith('complex', 'claude-opus-4-6'),
+          tierWith('reasoning', 'gemini-pro'),
+        ],
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            discoveredModel('gpt-4o-mini', 128_000),
+            discoveredModel('claude-opus-4-6', 200_000),
+            discoveredModel('gemini-pro', 1_000_000),
+          ]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'huge' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        150_000,
+      );
+
+      expect(out.model).toBe('claude-opus-4-6');
+      expect(out.tier).toBe('complex');
+      expect(out.size_escalated_from).toBe('standard');
+      expect(out.reason).toBe('size_escalated');
+    });
+
+    it('honours body.max_tokens as the reserved output when present', async () => {
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'gpt-4o-mini', ['claude-opus-4-6'])],
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            discoveredModel('gpt-4o-mini', 128_000),
+            discoveredModel('claude-opus-4-6', 200_000),
+          ]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      // 120K estimated + 10K max_tokens = 130K needed. 128K primary should
+      // be skipped, 200K fallback chosen.
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        10_000,
+        undefined,
+        undefined,
+        undefined,
+        120_000,
+      );
+      expect(out.model).toBe('claude-opus-4-6');
+    });
+
+    it('returns a context_window_exceeded response when no tier anywhere fits', async () => {
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'gpt-4o-mini'), tierWith('complex', 'claude-opus-4-6')],
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            discoveredModel('gpt-4o-mini', 128_000),
+            discoveredModel('claude-opus-4-6', 200_000),
+          ]),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'gigantic' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        1_000_000,
+      );
+
+      expect(out.reason).toBe('context_window_exceeded');
+      expect(out.model).toBeNull();
+      expect(out.largest_available_context).toBe(200_000);
+      expect(out.estimated_tokens).toBe(1_000_000);
+    });
+
+    it('falls back to legacy scored-tier behaviour when estimatedTokens is 0 (heartbeat / unknown)', async () => {
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'gpt-4o-mini')],
+        getEffectiveModel: jest.fn().mockResolvedValue('gpt-4o-mini'),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        0,
+      );
+
+      expect(out.model).toBe('gpt-4o-mini');
+      expect(out.estimated_tokens).toBeUndefined();
+      expect(out.used_context_window).toBeUndefined();
+    });
+
+    it('ignores models discovery does not know about — they would fail at the provider anyway', async () => {
+      // The tier points at 'ghost-model'. Discovery returns no entry for
+      // it, so we pretend it doesn't exist and fall through to the next
+      // candidate. Protects against stale tier assignments referring to
+      // disconnected providers.
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'ghost-model', ['gpt-4o-mini'])],
+        getModelsForAgent: jest.fn().mockResolvedValue([discoveredModel('gpt-4o-mini', 128_000)]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      expect(out.model).toBe('gpt-4o-mini');
+    });
+
+    it('dedupes a model that appears as both primary and a fallback in the same tier', async () => {
+      // Uncommon but legal tier config: primary and the first fallback
+      // reference the same model id. Walking the candidates with a Set
+      // keeps us from probing the same model twice.
+      const getModelsForAgent = jest
+        .fn()
+        .mockResolvedValue([discoveredModel('gpt-4o-mini', 128_000)]);
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'gpt-4o-mini', ['gpt-4o-mini'])],
+        getModelsForAgent,
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      expect(getModelsForAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips discovered models with a non-positive contextWindow — misconfigured providers', async () => {
+      // Defensive: a provider whose cached_models row has contextWindow=0
+      // should be treated as invisible, not as a model that "fits anything
+      // under 0 tokens". Exercises the <= 0 guard in buildFitCandidates.
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'broken', ['gpt-4o-mini'])],
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([
+            discoveredModel('broken', 0),
+            discoveredModel('gpt-4o-mini', 128_000),
+          ]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      // broken was filtered out, so we fell through to the fallback.
+      expect(out.model).toBe('gpt-4o-mini');
+    });
+
+    it('preserves the scorer reason (not size_escalated) when the scored-tier primary fits — defends #1617 RFC wording', async () => {
+      // Easy-to-regress invariant: the final `reason` literal on a happy-path
+      // fit must be whatever the scorer returned (e.g. 'tool_detected',
+      // 'scored'), NEVER 'size_escalated'. A refactor that rewrites the
+      // `escalated ? REASON_SIZE_ESCALATED : scored.reason` ternary into an
+      // unconditional REASON_SIZE_ESCALATED would silently make every
+      // size-aware response claim it was escalated — confusing for anyone
+      // analysing the reason column in agent_messages later.
+      scoring.scoreRequest.mockReturnValue({
+        tier: 'standard',
+        confidence: 0.9,
+        score: 30,
+        reason: 'tool_detected',
+      });
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'gpt-4o-mini')],
+        getModelsForAgent: jest.fn().mockResolvedValue([discoveredModel('gpt-4o-mini', 128_000)]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        10_000,
+      );
+
+      expect(out.reason).toBe('tool_detected');
+      expect(out.reason).not.toBe('size_escalated');
+      expect(out.size_escalated_from).toBeUndefined();
+    });
+
+    it('reports largest_available=0 when no model is discovered at all', async () => {
+      // Pathological but reachable state: tier assignment exists but
+      // discovery is empty. We still want a sane number in the error body
+      // instead of `undefined` or `-Infinity`.
+      const { svc } = makeService({
+        tiers: [tierWith('standard', 'ghost-model')],
+        getModelsForAgent: jest.fn().mockResolvedValue([]),
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      expect(out.reason).toBe('context_window_exceeded');
+      expect(out.largest_available_context).toBe(0);
     });
   });
 });

--- a/packages/backend/src/routing/resolve/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.spec.ts
@@ -902,6 +902,100 @@ describe('ResolveService', () => {
       expect(out.model).toBe('gpt-4o-mini');
     });
 
+    it('does not inherit override_auth_type when the chosen model is not the override_model (#1678 cubic P1)', async () => {
+      // Credentials-leak guard: user pinned an OpenAI `subscription`
+      // model as the override. It went stale. We fell through to the
+      // auto-assigned Anthropic model. Previously the override's
+      // `subscription` auth_type would still be applied, making us
+      // reach for OpenAI-shaped subscription auth on an Anthropic
+      // model. Fix: override_auth_type only applies when the chosen
+      // model IS the override_model.
+      const getAuthType = jest.fn().mockResolvedValue('api_key');
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'standard',
+            override_model: 'openai/stale-override',
+            override_provider: 'openai',
+            override_auth_type: 'subscription',
+            auto_assigned_model: 'anthropic/claude-opus-4-6',
+            fallback_models: null,
+          },
+        ],
+        // Override not in discovery — stale. Only the auto-assigned
+        // model is actually routable. Slash-prefixed names so
+        // inferProviderFromModelName returns 'anthropic' / 'openai'.
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([discoveredModel('anthropic/claude-opus-4-6', 200_000)]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+        getAuthType,
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      // The auto-assigned Anthropic model took the request — its auth
+      // type came from getAuthType for Anthropic (`api_key`), NOT from
+      // the override's `subscription` value.
+      expect(out.model).toBe('anthropic/claude-opus-4-6');
+      expect(out.provider).toBe('anthropic');
+      expect(out.auth_type).toBe('api_key');
+      // Explicit proof that we consulted getAuthType rather than
+      // inheriting the pinned override_auth_type.
+      expect(getAuthType).toHaveBeenCalledWith('agent-1', 'anthropic');
+    });
+
+    it('preserves override_auth_type when the override_model is the one actually used', async () => {
+      // Positive control for the previous test: when the override model
+      // IS serviceable, its pinned auth type must still be honoured —
+      // otherwise we've broken a legitimate user-configured path.
+      const getAuthType = jest.fn().mockResolvedValue('api_key');
+      const { svc } = makeService({
+        tiers: [
+          {
+            tier: 'standard',
+            override_model: 'openai/gpt-4o-mini',
+            override_provider: 'openai',
+            override_auth_type: 'subscription',
+            auto_assigned_model: null,
+            fallback_models: null,
+          },
+        ],
+        getModelsForAgent: jest
+          .fn()
+          .mockResolvedValue([discoveredModel('openai/gpt-4o-mini', 128_000)]),
+        hasActiveProvider: jest.fn().mockResolvedValue(true),
+        getAuthType,
+      });
+
+      const out = await svc.resolve(
+        'agent-1',
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        50_000,
+      );
+
+      expect(out.model).toBe('openai/gpt-4o-mini');
+      expect(out.auth_type).toBe('subscription');
+      // getAuthType wasn't called — we used the pinned override_auth_type.
+      expect(getAuthType).not.toHaveBeenCalled();
+    });
+
     it('skips discovered models with a non-positive contextWindow — misconfigured providers', async () => {
       // Defensive: a provider whose cached_models row has contextWindow=0
       // should be treated as invisible, not as a model that "fits anything

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -241,9 +241,15 @@ export class ResolveService {
     assignment: TierAssignment,
     contextByModel: Map<string, number>,
   ): FitCandidate[] {
+    // Push override first (user intent wins), then auto-assigned as a live
+    // fallback for when the override is stale / points at a disconnected
+    // provider, then the configured fallback chain. Matches the resilience
+    // of `ProviderKeyService.getEffectiveModel` — without this, a stale
+    // override_model would eliminate the tier from the size-aware walk
+    // even when the auto-assigned model is perfectly serviceable.
     const ordered: string[] = [];
-    const primary = assignment.override_model ?? assignment.auto_assigned_model;
-    if (primary) ordered.push(primary);
+    if (assignment.override_model) ordered.push(assignment.override_model);
+    if (assignment.auto_assigned_model) ordered.push(assignment.auto_assigned_model);
     if (assignment.fallback_models) ordered.push(...assignment.fallback_models);
 
     const seen = new Set<string>();

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -272,9 +272,17 @@ export class ResolveService {
 
   /**
    * Shared helper for the two success paths in this service: look up the
-   * provider for a chosen model, then resolve the auth type (honouring a
-   * per-tier override). Identical logic across both paths by design — the
-   * only variance is which model gets passed in.
+   * provider for a chosen model, then resolve the auth type. Identical
+   * logic across both paths by design — the only variance is which model
+   * gets passed in.
+   *
+   * `override_auth_type` is applied **only** when the chosen model is the
+   * override_model itself. When we fell through to the auto-assigned
+   * model or a fallback (because the override was stale), inheriting the
+   * override's auth type would leak credentials to a different provider
+   * — e.g. the user pinned an OpenAI subscription model, it went stale,
+   * we fell through to a Claude model, and we'd reach for OpenAI
+   * subscription auth on an Anthropic model.
    */
   private async resolveProviderAndAuth(
     agentId: string,
@@ -282,10 +290,14 @@ export class ResolveService {
     model: string,
   ): Promise<{ provider: string | null; authType: AuthType | undefined }> {
     const provider = await this.resolveProvider(agentId, assignment, model);
-    const authType = provider
-      ? ((assignment.override_auth_type as AuthType | null) ??
-        (await this.providerKeyService.getAuthType(agentId, provider)))
-      : undefined;
+    if (!provider) return { provider: null, authType: undefined };
+
+    const isOverrideModel = assignment.override_model === model;
+    const pinnedAuthType = isOverrideModel
+      ? (assignment.override_auth_type as AuthType | null)
+      : null;
+    const authType =
+      pinnedAuthType ?? (await this.providerKeyService.getAuthType(agentId, provider));
     return { provider, authType };
   }
 

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -6,10 +6,33 @@ import { SpecificityPenaltyService } from '../routing-core/specificity-penalty.s
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { scoreRequest, ScorerInput, MomentumInput, scanMessages } from '../../scoring';
-import { Tier } from '../../scoring/types';
-import { ResolveResponse } from '../dto/resolve-response';
+import { Tier, TIERS } from '../../scoring/types';
+import {
+  ResolveResponse,
+  ResolveReason,
+  AuthType,
+  REASON_SIZE_ESCALATED,
+  REASON_CONTEXT_WINDOW_EXCEEDED,
+} from '../dto/resolve-response';
 import { inferProviderFromModelName } from '../../common/utils/provider-aliases';
+import { findFittingCandidate, FitCandidate, DEFAULT_RESERVED_OUTPUT_TOKENS } from './context-fit';
+import { TierAssignment } from '../../entities/tier-assignment.entity';
 import type { SpecificityCategory } from 'manifest-shared';
+
+/** Outcome of the score step that gets handed to the resolution helpers. */
+interface ScoredResult {
+  tier: Tier;
+  confidence: number;
+  score: number;
+  reason: ResolveReason;
+}
+
+/** A concrete tier + model pick from the size-aware walk. */
+interface TierPick {
+  tier: Tier;
+  assignment: TierAssignment;
+  fit: FitCandidate;
+}
 
 /**
  * When specificity detection is below this confidence, skip specificity
@@ -36,6 +59,13 @@ export class ResolveService {
     private readonly penaltyService: SpecificityPenaltyService,
   ) {}
 
+  /**
+   * @param estimatedTokens  When `>0`, the resolver runs the Phase 2
+   *   size-aware walk (filter tier candidates by context window, escalate
+   *   if nothing fits). When 0 or undefined, the legacy scored-tier pick
+   *   is used — used by heartbeat traffic and any caller that doesn't
+   *   need size-awareness (e.g. the /resolve REST endpoint).
+   */
   async resolve(
     agentId: string,
     messages: ScorerInput['messages'],
@@ -45,6 +75,7 @@ export class ResolveService {
     recentTiers?: MomentumInput['recentTiers'],
     specificityOverride?: string,
     recentCategories?: readonly SpecificityCategory[],
+    estimatedTokens?: number,
   ): Promise<ResolveResponse> {
     const specificityResult = await this.resolveSpecificity(
       agentId,
@@ -59,57 +90,207 @@ export class ResolveService {
     const momentum: MomentumInput | undefined =
       recentTiers && recentTiers.length > 0 ? { recentTiers } : undefined;
 
-    const result = scoreRequest(input, undefined, momentum);
-
+    const scored: ScoredResult = scoreRequest(input, undefined, momentum);
     const tiers = await this.tierService.getTiers(agentId);
-    const assignment = tiers.find((t) => t.tier === result.tier);
 
+    if (estimatedTokens !== undefined && estimatedTokens > 0) {
+      return this.resolveWithSizeCheck(agentId, tiers, scored, estimatedTokens, maxTokens);
+    }
+
+    return this.resolveForScoredTier(agentId, tiers, scored);
+  }
+
+  private async resolveForScoredTier(
+    agentId: string,
+    tiers: TierAssignment[],
+    scored: ScoredResult,
+  ): Promise<ResolveResponse> {
+    const assignment = tiers.find((t) => t.tier === scored.tier);
     if (!assignment) {
       this.logger.warn(
-        `No tier assignment found for agent=${agentId} tier=${result.tier} ` +
+        `No tier assignment found for agent=${agentId} tier=${scored.tier} ` +
           `(available tiers: ${tiers.map((t) => t.tier).join(', ') || 'none'})`,
       );
-      return {
-        tier: result.tier,
-        model: null,
-        provider: null,
-        confidence: result.confidence,
-        score: result.score,
-        reason: result.reason,
-      };
+      return this.emptyResponse(scored);
     }
 
     const model = await this.providerKeyService.getEffectiveModel(agentId, assignment);
-
     if (!model) {
       this.logger.warn(
-        `getEffectiveModel returned null for agent=${agentId} tier=${result.tier} ` +
+        `getEffectiveModel returned null for agent=${agentId} tier=${scored.tier} ` +
           `override=${assignment.override_model} auto=${assignment.auto_assigned_model}`,
       );
+      return this.emptyResponse(scored);
+    }
+
+    const { provider, authType } = await this.resolveProviderAndAuth(agentId, assignment, model);
+
+    return {
+      tier: scored.tier,
+      model,
+      provider,
+      confidence: scored.confidence,
+      score: scored.score,
+      reason: scored.reason,
+      auth_type: authType,
+    };
+  }
+
+  /**
+   * Size-aware variant — walks scored tier → higher tiers, picks the first
+   * model that fits, falls back to a `context_window_exceeded` response if
+   * nothing in any tier fits. Never silently routes to a too-small model
+   * (see #1617). Delegates the "which tier?" logic to `pickFittingTier` so
+   * this method just orchestrates the happy/sad branches.
+   */
+  private async resolveWithSizeCheck(
+    agentId: string,
+    tiers: TierAssignment[],
+    scored: ScoredResult,
+    estimatedTokens: number,
+    maxTokens: number | undefined,
+  ): Promise<ResolveResponse> {
+    const reservedOutput = maxTokens && maxTokens > 0 ? maxTokens : DEFAULT_RESERVED_OUTPUT_TOKENS;
+    const discovered = await this.discoveryService.getModelsForAgent(agentId);
+    const contextByModel = new Map(discovered.map((m) => [m.id, m.contextWindow]));
+    const walk = this.pickFittingTier(
+      tiers,
+      scored.tier,
+      contextByModel,
+      estimatedTokens,
+      reservedOutput,
+    );
+
+    if (!walk.pick) {
+      this.logger.warn(
+        `context_window_exceeded agent=${agentId} estimated=${estimatedTokens} ` +
+          `reserved=${reservedOutput} largest=${walk.largestSeen}`,
+      );
       return {
-        tier: result.tier,
+        tier: scored.tier,
         model: null,
         provider: null,
-        confidence: result.confidence,
-        score: result.score,
-        reason: result.reason,
+        confidence: scored.confidence,
+        score: scored.score,
+        reason: REASON_CONTEXT_WINDOW_EXCEEDED,
+        estimated_tokens: estimatedTokens,
+        reserved_output_tokens: reservedOutput,
+        largest_available_context: walk.largestSeen,
       };
     }
 
-    const provider = await this.resolveProvider(agentId, assignment, model);
-    const authType = provider
-      ? (assignment.override_auth_type ??
-        (await this.providerKeyService.getAuthType(agentId, provider)))
-      : undefined;
+    const { tier, assignment, fit } = walk.pick;
+    const { provider, authType } = await this.resolveProviderAndAuth(
+      agentId,
+      assignment,
+      fit.model,
+    );
+    const escalated = tier !== scored.tier;
 
     return {
-      tier: result.tier,
-      model,
+      tier,
+      model: fit.model,
       provider,
-      confidence: result.confidence,
-      score: result.score,
-      reason: result.reason,
+      confidence: scored.confidence,
+      score: scored.score,
+      reason: escalated ? REASON_SIZE_ESCALATED : scored.reason,
       auth_type: authType,
+      estimated_tokens: estimatedTokens,
+      used_context_window: fit.contextWindow,
+      size_escalated_from: escalated ? scored.tier : undefined,
+    };
+  }
+
+  /**
+   * Walks the tiers from the scored tier upward and returns the first
+   * tier whose candidates contain a model that fits. Also returns the
+   * largest context window seen across all walked tiers so the caller
+   * can build a useful `context_window_exceeded` error when nothing fits.
+   */
+  private pickFittingTier(
+    tiers: TierAssignment[],
+    scoredTier: Tier,
+    contextByModel: Map<string, number>,
+    estimatedTokens: number,
+    reservedOutput: number,
+  ): { pick: TierPick | null; largestSeen: number } {
+    // Cheapest fitting tier wins — walk upward from the scored tier.
+    const scoredIndex = TIERS.indexOf(scoredTier);
+    let largestSeen = 0;
+    let pick: TierPick | null = null;
+
+    for (let i = scoredIndex; i < TIERS.length; i++) {
+      const tier = TIERS[i]!;
+      const assignment = tiers.find((t) => t.tier === tier);
+      if (!assignment) continue;
+
+      const candidates = this.buildFitCandidates(assignment, contextByModel);
+      for (const { contextWindow } of candidates) {
+        if (contextWindow > largestSeen) largestSeen = contextWindow;
+      }
+
+      if (pick) continue;
+      const fit = findFittingCandidate(candidates, estimatedTokens, reservedOutput);
+      if (fit) pick = { tier, assignment, fit };
+    }
+
+    return { pick, largestSeen };
+  }
+
+  private buildFitCandidates(
+    assignment: TierAssignment,
+    contextByModel: Map<string, number>,
+  ): FitCandidate[] {
+    const ordered: string[] = [];
+    const primary = assignment.override_model ?? assignment.auto_assigned_model;
+    if (primary) ordered.push(primary);
+    if (assignment.fallback_models) ordered.push(...assignment.fallback_models);
+
+    const seen = new Set<string>();
+    const candidates: FitCandidate[] = [];
+    for (const model of ordered) {
+      if (seen.has(model)) continue;
+      seen.add(model);
+      const contextWindow = contextByModel.get(model);
+      if (contextWindow === undefined) continue;
+      if (contextWindow <= 0) {
+        // Misconfigured provider — log once so ops can track down the bad
+        // `cached_models` row instead of silently black-holing the model.
+        this.logger.debug(`Skipping model ${model}: non-positive contextWindow ${contextWindow}`);
+        continue;
+      }
+      candidates.push({ model, contextWindow });
+    }
+    return candidates;
+  }
+
+  /**
+   * Shared helper for the two success paths in this service: look up the
+   * provider for a chosen model, then resolve the auth type (honouring a
+   * per-tier override). Identical logic across both paths by design — the
+   * only variance is which model gets passed in.
+   */
+  private async resolveProviderAndAuth(
+    agentId: string,
+    assignment: Pick<TierAssignment, 'override_model' | 'override_provider' | 'override_auth_type'>,
+    model: string,
+  ): Promise<{ provider: string | null; authType: AuthType | undefined }> {
+    const provider = await this.resolveProvider(agentId, assignment, model);
+    const authType = provider
+      ? ((assignment.override_auth_type as AuthType | null) ??
+        (await this.providerKeyService.getAuthType(agentId, provider)))
+      : undefined;
+    return { provider, authType };
+  }
+
+  private emptyResponse(scored: ScoredResult): ResolveResponse {
+    return {
+      tier: scored.tier,
+      model: null,
+      provider: null,
+      confidence: scored.confidence,
+      score: scored.score,
+      reason: scored.reason,
     };
   }
 

--- a/packages/backend/test/context-advertisement.e2e-spec.ts
+++ b/packages/backend/test/context-advertisement.e2e-spec.ts
@@ -1,0 +1,163 @@
+/**
+ * End-to-end coverage for the Phase 1 "honest context window advertisement"
+ * feature (issues #1617, #1612, #1450). These tests exercise the full
+ * request path — bearer-token auth → ContextAdvertisementService → response
+ * shape — that clients like OpenClaw, OpenAI SDK, LangChain etc. actually
+ * touch when they probe GET /v1/models.
+ */
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import {
+  createTestApp,
+  TEST_AGENT_ID,
+  TEST_API_KEY,
+  TEST_OTLP_KEY,
+} from './helpers';
+import { PricingSyncService } from '../src/database/pricing-sync.service';
+import { ModelPricingCacheService } from '../src/model-prices/model-pricing-cache.service';
+import { TierAutoAssignService } from '../src/routing/routing-core/tier-auto-assign.service';
+import { RoutingCacheService } from '../src/routing/routing-core/routing-cache.service';
+
+let app: INestApplication;
+
+const api = () => request(app.getHttpServer());
+const bearer = (r: request.Test) => r.set('Authorization', `Bearer ${TEST_OTLP_KEY}`);
+
+beforeAll(async () => {
+  app = await createTestApp();
+
+  // Seed the OpenRouter pricing cache with two differently-sized models so
+  // the min() across routed models is observable from the outside.
+  const pricingSync = app.get(PricingSyncService);
+  const orCache = pricingSync.getAll() as Map<
+    string,
+    { input: number; output: number; contextWindow?: number }
+  >;
+  orCache.set('openai/gpt-4o-mini', {
+    input: 0.00000015,
+    output: 0.0000006,
+    contextWindow: 128_000,
+  });
+  orCache.set('anthropic/claude-opus-4-6', {
+    input: 0.000015,
+    output: 0.000075,
+    contextWindow: 200_000,
+  });
+  await app.get(ModelPricingCacheService).reload();
+
+  // Connect openai + anthropic providers and seed discovered models so tier
+  // auto-assign actually has something to route to.
+  await api()
+    .post('/api/v1/routing/test-agent/providers')
+    .set('x-api-key', TEST_API_KEY)
+    .send({ provider: 'openai', apiKey: 'sk-fake-openai' })
+    .expect(201);
+  await api()
+    .post('/api/v1/routing/test-agent/providers')
+    .set('x-api-key', TEST_API_KEY)
+    .send({ provider: 'anthropic', apiKey: 'sk-fake-anthropic' })
+    .expect(201);
+
+  const ds = app.get(DataSource);
+  const openaiModels = JSON.stringify([
+    {
+      id: 'gpt-4o-mini',
+      displayName: 'gpt-4o-mini',
+      provider: 'openai',
+      contextWindow: 128_000,
+      inputPricePerToken: 0.00000015,
+      outputPricePerToken: 0.0000006,
+      capabilityReasoning: false,
+      capabilityCode: true,
+      qualityScore: 2,
+    },
+  ]);
+  const anthropicModels = JSON.stringify([
+    {
+      id: 'claude-opus-4-6',
+      displayName: 'claude-opus-4-6',
+      provider: 'anthropic',
+      contextWindow: 200_000,
+      inputPricePerToken: 0.000015,
+      outputPricePerToken: 0.000075,
+      capabilityReasoning: true,
+      capabilityCode: true,
+      qualityScore: 5,
+    },
+  ]);
+  await ds.query(
+    `UPDATE user_providers SET cached_models = $1 WHERE agent_id = $2 AND provider = $3`,
+    [openaiModels, TEST_AGENT_ID, 'openai'],
+  );
+  await ds.query(
+    `UPDATE user_providers SET cached_models = $1 WHERE agent_id = $2 AND provider = $3`,
+    [anthropicModels, TEST_AGENT_ID, 'anthropic'],
+  );
+
+  // Run tier auto-assign so at least one tier points at each model — this
+  // is what makes both 200K and 128K land in the candidate set.
+  const autoAssign = app.get(TierAutoAssignService);
+  await autoAssign.recalculate(TEST_AGENT_ID);
+}, 30000);
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('GET /v1/models — honest context window advertisement', () => {
+  it('rejects unauthenticated requests with HTTP 401', async () => {
+    // Same guard as /v1/chat/completions — clients that forget the bearer
+    // must not get a stale / default value.
+    const res = await api().get('/v1/models').expect(401);
+    expect(res.body.error.type).toBe('auth_error');
+  });
+
+  it('returns the minimum context window across all tier primaries and fallbacks', async () => {
+    // After auto-assign the tiers include both gpt-4o-mini (128K) and
+    // claude-opus-4-6 (200K). The floor is 128K — that's the invariant
+    // the feature protects.
+    const res = await bearer(api().get('/v1/models')).expect(200);
+
+    expect(res.body.object).toBe('list');
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+
+    const [model] = res.body.data;
+    expect(model.id).toBe('auto');
+    expect(model.object).toBe('model');
+    expect(model.owned_by).toBe('manifest');
+    expect(Number.isInteger(model.context_length)).toBe(true);
+    expect(model.context_length).toBeGreaterThan(0);
+    expect(model.context_length).toBe(128_000);
+    // `created` is a Unix timestamp (seconds). Don't pin the exact number —
+    // just verify the shape clients depend on.
+    expect(typeof model.created).toBe('number');
+    expect(Number.isInteger(model.created)).toBe(true);
+    expect(model.created).toBeGreaterThan(0);
+  });
+
+  it('honours context_floor_override when the user sets one', async () => {
+    // Bypass the DTO/controller so we can pin the column value to something
+    // that wouldn't otherwise be computed (50_000 isn't any model's window).
+    const ds = app.get(DataSource);
+    await ds.query(`UPDATE agents SET context_floor_override = $1 WHERE id = $2`, [
+      50_000,
+      TEST_AGENT_ID,
+    ]);
+    // The advertisement service reads tiers via an in-memory cache — flush
+    // it so the update takes effect immediately.
+    app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
+
+    try {
+      const res = await bearer(api().get('/v1/models')).expect(200);
+
+      expect(res.body.data[0].context_length).toBe(50_000);
+    } finally {
+      await ds.query(`UPDATE agents SET context_floor_override = NULL WHERE id = $1`, [
+        TEST_AGENT_ID,
+      ]);
+      app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
+    }
+  });
+});

--- a/packages/backend/test/context-aware-routing.e2e-spec.ts
+++ b/packages/backend/test/context-aware-routing.e2e-spec.ts
@@ -1,0 +1,341 @@
+/**
+ * Phase 2 end-to-end coverage (issues #1617, #1612, #1450). These tests
+ * exercise the full proxy path — bearer auth → token estimate → size
+ * check → routing — for the three failure modes users reported:
+ *
+ *   1. Normal-size request: the scored-tier primary is used, new context
+ *      headers are emitted.
+ *   2. Oversized request: the scored tier can't fit, so the router
+ *      escalates to a bigger-context tier and forwards there.
+ *   3. Payload bigger than every connected model: user gets the friendly
+ *      "context_window_exceeded" message instead of a silent truncation
+ *      or an opaque provider 400.
+ */
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { createTestApp, TEST_AGENT_ID, TEST_API_KEY, TEST_OTLP_KEY } from './helpers';
+import { PricingSyncService } from '../src/database/pricing-sync.service';
+import { ModelPricingCacheService } from '../src/model-prices/model-pricing-cache.service';
+import { TierAutoAssignService } from '../src/routing/routing-core/tier-auto-assign.service';
+import { RoutingCacheService } from '../src/routing/routing-core/routing-cache.service';
+
+let app: INestApplication;
+
+const api = () => request(app.getHttpServer());
+const bearer = (r: request.Test) => r.set('Authorization', `Bearer ${TEST_OTLP_KEY}`);
+
+beforeAll(async () => {
+  app = await createTestApp();
+
+  const pricingSync = app.get(PricingSyncService);
+  const orCache = pricingSync.getAll() as Map<
+    string,
+    { input: number; output: number; contextWindow?: number }
+  >;
+  orCache.set('openai/gpt-4o-mini', {
+    input: 0.00000015,
+    output: 0.0000006,
+    contextWindow: 128_000,
+  });
+  orCache.set('anthropic/claude-opus-4-6', {
+    input: 0.000015,
+    output: 0.000075,
+    contextWindow: 200_000,
+  });
+  await app.get(ModelPricingCacheService).reload();
+
+  await api()
+    .post('/api/v1/routing/test-agent/providers')
+    .set('x-api-key', TEST_API_KEY)
+    .send({ provider: 'openai', apiKey: 'sk-fake-openai' })
+    .expect(201);
+  await api()
+    .post('/api/v1/routing/test-agent/providers')
+    .set('x-api-key', TEST_API_KEY)
+    .send({ provider: 'anthropic', apiKey: 'sk-fake-anthropic' })
+    .expect(201);
+
+  const ds = app.get(DataSource);
+  const openaiModels = JSON.stringify([
+    {
+      id: 'gpt-4o-mini',
+      displayName: 'gpt-4o-mini',
+      provider: 'openai',
+      contextWindow: 128_000,
+      inputPricePerToken: 0.00000015,
+      outputPricePerToken: 0.0000006,
+      capabilityReasoning: false,
+      capabilityCode: true,
+      qualityScore: 2,
+    },
+  ]);
+  const anthropicModels = JSON.stringify([
+    {
+      id: 'claude-opus-4-6',
+      displayName: 'claude-opus-4-6',
+      provider: 'anthropic',
+      contextWindow: 200_000,
+      inputPricePerToken: 0.000015,
+      outputPricePerToken: 0.000075,
+      capabilityReasoning: true,
+      capabilityCode: true,
+      qualityScore: 5,
+    },
+  ]);
+  await ds.query(
+    `UPDATE user_providers SET cached_models = $1 WHERE agent_id = $2 AND provider = $3`,
+    [openaiModels, TEST_AGENT_ID, 'openai'],
+  );
+  await ds.query(
+    `UPDATE user_providers SET cached_models = $1 WHERE agent_id = $2 AND provider = $3`,
+    [anthropicModels, TEST_AGENT_ID, 'anthropic'],
+  );
+
+  const autoAssign = app.get(TierAutoAssignService);
+  await autoAssign.recalculate(TEST_AGENT_ID);
+}, 30000);
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('Context-aware routing — Phase 2 (#1617)', () => {
+  it('returns the friendly context_window_exceeded response when nothing fits', async () => {
+    // Trigger the size check via max_tokens instead of payload size — a
+    // huge max_tokens eats every model's context budget and makes the
+    // request unable to fit anywhere, which is the exact class of
+    // failure #1617 reports. Keeps the HTTP body tiny so we don't trip
+    // express.json's limit.
+    const res = await bearer(api().post('/v1/chat/completions'))
+      .set('Accept', 'text/event-stream')
+      .send({
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 5_000_000,
+      })
+      .expect(200);
+
+    const content = res.body.choices[0].message.content;
+    expect(content).toContain('200,000');
+    expect(content).toContain('Manifest');
+    expect(content).not.toContain('no providers are set up yet');
+  });
+
+  it('surfaces the context-exceeded reason to non-chat clients too', async () => {
+    // Without the Accept: text/event-stream header the exception filter
+    // classifies us as a CI/monitor caller. The response body is still a
+    // chat-completion envelope because buildFriendlyResponse keeps the
+    // shape consistent across client types.
+    const res = await bearer(api().post('/v1/chat/completions'))
+      .send({
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 5_000_000,
+      })
+      .expect(200);
+
+    expect(res.body.choices[0].message.content).toContain('200,000');
+  });
+
+  /**
+   * The fix I was asked to defend: before the rewrite, the exceeded
+   * message merged input tokens and the reserved-output budget into a
+   * single "Request needs ~N tokens" number, so when the blocker was
+   * `max_tokens` (e.g. a caller asking for 5M output tokens on a 5-char
+   * prompt), the message read nonsensically — it told users to "shorten
+   * the conversation" with no hint that the real problem was their
+   * max_tokens parameter. This asserts both the input total and the
+   * reserved-output breakdown are present in the body so the message is
+   * actionable. Anchors are "Request needs" + "reserved for output" —
+   * the exact token count depends on the estimator's safety multiplier
+   * and would make the test brittle otherwise.
+   */
+  it('breaks input vs reserved-output in the exceeded message when max_tokens is the blocker', async () => {
+    const res = await bearer(api().post('/v1/chat/completions'))
+      .set('Accept', 'text/event-stream')
+      .send({
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 5_000_000,
+      })
+      .expect(200);
+
+    const content = res.body.choices[0].message.content as string;
+    // Key anchors — the message must break out the components.
+    expect(content).toMatch(/Request needs/);
+    expect(content).toMatch(/reserved for output/);
+    expect(content).toMatch(/input/);
+    // And must include the explicit 5,000,000 reserved-output token count
+    // so the user sees *their* max_tokens number reflected back.
+    expect(content).toContain('5,000,000');
+  });
+});
+
+/**
+ * User-journey regression coverage for the top three issues users opened
+ * against Phase 2 — #1617 (fuzhyperblue, "200K configured, routed to
+ * 128K"), the RFC's cross-tier escalation promise, and the happy-path
+ * signal contract EthanFrostpro asked for. These tests are anchored to
+ * the *reported complaint*, not to implementation lines — they protect
+ * the user-visible behaviour regardless of how the resolver is refactored.
+ *
+ * Upstream provider calls are stubbed with a canned 200 response so
+ * tests stay deterministic and don't depend on network / provider keys.
+ */
+describe('Context-aware routing — user-journey scenarios', () => {
+  const api2 = () => request(app.getHttpServer());
+  const bearer2 = (r: request.Test) => r.set('Authorization', `Bearer ${TEST_OTLP_KEY}`);
+
+  /** Minimal OpenAI-compatible chat completion body for upstream stubs. */
+  const makeCompletionBody = (model: string) =>
+    JSON.stringify({
+      id: 'chatcmpl-stub',
+      object: 'chat.completion',
+      created: 1_700_000_000,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'ok' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+
+  let originalFetch: typeof global.fetch;
+
+  beforeAll(async () => {
+    // Install an upstream stub that returns a canned 200 for any provider
+    // call (OpenAI, Anthropic, Google). OpenRouter pricing calls would
+    // already be served from cache since createTestApp pre-loaded it.
+    originalFetch = global.fetch;
+    global.fetch = (async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ): Promise<Response> => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      // Any provider completion endpoint — return a deterministic 200.
+      if (
+        url.includes('api.openai.com') ||
+        url.includes('api.anthropic.com') ||
+        url.includes('generativelanguage.googleapis.com')
+      ) {
+        return new Response(makeCompletionBody('stubbed'), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  /**
+   * Cleanup: any per-test tier overrides / fallback lists are rolled back
+   * so tests don't pollute one another. We restore the seeded baseline by
+   * resetting overrides + re-running auto-assign.
+   */
+  afterEach(async () => {
+    const ds = app.get(DataSource);
+    await ds.query(
+      `UPDATE tier_assignments SET override_model = NULL, override_provider = NULL,
+         override_auth_type = NULL, fallback_models = NULL WHERE agent_id = $1`,
+      [TEST_AGENT_ID],
+    );
+    app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
+    await app.get(TierAutoAssignService).recalculate(TEST_AGENT_ID);
+    app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
+  });
+
+  it('Hermes user with a 200K fallback keeps the 200K model when the 128K primary is too small (#1617 fuzhyperblue)', async () => {
+    // fuzhyperblue on #1617: "I have the 200K Opus configured as fallback
+    // for standard tier, but Manifest still routed my 150K conversation
+    // to gpt-4o-mini (128K) and it got silently truncated."  After Phase
+    // 2, the resolver must skip the too-small primary and pick the
+    // within-tier fallback; the response must advertise the 200K window
+    // it actually used, and must NOT claim an escalation happened.
+    await api2()
+      .put(`/api/v1/routing/test-agent/tiers/simple/fallbacks`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({ models: ['claude-opus-4-6'] })
+      .expect(200);
+
+    const res = await bearer2(api2().post('/v1/chat/completions'))
+      .send({
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 150_000,
+        stream: false,
+      });
+
+    // Whatever the upstream result, Manifest's routing headers must be
+    // set before we forward. The key assertion is `Context-Used`.
+    expect(res.headers['x-manifest-context-used']).toBe('200000');
+    // Same tier — no escalation header expected.
+    expect(res.headers['x-manifest-context-escalated']).toBeUndefined();
+    // The routed model must be the 200K fallback, not the 128K primary.
+    expect(res.headers['x-manifest-model']).toBe('claude-opus-4-6');
+  });
+
+  it('escalates across tiers with an ASCII-arrow header when no model in the scored tier fits (#1617 RFC)', async () => {
+    // The RFC in #1617 promises: "if the scored tier is simple and the
+    // request is 200K, the router must escalate upward to a tier whose
+    // model can handle it, and the escalation must be visible to the
+    // client via a response header." This test pins standard tier to a
+    // 200K model so that a simple-scored oversized request walks
+    // simple (128K, unfit) → standard (200K, fits).
+    await api2()
+      .put(`/api/v1/routing/test-agent/tiers/standard`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({ model: 'claude-opus-4-6', provider: 'anthropic' })
+      .expect(200);
+
+    const res = await bearer2(api2().post('/v1/chat/completions'))
+      .send({
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 150_000,
+        stream: false,
+      });
+
+    // Escalation header must use ASCII arrow — Unicode → would be
+    // silently stripped by Node's http layer (manually smoked 2026-04-22).
+    expect(res.headers['x-manifest-context-escalated']).toBe('simple->standard');
+    expect(res.headers['x-manifest-context-escalated']).not.toContain('→');
+    expect(res.headers['x-manifest-model']).toBe('claude-opus-4-6');
+    expect(res.headers['x-manifest-tier']).toBe('standard');
+  });
+
+  it('emits Context-Estimated and Context-Used on a happy-path request, without any Escalated header (#1617 EthanFrostpro)', async () => {
+    // EthanFrostpro asked on #1617 for an agent-readable signal so agents
+    // can adapt compaction mid-conversation without a second round trip:
+    // "just give me the model's context window in a response header."
+    // On a normal, within-tier request, Estimated + Used must be set,
+    // and Escalated must be absent (otherwise every client would log
+    // escalations that never happened).
+    const res = await bearer2(api2().post('/v1/chat/completions'))
+      .send({
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+
+    expect(res.headers['x-manifest-context-estimated']).toBeDefined();
+    const estimated = Number(res.headers['x-manifest-context-estimated']);
+    expect(Number.isFinite(estimated)).toBe(true);
+    expect(estimated).toBeGreaterThan(0);
+    expect(estimated).toBeLessThan(1_000); // trivial "hi" must not inflate
+
+    expect(res.headers['x-manifest-context-used']).toBeDefined();
+    const used = Number(res.headers['x-manifest-context-used']);
+    expect(Number.isFinite(used)).toBe(true);
+    expect(used).toBeGreaterThanOrEqual(128_000);
+
+    // Happy path = no escalation. If this leaks, clients log false alarms.
+    expect(res.headers['x-manifest-context-escalated']).toBeUndefined();
+  });
+});

--- a/packages/frontend/src/components/OpenClawSetup.tsx
+++ b/packages/frontend/src/components/OpenClawSetup.tsx
@@ -73,6 +73,13 @@ const OpenClawSetup: Component<Props> = (props) => {
         Register Manifest in your OpenClaw config to route each request to the best provider using
         the model <code class="setup-model-hint__code">manifest/auto</code>
       </p>
+      <p class="setup-step__desc" style="font-size: var(--font-size-sm);">
+        OpenClaw reads the context window from <code>GET /v1/models</code> automatically, so the
+        snippet below intentionally doesn't hardcode <code>contextWindow</code>. If an older
+        Manifest guide told you to paste <code>contextWindow: 2000000</code> or similar, remove that
+        line — it prevents OpenClaw from compacting and will cause requests to overflow smaller
+        routed models.
+      </p>
 
       <div
         class="setup-segment setup-segment--full"

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,6 +1,13 @@
 import { Meta, Title } from '@solidjs/meta';
 import { useLocation, useNavigate, useParams } from '@solidjs/router';
-import { createResource, createSignal, ErrorBoundary, Show, type Component } from 'solid-js';
+import {
+  createEffect,
+  createResource,
+  createSignal,
+  ErrorBoundary,
+  Show,
+  type Component,
+} from 'solid-js';
 import CopyButton from '../components/CopyButton.jsx';
 import ErrorState from '../components/ErrorState.jsx';
 import AgentTypeGrid from '../components/AgentTypeGrid.jsx';
@@ -11,6 +18,7 @@ import {
   deleteAgent,
   getAgentInfo,
   getAgentKey,
+  getContextWindow,
   renameAgent,
   rotateAgentKey,
   updateAgent,
@@ -50,6 +58,51 @@ const Settings: Component = () => {
 
   const [agentInfo, { refetch: refetchInfo }] = createResource(() => agentName(), getAgentInfo);
   const [apiKeyData, { refetch: refetchKey }] = createResource(() => agentName(), getAgentKey);
+  const [contextWindow, { refetch: refetchContext }] = createResource(
+    () => agentName(),
+    getContextWindow,
+  );
+
+  const [ctxMode, setCtxMode] = createSignal<'auto' | 'custom'>('auto');
+  const [ctxValue, setCtxValue] = createSignal('');
+  const [ctxSaving, setCtxSaving] = createSignal(false);
+
+  createEffect(() => {
+    const info = agentInfo();
+    if (!info) return;
+    const override = info.context_floor_override ?? null;
+    if (override === null) {
+      setCtxMode('auto');
+      setCtxValue('');
+    } else {
+      setCtxMode('custom');
+      setCtxValue(String(override));
+    }
+  });
+
+  const handleSaveContext = async () => {
+    setCtxSaving(true);
+    try {
+      let override: number | null = null;
+      if (ctxMode() === 'custom') {
+        const parsed = Number(ctxValue());
+        if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1024) {
+          toast.error('Context window must be an integer of at least 1,024 tokens');
+          setCtxSaving(false);
+          return;
+        }
+        override = parsed;
+      }
+      await updateAgent(agentName(), { context_floor_override: override });
+      await refetchInfo();
+      await refetchContext();
+      toast.success('Context window updated');
+    } catch {
+      /* toast handled by fetchMutate */
+    } finally {
+      setCtxSaving(false);
+    }
+  };
 
   const currentCategory = () => (agentInfo()?.agent_category as AgentCategory) ?? null;
   const currentPlatform = () => (agentInfo()?.agent_platform as AgentPlatform) ?? null;
@@ -215,6 +268,85 @@ const Settings: Component = () => {
               Change
             </button>
           </div>
+        </div>
+      </div>
+
+      {/* -- Context window ----------------------------- */}
+      <h3 class="settings-section__title">Context window</h3>
+      <div class="settings-card">
+        <div class="settings-card__row">
+          <div class="settings-card__label">
+            <span class="settings-card__label-title">Advertised context window</span>
+            <span class="settings-card__label-desc">
+              The <code>context_length</code> your agent sees on <code>GET /v1/models</code>. In{' '}
+              <strong>Auto</strong> mode, Manifest advertises the smallest context among the models
+              this agent can be routed to — the honest floor any routed request will fit in. Use{' '}
+              <strong>Custom</strong> only if your client needs a specific value.
+            </span>
+          </div>
+          <div class="settings-card__control" style="flex-direction: column; gap: 8px;">
+            <div
+              role="radiogroup"
+              aria-label="Context window mode"
+              style="display: flex; gap: 12px;"
+            >
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input
+                  type="radio"
+                  name="ctx-mode"
+                  value="auto"
+                  checked={ctxMode() === 'auto'}
+                  onChange={() => setCtxMode('auto')}
+                />
+                <span>
+                  Auto{' '}
+                  <Show when={contextWindow()}>
+                    <span class="settings-card__label-desc">
+                      ({contextWindow()!.context_length.toLocaleString()} tokens)
+                    </span>
+                  </Show>
+                </span>
+              </label>
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input
+                  type="radio"
+                  name="ctx-mode"
+                  value="custom"
+                  checked={ctxMode() === 'custom'}
+                  onChange={() => setCtxMode('custom')}
+                />
+                <span>Custom</span>
+              </label>
+            </div>
+            <Show when={ctxMode() === 'custom'}>
+              <input
+                class="settings-card__input"
+                type="number"
+                min={1024}
+                step={1024}
+                aria-label="Custom context window in tokens"
+                placeholder="e.g. 128000"
+                value={ctxValue()}
+                onInput={(e) => setCtxValue(e.currentTarget.value)}
+              />
+            </Show>
+          </div>
+        </div>
+        <div class="settings-card__footer">
+          <button
+            class="btn btn--primary btn--sm"
+            onClick={handleSaveContext}
+            disabled={ctxSaving()}
+          >
+            {ctxSaving() ? (
+              <>
+                <span class="spinner" />
+                <span class="sr-only">Saving...</span>
+              </>
+            ) : (
+              'Save'
+            )}
+          </button>
         </div>
       </div>
 

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -9,6 +9,7 @@ export interface AgentInfo {
   display_name: string;
   agent_category: string | null;
   agent_platform: string | null;
+  context_floor_override: number | null;
 }
 
 export function getAgentInfo(agentName: string): Promise<AgentInfo | null> {
@@ -35,6 +36,7 @@ export function updateAgent(
     name?: string;
     agent_category?: string;
     agent_platform?: string;
+    context_floor_override?: number | null;
   },
 ) {
   return fetchMutate<Record<string, unknown>>(`/agents/${encodeURIComponent(currentName)}`, {

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -185,6 +185,15 @@ export function refreshModels(agentName: string) {
   });
 }
 
+export interface ContextWindowInfo {
+  context_length: number;
+  overridden: boolean;
+}
+
+export function getContextWindow(agentName: string) {
+  return fetchJson<ContextWindowInfo>(routingPath(agentName, 'context-window'));
+}
+
 /* -- Routing: Pricing cache health -- */
 
 export interface PricingHealth {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -20,6 +20,7 @@ const mockDeleteAgent = vi.fn();
 const mockRenameAgent = vi.fn();
 const mockRotateAgentKey = vi.fn();
 const mockUpdateAgent = vi.fn();
+const mockGetContextWindow = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getAgentKey: (...args: unknown[]) => mockGetAgentKey(...args),
   getAgentInfo: (...args: unknown[]) => mockGetAgentInfo(...args),
@@ -27,10 +28,18 @@ vi.mock("../../src/services/api.js", () => ({
   renameAgent: (...args: unknown[]) => mockRenameAgent(...args),
   rotateAgentKey: (...args: unknown[]) => mockRotateAgentKey(...args),
   updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),
+  getContextWindow: (...args: unknown[]) => mockGetContextWindow(...args),
 }));
 
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+
 vi.mock("../../src/services/toast-store.js", () => ({
-  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    warning: vi.fn(),
+  },
 }));
 
 vi.mock("../../src/components/ErrorState.jsx", () => ({
@@ -126,11 +135,17 @@ describe("Settings", () => {
     mockAgentName = "test-agent";
     mockSetupThrows = false;
     mockGetAgentKey.mockResolvedValue({ keyPrefix: "mnfst_abc" });
-    mockGetAgentInfo.mockResolvedValue({ agent_name: "test-agent", agent_category: "personal", agent_platform: "openclaw" });
+    mockGetAgentInfo.mockResolvedValue({
+      agent_name: "test-agent",
+      agent_category: "personal",
+      agent_platform: "openclaw",
+      context_floor_override: null,
+    });
     mockDeleteAgent.mockResolvedValue(undefined);
     mockRenameAgent.mockResolvedValue({ renamed: true, name: "new-name" });
     mockRotateAgentKey.mockResolvedValue({ apiKey: "new-key" });
     mockUpdateAgent.mockResolvedValue({});
+    mockGetContextWindow.mockResolvedValue({ context_length: 128000, overridden: false });
   });
 
   it("renders Settings heading", () => {
@@ -246,10 +261,14 @@ describe("Settings", () => {
   });
 
   it("save button enables when agent name changes", () => {
-    render(() => <Settings />);
+    const { container } = render(() => <Settings />);
     const input = screen.getByLabelText("Agent name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-name" } });
-    const saveBtn = screen.getByText("Save") as HTMLButtonElement;
+    // With the new Context window card there are multiple Save buttons; grab
+    // the one in the Agent name card (first Save in document order).
+    const saveBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Save",
+    ) as HTMLButtonElement;
     expect(saveBtn.disabled).toBe(false);
   });
 
@@ -257,9 +276,12 @@ describe("Settings", () => {
     const replaceFn = vi.fn();
     const originalLocation = window.location;
     Object.defineProperty(window, "location", { value: { ...originalLocation, replace: replaceFn }, writable: true, configurable: true });
-    render(() => <Settings />);
+    const { container } = render(() => <Settings />);
     fireEvent.input(screen.getByLabelText("Agent name"), { target: { value: "new-name" } });
-    fireEvent.click(screen.getByText("Save"));
+    const saveBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Save",
+    ) as HTMLButtonElement;
+    fireEvent.click(saveBtn);
     await vi.waitFor(() => { expect(mockRenameAgent).toHaveBeenCalledWith("test-agent", "new-name"); });
     await vi.waitFor(() => { expect(replaceFn).toHaveBeenCalledWith("/agents/new-name/settings"); });
     Object.defineProperty(window, "location", { value: originalLocation, writable: true, configurable: true });
@@ -267,10 +289,13 @@ describe("Settings", () => {
 
   it("resets name on rename error", async () => {
     mockRenameAgent.mockRejectedValueOnce(new Error("Conflict"));
-    render(() => <Settings />);
+    const { container } = render(() => <Settings />);
     const input = screen.getByLabelText("Agent name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "bad-name" } });
-    fireEvent.click(screen.getByText("Save"));
+    const saveBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Save",
+    ) as HTMLButtonElement;
+    fireEvent.click(saveBtn);
     await vi.waitFor(() => { expect(input.value).toBe("test-agent"); });
   });
 
@@ -521,6 +546,293 @@ describe("Settings", () => {
     const { container } = render(() => <Settings />);
     await vi.waitFor(() => {
       expect(container.textContent).toContain("mnfst_xyz...");
+    });
+  });
+
+  /**
+   * "Advertised context window" card — the UI lever for issues
+   * #1617 / #1612 / #1450. These tests defend the three behaviours a user
+   * actually goes through: prefill from /v1/models, save a custom override,
+   * and roll back to auto. If the input validation regresses we start
+   * sending `0` or `500` through PATCH again.
+   */
+  describe("context window card", () => {
+    it("renders the Auto option with the live context_length from getContextWindow", async () => {
+      mockGetContextWindow.mockResolvedValue({ context_length: 128000, overridden: false });
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("128,000 tokens");
+      });
+    });
+
+    it("starts in Custom mode with the current override when agentInfo.context_floor_override is set", async () => {
+      mockGetAgentInfo.mockResolvedValue({
+        agent_name: "test-agent",
+        agent_category: "personal",
+        agent_platform: "openclaw",
+        context_floor_override: 64000,
+      });
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        const customInput = container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement | null;
+        expect(customInput).not.toBeNull();
+        expect(customInput!.value).toBe("64000");
+      });
+    });
+
+    it("reveals the numeric input only when the Custom radio is selected", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+      // No override → Auto by default → numeric input should not be in DOM.
+      expect(
+        container.querySelector('input[aria-label="Custom context window in tokens"]'),
+      ).toBeNull();
+
+      const customRadio = container.querySelector(
+        'input[name="ctx-mode"][value="custom"]',
+      ) as HTMLInputElement;
+      expect(customRadio).not.toBeNull();
+      fireEvent.click(customRadio);
+
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+    });
+
+    it("saves a valid custom value by PATCH-ing context_floor_override as a number", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      const numericInput = container.querySelector(
+        'input[aria-label="Custom context window in tokens"]',
+      ) as HTMLInputElement;
+      fireEvent.input(numericInput, { target: { value: "64000" } });
+
+      // The Save button lives inside the Context window card — identify it by
+      // finding the card that owns the radiogroup and grabbing the Save button
+      // in its footer.
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalledWith("test-agent", {
+          context_floor_override: 64000,
+        });
+      });
+    });
+
+    it("saves Auto mode by PATCH-ing context_floor_override: null", async () => {
+      // Start in Custom so we can toggle back to Auto and prove the reset
+      // writes null (not the previous numeric value).
+      mockGetAgentInfo.mockResolvedValue({
+        agent_name: "test-agent",
+        agent_category: "personal",
+        agent_platform: "openclaw",
+        context_floor_override: 64000,
+      });
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        const customInput = container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement | null;
+        expect(customInput).not.toBeNull();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="auto"]') as HTMLInputElement,
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalledWith("test-agent", {
+          context_floor_override: null,
+        });
+      });
+    });
+
+    it("rejects a value below 1024 with a toast and does NOT call updateAgent", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "500" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith(
+          expect.stringContaining("1,024"),
+        );
+      });
+      expect(mockUpdateAgent).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-integer value with a toast and does NOT call updateAgent", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "abc" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockToastError).toHaveBeenCalled();
+      });
+      expect(mockUpdateAgent).not.toHaveBeenCalled();
+    });
+
+    it("shows a success toast when the override saves", async () => {
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "128000" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          expect.stringContaining("Context window"),
+        );
+      });
+    });
+
+    it("swallows updateAgent errors (toast is handled by fetchMutate)", async () => {
+      mockUpdateAgent.mockRejectedValueOnce(new Error("network"));
+      const { container } = render(() => <Settings />);
+      await vi.waitFor(() => {
+        expect(mockGetAgentInfo).toHaveBeenCalled();
+      });
+
+      fireEvent.click(
+        container.querySelector('input[name="ctx-mode"][value="custom"]') as HTMLInputElement,
+      );
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('input[aria-label="Custom context window in tokens"]'),
+        ).not.toBeNull();
+      });
+      fireEvent.input(
+        container.querySelector(
+          'input[aria-label="Custom context window in tokens"]',
+        ) as HTMLInputElement,
+        { target: { value: "128000" } },
+      );
+
+      const cards = Array.from(container.querySelectorAll(".settings-card"));
+      const ctxCard = cards.find((c) =>
+        c.querySelector('[aria-label="Context window mode"]'),
+      )!;
+      const saveBtn = ctxCard.querySelector(
+        ".settings-card__footer button",
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+
+      await vi.waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalled();
+      });
+      // Save button must re-enable even though the PATCH rejected.
+      await vi.waitFor(() => {
+        expect(saveBtn.hasAttribute("disabled")).toBe(false);
+      });
     });
   });
 

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -46,6 +46,7 @@ import {
   clearFallbacks,
   getPricingHealth,
   refreshPricing,
+  getContextWindow,
   setMessageFeedback,
   clearMessageFeedback,
   getMessageDetails,
@@ -447,6 +448,52 @@ describe('updateAgent', () => {
 
     await expect(updateAgent('my-agent', { agent_category: 'bad' })).rejects.toThrow('Invalid category');
     expect(toast.error).toHaveBeenCalledWith('Invalid category');
+  });
+
+  // context_floor_override is the Phase 1 lever that drives GET /v1/models —
+  // make sure the PATCH body serialises numeric and null values as-is so the
+  // backend's class-validator DTO sees the right types.
+  it('serialises context_floor_override as a number in the PATCH body', async () => {
+    mockMutateOk({ context_floor_override: 50000 });
+
+    await updateAgent('my-agent', { context_floor_override: 50000 });
+
+    const call = mockFetch.mock.calls[0];
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({
+      context_floor_override: 50000,
+    });
+  });
+
+  it('serialises context_floor_override: null to clear the override', async () => {
+    mockMutateOk({ context_floor_override: null });
+
+    await updateAgent('my-agent', { context_floor_override: null });
+
+    const call = mockFetch.mock.calls[0];
+    expect(JSON.parse(String((call?.[1] as RequestInit).body))).toEqual({
+      context_floor_override: null,
+    });
+  });
+});
+
+describe('getContextWindow', () => {
+  it('fetches /routing/:agentName/context-window and returns the floor', async () => {
+    const payload = { context_length: 128000, overridden: false };
+    mockOk(payload);
+
+    const result = await getContextWindow('my-agent');
+    expect(result).toEqual(payload);
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain('/api/v1/routing/my-agent/context-window');
+  });
+
+  it('URL-encodes the agent name', async () => {
+    mockOk({ context_length: 128000, overridden: false });
+
+    await getContextWindow('agent/with slash');
+
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain('/agent%2Fwith%20slash/context-window');
   });
 });
 


### PR DESCRIPTION
## Summary

- Estimates token count for every chat-completion request up front (js-tiktoken cl100k_base + 10% safety margin) in a new `token-estimate.ts` helper.
- Filters each tier's candidate models by whether `contextWindow >= estimatedTokens + (max_tokens ?? 4096)`. Escalates upward (simple → standard → complex → reasoning) if nothing in the scored tier fits. Structured `context_window_exceeded` friendly response if nothing in any tier fits.
- Emits `X-Manifest-Context-Estimated`, `X-Manifest-Context-Used`, and `X-Manifest-Context-Escalated: <from>-><to>` response headers so agents can adapt per-response (EthanFrostpro's ask on #1617).

## Why

Phase 1 (#1648) advertised an honest context window on `GET /v1/models`. It tells the client the truth but doesn't stop the router from picking a model too small for the current request. Users in #1617 / #1612 / #1450 kept hitting overflow failures on specific large-history requests — exactly the failure mode Phase 1 can't address. Phase 2 makes the router _act_ on per-model context windows.

Closes #1646.

## Stacking

This PR is stacked on #1648 (base = `ctx`). When #1648 merges to `main`, GitHub re-points this PR's base to `main` automatically. Reviewing: focus on the new files + the changes to `resolve.service.ts` and `proxy.service.ts`. The `CLAUDE.md` table addition and `dto/resolve-response.ts` reason constants carry over from Phase 1's groundwork.

## Before / after (tied to reported failure modes)

| Complaint | Today | After Phase 2 |
|---|---|---|
| #1617 fuzhyperblue: "Hermes 200K setting, routed to 128K model → error" | Router picks 128K primary → overflow → cryptic 400 | Router skips the 128K candidate, picks the 200K fallback → success. `X-Manifest-Context-Used: 200000` on the response. |
| #1617 RFC: "Intelligent Routing based on Input Length" | Not implemented | Implemented. Escalates across tiers when scored tier can't fit. `X-Manifest-Context-Escalated: simple->standard` when it happens. |
| #1617 EthanFrostpro: "a simple header telling agents what window was used" | No such header | Three headers on every response: `Context-Estimated`, `Context-Used`, `Context-Escalated`. |
| #1612 Alexmen97: "Does OpenClaw compact even if the model doesn't support that CTX?" | No. Overflow silently. | Router refuses to route to a model that can't fit. If nothing fits, returns a structured 413-style friendly response instead. |

## Two bugs found and fixed during manual smoke testing

1. **Nonsense exceeded-message when `max_tokens` was the blocker.** Message read "Request (~13 tokens) is larger than 400,000" which is literally false. Fixed: message now breaks out input vs reserved-output — `"Request needs ~5,000,013 tokens (13 input + 5,000,000 reserved for output), but the largest connected model's context window is 400,000. Shorten the conversation, lower max_tokens, or connect a larger-context provider."` Regression test in `context-aware-routing.e2e-spec.ts`.
2. **`X-Manifest-Context-Escalated` header silently dropped by Node's http layer** because the value contained Unicode `→` (U+2192), outside Latin-1. Debug logs showed the header in the outgoing map but curl never saw it. Fixed: ASCII `->`. Regression test in `proxy-response-handler.spec.ts` byte-checks every char is < 128.

## Test plan

- [x] Backend unit tests: **4078 passing**, 214 suites. 100% line coverage on `token-estimate.ts`, `context-fit.ts`, `resolve.service.ts`, `proxy-response-handler.ts`, `proxy-friendly-response.ts`.
- [x] Backend E2E tests: **134 passing**, 18 suites. New `context-aware-routing.e2e-spec.ts` covers the user-journey scenarios above.
- [x] Frontend tests + TypeScript clean on both packages.
- [x] Manual smoke on fresh PostgreSQL (`manifest_fbc2b2`, fresh port 34282): connected OpenAI + Anthropic, pinned tiers to small models, verified `/v1/models` floor tracks, verified `X-Manifest-Context-Escalated: simple->standard` is emitted, verified friendly message for over-capacity requests.

## Out of scope

- **Phase 3** — opt-in middle-out compaction via `X-Manifest-Transform: middle-out` header (OpenRouter-shape). Separate PR; carries data-loss risk and needs careful handling of system prompt + last user message preservation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds context-aware routing to the proxy. We estimate tokens per request, skip models that can’t fit, escalate tiers when needed, and return a clear message if nothing fits, with headers so agents can adapt.

- **New Features**
  - Token estimate via `js-tiktoken` `cl100k_base` with a 20% safety margin.
  - Route only to candidates where context_window >= estimated + (`max_tokens` or 4096).
  - Escalate simple→standard→complex→reasoning when the scored tier can’t fit; pick the first fitting candidate to preserve cost order.
  - If nothing fits, return a friendly `context_window_exceeded` message that breaks out input vs reserved output.
  - Emit headers: `X-Manifest-Context-Estimated`, `X-Manifest-Context-Used`, `X-Manifest-Context-Escalated: <from>-><to>`.

- **Bug Fixes**
  - Fixed misleading exceeded message when `max_tokens` was the blocker by breaking out input vs reserved output.
  - Use ASCII `->` in `X-Manifest-Context-Escalated` to prevent Node from dropping the header.
  - Heartbeat fast-path is now gated by estimated tokens (<= 1000); large payloads mentioning HEARTBEAT_OK still go through size-aware routing.
  - Heartbeat gate also considers reserved `max_tokens` (estimated_input + max_tokens), so tiny prompts with huge output budgets don’t bypass the size check.
  - If a tier’s `override_model` is stale/disconnected, fall back to its `auto_assigned_model` when building fit candidates.
  - Ensure `override_auth_type` only applies when the routed model is the `override_model`; no leak when falling back to the auto-assigned model.

<sup>Written for commit bf20c90b3c7dac980af80ac9b72547ceb66961b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

