### PR TITLE
fix(routing): compute cost for custom provider messages

### DIFF
--- a/.changeset/custom-provider-pricing.md
+++ b/.changeset/custom-provider-pricing.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix cost column showing "—" for self-hosted custom provider messages. Prices entered via the custom provider form are now indexed into the shared pricing cache under `custom:<uuid>/<model>` — the same key the proxy writes to `agent_messages.model` — so the cost recorder can look them up when a request is routed. The cache refreshes immediately on create, model edits, and delete, so new prices take effect without waiting for the daily 5am reload. Custom entries are scoped out of the public `/api/v1/model-prices` list so one tenant's providers can't leak into another's. Existing messages recorded with `cost_usd = null` stay null (no price snapshot is stored per message); only new messages benefit.

--- a/packages/backend/src/model-prices/model-prices.module.ts
+++ b/packages/backend/src/model-prices/model-prices.module.ts
@@ -7,9 +7,10 @@ import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
 import { UserProvider } from '../entities/user-provider.entity';
+import { CustomProvider } from '../entities/custom-provider.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserProvider])],
+  imports: [TypeOrmModule.forFeature([UserProvider, CustomProvider])],
   controllers: [ModelPricesController],
   providers: [
     ModelPricesService,

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -1,10 +1,22 @@
+import { Repository } from 'typeorm';
 import { ModelPricingCacheService } from './model-pricing-cache.service';
 import { PricingSyncService, OpenRouterPricingEntry } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
+import { CustomProvider } from '../entities/custom-provider.entity';
 
 function makeEntry(input: number, output: number): OpenRouterPricingEntry {
   return { input, output };
+}
+
+function makeCustomProviderRepo(rows: CustomProvider[] | Error) {
+  const find = jest.fn();
+  if (rows instanceof Error) {
+    find.mockRejectedValue(rows);
+  } else {
+    find.mockResolvedValue(rows);
+  }
+  return { find } as unknown as Repository<CustomProvider>;
 }
 
 function makeMockRegistry() {
@@ -618,6 +630,205 @@ describe('ModelPricingCacheService', () => {
       const entry = service.getByModel('claude-test');
       expect(entry).toBeDefined();
       expect(entry!.validated).toBe(false);
+    });
+  });
+
+  describe('custom provider entries', () => {
+    const makeCp = (overrides: Partial<CustomProvider> = {}): CustomProvider =>
+      ({
+        id: 'cp-uuid-1',
+        agent_id: 'agent-1',
+        user_id: 'user-1',
+        name: 'CPA',
+        base_url: 'https://example.com/v1',
+        models: [],
+        created_at: '2026-01-01T00:00:00.000Z',
+        ...overrides,
+      }) as CustomProvider;
+
+    function makeServiceWithCustom(rows: CustomProvider[] | Error) {
+      const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+      return new ModelPricingCacheService(
+        mockSync,
+        mockModelsDevSync as unknown as ModelsDevSyncService,
+        mockRegistry as unknown as ProviderModelRegistryService,
+        makeCustomProviderRepo(rows),
+      );
+    }
+
+    it('indexes prices under the `custom:<uuid>/<model>` key used by the proxy', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      const svc = makeServiceWithCustom([
+        makeCp({
+          models: [
+            {
+              model_name: 'gemini-3-flash',
+              input_price_per_million_tokens: 2,
+              output_price_per_million_tokens: 6,
+            },
+          ],
+        }),
+      ]);
+
+      await svc.reload();
+
+      const entry = svc.getByModel('custom:cp-uuid-1/gemini-3-flash');
+      expect(entry).toBeDefined();
+      // Per-million input/output → per-token (divide by 1e6).
+      expect(entry!.input_price_per_token).toBe(2 / 1_000_000);
+      expect(entry!.output_price_per_token).toBe(6 / 1_000_000);
+      expect(entry!.provider).toBe('Custom');
+      expect(entry!.source).toBe('custom');
+    });
+
+    it('excludes custom entries from getAll() to avoid leaking across tenants', async () => {
+      mockGetAll.mockReturnValue(
+        new Map<string, OpenRouterPricingEntry>([['openai/gpt-4o', makeEntry(0.001, 0.002)]]),
+      );
+      const svc = makeServiceWithCustom([
+        makeCp({
+          models: [
+            {
+              model_name: 'private-model',
+              input_price_per_million_tokens: 1,
+              output_price_per_million_tokens: 1,
+            },
+          ],
+        }),
+      ]);
+
+      await svc.reload();
+
+      // The custom model must still be resolvable by getByModel (the UUID
+      // makes the key globally unique), but must NOT appear in getAll()
+      // since /api/v1/model-prices is not scoped by user.
+      expect(svc.getByModel('custom:cp-uuid-1/private-model')).toBeDefined();
+      const all = svc.getAll();
+      expect(all.some((e) => e.model_name.startsWith('custom:'))).toBe(false);
+      expect(all.some((e) => e.model_name === 'openai/gpt-4o')).toBe(true);
+    });
+
+    it('handles models with only input or only output pricing set', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      const svc = makeServiceWithCustom([
+        makeCp({
+          models: [
+            { model_name: 'input-only', input_price_per_million_tokens: 5 },
+            { model_name: 'output-only', output_price_per_million_tokens: 10 },
+          ],
+        }),
+      ]);
+
+      await svc.reload();
+
+      const inputOnly = svc.getByModel('custom:cp-uuid-1/input-only');
+      expect(inputOnly!.input_price_per_token).toBe(5 / 1_000_000);
+      expect(inputOnly!.output_price_per_token).toBeNull();
+
+      const outputOnly = svc.getByModel('custom:cp-uuid-1/output-only');
+      expect(outputOnly!.input_price_per_token).toBeNull();
+      expect(outputOnly!.output_price_per_token).toBe(10 / 1_000_000);
+    });
+
+    it('skips entries with no pricing at all (nothing to compute)', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      const svc = makeServiceWithCustom([
+        makeCp({
+          models: [{ model_name: 'no-price' }],
+        }),
+      ]);
+
+      await svc.reload();
+
+      expect(svc.getByModel('custom:cp-uuid-1/no-price')).toBeUndefined();
+    });
+
+    it('skips rows with a missing/empty models array without crashing', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      const svc = makeServiceWithCustom([
+        makeCp({ models: undefined as unknown as CustomProvider['models'] }),
+        makeCp({ id: 'cp-uuid-2', models: [] }),
+      ]);
+
+      await expect(svc.reload()).resolves.toBeUndefined();
+      expect(svc.getAll()).toEqual([]);
+    });
+
+    it('skips rows whose model_name is empty (no valid cache key)', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      const svc = makeServiceWithCustom([
+        makeCp({
+          models: [
+            {
+              model_name: '',
+              input_price_per_million_tokens: 1,
+              output_price_per_million_tokens: 2,
+            },
+          ],
+        }),
+      ]);
+
+      await svc.reload();
+      // No entry keyed on an empty model name should end up in the cache.
+      expect(svc.getAll()).toEqual([]);
+    });
+
+    it('degrades gracefully when the custom provider repo read fails', async () => {
+      mockGetAll.mockReturnValue(
+        new Map<string, OpenRouterPricingEntry>([['openai/gpt-4o', makeEntry(0.001, 0.002)]]),
+      );
+      const svc = makeServiceWithCustom(new Error('db down'));
+
+      await expect(svc.reload()).resolves.toBeUndefined();
+      // OpenRouter entries must still be present even if custom load fails.
+      expect(svc.getByModel('openai/gpt-4o')).toBeDefined();
+    });
+
+    it('works when no custom provider repo is injected (legacy wiring)', async () => {
+      const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+      const svc = new ModelPricingCacheService(
+        mockSync,
+        mockModelsDevSync as unknown as ModelsDevSyncService,
+        mockRegistry as unknown as ProviderModelRegistryService,
+      );
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.001, 0.002)]]));
+
+      await expect(svc.reload()).resolves.toBeUndefined();
+      expect(svc.getByModel('openai/gpt-4o')).toBeDefined();
+    });
+
+    it('drops stale custom entries on reload when rows are removed', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      // Mutable rows array so we can simulate a removal between reloads.
+      const rows: CustomProvider[] = [
+        makeCp({
+          models: [
+            {
+              model_name: 'gemini-3-flash',
+              input_price_per_million_tokens: 2,
+              output_price_per_million_tokens: 6,
+            },
+          ],
+        }),
+      ];
+      const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+      const repo = {
+        find: jest.fn().mockImplementation(() => Promise.resolve(rows)),
+      } as unknown as Repository<CustomProvider>;
+      const svc = new ModelPricingCacheService(
+        mockSync,
+        mockModelsDevSync as unknown as ModelsDevSyncService,
+        mockRegistry as unknown as ProviderModelRegistryService,
+        repo,
+      );
+
+      await svc.reload();
+      expect(svc.getByModel('custom:cp-uuid-1/gemini-3-flash')).toBeDefined();
+
+      // Simulate provider deletion → repo now returns an empty list.
+      rows.length = 0;
+      await svc.reload();
+      expect(svc.getByModel('custom:cp-uuid-1/gemini-3-flash')).toBeUndefined();
     });
   });
 });

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger, OnApplicationBootstrap, Inject, Optional } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Cron } from '@nestjs/schedule';
 import { buildAliasMap, resolveModelName } from './model-name-normalizer';
 import { PricingSyncService } from '../database/pricing-sync.service';
