### PR TITLE
docs: add LM Studio to supported providers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Works with 300+ models across these providers. Connect with an API key, or reuse
 | [Z.ai (Zhipu)](https://z.ai/)                                                  |   ✅    | ✅ GLM Coding Plan           |
 | [GitHub Copilot](https://github.com/features/copilot)                          |         | ✅ Copilot subscription      |
 | [OpenRouter](https://openrouter.ai/)                                           |   ✅    |                            |
+| [LM Studio](https://lmstudio.ai/)                                              |   ✅ Local   |                            |
 | [Ollama](https://ollama.com/)                                                  |   ✅ Local   | ✅ Ollama Cloud              |
 | Custom providers (OpenAI-compatible)                                           |   ✅    |                            |
 


### PR DESCRIPTION
## Summary
- Add LM Studio as a local provider entry in the README's supported providers table, between OpenRouter and Ollama.

LM Studio is already a fully-supported local provider in the codebase (`packages/shared/src/providers.ts:144`, `docker/DOCKER_README.md:301`) but was missing from the README, so users scanning the list wouldn't know it's available.

## Test plan
- [x] Verify LM Studio is a real provider in `packages/shared/src/providers.ts`
- [x] README renders the new row between OpenRouter and Ollama

https://claude.ai/code/session_016c5QPpeFYSaba1TrQFeuKs

---
_Generated by [Claude Code](https://claude.ai/code/session_016c5QPpeFYSaba1TrQFeuKs)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add LM Studio as a local provider in the README’s supported providers table so users can see it’s supported. This aligns the docs with existing support in the codebase and Docker docs.

<sup>Written for commit 6ea56882dccace8c72419de602995f6137d09f04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

