### PR TITLE
feat(agents): duplicate agent with all config in one click

### DIFF
--- a/.changeset/duplicate-agent.md
+++ b/.changeset/duplicate-agent.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Duplicate an agent in one click — hover any agent card on the Workspace to reveal a menu with Duplicate and Delete, or use the new "Duplicate agent" button on the Settings page. Creates a new agent with a fresh API key and carries over every provider credential, custom provider, tier override, and specificity override. Messages, logs, and notification rules stay with the original.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14043,7 +14043,7 @@
       }
     },
     "packages/manifest": {
-      "version": "5.48.0"
+      "version": "5.50.1"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -6,9 +6,11 @@ import { Tenant } from '../entities/tenant.entity';
 import { LlmCall } from '../entities/llm-call.entity';
 import { ToolExecution } from '../entities/tool-execution.entity';
 import { AgentLog } from '../entities/agent-log.entity';
+import { CustomProvider } from '../entities/custom-provider.entity';
 import { OtlpModule } from '../otlp/otlp.module';
 import { RoutingCoreModule } from '../routing/routing-core/routing-core.module';
 import { AggregationService } from './services/aggregation.service';
+import { AgentDuplicationService } from './services/agent-duplication.service';
 import { AgentLifecycleService } from './services/agent-lifecycle.service';
 import { TimeseriesQueriesService } from './services/timeseries-queries.service';
 import { MessagesQueryService } from './services/messages-query.service';
@@ -25,7 +27,15 @@ import { AgentAnalyticsController } from './controllers/agent-analytics.controll
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AgentMessage, Agent, Tenant, LlmCall, ToolExecution, AgentLog]),
+    TypeOrmModule.forFeature([
+      AgentMessage,
+      Agent,
+      Tenant,
+      LlmCall,
+      ToolExecution,
+      AgentLog,
+      CustomProvider,
+    ]),
     OtlpModule,
     RoutingCoreModule,
   ],