@@ -9,10 +11,14 @@ import {
   PROVIDER_BY_ID_OR_ALIAS,
 } from '../common/constants/providers';
 import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
+import { CustomProvider } from '../entities/custom-provider.entity';
+
+const CUSTOM_PROVIDER_LABEL = 'Custom';
 
 /**
  * Lightweight pricing entry used for cost calculation and provider detection.
- * Reads from models.dev (preferred) and OpenRouter cache (fallback).
+ * Reads from models.dev (preferred), OpenRouter cache (fallback), and the
+ * `custom_providers` table (user-defined OpenAI-compatible endpoints).
  */
 export interface PricingEntry {
   model_name: string;
@@ -22,8 +28,8 @@ export interface PricingEntry {
   display_name: string | null;
   /** True if confirmed via provider-native API, false if unverified, undefined if no data. */
   validated?: boolean;
-  /** Data source: models.dev (curated, native IDs) or openrouter (broad coverage). */
-  source?: 'models.dev' | 'openrouter';
+  /** Data source: models.dev (curated), openrouter (broad), or custom (user-defined). */
+  source?: 'models.dev' | 'openrouter' | 'custom';
 }
 
 @Injectable()
@@ -40,6 +46,9 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
     @Optional()
     @Inject(ProviderModelRegistryService)
     private readonly modelRegistry: ProviderModelRegistryService | null,
+    @Optional()
+    @InjectRepository(CustomProvider)
+    private readonly customProviderRepo: Repository<CustomProvider> | null = null,
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
@@ -83,6 +92,11 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
     // Overlay models.dev entries (curated, native IDs — preferred source)
     this.loadModelsDevEntries();
 
+    // Overlay user-defined custom provider pricing (from the custom_providers
+    // table). Keyed by `custom:<uuid>/<model_name>` — the same identifier
+    // written to agent_messages.model, so cost lookups hit.
+    await this.loadCustomProviderEntries();
+
     this.aliasMap = buildAliasMap([...this.cache.keys()]);
     this.logger.log(`Loaded ${this.cache.size} pricing entries`);
   }
