### PR TITLE
fix(security): recognize Docker ULA IPv6 addresses as private

### DIFF
--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -65,8 +65,8 @@ describe('isPrivateIp', () => {
     expect(isPrivateIp('fd00::1')).toBe(true);
   });
 
-  it('detects fdc4:f303:9324::254 as private IPv6 (ULA — Docker host.docker.internal)', () => {
-    expect(isPrivateIp('fdc4:f303:9324::254')).toBe(true);
+  it('detects fd12:3456:789a::1 as private IPv6 (ULA beyond the fd00:: literal prefix)', () => {
+    expect(isPrivateIp('fd12:3456:789a::1')).toBe(true);
   });
 
   it('detects fe80::1 as private IPv6 (link-local)', () => {

--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -65,6 +65,10 @@ describe('isPrivateIp', () => {
     expect(isPrivateIp('fd00::1')).toBe(true);
   });
 
+  it('detects fdc4:f303:9324::254 as private IPv6 (ULA — Docker host.docker.internal)', () => {
+    expect(isPrivateIp('fdc4:f303:9324::254')).toBe(true);
+  });
+
   it('detects fe80::1 as private IPv6 (link-local)', () => {
     expect(isPrivateIp('fe80::1')).toBe(true);
   });

--- a/packages/backend/src/common/utils/url-validation.ts
+++ b/packages/backend/src/common/utils/url-validation.ts
@@ -10,7 +10,10 @@ const PRIVATE_RANGES: { addr: bigint; mask: bigint }[] = [
   cidr('0.0.0.0', 8), // Current network
 ];
 
-const PRIVATE_V6_PREFIXES = ['::1', 'fc00::', 'fd00::', 'fe80::'];
+// ULA (fc00::/7) covers fc00::–fdff::, link-local is fe80::/10.
+// We match by two-character hex prefix to avoid false negatives on
+// addresses like fdc4:… that don't literally start with "fd00::".
+const PRIVATE_V6_PREFIXES = ['::1', 'fc', 'fd', 'fe80::'];
 
 function cidr(base: string, prefix: number): { addr: bigint; mask: bigint } {
   const addr = ipv4ToBigInt(base);


### PR DESCRIPTION
## Summary

- Fix SSRF validator rejecting `host.docker.internal` IPv6 ULA addresses as non-private
- `fdc4:f303:9324::254` (Docker Desktop's resolved address) was incorrectly classified as public because the string prefix check `startsWith('fd00::')` doesn't match the full `fc00::/7` ULA range
- Match on 2-char hex prefix (`'fc'`/`'fd'`) instead, covering all ULA addresses per RFC 4193

## Test plan

- [x] Backend unit tests pass (60/60) including new test for `fdc4:f303:9324::254`
- [ ] Verify Docker probe works: `docker exec mnfst-manifest-1 node -e "fetch('http://host.docker.internal:1234/v1/models').then(...)"`
- [ ] Connect LM Studio via the Manifest UI on a Docker install

Fixes #1685

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SSRF IP validator to treat IPv6 ULA (fc00::/7) as private so `host.docker.internal` is accepted inside Docker. Restores Docker-based connections to local endpoints.

- **Bug Fixes**
  - Expand IPv6 private check to match `fc`/`fd` prefixes per RFC 4193 (was `startsWith('fd00::')`).
  - Update unit test to use generic ULA `fd12:3456:789a::1` instead of a machine-specific address.

<sup>Written for commit 1ace2c241190286ae3a86f399a6e38f60b62fba6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