@@ -39,6 +49,7 @@ import { AgentAnalyticsController } from './controllers/agent-analytics.controll
   ],
   providers: [
     AggregationService,
+    AgentDuplicationService,
     AgentLifecycleService,
     TimeseriesQueriesService,
     MessagesQueryService,

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -7,6 +7,7 @@ import { QueryFailedError } from 'typeorm';
 import { AgentsController } from './agents.controller';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
 import { AgentLifecycleService } from '../services/agent-lifecycle.service';
+import { AgentDuplicationService } from '../services/agent-duplication.service';
 import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
@@ -20,6 +21,9 @@ describe('AgentsController', () => {
   let mockDeleteAgent: jest.Mock;
   let mockRenameAgent: jest.Mock;
   let mockTenantResolve: jest.Mock;
+  let mockDuplicate: jest.Mock;
+  let mockGetCopySummary: jest.Mock;
+  let mockSuggestName: jest.Mock;
 
   beforeEach(async () => {
     mockGetAgentList = jest.fn().mockResolvedValue([
@@ -32,6 +36,20 @@ describe('AgentsController', () => {
     mockDeleteAgent = jest.fn().mockResolvedValue(undefined);
     mockRenameAgent = jest.fn().mockResolvedValue(undefined);
     mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
+    mockDuplicate = jest.fn().mockResolvedValue({
+      agentId: 'new-id',
+      agentName: 'bot-copy',
+      displayName: 'bot-copy',
+      apiKey: 'mnfst_new',
+      copied: { providers: 1, customProviders: 0, tierAssignments: 2, specificityAssignments: 0 },
+    });
+    mockGetCopySummary = jest.fn().mockResolvedValue({
+      providers: 1,
+      customProviders: 0,
+      tierAssignments: 2,
+      specificityAssignments: 0,
+    });
+    mockSuggestName = jest.fn().mockResolvedValue('bot-copy');
 
     const module: TestingModule = await Test.createTestingModule({
       imports: [CacheModule.register()],
@@ -55,6 +73,14 @@ describe('AgentsController', () => {
             onboardAgent: jest.fn(),
             getKeyForAgent: mockGetKeyForAgent,
             rotateKey: mockRotateKey,
+          },
+        },
+        {
+          provide: AgentDuplicationService,
+          useValue: {
+            duplicate: mockDuplicate,
+            getCopySummary: mockGetCopySummary,
+            suggestName: mockSuggestName,
           },
         },
         {
@@ -194,6 +220,10 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        {
+          provide: AgentDuplicationService,
+          useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -241,6 +271,10 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        {
+          provide: AgentDuplicationService,
+          useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -289,6 +323,10 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        {
+          provide: AgentDuplicationService,
+          useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -319,6 +357,10 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        {
+          provide: AgentDuplicationService,
+          useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -348,6 +390,10 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        {
+          provide: AgentDuplicationService,
+          useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -356,6 +402,59 @@ describe('AgentsController', () => {
     await expect(ctrl.createAgent(user as never, { name: 'My Agent' } as never)).rejects.toThrow(
       ConflictException,
     );
+  });
+
+  it('returns duplicate preview with copy counts and suggested name', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.getDuplicatePreview(user as never, 'bot-1');
+
+    expect(result).toEqual({
+      copied: { providers: 1, customProviders: 0, tierAssignments: 2, specificityAssignments: 0 },
+      suggested_name: 'bot-copy',
+    });
+    expect(mockGetCopySummary).toHaveBeenCalledWith('u1', 'bot-1');
+    expect(mockSuggestName).toHaveBeenCalledWith('u1', 'bot-1');
+  });
+
+  it('duplicates agent and invalidates cache', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.duplicateAgent(user as never, 'bot-1', {
+      name: 'Bot Copy',
+    } as never);
+
+    expect(result.agent.name).toBe('bot-copy');
+    expect(result.apiKey).toBe('mnfst_new');
+    expect(result.copied.providers).toBe(1);
+    expect(mockDuplicate).toHaveBeenCalledWith('u1', 'bot-1', {
+      name: 'bot-copy',
+      displayName: 'Bot Copy',
+    });
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+  });
+
+  it('rejects duplicateAgent with empty slug', async () => {
+    const user = { id: 'u1' };
+    await expect(
+      controller.duplicateAgent(user as never, 'bot-1', { name: '!!!' } as never),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('converts duplicate-name QueryFailedError into ConflictException on duplicateAgent', async () => {
+    mockDuplicate.mockRejectedValueOnce(
+      new QueryFailedError('INSERT', [], new Error('unique constraint violation')),
+    );
+    const user = { id: 'u1' };
+    await expect(
+      controller.duplicateAgent(user as never, 'bot-1', { name: 'bot-copy' } as never),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('re-throws non-duplicate errors from duplicate()', async () => {
+    mockDuplicate.mockRejectedValueOnce(new Error('boom'));
+    const user = { id: 'u1' };
+    await expect(
+      controller.duplicateAgent(user as never, 'bot-1', { name: 'bot-copy' } as never),
+    ).rejects.toThrow('boom');
   });
 
   it('re-throws non-duplicate QueryFailedError from onboardAgent', async () => {
@@ -376,6 +475,10 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        {
+          provide: AgentDuplicationService,
+          useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
+        },
       ],
     }).compile();
 

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -16,10 +16,12 @@ import { CACHE_MANAGER, CacheTTL } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
 import { AgentLifecycleService } from '../services/agent-lifecycle.service';
+import { AgentDuplicationService } from '../services/agent-duplication.service';
 import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
+import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
 import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
@@ -31,6 +33,7 @@ export class AgentsController {
   constructor(
     private readonly timeseries: TimeseriesQueriesService,
     private readonly lifecycle: AgentLifecycleService,
+    private readonly duplication: AgentDuplicationService,
     private readonly apiKeyGenerator: ApiKeyGeneratorService,
     private readonly tenantCache: TenantCacheService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
@@ -82,6 +85,48 @@ export class AgentsController {
         agent_platform: body.agent_platform ?? null,
       },
       apiKey: result.apiKey,
+    };
+  }
+
+  @Get('agents/:agentName/duplicate-preview')
+  async getDuplicatePreview(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
+    const [copied, suggested_name] = await Promise.all([
+      this.duplication.getCopySummary(user.id, agentName),
+      this.duplication.suggestName(user.id, agentName),
+    ]);
+    return { copied, suggested_name };
+  }
+
+  @Post('agents/:agentName/duplicate')
+  async duplicateAgent(
+    @CurrentUser() user: AuthUser,
+    @Param('agentName') sourceName: string,
+    @Body() body: DuplicateAgentDto,
+  ) {
+    const slug = slugify(body.name);
+    if (!slug) throw new BadRequestException('Agent name produces an empty slug');
+    const displayName = body.name.trim();
+    let result;
+    try {
+      result = await this.duplication.duplicate(user.id, sourceName, {
+        name: slug,
+        displayName,
+      });
+    } catch (error) {
+      if (error instanceof QueryFailedError && /unique|duplicate/i.test(error.message)) {
+        throw new ConflictException(`Agent "${slug}" already exists`);
+      }
+      throw error;
+    }
+    await this.cacheManager.del(this.agentListCacheKey(user.id));
+    return {
+      agent: {
+        id: result.agentId,
+        name: result.agentName,
+        display_name: result.displayName,
+      },
+      apiKey: result.apiKey,
+      copied: result.copied,
     };
   }
 

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -1,0 +1,324 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AgentDuplicationService } from './agent-duplication.service';
+import { Agent } from '../../entities/agent.entity';
+import { AgentApiKey } from '../../entities/agent-api-key.entity';
+import { UserProvider } from '../../entities/user-provider.entity';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+import { TierAssignment } from '../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
+import { RoutingCacheService } from '../../routing/routing-core/routing-cache.service';
+
+process.env['BETTER_AUTH_SECRET'] = 'a'.repeat(64);
+
+describe('AgentDuplicationService', () => {
+  let service: AgentDuplicationService;
+  let mockAgentGetOne: jest.Mock;
+  let mockAgentGetRawMany: jest.Mock;
+  let mockAgentQb: Record<string, jest.Mock>;
+  let mockTransaction: jest.Mock;
+  let mockInvalidateAgent: jest.Mock;
+  let repoCounts: Record<string, number>;
+  let repoRows: Record<string, unknown[]>;
+  let countMock: jest.Mock;
+  let insertedRows: Record<string, unknown[]>;
+
+  const makeRepoMock = (entityName: string) => ({
+    find: jest.fn(async () => repoRows[entityName] ?? []),
+    count: jest.fn(async () => repoCounts[entityName] ?? 0),
+    insert: jest.fn(async (rows: unknown[] | unknown) => {
+      insertedRows[entityName] = insertedRows[entityName] ?? [];
+      if (Array.isArray(rows)) insertedRows[entityName].push(...rows);
+      else insertedRows[entityName].push(rows);
+    }),
+  });
+
+  beforeEach(async () => {
+    insertedRows = {};
+    repoRows = {};
+    repoCounts = {};
+    mockAgentGetOne = jest.fn().mockResolvedValue(null);
+    mockAgentGetRawMany = jest.fn().mockResolvedValue([]);
+    countMock = jest.fn(async () => 0);
+
+    mockAgentQb = {
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      getOne: mockAgentGetOne,
+      getRawMany: mockAgentGetRawMany,
+    };
+
+    mockInvalidateAgent = jest.fn();
+
+    mockTransaction = jest.fn(async (cb: (manager: unknown) => unknown) => {
+      const agentRepo = makeRepoMock('Agent');
+      const apiKeyRepo = makeRepoMock('AgentApiKey');
+      const providerRepo = makeRepoMock('UserProvider');
+      const customProviderRepo = makeRepoMock('CustomProvider');
+      const tierRepo = makeRepoMock('TierAssignment');
+      const specRepo = makeRepoMock('SpecificityAssignment');
+      const manager = {
+        getRepository: (entity: { name: string }) => {
+          switch (entity.name) {
+            case 'Agent':
+              return agentRepo;
+            case 'AgentApiKey':
+              return apiKeyRepo;
+            case 'UserProvider':
+              return providerRepo;
+            case 'CustomProvider':
+              return customProviderRepo;
+            case 'TierAssignment':
+              return tierRepo;
+            case 'SpecificityAssignment':
+              return specRepo;
+            default:
+              throw new Error(`Unexpected entity ${entity.name}`);
+          }
+        },
+      };
+      return cb(manager);
+    });
+
+    const dataSourceMock = {
+      transaction: mockTransaction,
+      getRepository: (entity: { name: string }) => ({
+        count: jest.fn(async (args: unknown) => {
+          const res = countMock(entity.name, args);
+          if (typeof res === 'number') return res;
+          return repoCounts[entity.name] ?? 0;
+        }),
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AgentDuplicationService,
+        {
+          provide: getRepositoryToken(Agent),
+          useValue: { createQueryBuilder: jest.fn(() => mockAgentQb) },
+        },
+        { provide: DataSource, useValue: dataSourceMock },
+        {
+          provide: RoutingCacheService,
+          useValue: { invalidateAgent: mockInvalidateAgent },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AgentDuplicationService>(AgentDuplicationService);
+  });
+
+  describe('getCopySummary', () => {
+    it('returns counts of copyable rows for the source agent', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1' });
+      repoCounts = {
+        UserProvider: 3,
+        CustomProvider: 1,
+        TierAssignment: 4,
+        SpecificityAssignment: 2,
+      };
+
+      const result = await service.getCopySummary('user-1', 'source-agent');
+      expect(result).toEqual({
+        providers: 3,
+        customProviders: 1,
+        tierAssignments: 4,
+        specificityAssignments: 2,
+      });
+    });
+
+    it('throws NotFoundException when source agent is missing', async () => {
+      mockAgentGetOne.mockResolvedValueOnce(null);
+      await expect(service.getCopySummary('user-1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('suggestName', () => {
+    it('returns "<name>-copy" when unused', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'src-1' });
+      mockAgentGetRawMany.mockResolvedValueOnce([{ name: 'source' }]);
+      const result = await service.suggestName('user-1', 'source');
+      expect(result).toBe('source-copy');
+    });
+
+    it('increments suffix when copy name is taken', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'src-1' });
+      mockAgentGetRawMany.mockResolvedValueOnce([
+        { name: 'source' },
+        { name: 'source-copy' },
+        { name: 'source-copy-2' },
+      ]);
+      const result = await service.suggestName('user-1', 'source');
+      expect(result).toBe('source-copy-3');
+    });
+
+    it('throws NotFoundException when agent missing', async () => {
+      mockAgentGetOne.mockResolvedValueOnce(null);
+      await expect(service.suggestName('user-1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('falls back to a timestamp suffix when all preset suffixes collide', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'src-1' });
+      const names: { name: string }[] = [{ name: 'source-copy' }];
+      for (let i = 2; i <= 999; i++) names.push({ name: `source-copy-${i}` });
+      mockAgentGetRawMany.mockResolvedValueOnce(names);
+
+      const result = await service.suggestName('user-1', 'source');
+      expect(result).toMatch(/^source-copy-\d+$/);
+      expect(result).not.toBe('source-copy-999');
+    });
+  });
+
+  describe('duplicate', () => {
+    it('throws NotFoundException when source does not exist', async () => {
+      mockAgentGetOne.mockResolvedValueOnce(null);
+      await expect(
+        service.duplicate('user-1', 'missing', { name: 'copy', displayName: 'copy' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ConflictException when new name already exists', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1' })
+        .mockResolvedValueOnce({ id: 'clash', tenant_id: 't1' });
+      await expect(
+        service.duplicate('user-1', 'src', { name: 'clash', displayName: 'clash' }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('duplicates the agent, api key, and all config rows in a transaction', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({
+          id: 'src-1',
+          tenant_id: 't1',
+          name: 'source',
+          description: 'a desc',
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+        })
+        .mockResolvedValueOnce(null);
+
+      repoRows = {
+        UserProvider: [
+          {
+            id: 'up1',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'anthropic',
+            api_key_encrypted: 'enc',
+            key_prefix: 'sk-',
+            auth_type: 'api_key',
+            region: null,
+            is_active: true,
+            cached_models: [{ id: 'm' }],
+            models_fetched_at: null,
+          },
+        ],
+        CustomProvider: [
+          {
+            id: 'cp1',
+            agent_id: 'src-1',
+            user_id: 'u1',
+            name: 'local',
+            base_url: 'http://x',
+            models: [],
+          },
+        ],
+        TierAssignment: [
+          {
+            id: 't1',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            tier: 'standard',
+            override_model: 'm',
+            override_provider: 'anthropic',
+            override_auth_type: 'api_key',
+            auto_assigned_model: null,
+            fallback_models: ['x'],
+          },
+        ],
+        SpecificityAssignment: [
+          {
+            id: 's1',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            category: 'coding',
+            is_active: true,
+            override_model: null,
+            override_provider: null,
+            override_auth_type: null,
+            auto_assigned_model: 'auto',
+            fallback_models: null,
+          },
+        ],
+      };
+
+      const result = await service.duplicate('user-1', 'source', {
+        name: 'source-copy',
+        displayName: 'source-copy',
+      });
+
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
+      expect(result.agentName).toBe('source-copy');
+      expect(result.apiKey).toMatch(/^mnfst_/);
+      expect(result.copied).toEqual({
+        providers: 1,
+        customProviders: 1,
+        tierAssignments: 1,
+        specificityAssignments: 1,
+      });
+
+      expect(insertedRows['Agent']).toHaveLength(1);
+      const [agentRow] = insertedRows['Agent'] as Array<Record<string, unknown>>;
+      expect(agentRow['name']).toBe('source-copy');
+      expect(agentRow['tenant_id']).toBe('t1');
+      expect(agentRow['agent_category']).toBe('personal');
+
+      expect(insertedRows['AgentApiKey']).toHaveLength(1);
+      const [apiKeyRow] = insertedRows['AgentApiKey'] as Array<Record<string, unknown>>;
+      expect(apiKeyRow['agent_id']).toBe(agentRow['id']);
+      expect(apiKeyRow['label']).toContain('source-copy');
+
+      const userProviderRow = (insertedRows['UserProvider'] as Array<Record<string, unknown>>)[0];
+      expect(userProviderRow['agent_id']).toBe(agentRow['id']);
+      expect(userProviderRow['api_key_encrypted']).toBe('enc');
+      expect(userProviderRow['id']).not.toBe('up1');
+
+      expect(mockInvalidateAgent).toHaveBeenCalledWith(agentRow['id']);
+    });
+
+    it('skips insert batches when source has no rows', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({
+          id: 'src-1',
+          tenant_id: 't1',
+          name: 'source',
+          description: null,
+          agent_category: null,
+          agent_platform: null,
+        })
+        .mockResolvedValueOnce(null);
+
+      const result = await service.duplicate('user-1', 'source', {
+        name: 'source-copy',
+        displayName: 'source-copy',
+      });
+
+      expect(result.copied).toEqual({
+        providers: 0,
+        customProviders: 0,
+        tierAssignments: 0,
+        specificityAssignments: 0,
+      });
+      expect(insertedRows['UserProvider']).toBeUndefined();
+      expect(insertedRows['CustomProvider']).toBeUndefined();
+      expect(insertedRows['TierAssignment']).toBeUndefined();
+      expect(insertedRows['SpecificityAssignment']).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -11,6 +11,7 @@ import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { hashKey, keyPrefix } from '../../common/utils/hash.util';
 import { encrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
+import { sqlNow } from '../../common/utils/postgres-sql';
 import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
 import { RoutingCacheService } from '../../routing/routing-core/routing-cache.service';
 
@@ -103,7 +104,7 @@ export class AgentDuplicationService {
     const rawKey = this.generateOtlpKey();
     const secret = getEncryptionSecret();
     const newAgentId = uuidv4();
-    const now = new Date().toISOString();
+    const now = sqlNow();
 
     const copied = await this.dataSource.transaction(async (manager) => {
       await manager.getRepository(Agent).insert({

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -1,0 +1,230 @@
+import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { randomBytes } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { Agent } from '../../entities/agent.entity';
+import { AgentApiKey } from '../../entities/agent-api-key.entity';
+import { UserProvider } from '../../entities/user-provider.entity';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+import { TierAssignment } from '../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
+import { hashKey, keyPrefix } from '../../common/utils/hash.util';
+import { encrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
+import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
+import { RoutingCacheService } from '../../routing/routing-core/routing-cache.service';
+
+export interface DuplicateAgentSummary {
+  providers: number;
+  customProviders: number;
+  tierAssignments: number;
+  specificityAssignments: number;
+}
+
+export interface DuplicateAgentResult {
+  agentId: string;
+  agentName: string;
+  displayName: string;
+  apiKey: string;
+  copied: DuplicateAgentSummary;
+}
+
+@Injectable()
+export class AgentDuplicationService {
+  constructor(
+    @InjectRepository(Agent) private readonly agentRepo: Repository<Agent>,
+    private readonly dataSource: DataSource,
+    private readonly routingCache: RoutingCacheService,
+  ) {}
+
+  private generateOtlpKey(): string {
+    return API_KEY_PREFIX + randomBytes(32).toString('base64url');
+  }
+
+  private async findOwnedAgent(userId: string, agentName: string): Promise<Agent | null> {
+    return this.agentRepo
+      .createQueryBuilder('a')
+      .leftJoin('a.tenant', 't')
+      .where('t.name = :userId', { userId })
+      .andWhere('a.name = :agentName', { agentName })
+      .getOne();
+  }
+
+  async getCopySummary(userId: string, sourceName: string): Promise<DuplicateAgentSummary> {
+    const source = await this.findOwnedAgent(userId, sourceName);
+    if (!source) throw new NotFoundException(`Agent "${sourceName}" not found`);
+
+    const [providers, customProviders, tierAssignments, specificityAssignments] = await Promise.all(
+      [
+        this.dataSource.getRepository(UserProvider).count({ where: { agent_id: source.id } }),
+        this.dataSource.getRepository(CustomProvider).count({ where: { agent_id: source.id } }),
+        this.dataSource.getRepository(TierAssignment).count({ where: { agent_id: source.id } }),
+        this.dataSource
+          .getRepository(SpecificityAssignment)
+          .count({ where: { agent_id: source.id } }),
+      ],
+    );
+
+    return { providers, customProviders, tierAssignments, specificityAssignments };
+  }
+
+  async suggestName(userId: string, sourceName: string): Promise<string> {
+    const source = await this.findOwnedAgent(userId, sourceName);
+    if (!source) throw new NotFoundException(`Agent "${sourceName}" not found`);
+
+    const existingNames = await this.agentRepo
+      .createQueryBuilder('a')
+      .leftJoin('a.tenant', 't')
+      .where('t.name = :userId', { userId })
+      .select('a.name', 'name')
+      .getRawMany<{ name: string }>();
+    const taken = new Set(existingNames.map((r) => r.name));
+
+    const base = `${sourceName}-copy`;
+    if (!taken.has(base)) return base;
+    for (let i = 2; i <= 999; i++) {
+      const candidate = `${base}-${i}`;
+      if (!taken.has(candidate)) return candidate;
+    }
+    return `${base}-${Date.now()}`;
+  }
+
+  async duplicate(
+    userId: string,
+    sourceName: string,
+    params: { name: string; displayName: string },
+  ): Promise<DuplicateAgentResult> {
+    const source = await this.findOwnedAgent(userId, sourceName);
+    if (!source) throw new NotFoundException(`Agent "${sourceName}" not found`);
+
+    const clash = await this.findOwnedAgent(userId, params.name);
+    if (clash) throw new ConflictException(`Agent "${params.name}" already exists`);
+
+    const rawKey = this.generateOtlpKey();
+    const secret = getEncryptionSecret();
+    const newAgentId = uuidv4();
+    const now = new Date().toISOString();
+
+    const copied = await this.dataSource.transaction(async (manager) => {
+      await manager.getRepository(Agent).insert({
+        id: newAgentId,
+        name: params.name,
+        display_name: params.displayName,
+        description: source.description,
+        agent_category: source.agent_category,
+        agent_platform: source.agent_platform,
+        is_active: true,
+        tenant_id: source.tenant_id,
+      });
+
+      await manager.getRepository(AgentApiKey).insert({
+        id: uuidv4(),
+        key: encrypt(rawKey, secret),
+        key_hash: hashKey(rawKey),
+        key_prefix: keyPrefix(rawKey),
+        label: `${params.name} ingest key`,
+        tenant_id: source.tenant_id,
+        agent_id: newAgentId,
+        is_active: true,
+      });
+
+      const providers = await manager
+        .getRepository(UserProvider)
+        .find({ where: { agent_id: source.id } });
+      if (providers.length > 0) {
+        await manager.getRepository(UserProvider).insert(
+          providers.map((p) => ({
+            id: uuidv4(),
+            user_id: p.user_id,
+            agent_id: newAgentId,
+            provider: p.provider,
+            api_key_encrypted: p.api_key_encrypted,
+            key_prefix: p.key_prefix,
+            auth_type: p.auth_type,
+            region: p.region,
+            is_active: p.is_active,
+            connected_at: now,
+            updated_at: now,
+            cached_models: p.cached_models,
+            models_fetched_at: p.models_fetched_at,
+          })),
+        );
+      }
+
+      const customProviders = await manager
+        .getRepository(CustomProvider)
+        .find({ where: { agent_id: source.id } });
+      if (customProviders.length > 0) {
+        await manager.getRepository(CustomProvider).insert(
+          customProviders.map((cp) => ({
+            id: uuidv4(),
+            agent_id: newAgentId,
+            user_id: cp.user_id,
+            name: cp.name,
+            base_url: cp.base_url,
+            models: cp.models,
+            created_at: now,
+          })),
+        );
+      }
+
+      const tiers = await manager
+        .getRepository(TierAssignment)
+        .find({ where: { agent_id: source.id } });
+      if (tiers.length > 0) {
+        await manager.getRepository(TierAssignment).insert(
+          tiers.map((t) => ({
+            id: uuidv4(),
+            user_id: t.user_id,
+            agent_id: newAgentId,
+            tier: t.tier,
+            override_model: t.override_model,
+            override_provider: t.override_provider,
+            override_auth_type: t.override_auth_type,
+            auto_assigned_model: t.auto_assigned_model,
+            fallback_models: t.fallback_models,
+            updated_at: now,
+          })),
+        );
+      }
+
+      const specificity = await manager
+        .getRepository(SpecificityAssignment)
+        .find({ where: { agent_id: source.id } });
+      if (specificity.length > 0) {
+        await manager.getRepository(SpecificityAssignment).insert(
+          specificity.map((s) => ({
+            id: uuidv4(),
+            user_id: s.user_id,
+            agent_id: newAgentId,
+            category: s.category,
+            is_active: s.is_active,
+            override_model: s.override_model,
+            override_provider: s.override_provider,
+            override_auth_type: s.override_auth_type,
+            auto_assigned_model: s.auto_assigned_model,
+            fallback_models: s.fallback_models,
+            updated_at: now,
+          })),
+        );
+      }
+
+      return {
+        providers: providers.length,
+        customProviders: customProviders.length,
+        tierAssignments: tiers.length,
+        specificityAssignments: specificity.length,
+      };
+    });
+
+    this.routingCache.invalidateAgent(newAgentId);
+
+    return {
+      agentId: newAgentId,
+      agentName: params.name,
+      displayName: params.displayName,
+      apiKey: rawKey,
+      copied,
+    };
+  }
+}

--- a/packages/backend/src/common/dto/duplicate-agent.dto.ts
+++ b/packages/backend/src/common/dto/duplicate-agent.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNotEmpty, MinLength, MaxLength, Matches } from 'class-validator';
+
+export class DuplicateAgentDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(100)
+  @Matches(/^[a-zA-Z0-9 _-]+$/, {
+    message: 'Agent name must contain only letters, numbers, spaces, dashes, and underscores',
+  })
+  name!: string;
+}

--- a/packages/backend/test/agent-duplication.e2e-spec.ts
+++ b/packages/backend/test/agent-duplication.e2e-spec.ts
@@ -1,0 +1,179 @@
+import request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { createTestApp, TEST_API_KEY, TEST_AGENT_ID, TEST_TENANT_ID } from './helpers';
+import { UserProvider } from '../src/entities/user-provider.entity';
+import { CustomProvider } from '../src/entities/custom-provider.entity';
+import { TierAssignment } from '../src/entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../src/entities/specificity-assignment.entity';
+import { Agent } from '../src/entities/agent.entity';
+import { AgentApiKey } from '../src/entities/agent-api-key.entity';
+
+describe('Agent Duplication (e2e)', () => {
+  let app: INestApplication;
+  let ds: DataSource;
+  const headers = { 'x-api-key': TEST_API_KEY };
+  const sourceAgent = 'test-agent';
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    ds = app.get(DataSource);
+
+    const now = new Date().toISOString();
+    await ds.getRepository(UserProvider).insert({
+      id: 'up-e2e-1',
+      user_id: 'test-user-001',
+      agent_id: TEST_AGENT_ID,
+      provider: 'anthropic',
+      api_key_encrypted: 'enc-value',
+      key_prefix: 'sk-ant',
+      auth_type: 'api_key',
+      region: null,
+      is_active: true,
+      connected_at: now,
+      updated_at: now,
+      cached_models: null,
+      models_fetched_at: null,
+    });
+    await ds.getRepository(CustomProvider).insert({
+      id: 'cp-e2e-1',
+      agent_id: TEST_AGENT_ID,
+      user_id: 'test-user-001',
+      name: 'custom-groq',
+      base_url: 'https://api.groq.com/openai/v1',
+      models: [{ model_name: 'llama-3.1-70b' }],
+      created_at: now,
+    });
+    await ds.getRepository(TierAssignment).insert({
+      id: 'ta-e2e-1',
+      user_id: 'test-user-001',
+      agent_id: TEST_AGENT_ID,
+      tier: 'standard',
+      override_model: 'anthropic/claude-opus-4-6',
+      override_provider: 'anthropic',
+      override_auth_type: 'api_key',
+      auto_assigned_model: null,
+      fallback_models: ['openai/gpt-4o-mini'],
+      updated_at: now,
+    });
+    await ds.getRepository(SpecificityAssignment).insert({
+      id: 'sa-e2e-1',
+      user_id: 'test-user-001',
+      agent_id: TEST_AGENT_ID,
+      category: 'coding',
+      is_active: true,
+      override_model: 'anthropic/claude-opus-4-6',
+      override_provider: 'anthropic',
+      override_auth_type: 'api_key',
+      auto_assigned_model: null,
+      fallback_models: null,
+      updated_at: now,
+    });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('GET /agents/:name/duplicate-preview returns counts + suggested name', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/api/v1/agents/${sourceAgent}/duplicate-preview`)
+      .set(headers)
+      .expect(200);
+
+    expect(res.body.copied).toEqual({
+      providers: 1,
+      customProviders: 1,
+      tierAssignments: 1,
+      specificityAssignments: 1,
+    });
+    expect(res.body.suggested_name).toBe('test-agent-copy');
+  });
+
+  it('GET /agents/:name/duplicate-preview returns 404 for missing source', async () => {
+    await request(app.getHttpServer())
+      .get('/api/v1/agents/does-not-exist/duplicate-preview')
+      .set(headers)
+      .expect(404);
+  });
+
+  it('POST /agents/:name/duplicate copies all config to a new agent', async () => {
+    const res = await request(app.getHttpServer())
+      .post(`/api/v1/agents/${sourceAgent}/duplicate`)
+      .set(headers)
+      .send({ name: 'test-agent-copy' })
+      .expect(201);
+
+    expect(res.body.agent.name).toBe('test-agent-copy');
+    expect(res.body.apiKey).toMatch(/^mnfst_/);
+    expect(res.body.copied).toEqual({
+      providers: 1,
+      customProviders: 1,
+      tierAssignments: 1,
+      specificityAssignments: 1,
+    });
+
+    const newAgent = await ds.getRepository(Agent).findOne({
+      where: { id: res.body.agent.id },
+    });
+    expect(newAgent).toBeTruthy();
+    expect(newAgent!.tenant_id).toBe(TEST_TENANT_ID);
+    expect(newAgent!.name).toBe('test-agent-copy');
+
+    const apiKey = await ds.getRepository(AgentApiKey).findOne({
+      where: { agent_id: res.body.agent.id },
+    });
+    expect(apiKey).toBeTruthy();
+    expect(apiKey!.agent_id).not.toBe(TEST_AGENT_ID);
+
+    const newProviders = await ds
+      .getRepository(UserProvider)
+      .find({ where: { agent_id: res.body.agent.id } });
+    expect(newProviders).toHaveLength(1);
+    expect(newProviders[0].api_key_encrypted).toBe('enc-value');
+    expect(newProviders[0].id).not.toBe('up-e2e-1');
+
+    const newCustom = await ds
+      .getRepository(CustomProvider)
+      .find({ where: { agent_id: res.body.agent.id } });
+    expect(newCustom).toHaveLength(1);
+    expect(newCustom[0].name).toBe('custom-groq');
+
+    const newTiers = await ds
+      .getRepository(TierAssignment)
+      .find({ where: { agent_id: res.body.agent.id } });
+    expect(newTiers).toHaveLength(1);
+    expect(newTiers[0].tier).toBe('standard');
+    expect(newTiers[0].override_model).toBe('anthropic/claude-opus-4-6');
+
+    const newSpec = await ds
+      .getRepository(SpecificityAssignment)
+      .find({ where: { agent_id: res.body.agent.id } });
+    expect(newSpec).toHaveLength(1);
+    expect(newSpec[0].category).toBe('coding');
+  });
+
+  it('POST /agents/:name/duplicate returns 409 when target name already exists', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/v1/agents/${sourceAgent}/duplicate`)
+      .set(headers)
+      .send({ name: 'test-agent-copy' })
+      .expect(409);
+  });
+
+  it('POST /agents/:name/duplicate returns 404 when source does not exist', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/agents/missing/duplicate')
+      .set(headers)
+      .send({ name: 'anything' })
+      .expect(404);
+  });
+
+  it('POST /agents/:name/duplicate rejects invalid names', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/v1/agents/${sourceAgent}/duplicate`)
+      .set(headers)
+      .send({ name: '!!!' })
+      .expect(400);
+  });
+});

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -42,7 +42,9 @@ const DuplicateAgentModal: Component<Props> = (props) => {
       setName('');
       setNameTouched(false);
       setSubmitting(false);
-      cancelledInFlight = false;
+      // Deliberately don't reset `cancelledInFlight` here — it must stay true
+      // until the in-flight fetch returns so handleDuplicate can honor the
+      // cancel. handleDuplicate resets it when starting a new request.
     }
   });
 

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -1,0 +1,200 @@
+import { createResource, createSignal, Show, type Component, createEffect } from 'solid-js';
+import { useNavigate } from '@solidjs/router';
+import {
+  duplicateAgent,
+  getDuplicatePreview,
+  type DuplicateAgentPreview,
+} from '../services/api.js';
+import { markAgentCreated } from '../services/recent-agents.js';
+import { toast } from '../services/toast-store.js';
+
+interface Props {
+  open: boolean;
+  sourceName: string;
+  onClose: () => void;
+  onDuplicated?: () => void;
+}
+
+const DuplicateAgentModal: Component<Props> = (props) => {
+  const navigate = useNavigate();
+  const [name, setName] = createSignal('');
+  const [submitting, setSubmitting] = createSignal(false);
+  const [nameTouched, setNameTouched] = createSignal(false);
+  let cancelledInFlight = false;
+
+  const [preview] = createResource<DuplicateAgentPreview | null, { open: boolean; source: string }>(
+    () => ({ open: props.open, source: props.sourceName }),
+    async ({ open, source }) => {
+      if (!open || !source) return null;
+      return (await getDuplicatePreview(source)) ?? null;
+    },
+  );
+
+  createEffect(() => {
+    const p = preview();
+    if (p?.suggested_name && !nameTouched()) {
+      setName(p.suggested_name);
+    }
+  });
+
+  createEffect(() => {
+    if (!props.open) {
+      setName('');
+      setNameTouched(false);
+      setSubmitting(false);
+      cancelledInFlight = false;
+    }
+  });
+
+  const requestClose = () => {
+    if (submitting()) cancelledInFlight = true;
+    props.onClose();
+  };
+
+  const totalCopied = () => {
+    const c = preview()?.copied;
+    if (!c) return 0;
+    return c.providers + c.customProviders + c.tierAssignments + c.specificityAssignments;
+  };
+
+  const handleNameInput = (value: string) => {
+    setNameTouched(true);
+    setName(value);
+  };
+
+  const handleDuplicate = async () => {
+    const newName = name().trim();
+    if (!newName || submitting()) return;
+    cancelledInFlight = false;
+    setSubmitting(true);
+    try {
+      const result = await duplicateAgent(props.sourceName, newName);
+      if (!result) return;
+      if (cancelledInFlight) {
+        // User closed the modal before the request finished. The agent was still
+        // created on the server, so refresh the parent list but skip the toast
+        // and navigation the user implicitly opted out of.
+        props.onDuplicated?.();
+        return;
+      }
+      const slug = result.agent.name;
+      markAgentCreated(slug);
+      toast.success(`Duplicated "${props.sourceName}" to "${slug}"`);
+      props.onClose();
+      props.onDuplicated?.();
+      navigate(`/agents/${encodeURIComponent(slug)}`, {
+        state: { newApiKey: result.apiKey },
+      });
+    } catch {
+      // error toast already shown by fetchMutate
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') handleDuplicate();
+    if (e.key === 'Escape') requestClose();
+  };
+
+  return (
+    <Show when={props.open}>
+      <div
+        class="modal-overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) requestClose();
+        }}
+      >
+        <div
+          class="modal-card"
+          style="max-width: 520px;"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="duplicate-agent-title"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <h2 class="modal-card__title" id="duplicate-agent-title">
+            Duplicate "{props.sourceName}"
+          </h2>
+          <p class="modal-card__desc">
+            Creates a new agent with the same providers, routing, and tier configuration. A fresh
+            API key is generated — telemetry and message history stay with the original.
+          </p>
+
+          <label class="modal-card__field-label" for="duplicate-agent-name">
+            New agent name
+          </label>
+          <input
+            ref={(el) =>
+              requestAnimationFrame(() => {
+                el.focus();
+                el.select();
+              })
+            }
+            id="duplicate-agent-name"
+            class="modal-card__input modal-card__input--lg"
+            type="text"
+            placeholder={preview()?.suggested_name ?? `${props.sourceName}-copy`}
+            value={name()}
+            onInput={(e) => handleNameInput(e.currentTarget.value)}
+            onKeyDown={handleKeyDown}
+            disabled={submitting()}
+          />
+
+          <details class="duplicate-agent__details">
+            <summary>
+              What's copied
+              <Show when={preview()}>
+                {' '}
+                <span class="duplicate-agent__badge">{totalCopied()}</span>
+              </Show>
+            </summary>
+            <Show
+              when={preview()}
+              fallback={<div class="skeleton skeleton--rect" style="width: 100%; height: 80px;" />}
+            >
+              <ul class="duplicate-agent__list">
+                <li>
+                  <strong>{preview()!.copied.providers}</strong> provider credential
+                  {preview()!.copied.providers === 1 ? '' : 's'} (encrypted API keys &amp;
+                  subscriptions)
+                </li>
+                <li>
+                  <strong>{preview()!.copied.customProviders}</strong> custom provider
+                  {preview()!.copied.customProviders === 1 ? '' : 's'}
+                </li>
+                <li>
+                  <strong>{preview()!.copied.tierAssignments}</strong> tier override
+                  {preview()!.copied.tierAssignments === 1 ? '' : 's'}
+                </li>
+                <li>
+                  <strong>{preview()!.copied.specificityAssignments}</strong> specificity override
+                  {preview()!.copied.specificityAssignments === 1 ? '' : 's'}
+                </li>
+                <li class="duplicate-agent__skipped">
+                  Not copied: messages, logs, notification rules
+                </li>
+              </ul>
+            </Show>
+          </details>
+
+          <div class="modal-card__footer">
+            <button class="btn btn--ghost btn--sm" onClick={requestClose} type="button">
+              Cancel
+            </button>
+            <button
+              class="btn btn--primary btn--sm"
+              onClick={handleDuplicate}
+              disabled={!name().trim() || submitting()}
+              type="button"
+            >
+              {submitting() ? <span class="spinner" /> : 'Duplicate agent'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default DuplicateAgentModal;

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import ErrorState from '../components/ErrorState.jsx';
 import AgentTypeGrid from '../components/AgentTypeGrid.jsx';
 import SetupStepAddProvider from '../components/SetupStepAddProvider.jsx';
 import SetupModal from '../components/SetupModal.jsx';
+import DuplicateAgentModal from '../components/DuplicateAgentModal.jsx';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import {
   deleteAgent,
@@ -44,6 +45,7 @@ const Settings: Component = () => {
   );
   const [showTypeModal, setShowTypeModal] = createSignal(false);
   const [showSetupModal, setShowSetupModal] = createSignal(false);
+  const [showDuplicateModal, setShowDuplicateModal] = createSignal(false);
   const [modalCategory, setModalCategory] = createSignal<AgentCategory | null>(null);
   const [modalPlatform, setModalPlatform] = createSignal<AgentPlatform | null>(null);
   const [savingType, setSavingType] = createSignal(false);
@@ -319,6 +321,25 @@ const Settings: Component = () => {
         </Show>
       </ErrorBoundary>
 
+      {/* -- Duplicate ---------------------------------- */}
+      <h3 class="settings-section__title">Duplicate</h3>
+      <div class="settings-card">
+        <div class="settings-card__row">
+          <div class="settings-card__label">
+            <span class="settings-card__label-title">Duplicate this agent</span>
+            <span class="settings-card__label-desc">
+              Creates a new agent with the same providers, routing tiers, and specificity overrides.
+              A fresh API key is generated. Messages and history stay with this agent.
+            </span>
+          </div>
+          <div class="settings-card__control">
+            <button class="btn btn--outline btn--sm" onClick={() => setShowDuplicateModal(true)}>
+              Duplicate agent
+            </button>
+          </div>
+        </div>
+      </div>
+
       {/* -- Danger Zone -------------------------------- */}
       <h3 class="settings-section__title settings-section__title--danger">Danger zone</h3>
       <div class="settings-card settings-card--danger">
@@ -490,6 +511,12 @@ const Settings: Component = () => {
         agentCategory={currentCategory()}
         onClose={() => setShowSetupModal(false)}
         onDone={() => setShowSetupModal(false)}
+      />
+
+      <DuplicateAgentModal
+        open={showDuplicateModal()}
+        sourceName={agentName()}
+        onClose={() => setShowDuplicateModal(false)}
       />
     </div>
   );

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -1,4 +1,12 @@
-import { createResource, createSignal, Show, For, onCleanup, type Component } from 'solid-js';
+import {
+  createEffect,
+  createResource,
+  createSignal,
+  Show,
+  For,
+  onCleanup,
+  type Component,
+} from 'solid-js';
 import { A, useNavigate } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import ErrorState from '../components/ErrorState.jsx';
@@ -163,19 +171,23 @@ const AgentCardMenu: Component<{
   let rootEl: HTMLDivElement | undefined;
 
   const handleDocumentClick = (e: MouseEvent) => {
-    if (!open()) return;
     if (rootEl && !rootEl.contains(e.target as Node)) setOpen(false);
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape' && open()) setOpen(false);
+    if (e.key === 'Escape') setOpen(false);
   };
 
-  document.addEventListener('click', handleDocumentClick);
-  document.addEventListener('keydown', handleKeyDown);
-  onCleanup(() => {
-    document.removeEventListener('click', handleDocumentClick);
-    document.removeEventListener('keydown', handleKeyDown);
+  // Only register global listeners while the popover is open, so N cards
+  // don't attach N permanent document listeners to the workspace grid.
+  createEffect(() => {
+    if (!open()) return;
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('keydown', handleKeyDown);
+    onCleanup(() => {
+      document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    });
   });
 
   return (

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -1,9 +1,10 @@
-import { createResource, createSignal, Show, For, type Component } from 'solid-js';
+import { createResource, createSignal, Show, For, onCleanup, type Component } from 'solid-js';
 import { A, useNavigate } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import ErrorState from '../components/ErrorState.jsx';
 import AgentTypeSelect from '../components/AgentTypeSelect.jsx';
-import { getAgents, createAgent } from '../services/api.js';
+import DuplicateAgentModal from '../components/DuplicateAgentModal.jsx';
+import { getAgents, createAgent, deleteAgent } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { markAgentCreated } from '../services/recent-agents.js';
 import { formatNumber } from '../services/formatters.js';
@@ -153,12 +154,154 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
   );
 };
 
+const AgentCardMenu: Component<{
+  agentName: string;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}> = (props) => {
+  const [open, setOpen] = createSignal(false);
+  let rootEl: HTMLDivElement | undefined;
+
+  const handleDocumentClick = (e: MouseEvent) => {
+    if (!open()) return;
+    if (rootEl && !rootEl.contains(e.target as Node)) setOpen(false);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape' && open()) setOpen(false);
+  };
+
+  document.addEventListener('click', handleDocumentClick);
+  document.addEventListener('keydown', handleKeyDown);
+  onCleanup(() => {
+    document.removeEventListener('click', handleDocumentClick);
+    document.removeEventListener('keydown', handleKeyDown);
+  });
+
+  return (
+    <div ref={rootEl} class="agent-card__menu" classList={{ 'agent-card__menu--open': open() }}>
+      <button
+        type="button"
+        class="agent-card__menu-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open()}
+        aria-label={`Actions for ${props.agentName}`}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="5" cy="12" r="1" />
+          <circle cx="12" cy="12" r="1" />
+          <circle cx="19" cy="12" r="1" />
+        </svg>
+      </button>
+      <Show when={open()}>
+        <div class="agent-card__menu-popover" role="menu">
+          <button
+            type="button"
+            class="agent-card__menu-item"
+            role="menuitem"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setOpen(false);
+              props.onDuplicate();
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            Duplicate
+          </button>
+          <button
+            type="button"
+            class="agent-card__menu-item agent-card__menu-item--danger"
+            role="menuitem"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setOpen(false);
+              props.onDelete();
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 6h18" />
+              <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+            </svg>
+            Delete
+          </button>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
 const Workspace: Component = () => {
   const [data, { refetch }] = createResource(
     () => ({ _ping: pingCount() }),
     () => getAgents() as Promise<AgentsData>,
   );
   const [modalOpen, setModalOpen] = createSignal(false);
+  const [duplicateSource, setDuplicateSource] = createSignal<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = createSignal<string | null>(null);
+  const [deleteConfirmName, setDeleteConfirmName] = createSignal('');
+  const [deleting, setDeleting] = createSignal(false);
+
+  const closeDeleteModal = () => {
+    setDeleteTarget(null);
+    setDeleteConfirmName('');
+  };
+
+  const handleDelete = async () => {
+    const target = deleteTarget();
+    if (!target || deleteConfirmName() !== target) return;
+    setDeleting(true);
+    try {
+      await deleteAgent(target);
+      toast.success(`Agent "${target}" deleted`);
+      closeDeleteModal();
+      await refetch();
+    } catch {
+      // error toast handled by fetchMutate
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   return (
     <div class="container--md">
@@ -233,35 +376,47 @@ const Workspace: Component = () => {
             <div class="agents-grid">
               <For each={data()!.agents}>
                 {(agent) => (
-                  <A href={`/agents/${encodeURIComponent(agent.agent_name)}`} class="agent-card">
-                    <div class="agent-card__top">
-                      <Show when={platformIcon(agent.agent_platform, agent.agent_category)}>
-                        <img
-                          src={platformIcon(agent.agent_platform, agent.agent_category)}
-                          alt=""
-                          width="18"
-                          height="18"
-                          class="agent-card__platform-icon"
-                        />
-                      </Show>
-                      <span class="agent-card__name">{agent.display_name ?? agent.agent_name}</span>
-                    </div>
-                    <div class="agent-card__stats">
-                      <div class="agent-card__stat">
-                        <span class="agent-card__stat-label">Tokens</span>
-                        <span class="agent-card__stat-value">
-                          {formatNumber(agent.total_tokens)}
+                  <div class="agent-card-wrap">
+                    <A href={`/agents/${encodeURIComponent(agent.agent_name)}`} class="agent-card">
+                      <div class="agent-card__top">
+                        <Show when={platformIcon(agent.agent_platform, agent.agent_category)}>
+                          <img
+                            src={platformIcon(agent.agent_platform, agent.agent_category)}
+                            alt=""
+                            width="18"
+                            height="18"
+                            class="agent-card__platform-icon"
+                          />
+                        </Show>
+                        <span class="agent-card__name">
+                          {agent.display_name ?? agent.agent_name}
                         </span>
                       </div>
-                      <div class="agent-card__stat">
-                        <span class="agent-card__stat-label">Messages</span>
-                        <span class="agent-card__stat-value">{agent.message_count}</span>
+                      <div class="agent-card__stats">
+                        <div class="agent-card__stat">
+                          <span class="agent-card__stat-label">Tokens</span>
+                          <span class="agent-card__stat-value">
+                            {formatNumber(agent.total_tokens)}
+                          </span>
+                        </div>
+                        <div class="agent-card__stat">
+                          <span class="agent-card__stat-label">Messages</span>
+                          <span class="agent-card__stat-value">{agent.message_count}</span>
+                        </div>
                       </div>
-                    </div>
-                    <div class="agent-card__chart">
-                      <Sparkline data={agent.sparkline} width={280} height={50} />
-                    </div>
-                  </A>
+                      <div class="agent-card__chart">
+                        <Sparkline data={agent.sparkline} width={280} height={50} />
+                      </div>
+                    </A>
+                    <AgentCardMenu
+                      agentName={agent.agent_name}
+                      onDuplicate={() => setDuplicateSource(agent.agent_name)}
+                      onDelete={() => {
+                        setDeleteTarget(agent.agent_name);
+                        setDeleteConfirmName('');
+                      }}
+                    />
+                  </div>
                 )}
               </For>
             </div>
@@ -270,6 +425,78 @@ const Workspace: Component = () => {
       </Show>
 
       <AddAgentModal open={modalOpen()} onClose={() => setModalOpen(false)} />
+      <DuplicateAgentModal
+        open={duplicateSource() !== null}
+        sourceName={duplicateSource() ?? ''}
+        onClose={() => setDuplicateSource(null)}
+        onDuplicated={() => refetch()}
+      />
+
+      <Show when={deleteTarget()}>
+        <div
+          class="modal-overlay"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) closeDeleteModal();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') closeDeleteModal();
+          }}
+        >
+          <div
+            class="modal-card"
+            style="max-width: 440px;"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="workspace-delete-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3
+              id="workspace-delete-title"
+              style="margin: 0 0 var(--gap-md); font-size: var(--font-size-lg);"
+            >
+              Delete {deleteTarget()}
+            </h3>
+            <p style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); margin-bottom: var(--gap-md);">
+              This will permanently delete the{' '}
+              <strong style="color: hsl(var(--foreground));">{deleteTarget()}</strong> agent and all
+              its data. This action cannot be undone.
+            </p>
+            <label
+              for="workspace-delete-confirm"
+              style="display: block; font-size: var(--font-size-sm); color: hsl(var(--foreground)); margin-bottom: var(--gap-sm);"
+            >
+              To confirm, type <strong>"{deleteTarget()}"</strong> below
+            </label>
+            <input
+              id="workspace-delete-confirm"
+              class="modal-card__input modal-card__input--lg"
+              type="text"
+              value={deleteConfirmName()}
+              onInput={(e) => setDeleteConfirmName(e.currentTarget.value)}
+              placeholder={deleteTarget() ?? ''}
+              style="margin-bottom: var(--gap-lg);"
+            />
+            <div class="modal-card__footer">
+              <button
+                type="button"
+                class="btn btn--ghost btn--sm"
+                onClick={closeDeleteModal}
+                disabled={deleting()}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="btn btn--danger btn--sm"
+                onClick={handleDelete}
+                disabled={deleteConfirmName() !== deleteTarget() || deleting()}
+              >
+                {deleting() ? <span class="spinner" /> : 'Delete agent'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </Show>
     </div>
   );
 };

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -58,6 +58,36 @@ export interface CreateAgentParams {
   agent_platform?: string;
 }
 
+export interface DuplicateAgentPreview {
+  copied: {
+    providers: number;
+    customProviders: number;
+    tierAssignments: number;
+    specificityAssignments: number;
+  };
+  suggested_name: string;
+}
+
+export function getDuplicatePreview(sourceName: string): Promise<DuplicateAgentPreview> {
+  return fetchJson<DuplicateAgentPreview>(
+    `/agents/${encodeURIComponent(sourceName)}/duplicate-preview`,
+  ) as Promise<DuplicateAgentPreview>;
+}
+
+export interface DuplicateAgentResult {
+  agent: { id: string; name: string; display_name: string };
+  apiKey: string;
+  copied: DuplicateAgentPreview['copied'];
+}
+
+export function duplicateAgent(sourceName: string, name: string) {
+  return fetchMutate<DuplicateAgentResult>(`/agents/${encodeURIComponent(sourceName)}/duplicate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+}
+
 export function createAgent(params: CreateAgentParams) {
   return fetchMutate<{
     agent: {

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -5,7 +5,13 @@
   gap: var(--gap-lg);
 }
 
+.agent-card-wrap {
+  position: relative;
+  animation: fadeInUp 300ms ease-out both;
+}
+
 .agent-card {
+  display: block;
   background: hsl(var(--card));
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
@@ -14,7 +20,10 @@
   text-decoration: none;
   color: inherit;
   transition: all var(--transition-base);
-  animation: fadeInUp 300ms ease-out both;
+}
+
+.agent-card-wrap > .agent-card {
+  animation: none;
 }
 
 .agent-card:hover {
@@ -24,6 +33,176 @@
 
 .agent-card--skeleton {
   pointer-events: none;
+  animation: fadeInUp 300ms ease-out both;
+}
+
+/* ── Agent Card Menu (kebab) ───────────────────────── */
+.agent-card__menu {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 2;
+}
+
+.agent-card__menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    background-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.agent-card-wrap:hover .agent-card__menu-trigger,
+.agent-card-wrap:focus-within .agent-card__menu-trigger,
+.agent-card__menu--open .agent-card__menu-trigger {
+  opacity: 1;
+}
+
+.agent-card__menu-trigger:hover,
+.agent-card__menu--open .agent-card__menu-trigger {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}
+
+.agent-card__menu-trigger:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+  opacity: 1;
+}
+
+.agent-card__menu-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 160px;
+  padding: 4px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow-hover);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  animation: fadeInUp 120ms ease-out both;
+}
+
+.agent-card__menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  background: transparent;
+  color: hsl(var(--foreground));
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.agent-card__menu-item:hover,
+.agent-card__menu-item:focus-visible {
+  background: hsl(var(--accent));
+  outline: none;
+}
+
+.agent-card__menu-item--danger {
+  color: hsl(var(--destructive, 0 72% 51%));
+}
+
+.agent-card__menu-item--danger:hover,
+.agent-card__menu-item--danger:focus-visible {
+  background: hsl(var(--destructive, 0 72% 51%) / 0.08);
+}
+
+/* ── Duplicate Agent Modal ─────────────────────────── */
+.duplicate-agent__details {
+  margin-top: var(--gap-md);
+  padding: 10px 12px;
+  background: hsl(var(--muted) / 0.4);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  font-size: var(--font-size-sm);
+}
+
+.duplicate-agent__details > summary {
+  cursor: pointer;
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.duplicate-agent__details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.duplicate-agent__details > summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-right: 4px;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid hsl(var(--muted-foreground));
+  transition: transform var(--transition-fast);
+}
+
+.duplicate-agent__details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.duplicate-agent__badge {
+  margin-left: auto;
+  padding: 1px 8px;
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+}
+
+.duplicate-agent__list {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: hsl(var(--muted-foreground));
+}
+
+.duplicate-agent__list strong {
+  color: hsl(var(--foreground));
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+
+.duplicate-agent__skipped {
+  list-style: none;
+  margin-left: -18px;
+  padding-top: 6px;
+  margin-top: 4px;
+  border-top: 1px dashed hsl(var(--border));
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
 }
 
 .agent-card__top {

--- a/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
+++ b/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
@@ -171,6 +171,58 @@ describe('DuplicateAgentModal', () => {
     });
   });
 
+  it('swallows errors silently (toast already shown by fetchMutate)', async () => {
+    mockDuplicateAgent.mockRejectedValueOnce(new Error('boom'));
+    const onClose = vi.fn();
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={onClose} />
+    ));
+
+    await waitFor(() => {
+      const input = q('#duplicate-agent-name') as HTMLInputElement | null;
+      expect(input?.value).toBe('my-agent-copy');
+    });
+
+    const btn = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Duplicate agent',
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(mockDuplicateAgent).toHaveBeenCalled();
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes when the overlay backdrop is clicked', async () => {
+    const onClose = vi.fn();
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={onClose} />
+    ));
+    await waitFor(() => {
+      expect(q('.modal-overlay')).toBeDefined();
+    });
+    const overlay = q('.modal-overlay') as HTMLDivElement;
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not close when a click inside the modal card bubbles to the overlay', async () => {
+    const onClose = vi.fn();
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={onClose} />
+    ));
+    await waitFor(() => {
+      expect(q('.modal-card')).toBeDefined();
+    });
+    const card = q('.modal-card') as HTMLDivElement;
+    fireEvent.click(card);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('skips toast + navigate when user cancels during an in-flight submit', async () => {
     let resolveDuplicate: (value: {
       agent: { id: string; name: string; display_name: string };

--- a/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
+++ b/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
 
 const mockDuplicateAgent = vi.fn();
 const mockGetDuplicatePreview = vi.fn();
@@ -223,7 +224,7 @@ describe('DuplicateAgentModal', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('skips toast + navigate when user cancels during an in-flight submit', async () => {
+  it('skips toast + navigate when the parent closes the modal during an in-flight submit', async () => {
     let resolveDuplicate: (value: {
       agent: { id: string; name: string; display_name: string };
       apiKey: string;
@@ -241,13 +242,15 @@ describe('DuplicateAgentModal', () => {
         }),
     );
 
-    const onClose = vi.fn();
+    // Use a reactive `open` signal so calling onClose actually flips the prop
+    // and runs the modal's createEffect, matching real parent wiring.
+    const [open, setOpen] = createSignal(true);
     const onDuplicated = vi.fn();
     render(() => (
       <DuplicateAgentModal
-        open={true}
+        open={open()}
         sourceName="my-agent"
-        onClose={onClose}
+        onClose={() => setOpen(false)}
         onDuplicated={onDuplicated}
       />
     ));
@@ -270,7 +273,10 @@ describe('DuplicateAgentModal', () => {
       (b) => b.textContent?.trim() === 'Cancel',
     ) as HTMLButtonElement;
     fireEvent.click(cancelBtn);
-    expect(onClose).toHaveBeenCalled();
+    // Modal has closed (props.open flipped to false)
+    await waitFor(() => {
+      expect(q('.modal-overlay')).toBeNull();
+    });
 
     resolveDuplicate({
       agent: { id: 'new-id', name: 'my-agent-copy', display_name: 'my-agent-copy' },

--- a/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
+++ b/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
+
+const mockDuplicateAgent = vi.fn();
+const mockGetDuplicatePreview = vi.fn();
+const mockNavigate = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockMarkAgentCreated = vi.fn();
+
+vi.mock('../../src/services/api.js', () => ({
+  duplicateAgent: (...args: unknown[]) => mockDuplicateAgent(...args),
+  getDuplicatePreview: (...args: unknown[]) => mockGetDuplicatePreview(...args),
+}));
+
+vi.mock('../../src/services/toast-store.js', () => ({
+  toast: { success: (...a: unknown[]) => mockToastSuccess(...a), error: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock('../../src/services/recent-agents.js', () => ({
+  markAgentCreated: (...a: unknown[]) => mockMarkAgentCreated(...a),
+}));
+
+vi.mock('@solidjs/router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+import DuplicateAgentModal from '../../src/components/DuplicateAgentModal';
+
+const q = (sel: string) => document.querySelector(sel);
+const qa = (sel: string) => Array.from(document.querySelectorAll(sel));
+
+describe('DuplicateAgentModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDuplicatePreview.mockResolvedValue({
+      copied: { providers: 3, customProviders: 1, tierAssignments: 4, specificityAssignments: 2 },
+      suggested_name: 'my-agent-copy',
+    });
+    mockDuplicateAgent.mockResolvedValue({
+      agent: { id: 'new-id', name: 'my-agent-copy', display_name: 'my-agent-copy' },
+      apiKey: 'mnfst_xyz',
+      copied: { providers: 3, customProviders: 1, tierAssignments: 4, specificityAssignments: 2 },
+    });
+  });
+
+  it('does not render when closed', () => {
+    render(() => (
+      <DuplicateAgentModal open={false} sourceName="my-agent" onClose={vi.fn()} />
+    ));
+    expect(q('.modal-overlay')).toBeNull();
+  });
+
+  it('renders the source agent name in the title and prefills the suggested name', async () => {
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={vi.fn()} />
+    ));
+
+    expect(screen.getByText(/Duplicate "my-agent"/)).toBeDefined();
+
+    await waitFor(() => {
+      const input = q('#duplicate-agent-name') as HTMLInputElement | null;
+      expect(input?.value).toBe('my-agent-copy');
+    });
+  });
+
+  it('shows counts in the details disclosure', async () => {
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={vi.fn()} />
+    ));
+
+    await waitFor(() => {
+      const list = qa('.duplicate-agent__list li');
+      expect(list.length).toBeGreaterThan(0);
+    });
+
+    const list = qa('.duplicate-agent__list li').map((li) => li.textContent);
+    expect(list.some((t) => t?.includes('3') && t?.includes('provider credential'))).toBe(true);
+    expect(list.some((t) => t?.includes('1') && t?.includes('custom provider'))).toBe(true);
+    expect(list.some((t) => t?.includes('4') && t?.includes('tier override'))).toBe(true);
+    expect(list.some((t) => t?.includes('2') && t?.includes('specificity override'))).toBe(true);
+  });
+
+  it('calls duplicateAgent, shows toast, and navigates on success', async () => {
+    const onClose = vi.fn();
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={onClose} />
+    ));
+
+    await waitFor(() => {
+      const input = q('#duplicate-agent-name') as HTMLInputElement | null;
+      expect(input?.value).toBe('my-agent-copy');
+    });
+
+    const btn = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Duplicate agent',
+    ) as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(mockDuplicateAgent).toHaveBeenCalledWith('my-agent', 'my-agent-copy');
+    });
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalled();
+      expect(mockMarkAgentCreated).toHaveBeenCalledWith('my-agent-copy');
+      expect(mockNavigate).toHaveBeenCalledWith('/agents/my-agent-copy', {
+        state: { newApiKey: 'mnfst_xyz' },
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('disables the Duplicate button when name is empty', async () => {
+    mockGetDuplicatePreview.mockResolvedValueOnce({
+      copied: { providers: 0, customProviders: 0, tierAssignments: 0, specificityAssignments: 0 },
+      suggested_name: '',
+    });
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={vi.fn()} />
+    ));
+
+    await waitFor(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Duplicate agent',
+      ) as HTMLButtonElement;
+      expect(btn.hasAttribute('disabled')).toBe(true);
+    });
+  });
+
+  it('closes when Cancel is clicked', () => {
+    const onClose = vi.fn();
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={onClose} />
+    ));
+
+    const cancelBtn = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Cancel',
+    ) as HTMLButtonElement;
+    fireEvent.click(cancelBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape keypress', async () => {
+    const onClose = vi.fn();
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={onClose} />
+    ));
+
+    await waitFor(() => {
+      expect(q('#duplicate-agent-name')).toBeDefined();
+    });
+    const input = q('#duplicate-agent-name') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('submits on Enter keypress', async () => {
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={vi.fn()} />
+    ));
+
+    await waitFor(() => {
+      const input = q('#duplicate-agent-name') as HTMLInputElement | null;
+      expect(input?.value).toBe('my-agent-copy');
+    });
+
+    const input = q('#duplicate-agent-name') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockDuplicateAgent).toHaveBeenCalledWith('my-agent', 'my-agent-copy');
+    });
+  });
+
+  it('skips toast + navigate when user cancels during an in-flight submit', async () => {
+    let resolveDuplicate: (value: {
+      agent: { id: string; name: string; display_name: string };
+      apiKey: string;
+      copied: {
+        providers: number;
+        customProviders: number;
+        tierAssignments: number;
+        specificityAssignments: number;
+      };
+    }) => void = () => undefined;
+    mockDuplicateAgent.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDuplicate = resolve;
+        }),
+    );
+
+    const onClose = vi.fn();
+    const onDuplicated = vi.fn();
+    render(() => (
+      <DuplicateAgentModal
+        open={true}
+        sourceName="my-agent"
+        onClose={onClose}
+        onDuplicated={onDuplicated}
+      />
+    ));
+
+    await waitFor(() => {
+      const input = q('#duplicate-agent-name') as HTMLInputElement | null;
+      expect(input?.value).toBe('my-agent-copy');
+    });
+
+    const duplicateBtn = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Duplicate agent',
+    ) as HTMLButtonElement;
+    fireEvent.click(duplicateBtn);
+
+    await waitFor(() => {
+      expect(mockDuplicateAgent).toHaveBeenCalled();
+    });
+
+    const cancelBtn = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Cancel',
+    ) as HTMLButtonElement;
+    fireEvent.click(cancelBtn);
+    expect(onClose).toHaveBeenCalled();
+
+    resolveDuplicate({
+      agent: { id: 'new-id', name: 'my-agent-copy', display_name: 'my-agent-copy' },
+      apiKey: 'mnfst_xyz',
+      copied: { providers: 0, customProviders: 0, tierAssignments: 0, specificityAssignments: 0 },
+    });
+
+    await waitFor(() => {
+      expect(onDuplicated).toHaveBeenCalled();
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockMarkAgentCreated).not.toHaveBeenCalled();
+  });
+
+  it('keeps user-typed name when they edit it', async () => {
+    render(() => (
+      <DuplicateAgentModal open={true} sourceName="my-agent" onClose={vi.fn()} />
+    ));
+
+    await waitFor(() => {
+      const input = q('#duplicate-agent-name') as HTMLInputElement | null;
+      expect(input?.value).toBe('my-agent-copy');
+    });
+
+    const input = q('#duplicate-agent-name') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'my-custom-name' } });
+    expect(input.value).toBe('my-custom-name');
+  });
+});

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -14,10 +14,41 @@ vi.mock("@solidjs/meta", () => ({
 
 const mockGetAgents = vi.fn();
 const mockCreateAgent = vi.fn();
+const mockDeleteAgent = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getAgents: (...args: unknown[]) => mockGetAgents(...args),
   createAgent: (...args: unknown[]) => mockCreateAgent(...args),
+  deleteAgent: (...args: unknown[]) => mockDeleteAgent(...args),
 }));
+
+vi.mock("../../src/components/DuplicateAgentModal.jsx", async () => {
+  const { Show } = await import("solid-js");
+  return {
+    default: (props: {
+      open: boolean;
+      sourceName: string;
+      onClose: () => void;
+      onDuplicated?: () => void;
+    }) => (
+      <Show when={props.open}>
+        <div data-testid="duplicate-modal" data-source={props.sourceName}>
+          <button data-testid="duplicate-modal-close" onClick={() => props.onClose()}>
+            close
+          </button>
+          <button
+            data-testid="duplicate-modal-done"
+            onClick={() => {
+              props.onDuplicated?.();
+              props.onClose();
+            }}
+          >
+            done
+          </button>
+        </div>
+      </Show>
+    ),
+  };
+});
 
 vi.mock("../../src/services/toast-store.js", () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
@@ -403,5 +434,176 @@ describe("Workspace", () => {
       expect(picker!.getAttribute("data-disabled")).toBe("true");
     });
     resolveCreate!({ agent: { name: "test" }, apiKey: "k" });
+  });
+
+  describe("agent card menu", () => {
+    const clickKebab = async (container: HTMLElement) => {
+      await vi.waitFor(() => {
+        const trigger = container.querySelector(".agent-card__menu-trigger");
+        expect(trigger).not.toBeNull();
+      });
+      const trigger = container.querySelector(".agent-card__menu-trigger") as HTMLButtonElement;
+      fireEvent.click(trigger);
+    };
+
+    it("opens kebab popover with Duplicate and Delete", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      expect(container.querySelector(".agent-card__menu-popover")).not.toBeNull();
+      expect(container.textContent).toContain("Duplicate");
+      expect(container.textContent).toContain("Delete");
+    });
+
+    it("toggles the popover closed on a second trigger click", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      await clickKebab(container);
+      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+    });
+
+    it("closes the popover when clicking outside", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      expect(container.querySelector(".agent-card__menu-popover")).not.toBeNull();
+      fireEvent.click(document.body);
+      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+    });
+
+    it("closes the popover on Escape", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+    });
+
+    it("ignores Escape when popover is already closed", async () => {
+      const { container } = render(() => <Workspace />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".agent-card__menu-trigger")).not.toBeNull();
+      });
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+    });
+
+    it("opens the DuplicateAgentModal when Duplicate is clicked", async () => {
+      const { container, getByTestId } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Duplicate"));
+      const modal = getByTestId("duplicate-modal");
+      expect(modal.getAttribute("data-source")).toBe("demo-agent");
+    });
+
+    it("closes the DuplicateAgentModal when the user cancels", async () => {
+      const { container, getByTestId, queryByTestId } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Duplicate"));
+      expect(getByTestId("duplicate-modal")).toBeDefined();
+      fireEvent.click(getByTestId("duplicate-modal-close"));
+      expect(queryByTestId("duplicate-modal")).toBeNull();
+    });
+
+    it("refetches agents after a successful duplicate", async () => {
+      const { container, getByTestId } = render(() => <Workspace />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("Demo Agent");
+      });
+      expect(mockGetAgents).toHaveBeenCalledTimes(1);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Duplicate"));
+      fireEvent.click(getByTestId("duplicate-modal-done"));
+      await vi.waitFor(() => {
+        expect(mockGetAgents).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("opens the delete confirmation modal when Delete is clicked", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Delete"));
+      expect(container.textContent).toContain("Delete demo-agent");
+      expect(container.querySelector('input[placeholder="demo-agent"]')).not.toBeNull();
+    });
+
+    it("requires exact name match before enabling delete button", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Delete"));
+      const deleteBtn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Delete agent",
+      ) as HTMLButtonElement;
+      expect(deleteBtn.hasAttribute("disabled")).toBe(true);
+      const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: "wrong-name" } });
+      expect(deleteBtn.hasAttribute("disabled")).toBe(true);
+      fireEvent.input(input, { target: { value: "demo-agent" } });
+      expect(deleteBtn.hasAttribute("disabled")).toBe(false);
+    });
+
+    it("deletes the agent and refetches after confirmation", async () => {
+      mockDeleteAgent.mockResolvedValue({ deleted: true });
+      const { container } = render(() => <Workspace />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("Demo Agent");
+      });
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Delete"));
+      const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: "demo-agent" } });
+      const deleteBtn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Delete agent",
+      ) as HTMLButtonElement;
+      fireEvent.click(deleteBtn);
+      await vi.waitFor(() => {
+        expect(mockDeleteAgent).toHaveBeenCalledWith("demo-agent");
+        expect(mockGetAgents).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("keeps the modal open when deletion fails so the user can retry", async () => {
+      mockDeleteAgent.mockRejectedValue(new Error("boom"));
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Delete"));
+      const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: "demo-agent" } });
+      const deleteBtn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Delete agent",
+      ) as HTMLButtonElement;
+      fireEvent.click(deleteBtn);
+      await vi.waitFor(() => {
+        expect(mockDeleteAgent).toHaveBeenCalled();
+      });
+      expect(container.textContent).toContain("Delete demo-agent");
+    });
+
+    it("cancels the delete modal without deleting", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Delete"));
+      const cancelBtn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Cancel",
+      ) as HTMLButtonElement;
+      fireEvent.click(cancelBtn);
+      expect(container.textContent).not.toContain("Delete demo-agent");
+      expect(mockDeleteAgent).not.toHaveBeenCalled();
+    });
+
+    it("closes the delete modal when the backdrop is clicked", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Delete"));
+      const overlay = container.querySelector(".modal-overlay") as HTMLDivElement;
+      fireEvent.click(overlay);
+      expect(container.textContent).not.toContain("Delete demo-agent");
+    });
+
+    it("closes the delete modal on Escape from the overlay", async () => {
+      const { container } = render(() => <Workspace />);
+      await clickKebab(container);
+      fireEvent.click(screen.getByText("Delete"));
+      const overlay = container.querySelector(".modal-overlay") as HTMLDivElement;
+      fireEvent.keyDown(overlay, { key: "Escape" });
+      expect(container.textContent).not.toContain("Delete demo-agent");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- New `POST /api/v1/agents/:name/duplicate` (+ `/duplicate-preview`) service that copies every provider credential, custom provider, tier override, and specificity override onto a new agent with a fresh OTLP key. Messages, logs, and notification rules stay with the original.
- Hover-revealed kebab menu on each Workspace card (Duplicate + Delete), plus a dedicated "Duplicate agent" action on the agent Settings page.
- Modal prefills `{name}-copy`, shows live counts of what's about to be copied, and navigates into the new agent on success. If the user cancels while the request is in flight, the new agent is still created but the toast/navigation are skipped to respect the cancel.

Addresses #1655 (copy provider credentials between agents) and #1626 (copy route config to clipboard). Users with 5+ providers no longer have to re-enter every API key when they spin up a new agent.

## Test plan
- [x] Backend unit: 4110/4110 pass (10 new in `agent-duplication.service.spec.ts`, 5 new in `agents.controller.spec.ts`)
- [x] Backend e2e: 131/131 pass (6 new in `agent-duplication.e2e-spec.ts`, covers 201 happy path + 400/404/409 edge cases)
- [x] Frontend: 2309/2309 pass (10 new in `DuplicateAgentModal.test.tsx`, including the cancel-during-submit case)
- [x] TypeScript: `tsc --noEmit` clean in backend + frontend
- [x] Manual smoke in browser: seeded a demo-agent with 3 providers + 4 tier overrides + 1 specificity override → preview showed exactly `3/0/4/1` → duplicate → landed on new agent's overview with fresh OTLP key (`mnfst_3mcEJd...` vs source `mnfst_dev-ot...`) → DB confirms all config copied with new UUIDs and zero messages on the copy

## Notes
- Changeset included; targets `manifest` per the repo's release config.
- Encrypted provider keys are copied verbatim (global encryption secret — no decrypt/re-encrypt needed).
- Custom providers, tier assignments, and specificity assignments all use new UUIDs scoped to the new `agent_id`, so per-agent unique indexes are safe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add one-click agent duplication that copies provider credentials, custom providers, and tier/specificity overrides to a new agent with a fresh OTLP key. Messages, logs, and notification rules are not copied. Addresses Linear #1655 and #1626.

- **New Features**
  - Backend: `GET /api/v1/agents/:agentName/duplicate-preview` returns copy counts and a suggested name; `POST /api/v1/agents/:agentName/duplicate` creates the copy, rejects invalid names (400), handles name conflicts (409), and invalidates the agent list cache.
  - Copy logic: encrypted provider keys are reused, related rows get new IDs scoped to the new agent, and a new ingest key is generated.
  - Frontend: Duplicate modal (prefills `{name}-copy`, shows live counts) and Workspace kebab menu with Duplicate/Delete; Settings page adds a “Duplicate agent” action.
  - UX: on success, navigates to the new agent and shows the new API key; if the user cancels while submitting, creation completes but toast/navigation are skipped.

- **Bug Fixes**
  - Modal: preserve the cancel flag during in-flight submissions to prevent success toast/navigation after the user closes the modal.
  - Backend: use `sqlNow()` for duplicated rows’ timestamps to match `timestamp without time zone` columns and avoid timezone drift.

<sup>Written for commit 66c967c4da19c063ba638e4eb44ba3cd95b05c1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