@@ -100,9 +114,15 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
   getAll(): PricingEntry[] {
     // Deduplicate: canonical aliases point to the same model_name,
     // so filter to unique model_name values.
+    //
+    // Custom provider entries (keyed by `custom:<uuid>/...`) are excluded
+    // here because the public /api/v1/model-prices endpoint is not scoped
+    // by user — returning them would leak one tenant's custom providers
+    // to every other tenant.
     const seen = new Set<string>();
     const result: PricingEntry[] = [];
     for (const entry of this.cache.values()) {
+      if (entry.source === 'custom') continue;
       if (!seen.has(entry.model_name)) {
         seen.add(entry.model_name);
         result.push(entry);
@@ -192,6 +212,62 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
 
     if (count > 0) {
       this.logger.log(`Overlaid ${count} models.dev pricing entries`);
+    }
+  }
+
+  /**
+   * Load user-defined pricing for custom (OpenAI-compatible) providers.
+   *
+   * The proxy writes `custom:<uuid>/<model_name>` to agent_messages.model
+   * and the cost recorder calls getByModel() with that exact string — so we
+   * index custom pricing under the same key. UUIDs are globally unique
+   * (randomUUID), so cross-tenant collisions are impossible.
+   *
+   * Prices are stored per million tokens in the entity; divide by 1e6 to
+   * match PricingEntry's per-token contract.
+   */
+  private async loadCustomProviderEntries(): Promise<void> {
+    if (!this.customProviderRepo) return;
+
+    let rows: CustomProvider[];
+    try {
+      rows = await this.customProviderRepo.find();
+    } catch (err) {
+      this.logger.warn(`Failed to load custom provider pricing: ${(err as Error).message}`);
+      return;
+    }
+
+    let count = 0;
+    for (const cp of rows) {
+      if (!Array.isArray(cp.models)) continue;
+      for (const model of cp.models) {
+        if (!model.model_name) continue;
+        const inputPerToken =
+          model.input_price_per_million_tokens != null
+            ? model.input_price_per_million_tokens / 1_000_000
+            : null;
+        const outputPerToken =
+          model.output_price_per_million_tokens != null
+            ? model.output_price_per_million_tokens / 1_000_000
+            : null;
+        // Skip entries without any pricing — nothing to compute from.
+        if (inputPerToken === null && outputPerToken === null) continue;
+
+        const key = `custom:${cp.id}/${model.model_name}`;
+        this.cache.set(key, {
+          model_name: key,
+          provider: CUSTOM_PROVIDER_LABEL,
+          input_price_per_token: inputPerToken,
+          output_price_per_token: outputPerToken,
+          display_name: model.model_name,
+          source: 'custom',
+        });
+        count++;
+      }
+    }
+
+    if (count > 0) {
+      this.logger.log(`Loaded ${count} custom provider pricing entries`);
     }
   }
 

--- a/packages/backend/src/routing/custom-provider/custom-provider.module.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { RoutingCoreModule } from '../routing-core/routing-core.module';
+import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { CustomProviderController } from './custom-provider.controller';
 import { CustomProviderService } from './custom-provider.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CustomProvider]), RoutingCoreModule],
+  imports: [TypeOrmModule.forFeature([CustomProvider]), RoutingCoreModule, ModelPricesModule],
   controllers: [CustomProviderController],
   providers: [CustomProviderService],
   exports: [CustomProviderService],

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -12,6 +12,7 @@ import { CustomProvider } from '../../entities/custom-provider.entity';
 import { ProviderService } from '../routing-core/provider.service';
 import { RoutingCacheService } from '../routing-core/routing-cache.service';
 import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
+import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { validatePublicUrl } = require('../../common/utils/url-validation');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -49,7 +50,16 @@ function makeDeps(overrides: {
   const recalculate = jest.fn().mockResolvedValue(undefined);
   const autoAssign = { recalculate } as unknown as TierAutoAssignService;
 
-  const svc = new CustomProviderService(repo, providerService, routingCache, autoAssign);
+  const reloadPricing = jest.fn().mockResolvedValue(undefined);
+  const pricingCache = { reload: reloadPricing } as unknown as ModelPricingCacheService;
+
+  const svc = new CustomProviderService(
+    repo,
+    providerService,
+    routingCache,
+    autoAssign,
+    pricingCache,
+  );
 
   return {
     svc,
@@ -64,6 +74,7 @@ function makeDeps(overrides: {
     setCustomProviders,
     invalidateAgent,
     recalculate,
+    reloadPricing,
   };
 }
 
@@ -144,7 +155,7 @@ describe('CustomProviderService', () => {
     });
 
     it('inserts the row, upserts a UserProvider, and defaults context_window to 128k', async () => {
-      const { svc, insert, upsertProvider } = makeDeps({ findOneResults: [null] });
+      const { svc, insert, upsertProvider, reloadPricing } = makeDeps({ findOneResults: [null] });
       const cp = await svc.create('agent-1', 'user-1', dto);
 
       expect(insert).toHaveBeenCalledTimes(1);
@@ -153,6 +164,9 @@ describe('CustomProviderService', () => {
       expect(cp.models[0].context_window).toBe(128_000);
       expect(upsertProvider).toHaveBeenCalledWith('agent-1', 'user-1', `custom:${cp.id}`, 'sk-x');
       expect(validatePublicUrl).toHaveBeenCalledWith(dto.base_url, { allowPrivate: false });
+      // Price lookup cache must be refreshed so the proxy can compute cost
+      // for messages routed to this provider's models immediately.
+      expect(reloadPricing).toHaveBeenCalledTimes(1);
     });
 
     it('passes allowPrivate=true in the self-hosted version so private URLs are accepted', async () => {
@@ -186,13 +200,16 @@ describe('CustomProviderService', () => {
 
     it('renames and persists when no collision', async () => {
       const existing = { id: 'cp1', agent_id: 'agent-1', name: 'old' } as CustomProvider;
-      const { svc, save, invalidateAgent } = makeDeps({
+      const { svc, save, invalidateAgent, reloadPricing } = makeDeps({
         findOneResults: [existing, null],
       });
       await svc.update('agent-1', 'cp1', 'user-1', { name: 'new' });
       expect(existing.name).toBe('new');
       expect(save).toHaveBeenCalledWith(existing);
       expect(invalidateAgent).toHaveBeenCalledWith('agent-1');
+      // A rename-only update cannot affect prices, so the shared pricing
+      // cache should be left alone (reload is expensive for large installs).
+      expect(reloadPricing).not.toHaveBeenCalled();
     });
 
     it('validates and updates base_url when provided', async () => {
@@ -231,7 +248,9 @@ describe('CustomProviderService', () => {
 
     it('rewrites models (defaulting context_window) and recalculates tiers when the api key is not touched', async () => {
       const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
-      const { svc, recalculate, upsertProvider } = makeDeps({ findOneResults: [existing] });
+      const { svc, recalculate, upsertProvider, reloadPricing } = makeDeps({
+        findOneResults: [existing],
+      });
       await svc.update('agent-1', 'cp1', 'user-1', {
         models: [
           {
@@ -244,11 +263,16 @@ describe('CustomProviderService', () => {
       expect(existing.models[0].context_window).toBe(128_000);
       expect(recalculate).toHaveBeenCalledWith('agent-1');
       expect(upsertProvider).not.toHaveBeenCalled();
+      // Edited prices must flow into the shared pricing cache so the next
+      // proxied message picks up the new per-token cost.
+      expect(reloadPricing).toHaveBeenCalledTimes(1);
     });
 
     it('delegates tier recalculation to provider upsert when the api key is also updated', async () => {
       const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
-      const { svc, recalculate, upsertProvider } = makeDeps({ findOneResults: [existing] });
+      const { svc, recalculate, upsertProvider, reloadPricing } = makeDeps({
+        findOneResults: [existing],
+      });
       await svc.update('agent-1', 'cp1', 'user-1', {
         apiKey: 'sk-new',
         models: [
@@ -264,6 +288,8 @@ describe('CustomProviderService', () => {
       // When api key is updated, the upsert triggers its own recalc — service should not double-call.
       expect(recalculate).not.toHaveBeenCalled();
       expect(existing.models[0].context_window).toBe(64_000);
+      // Prices still changed → pricing cache must still be refreshed.
+      expect(reloadPricing).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -275,10 +301,13 @@ describe('CustomProviderService', () => {
 
     it('deletes the row and attempts provider removal', async () => {
       const cp = { id: 'cp1', agent_id: 'agent-1' } as CustomProvider;
-      const { svc, removeProvider, remove } = makeDeps({ findOneResults: [cp] });
+      const { svc, removeProvider, remove, reloadPricing } = makeDeps({ findOneResults: [cp] });
       await svc.remove('agent-1', 'cp1');
       expect(removeProvider).toHaveBeenCalledWith('agent-1', 'custom:cp1');
       expect(remove).toHaveBeenCalledWith(cp);
+      // Stale pricing entries for this provider must be dropped from the
+      // cache so getAll() stops returning them.
+      expect(reloadPricing).toHaveBeenCalledTimes(1);
     });
 
     it('swallows errors from provider removal (partial-state cleanup)', async () => {

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -14,6 +14,7 @@ import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service'
 import { CreateCustomProviderDto, UpdateCustomProviderDto } from '../dto/custom-provider.dto';
 import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
+import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { classifyProbeError } from './probe-error';
 
 const PROBE_TIMEOUT_MS = 5000;
@@ -41,6 +42,7 @@ export class CustomProviderService {
     private readonly providerService: ProviderService,
     private readonly routingCache: RoutingCacheService,
     private readonly autoAssign: TierAutoAssignService,
+    private readonly pricingCache: ModelPricingCacheService,
   ) {}
 
   /** Provider key used in UserProvider tables. */
@@ -118,6 +120,11 @@ export class CustomProviderService {
     // Create UserProvider + trigger tier recalculation
     await this.providerService.upsertProvider(agentId, userId, provKey, dto.apiKey);
 
+    // Rebuild the shared pricing cache so the proxy can compute cost for
+    // requests routed to this custom provider's models immediately (without
+    // waiting for the daily 5am reload).
+    await this.pricingCache.reload();
+
     return cp;
   }
 
@@ -178,6 +185,12 @@ export class CustomProviderService {
     await this.repo.save(cp);
     this.routingCache.invalidateAgent(agentId);
 
+    // Reload pricing cache when the model list changes so new prices (or
+    // edits to existing ones) are used for subsequent cost computations.
+    if (dto.models !== undefined) {
+      await this.pricingCache.reload();
+    }
+
     return cp;
   }
 
@@ -198,6 +211,9 @@ export class CustomProviderService {
 
     // Delete CustomProvider row
     await this.repo.remove(cp);
+
+    // Drop stale pricing entries for this provider's models from the cache.
+    await this.pricingCache.reload();
   }
 
   async getById(id: string): Promise<CustomProvider | null> {


### PR DESCRIPTION
## Summary

- Fixes #1645 — cost column staying `—` for messages routed to user-defined custom providers in the self-hosted version, even after prices were entered in the custom provider form.
- Root cause: `ModelPricingCacheService` only loaded OpenRouter + models.dev, never the `custom_providers` table. The proxy writes `custom:<uuid>/<model>` to `agent_messages.model`, but `pricingCache.getByModel(...)` returned `undefined` for that key, so `computeTokenCost()` returned `null` and `cost_usd` was persisted as `null`.
- Fix: index custom provider pricing under the same `custom:<uuid>/<model>` key in the shared cache, and reload on create / model edit / delete so new prices take effect immediately instead of waiting for the 5am cron. Custom entries are scoped out of the public `/api/v1/model-prices` list to avoid leaking per-user providers across tenants (UUIDs are globally unique so `getByModel` lookups are safe — only `getAll()` needs filtering).

**Caveat:** messages already written with `cost_usd = null` stay null — we don't snapshot prices per message, so a backfill would silently rewrite history with current prices. Only messages recorded after the provider is saved will have correct cost.

## Test plan

- [x] `npx jest` in `packages/backend` — 4095 tests pass
- [x] `npm run test:e2e --workspace=packages/backend` against a fresh Postgres DB — 125 tests pass
- [x] `npx vitest run` in `packages/frontend` — 2299 tests pass
- [x] `npx jest` in `packages/shared` — 83 tests pass
- [x] `npx tsc --noEmit` clean in both backend and frontend
- [x] 100% line coverage on the two modified source files (`model-pricing-cache.service.ts`, `custom-provider.service.ts`)
- [ ] Smoke-tested manually against a running custom provider in self-hosted mode (reviewer — please verify the Overview / Messages views now show non-"—" cost for new custom provider messages)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing cost computation for self-hosted custom provider messages by indexing custom provider prices into the shared pricing cache and reloading it on provider changes, so new messages show correct costs immediately.

- **Bug Fixes**
  - Load pricing from `custom_providers` into the cache under `custom:<uuid>/<model>`; exclude these entries from `getAll()` and `/api/v1/model-prices` to avoid cross-tenant leaks.
  - Reload the pricing cache on provider create, model edits, and delete so updates apply without waiting for the daily cron.
  - Existing messages with `cost_usd = null` are not backfilled; only new messages will have correct costs.

<sup>Written for commit 37308eaf915270ca97c9a4d0fa19b2b91a21abcc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

