### PR TITLE
feat(routing): polish routing page copy and UX

### DIFF
--- a/.changeset/routing-copy-polish.md
+++ b/.changeset/routing-copy-polish.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Polish routing page copy and UX: rewrite tier descriptions, standardize casing and pluralization, always show the "How routing works" help button, toggle tiers by clicking the manage-modal row, and add a pen icon on custom tier cards to open the edit modal directly.

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -320,9 +320,9 @@ const FallbackList: Component<FallbackListProps> = (props) => {
             >
               <path d="M6 22h2V8h4L7 2 2 8h4zM19 2h-2v14h-4l5 6 5-6h-4z" />
             </svg>
-            <span class="fallback-list__empty-title">No fallback</span>
+            <span class="fallback-list__empty-title">No fallbacks</span>
             <span class="fallback-list__empty-desc">
-              Add fallback models to guarantee responses at all times
+              Add fallback models to guarantee a response if the provider fails.
             </span>
             <button
               class="btn btn--outline btn--sm fallback-list__add"

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -43,6 +43,7 @@ interface Props {
   connectedProviders: RoutingProvider[];
   onOverride: (model: string, provider: string, authType?: AuthType) => void | Promise<void>;
   onFallbacksUpdate: (fallbacks: string[]) => void;
+  onEdit?: () => void;
 }
 
 const HeaderTierCard: Component<Props> = (props) => {
@@ -139,6 +140,26 @@ const HeaderTierCard: Component<Props> = (props) => {
               <path d="m20.42 13.4-.51-.29c.05-.37.08-.74.08-1.11s-.03-.74-.08-1.11l.51-.29c.96-.55 1.28-1.78.73-2.73l-1-1.73a2.006 2.006 0 0 0-2.73-.73l-.53.31c-.58-.46-1.22-.83-1.9-1.11v-.6c0-1.1-.9-2-2-2h-2c-1.1 0-2 .9-2 2v.6c-.67.28-1.31.66-1.9 1.11l-.53-.31c-.96-.55-2.18-.22-2.73.73l-1 1.73c-.55.96-.22 2.18.73 2.73l.51.29c-.05.37-.08.74-.08 1.11s.03.74.08 1.11l-.51.29c-.96.55-1.28 1.78-.73 2.73l1 1.73c.55.95 1.78 1.28 2.73.73l.53-.31c.58.46 1.22.83 1.9 1.11v.6c0 1.1.9 2 2 2h2c1.1 0 2-.9 2-2v-.6a8.7 8.7 0 0 0 1.9-1.11l.53.31c.95.55 2.18.22 2.73-.73l1-1.73c.55-.96.22-2.18-.73-2.73m-2.59-2.78c.11.45.17.92.17 1.38s-.06.92-.17 1.38a1 1 0 0 0 .47 1.11l1.12.65-1 1.73-1.14-.66c-.38-.22-.87-.16-1.19.14-.68.65-1.51 1.13-2.38 1.4-.42.13-.71.52-.71.96v1.3h-2v-1.3c0-.44-.29-.83-.71-.96-.88-.27-1.7-.75-2.38-1.4a1.01 1.01 0 0 0-1.19-.15l-1.14.66-1-1.73 1.12-.65c.39-.22.58-.68.47-1.11-.11-.45-.17-.92-.17-1.38s.06-.93.17-1.38A1 1 0 0 0 5.7 9.5l-1.12-.65 1-1.73 1.14.66c.38.22.87.16 1.19-.14.68-.65 1.51-1.13 2.38-1.4.42-.13.71-.52.71-.96v-1.3h2v1.3c0 .44.29.83.71.96.88.27 1.7.75 2.38 1.4.32.31.81.36 1.19.14l1.14-.66 1 1.73-1.12.65c-.39.22-.58.68-.47 1.11Z" />
             </svg>
           </button>
+          <Show when={props.onEdit}>
+            <button
+              type="button"
+              class="header-tier-card__icon-btn"
+              onClick={() => props.onEdit?.()}
+              aria-label={`Edit ${props.tier.name}`}
+              title="Edit tier"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path d="M4 22h16v-2H4zM20.71 5.63l-2.34-2.34a1 1 0 0 0-1.41 0l-1.84 1.84 3.75 3.75 1.84-1.84a1 1 0 0 0 0-1.41zM3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" />
+              </svg>
+            </button>
+          </Show>
         </span>
         <Show when={!currentModel()}>
           <button class="routing-card__header-add" onClick={() => setPickerMode('primary')}>

--- a/packages/frontend/src/components/HeaderTierModal.tsx
+++ b/packages/frontend/src/components/HeaderTierModal.tsx
@@ -157,7 +157,7 @@ const HeaderTierModal: Component<Props> = (props) => {
   const titleText = editingTier ? 'Edit custom tier' : 'Create custom tier';
   const descText = editingTier
     ? 'Update the header rule, name, or color for this tier. Model and fallbacks are managed on the card.'
-    : 'Route requests that carry a specific HTTP header to a model of your choice.';
+    : 'Custom routing lets you identify requests based on their headers and assign specific models to them.';
   const submitLabel = (): string => {
     if (editingTier) return submitting() ? 'Saving…' : 'Save changes';
     return submitting() ? 'Creating…' : 'Create tier';
@@ -222,7 +222,7 @@ const HeaderTierModal: Component<Props> = (props) => {
           classList={{ 'modal-card__input--error': nameError() !== undefined }}
           type="text"
           value={name()}
-          placeholder="Premium Users"
+          placeholder="My custom tier"
           maxlength={MAX_NAME_LEN}
           onInput={(e) => setName(e.currentTarget.value)}
         />
@@ -252,7 +252,7 @@ const HeaderTierModal: Component<Props> = (props) => {
           value={headerValue()}
           onInput={setHeaderValue}
           suggestions={valueSuggestions()}
-          placeholder="premium"
+          placeholder="custom-value"
           invalid={valueError() !== undefined}
           errorMessage={valueError()}
           disabled={!headerKey().trim()}

--- a/packages/frontend/src/components/RoutingPipelineCard.tsx
+++ b/packages/frontend/src/components/RoutingPipelineCard.tsx
@@ -8,55 +8,53 @@ interface PipelineStep {
 
 /**
  * Builds the pipeline help modal content.
- * Returns null when no layers are active (Default only).
  */
 export function buildPipelineHelp(
   complexity: boolean,
   specificity: boolean,
   custom: boolean,
-): JSX.Element | null {
-  const active = [custom, specificity, complexity].filter(Boolean).length;
-  if (active === 0) return null;
-
+): JSX.Element {
   const steps: PipelineStep[] = [];
   let n = 1;
 
   if (custom) {
     steps.push({
       num: n++,
-      name: 'Custom',
-      desc: 'Checked first. If a request header matches a custom routing rule, it routes there immediately.',
+      name: 'Custom routing',
+      desc: 'If a request header matches a custom tier rule, it is routed to the corresponding model.',
     });
   }
 
   if (specificity) {
     steps.push({
       num: n++,
-      name: 'Task-specific',
-      desc: 'If the request matches a task type like coding or trading, it goes to the dedicated model for that category.',
+      name: 'Task-specific routing',
+      desc: 'Manifest semantically analyzes the query, and if it matches an active task-specific tier (coding, image generation\u2026), it is routed to the corresponding model.',
     });
   }
 
   if (complexity) {
     steps.push({
       num: n++,
-      name: 'Complexity',
-      desc: 'The request gets scored and routed to the tier that fits its difficulty. Cheap models handle simple tasks, better ones take on harder work.',
+      name: 'Complexity routing',
+      desc: 'Manifest semantically analyzes the query, scores its complexity, and assigns it to a tier ranging from \u201csimple\u201d to \u201creasoning\u201d.',
     });
   }
 
   steps.push({
     num: n,
-    name: 'Default',
-    desc: complexity
-      ? 'Catches any request that the other routing layers couldn\u2019t handle, for example when a complexity routing tier has no model assigned.'
-      : 'Handles every request that didn\u2019t match an earlier rule.',
+    name: 'Default routing',
+    desc: 'Default model and fallbacks for all queries. Default routing is triggered when other routing strategies are not enabled, or if they do not catch the query.',
   });
 
   return (
     <div class="routing-pipeline-help-steps">
       <p class="routing-pipeline-help-summary">
-        Each request stops at the first match. Everything else falls through to the next step.
+        Routing is a powerful technique that allows Manifest to intercept queries on the fly and
+        redirect them to the corresponding model.
+      </p>
+      <p class="routing-pipeline-help-summary">
+        This is what your current configuration looks like:
       </p>
       {steps.map((step) => (
         <div class="routing-pipeline-help-step">

--- a/packages/frontend/src/pages/RoutingComplexitySection.tsx
+++ b/packages/frontend/src/pages/RoutingComplexitySection.tsx
@@ -110,8 +110,8 @@ const RoutingComplexitySection: Component<RoutingComplexitySectionProps> = (prop
           <div class="complexity-empty">
             <span class="complexity-empty__title">Complexity routing is off</span>
             <span class="complexity-empty__desc">
-              Most requests don't need your top model. Each one gets scored and routed to something
-              cheaper when it fits. Can shave up to 70% off your LLM bill.
+              Most requests don't need your top model. Save up to 70% by using cheaper alternatives
+              when possible.
             </span>
             <button
               class="btn btn--primary btn--sm"
@@ -208,7 +208,8 @@ const RoutingComplexitySection: Component<RoutingComplexitySectionProps> = (prop
         >
           <div>
             <span class="routing-section__subtitle">
-              Picks a cheap model for easy requests and your best for the rest.
+              Analyzes the complexity of each request on the fly and routes it to the matching tier.
+              Replaces default routing.
             </span>
           </div>
           {actionButton()}
@@ -224,7 +225,8 @@ const RoutingComplexitySection: Component<RoutingComplexitySectionProps> = (prop
         <div>
           <span class="routing-section__title">Complexity routing</span>
           <span class="routing-section__subtitle">
-            Picks a cheap model for easy requests and your best for the rest.
+            Analyzes the complexity of each request on the fly and routes it to the matching tier.
+            Replaces default routing.
           </span>
         </div>
         {actionButton()}

--- a/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
+++ b/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
@@ -35,7 +35,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
   const subtitle = () =>
     props.complexityEnabled()
       ? 'Acts as a safety net and handles requests that complexity routing can\u2019t resolve'
-      : 'All requests route through this model';
+      : 'All requests are routed to this model, or to the fallback models if it fails.';
 
   const card = () => (
     <div

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -49,8 +49,6 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
   const [manageOpen, setManageOpen] = createSignal(false);
   // Create/edit modal: `null` = closed, `'new'` = create, otherwise editing.
   const [modalTier, setModalTier] = createSignal<HeaderTier | 'new' | null>(null);
-  // When editing from manage modal, track so we can go back.
-  const [editFromManage, setEditFromManage] = createSignal(false);
   // After a tier is freshly created, auto-open the SDK snippet modal.
   const [snippetTier, setSnippetTier] = createSignal<HeaderTier | null>(null);
   // Which tier is currently being toggled (loading state).
@@ -103,33 +101,21 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
     }
   };
 
-  const openEditFromManage = (tier: HeaderTier) => {
-    setManageOpen(false);
-    setEditFromManage(true);
-    setModalTier(tier);
-  };
-
-  const handleBackToManage = () => {
-    setModalTier(null);
-    setEditFromManage(false);
-    setManageOpen(true);
-  };
-
   const handleDeleteFromEdit = async (id: string) => {
     await handleDelete(id);
     setModalTier(null);
-    setEditFromManage(false);
-    setManageOpen(true);
   };
 
   const manageButton = () => (
-    <button
-      type="button"
-      class="btn btn--primary btn--sm routing-section__cta"
-      onClick={openCreateOrManage}
-    >
-      {tiers().length > 0 ? 'Manage custom routing' : 'Create custom tier'}
-    </button>
+    <Show when={tiers().length > 0}>
+      <button
+        type="button"
+        class="btn btn--primary btn--sm routing-section__cta"
+        onClick={openCreateOrManage}
+      >
+        Manage custom routing
+      </button>
+    </Show>
   );
 
   const content = () => (
@@ -138,10 +124,9 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
         when={enabledTiers().length > 0}
         fallback={
           <div class="routing-section__empty">
-            <div class="routing-section__empty-title">No custom tier yet</div>
+            <div class="routing-section__empty-title">No custom tiers activated</div>
             <div class="routing-section__empty-desc">
-              Create a tier triggered by a header like <code>x-manifest-tier: premium</code> to
-              force specific requests to a chosen model.
+              Create or activate custom tiers to route matching requests to the models you choose.
             </div>
             <button type="button" class="btn btn--primary btn--sm" onClick={openCreateOrManage}>
               {tiers().length > 0 ? 'Manage custom routing' : 'Create custom tier'}
@@ -160,6 +145,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 connectedProviders={props.connectedProviders()}
                 onOverride={(m, p, a) => handleOverride(tier.id, m, p, a)}
                 onFallbacksUpdate={() => refetch()}
+                onEdit={() => setModalTier(tier)}
               />
             )}
           </For>
@@ -188,24 +174,27 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
               Manage custom routing
             </h2>
             <p class="specificity-modal__desc">
-              Click a tier to edit its header rule, name, or color. Create new tiers or remove
-              existing ones.
+              Toggle tiers on or off. Create new tiers or edit them directly on their card.
             </p>
             <div class="specificity-modal__list">
               <For each={tiers()}>
                 {(tier) => {
                   const loading = () => toggling() === tier.id;
+                  const toggle = () => {
+                    if (!loading()) handleToggle(tier.id, !tier.enabled);
+                  };
                   return (
                     <div
                       class="specificity-modal__row"
                       role="button"
                       tabIndex={0}
+                      aria-pressed={tier.enabled}
                       style="cursor: pointer;"
-                      onClick={() => openEditFromManage(tier)}
+                      onClick={toggle}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault();
-                          openEditFromManage(tier);
+                          toggle();
                         }
                       }}
                     >
@@ -215,17 +204,12 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                           {tier.header_key}: {tier.header_value}
                         </span>
                       </div>
-                      <button
+                      <span
                         class="specificity-modal__toggle"
                         classList={{
                           'specificity-modal__toggle--on': tier.enabled,
                         }}
-                        disabled={loading()}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          if (!loading()) handleToggle(tier.id, !tier.enabled);
-                        }}
-                        aria-label={`${tier.enabled ? 'Disable' : 'Enable'} ${tier.name}`}
+                        aria-hidden="true"
                       >
                         <Show
                           when={loading()}
@@ -235,7 +219,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                             <span class="spinner" style="width: 10px; height: 10px;" />
                           </span>
                         </Show>
-                      </button>
+                      </span>
                     </div>
                   );
                 }}
@@ -278,19 +262,14 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
             agentName={props.agentName()}
             existingTiers={tiers()}
             editing={state === 'new' ? undefined : state}
-            onClose={() => {
-              setModalTier(null);
-              setEditFromManage(false);
-            }}
+            onClose={() => setModalTier(null)}
             onSaved={(saved) => {
               const wasCreate = state === 'new';
               setModalTier(null);
-              setEditFromManage(false);
               refetch();
               if (wasCreate) setSnippetTier(saved);
             }}
-            onBack={editFromManage() ? handleBackToManage : undefined}
-            onDelete={editFromManage() ? handleDeleteFromEdit : undefined}
+            onDelete={state !== 'new' ? handleDeleteFromEdit : undefined}
           />
         )}
       </Show>
@@ -316,8 +295,8 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
         >
           <div>
             <span class="routing-section__subtitle">
-              Route requests by HTTP header. Custom routing runs before complexity and task-specific
-              routing.
+              Assign requests to tiers based on their HTTP headers. Custom routing is evaluated
+              before any other routing method.
             </span>
           </div>
           {manageButton()}
@@ -333,8 +312,8 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
         <div>
           <h2 class="routing-section__title">Custom routing</h2>
           <p class="routing-section__subtitle">
-            Route requests by HTTP header. Custom routing runs before complexity and task-specific
-            routing.
+            Assign requests to tiers based on their HTTP headers. Custom routing is evaluated before
+            any other routing method.
           </p>
         </div>
         {manageButton()}

--- a/packages/frontend/src/pages/RoutingPanels.tsx
+++ b/packages/frontend/src/pages/RoutingPanels.tsx
@@ -91,7 +91,7 @@ export const EnableRoutingCard: Component<EnableRoutingCardProps> = (props) => (
       your LLM providers to get started.
     </p>
     <button class="btn btn--primary" onClick={() => props.onEnable()}>
-      Enable Routing
+      Enable routing
     </button>
   </div>
 );
@@ -178,7 +178,7 @@ export const RoutingFooter: Component<RoutingFooterProps> = (props) => (
       onClick={() => props.onDisable()}
       disabled={props.disabling()}
     >
-      {props.disabling() ? <span class="spinner" /> : 'Disable Routing'}
+      {props.disabling() ? <span class="spinner" /> : 'Disable routing'}
     </button>
     <Show when={props.hasOverrides()}>
       <button

--- a/packages/frontend/src/pages/RoutingSpecificitySection.tsx
+++ b/packages/frontend/src/pages/RoutingSpecificitySection.tsx
@@ -189,9 +189,11 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
   };
 
   const manageButton = () => (
-    <button class="btn btn--primary btn--sm" onClick={() => setShowModal(true)}>
-      {hasAnyActive() ? 'Manage task-specific routing' : 'Enable task-specific routing'}
-    </button>
+    <Show when={hasAnyActive()}>
+      <button class="btn btn--primary btn--sm" onClick={() => setShowModal(true)}>
+        Manage task-specific routing
+      </button>
+    </Show>
   );
 
   const content = () => (
@@ -200,12 +202,12 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
         when={activeTiers().length > 0}
         fallback={
           <div class="specificity-empty">
-            <span class="specificity-empty__title">No task-specific rules yet</span>
+            <span class="specificity-empty__title">No task-specific tiers yet</span>
             <span class="specificity-empty__desc">
               Route specialized tasks to dedicated models.
             </span>
             <button class="btn btn--primary btn--sm" onClick={() => setShowModal(true)}>
-              Enable task-specific routing
+              Add a task-specific tier
             </button>
           </div>
         }
@@ -265,7 +267,8 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
               Manage task-specific routing
             </h2>
             <p class="specificity-modal__desc">
-              Route specialized tasks to dedicated models. Overrides complexity and default.
+              Route specialized tasks to dedicated models. Overrides complexity and default routing
+              when a task matches.
             </p>
             <div class="specificity-modal__list">
               <For each={SPECIFICITY_STAGES}>
@@ -346,8 +349,8 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
         <div class="routing-section__header specificity-header" style="margin-bottom: 16px;">
           <div class="specificity-header__left">
             <span class="routing-section__subtitle">
-              Send specific kinds of work (coding, trading, image gen…) to dedicated models.
-              Overrides everything else.
+              Send specific tasks (coding, trading, image gen…) to dedicated models. Overrides
+              default and complexity routing when a task matches.
             </span>
           </div>
           {manageButton()}
@@ -363,8 +366,8 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
         <div class="specificity-header__left">
           <span class="routing-section__title">Task-specific routing</span>
           <span class="routing-section__subtitle">
-            Send specific kinds of work (coding, trading, image gen…) to dedicated models. Overrides
-            everything else.
+            Send specific tasks (coding, trading, image gen…) to dedicated models. Overrides default
+            and complexity routing when a task matches.
           </span>
         </div>
         {manageButton()}

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -70,7 +70,7 @@ describe("FallbackList", () => {
       <FallbackList {...defaultProps} fallbacks={[]} />
     ));
 
-    expect(screen.getByText("No fallback")).toBeDefined();
+    expect(screen.getByText("No fallbacks")).toBeDefined();
     expect(container.querySelector(".fallback-list__empty")).not.toBeNull();
     expect(container.querySelector(".fallback-list__items")).toBeNull();
   });

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -125,11 +125,13 @@ interface MountOptions {
   connectedProviders?: never[];
   onOverride?: ReturnType<typeof vi.fn>;
   onFallbacksUpdate?: ReturnType<typeof vi.fn>;
+  onEdit?: ReturnType<typeof vi.fn>;
 }
 
 function mount(opts: MountOptions = {}) {
   const onOverride = opts.onOverride ?? vi.fn();
   const onFallbacksUpdate = opts.onFallbacksUpdate ?? vi.fn();
+  const onEdit = opts.onEdit;
   const result = render(() => (
     <HeaderTierCard
       agentName="my-agent"
@@ -150,9 +152,10 @@ function mount(opts: MountOptions = {}) {
       connectedProviders={opts.connectedProviders ?? []}
       onOverride={onOverride}
       onFallbacksUpdate={onFallbacksUpdate}
+      onEdit={onEdit}
     />
   ));
-  return { ...result, onOverride, onFallbacksUpdate };
+  return { ...result, onOverride, onFallbacksUpdate, onEdit };
 }
 
 describe('HeaderTierCard', () => {
@@ -349,6 +352,25 @@ describe('HeaderTierCard', () => {
     expect(gearBtn).not.toBeNull();
     fireEvent.click(gearBtn!);
     await waitFor(() => expect(getByText(/Send the .* header/)).toBeDefined());
+  });
+
+  it('renders the edit button only when onEdit is provided', () => {
+    const onEdit = vi.fn();
+    const { container: withEdit } = mount({ onEdit });
+    expect(withEdit.querySelector(`button[aria-label="Edit ${baseTier.name}"]`)).not.toBeNull();
+
+    const { container: withoutEdit } = mount();
+    expect(withoutEdit.querySelector('button[aria-label^="Edit "]')).toBeNull();
+  });
+
+  it('calls onEdit when the edit button is clicked', () => {
+    const onEdit = vi.fn();
+    const { container } = mount({ onEdit });
+    const editBtn = container.querySelector(
+      `button[aria-label="Edit ${baseTier.name}"]`,
+    ) as HTMLButtonElement;
+    fireEvent.click(editBtn);
+    expect(onEdit).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to the provider db-id when the model name has no recognizable prefix', () => {

--- a/packages/frontend/tests/components/HeaderTierModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierModal.test.tsx
@@ -128,7 +128,7 @@ describe('HeaderTierModal', () => {
       const { container, getByText, getByPlaceholderText } = mount();
       fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: 'Test' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'authorization' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'x' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'x' } });
       fireEvent.click(getByText('Create tier'));
       expect(container.textContent).toContain('stripped for security');
       expect(createHeaderTierMock).not.toHaveBeenCalled();
@@ -138,7 +138,7 @@ describe('HeaderTierModal', () => {
       const { container, getByText, getByPlaceholderText } = mount();
       fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: 'Test' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'X_BAD' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'v' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'v' } });
       fireEvent.click(getByText('Create tier'));
       expect(container.textContent).toContain(
         'Header keys can only contain lowercase letters, digits, and hyphens',
@@ -151,7 +151,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'EXISTING' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-new' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'v' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'v' } });
       fireEvent.click(getByText('Create tier'));
       expect(container.textContent).toContain('A tier with this name already exists');
     });
@@ -161,7 +161,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'New Name' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-existing' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'yes' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'yes' } });
       fireEvent.click(getByText('Create tier'));
       expect(container.textContent).toContain('already matches this header key and value');
     });
@@ -173,7 +173,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'Premium' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-manifest-tier' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'premium' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'premium' } });
       const violet = container.querySelector('.header-tier-modal__swatch--violet') as HTMLElement;
       fireEvent.click(violet);
       fireEvent.click(getByText('Create tier'));
@@ -195,7 +195,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'X' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-a' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'a' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'a' } });
       fireEvent.click(getByText('Create tier'));
       await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('boom'));
     });
@@ -206,7 +206,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'X' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-a' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'a' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'a' } });
       fireEvent.click(getByText('Create tier'));
       await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('Failed to create tier'));
     });
@@ -216,7 +216,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'a'.repeat(33) } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-a' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'a' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'a' } });
       fireEvent.click(getByText('Create tier'));
       expect(container.textContent).toContain('Name must be 32 characters or fewer');
       expect(createHeaderTierMock).not.toHaveBeenCalled();
@@ -227,7 +227,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'Name' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-a' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'v'.repeat(129) } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'v'.repeat(129) } });
       fireEvent.click(getByText('Create tier'));
       expect(container.textContent).toContain('Header value must be 128 characters or fewer');
       expect(createHeaderTierMock).not.toHaveBeenCalled();
@@ -239,7 +239,7 @@ describe('HeaderTierModal', () => {
         const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
         fireEvent.input(nameInput, { target: { value: 'Name' } });
         fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-a' } });
-        fireEvent.input(getByPlaceholderText('premium'), { target: { value: bad } });
+        fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: bad } });
         fireEvent.click(getByText('Create tier'));
         expect(container.textContent).toContain('cannot contain quotes or backslashes');
         expect(createHeaderTierMock).not.toHaveBeenCalled();
@@ -258,7 +258,7 @@ describe('HeaderTierModal', () => {
       const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
       fireEvent.input(nameInput, { target: { value: 'Name' } });
       fireEvent.input(getByPlaceholderText('x-manifest-tier'), { target: { value: 'x-a' } });
-      fireEvent.input(getByPlaceholderText('premium'), { target: { value: 'a' } });
+      fireEvent.input(getByPlaceholderText('custom-value'), { target: { value: 'a' } });
       fireEvent.click(getByText('Create tier'));
       await waitFor(() => expect(getByText('Creating…')).toBeDefined());
       const submitBtn = getByText('Creating…') as HTMLButtonElement;
@@ -284,7 +284,7 @@ describe('HeaderTierModal', () => {
         (container.querySelector('input[placeholder="x-manifest-tier"]') as HTMLInputElement).value,
       ).toBe('x-existing');
       expect(
-        (container.querySelector('input[placeholder="premium"]') as HTMLInputElement).value,
+        (container.querySelector('input[placeholder="custom-value"]') as HTMLInputElement).value,
       ).toBe('yes');
       expect(
         container.querySelector('.header-tier-modal__swatch--rose')!.getAttribute('aria-checked'),

--- a/packages/frontend/tests/components/RoutingPipelineCard.test.tsx
+++ b/packages/frontend/tests/components/RoutingPipelineCard.test.tsx
@@ -4,42 +4,45 @@ import { buildPipelineHelp } from '../../src/components/RoutingPipelineCard';
 
 function renderHelp(complexity: boolean, specificity: boolean, custom: boolean) {
   const content = buildPipelineHelp(complexity, specificity, custom);
-  if (!content) return null;
   render(() => <div>{content}</div>);
   return true;
 }
 
 describe('buildPipelineHelp', () => {
-  it('returns null when all layers are disabled', () => {
-    expect(buildPipelineHelp(false, false, false)).toBeNull();
+  it('shows only the Default step when all layers are disabled', () => {
+    renderHelp(false, false, false);
+    expect(screen.getByText('Default routing')).toBeDefined();
+    expect(screen.queryByText('Complexity routing')).toBeNull();
+    expect(screen.queryByText('Task-specific routing')).toBeNull();
+    expect(screen.queryByText('Custom routing')).toBeNull();
   });
 
   it('shows Complexity and Default steps when only complexity is enabled', () => {
     renderHelp(true, false, false);
-    expect(screen.getByText('Complexity')).toBeDefined();
-    expect(screen.getByText('Default')).toBeDefined();
-    expect(screen.getByText(/scored and routed/)).toBeDefined();
+    expect(screen.getByText('Complexity routing')).toBeDefined();
+    expect(screen.getByText('Default routing')).toBeDefined();
+    expect(screen.getByText(/scores its complexity/)).toBeDefined();
   });
 
   it('shows all four steps when everything is enabled', () => {
     renderHelp(true, true, true);
-    expect(screen.getByText('Custom')).toBeDefined();
-    expect(screen.getByText('Task-specific')).toBeDefined();
-    expect(screen.getByText('Complexity')).toBeDefined();
-    expect(screen.getByText('Default')).toBeDefined();
+    expect(screen.getByText('Custom routing')).toBeDefined();
+    expect(screen.getByText('Task-specific routing')).toBeDefined();
+    expect(screen.getByText('Complexity routing')).toBeDefined();
+    expect(screen.getByText('Default routing')).toBeDefined();
   });
 
   it('shows Task-specific and Default when only specificity', () => {
     renderHelp(false, true, false);
-    expect(screen.getByText('Task-specific')).toBeDefined();
-    expect(screen.getByText('Default')).toBeDefined();
-    expect(screen.queryByText('Complexity')).toBeNull();
+    expect(screen.getByText('Task-specific routing')).toBeDefined();
+    expect(screen.getByText('Default routing')).toBeDefined();
+    expect(screen.queryByText('Complexity routing')).toBeNull();
   });
 
   it('shows Custom and Default when only custom', () => {
     renderHelp(false, false, true);
-    expect(screen.getByText('Custom')).toBeDefined();
-    expect(screen.getByText('Default')).toBeDefined();
+    expect(screen.getByText('Custom routing')).toBeDefined();
+    expect(screen.getByText('Default routing')).toBeDefined();
   });
 
   it('numbers steps sequentially', () => {
@@ -52,18 +55,19 @@ describe('buildPipelineHelp', () => {
     expect(nums[3].textContent).toBe('4');
   });
 
-  it('shows safety net description for Default when complexity is on', () => {
+  it('shows the same Default description regardless of complexity state', () => {
     renderHelp(true, false, false);
-    expect(screen.getByText(/couldn\u2019t handle/)).toBeDefined();
+    expect(screen.getByText(/Default model and fallbacks for all queries/)).toBeDefined();
   });
 
-  it('shows generic description for Default when complexity is off', () => {
+  it('shows Default description when complexity is off', () => {
     renderHelp(false, true, false);
-    expect(screen.getByText(/didn\u2019t match an earlier rule/)).toBeDefined();
+    expect(screen.getByText(/Default model and fallbacks for all queries/)).toBeDefined();
   });
 
   it('shows the summary line', () => {
     renderHelp(true, false, false);
-    expect(screen.getByText(/first match/i)).toBeDefined();
+    expect(screen.getByText(/intercept queries on the fly/i)).toBeDefined();
+    expect(screen.getByText(/current configuration looks like/i)).toBeDefined();
   });
 });

--- a/packages/frontend/tests/pages/Routing-complexity-integration.test.tsx
+++ b/packages/frontend/tests/pages/Routing-complexity-integration.test.tsx
@@ -218,7 +218,7 @@ describe('Routing — default tier + complexity integration', () => {
     mockGetComplexityStatus.mockResolvedValue({ enabled: false });
     render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('All requests route through this model')).toBeDefined();
+      expect(screen.getByText('All requests are routed to this model, or to the fallback models if it fails.')).toBeDefined();
     });
   });
 
@@ -245,7 +245,7 @@ describe('Routing — default tier + complexity integration', () => {
     });
   });
 
-  it('hides pipeline description when complexity is off and no specificity', async () => {
+  it('shows pipeline help button even when complexity is off and no specificity', async () => {
     mockGetComplexityStatus.mockResolvedValue({ enabled: false });
     const { getSpecificityAssignments } = await import('../../src/services/api.js');
     vi.mocked(getSpecificityAssignments).mockResolvedValue([]);
@@ -253,6 +253,6 @@ describe('Routing — default tier + complexity integration', () => {
     await waitFor(() => {
       expect(screen.getByRole('tablist')).toBeDefined();
     });
-    expect(screen.queryByLabelText('How routing works')).toBeNull();
+    expect(screen.queryByLabelText('How routing works')).not.toBeNull();
   });
 });

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -161,7 +161,7 @@ describe("Routing — enabled state (providers active)", () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
     fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
-    const emptyStates = await screen.findAllByText("No fallback");
+    const emptyStates = await screen.findAllByText("No fallbacks");
     expect(emptyStates.length).toBe(4); // one per tier
   });
 
@@ -182,7 +182,7 @@ describe("Routing — enabled state (providers active)", () => {
 
   it("shows Disable Routing button", async () => {
     render(() => <Routing />);
-    expect(await screen.findByText("Disable Routing")).toBeDefined();
+    expect(await screen.findByText("Disable routing")).toBeDefined();
   });
 
   it("shows Setup instructions link in footer", async () => {
@@ -387,7 +387,7 @@ describe("Routing — enabled state (providers active)", () => {
 
   it("calls deactivateAllProviders when Disable Routing is confirmed", async () => {
     render(() => <Routing />);
-    const disableBtn = await screen.findByText("Disable Routing");
+    const disableBtn = await screen.findByText("Disable routing");
     fireEvent.click(disableBtn);
 
     // Confirm dialog appears — click the "Disable" button
@@ -635,7 +635,7 @@ describe("Routing — disabled state (no active providers)", () => {
 
   it("shows Enable Routing button when no providers active", async () => {
     render(() => <Routing />);
-    expect(await screen.findByText("Enable Routing")).toBeDefined();
+    expect(await screen.findByText("Enable routing")).toBeDefined();
   });
 
   it("shows description about smart routing", async () => {
@@ -645,14 +645,14 @@ describe("Routing — disabled state (no active providers)", () => {
 
   it("opens provider modal when Enable Routing is clicked", async () => {
     render(() => <Routing />);
-    const enableBtn = await screen.findByText("Enable Routing");
+    const enableBtn = await screen.findByText("Enable routing");
     fireEvent.click(enableBtn);
     expect(screen.getByTestId("provider-modal")).toBeDefined();
   });
 
   it("does not show Setup instructions when no providers ever existed", async () => {
     render(() => <Routing />);
-    await screen.findByText("Enable Routing");
+    await screen.findByText("Enable routing");
     expect(screen.queryByText("Setup instructions")).toBeNull();
   });
 
@@ -710,7 +710,7 @@ describe("Routing — helper functions", () => {
   it("handles deactivateAllProviders error gracefully", async () => {
     mockDeactivateAllProviders.mockRejectedValueOnce(new Error("fail"));
     render(() => <Routing />);
-    const disableBtn = await screen.findByText("Disable Routing");
+    const disableBtn = await screen.findByText("Disable routing");
     fireEvent.click(disableBtn);
 
     const confirmBtn = await screen.findByText("Disable");
@@ -723,7 +723,7 @@ describe("Routing — helper functions", () => {
 
   it("closes confirm disable modal on overlay click", async () => {
     render(() => <Routing />);
-    const disableBtn = await screen.findByText("Disable Routing");
+    const disableBtn = await screen.findByText("Disable routing");
     fireEvent.click(disableBtn);
     await waitFor(() => {
       expect(screen.getByText("Disable routing?")).toBeDefined();
@@ -741,7 +741,7 @@ describe("Routing — helper functions", () => {
 
   it("closes confirm disable modal on Escape key", async () => {
     render(() => <Routing />);
-    const disableBtn = await screen.findByText("Disable Routing");
+    const disableBtn = await screen.findByText("Disable routing");
     fireEvent.click(disableBtn);
     await waitFor(() => {
       expect(screen.getByText("Disable routing?")).toBeDefined();
@@ -993,7 +993,7 @@ describe("Routing — handleProviderUpdate", () => {
     mockDeactivateAllProviders.mockResolvedValue({ ok: true });
 
     render(() => <Routing />);
-    const enableBtn = await screen.findByText("Enable Routing");
+    const enableBtn = await screen.findByText("Enable routing");
     fireEvent.click(enableBtn);
 
     mockGetProviders.mockResolvedValue([
@@ -1032,7 +1032,7 @@ describe("Routing — handleProviderUpdate", () => {
     mockDeactivateAllProviders.mockResolvedValue({ ok: true });
 
     render(() => <Routing />);
-    const enableBtn = await screen.findByText("Enable Routing");
+    const enableBtn = await screen.findByText("Enable routing");
     fireEvent.click(enableBtn);
 
     // Simulate provider connected via update
@@ -1059,7 +1059,7 @@ describe("Routing — handleProviderUpdate", () => {
     mockDeactivateAllProviders.mockResolvedValue({ ok: true });
 
     render(() => <Routing />);
-    const enableBtn = await screen.findByText("Enable Routing");
+    const enableBtn = await screen.findByText("Enable routing");
     fireEvent.click(enableBtn);
 
     // Simulate provider re-activated via update

--- a/packages/frontend/tests/pages/RoutingComplexitySection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingComplexitySection.test.tsx
@@ -118,7 +118,7 @@ describe('RoutingComplexitySection', () => {
     render(() => <RoutingComplexitySection {...makeProps()} />);
     expect(screen.getByText('Complexity routing')).toBeDefined();
     expect(
-      screen.getByText('Picks a cheap model for easy requests and your best for the rest.'),
+      screen.getByText('Analyzes the complexity of each request on the fly and routes it to the matching tier. Replaces default routing.'),
     ).toBeDefined();
   });
 

--- a/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
@@ -107,7 +107,7 @@ describe('RoutingDefaultTierSection', () => {
 
   it('shows the "All requests" subtitle when complexity is off', () => {
     render(() => <RoutingDefaultTierSection {...makeProps({ complexityEnabled: () => false })} />);
-    expect(screen.getByText('All requests route through this model')).toBeDefined();
+    expect(screen.getByText('All requests are routed to this model, or to the fallback models if it fails.')).toBeDefined();
   });
 
   it('shows the "Safety net" subtitle when complexity is on', () => {
@@ -140,7 +140,7 @@ describe('RoutingDefaultTierSection', () => {
 
   it('skips subtitle while tiers are loading', () => {
     render(() => <RoutingDefaultTierSection {...makeProps({ tiersLoading: true })} />);
-    expect(screen.queryByText('All requests route through this model')).toBeNull();
+    expect(screen.queryByText('All requests are routed to this model, or to the fallback models if it fails.')).toBeNull();
     expect(
       screen.queryByText('Acts as a safety net and handles requests that complexity routing can\u2019t resolve'),
     ).toBeNull();

--- a/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
     onOverride: (m: string, p: string) => void;
     onReset?: () => void;
     onFallbacksUpdate: () => void;
+    onEdit?: () => void;
   }) => (
     <div
       data-testid={`card-${props.tier.id}`}
@@ -41,6 +42,11 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
       <button data-testid={`override-${props.tier.id}`} onClick={() => props.onOverride('gpt-4o', 'OpenAI')}>
         override
       </button>
+      {props.onEdit && (
+        <button data-testid={`edit-${props.tier.id}`} onClick={() => props.onEdit!()}>
+          edit
+        </button>
+      )}
     </div>
   ),
 }));
@@ -156,7 +162,7 @@ describe('RoutingHeaderTiersSection', () => {
   it('renders the empty state when no tiers exist', async () => {
     listHeaderTiersMock.mockResolvedValue([]);
     const { container } = mount();
-    await waitFor(() => expect(container.textContent).toContain('No custom tier yet'));
+    await waitFor(() => expect(container.textContent).toContain('No custom tiers activated'));
   });
 
   it('renders a card per tier when tiers load', async () => {
@@ -310,14 +316,40 @@ describe('RoutingHeaderTiersSection', () => {
     expect(getByRole('dialog')).toBeDefined();
   });
 
-  it('toggles a tier on/off from manage modal', async () => {
+  it('toggles a tier on/off by clicking the manage modal row', async () => {
     toggleHeaderTierMock.mockResolvedValue({ ...baseTier, enabled: false });
     listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByLabelText } = mount();
+    const { container } = mount();
     await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
     fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => expect(getByLabelText('Disable Premium')).toBeDefined());
-    fireEvent.click(getByLabelText('Disable Premium'));
+    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
+    fireEvent.click(container.querySelector('.specificity-modal__row')!);
+    await waitFor(() => {
+      expect(toggleHeaderTierMock).toHaveBeenCalledWith('my-agent', 'ht-1', false);
+    });
+  });
+
+  it('toggles a tier via Enter key on manage row', async () => {
+    toggleHeaderTierMock.mockResolvedValue({ ...baseTier, enabled: false });
+    listHeaderTiersMock.mockResolvedValue([baseTier]);
+    const { container } = mount();
+    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
+    fireEvent.click(container.querySelector('.routing-section__cta')!);
+    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
+    fireEvent.keyDown(container.querySelector('.specificity-modal__row')!, { key: 'Enter' });
+    await waitFor(() => {
+      expect(toggleHeaderTierMock).toHaveBeenCalledWith('my-agent', 'ht-1', false);
+    });
+  });
+
+  it('toggles a tier via Space key on manage row', async () => {
+    toggleHeaderTierMock.mockResolvedValue({ ...baseTier, enabled: false });
+    listHeaderTiersMock.mockResolvedValue([baseTier]);
+    const { container } = mount();
+    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
+    fireEvent.click(container.querySelector('.routing-section__cta')!);
+    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
+    fireEvent.keyDown(container.querySelector('.specificity-modal__row')!, { key: ' ' });
     await waitFor(() => {
       expect(toggleHeaderTierMock).toHaveBeenCalledWith('my-agent', 'ht-1', false);
     });
@@ -326,105 +358,59 @@ describe('RoutingHeaderTiersSection', () => {
   it('toasts error when toggle fails', async () => {
     toggleHeaderTierMock.mockRejectedValue(new Error('toggle fail'));
     listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByLabelText } = mount();
+    const { container } = mount();
     await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
     fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => getByLabelText('Disable Premium'));
-    fireEvent.click(getByLabelText('Disable Premium'));
+    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
+    fireEvent.click(container.querySelector('.specificity-modal__row')!);
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('toggle fail'));
   });
 
   it('toasts generic error when toggle rejects with non-Error', async () => {
     toggleHeaderTierMock.mockRejectedValue('plain');
     listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByLabelText } = mount();
+    const { container } = mount();
     await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
     fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => getByLabelText('Disable Premium'));
-    fireEvent.click(getByLabelText('Disable Premium'));
+    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
+    fireEvent.click(container.querySelector('.specificity-modal__row')!);
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('Failed to toggle tier'));
   });
 
-  it('opens edit modal from manage modal row click', async () => {
+  it('opens edit modal from the card edit button', async () => {
     listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByTestId } = mount();
-    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
-    fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => {
-      expect(container.querySelector('[role="button"]')).not.toBeNull();
-    });
-    fireEvent.click(container.querySelector('.specificity-modal__row')!);
+    const { getByTestId } = mount();
+    await waitFor(() => expect(getByTestId('edit-ht-1')).toBeDefined());
+    fireEvent.click(getByTestId('edit-ht-1'));
     await waitFor(() => {
       const modal = getByTestId('mock-modal');
       expect(modal.getAttribute('data-mode')).toBe('edit');
       expect(modal.getAttribute('data-editing-id')).toBe('ht-1');
-      expect(modal.getAttribute('data-has-back')).toBe('true');
       expect(modal.getAttribute('data-has-delete')).toBe('true');
+      expect(modal.getAttribute('data-has-back')).toBe('false');
     });
   });
 
-  it('opens edit modal from manage row via Enter key', async () => {
-    listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByTestId } = mount();
-    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
-    fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
-    fireEvent.keyDown(container.querySelector('.specificity-modal__row')!, { key: 'Enter' });
-    await waitFor(() => {
-      expect(getByTestId('mock-modal').getAttribute('data-mode')).toBe('edit');
-    });
-  });
-
-  it('opens edit modal from manage row via Space key', async () => {
-    listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByTestId } = mount();
-    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
-    fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
-    fireEvent.keyDown(container.querySelector('.specificity-modal__row')!, { key: ' ' });
-    await waitFor(() => {
-      expect(getByTestId('mock-modal').getAttribute('data-mode')).toBe('edit');
-    });
-  });
-
-  it('back from edit returns to manage modal', async () => {
-    listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByTestId, queryByTestId, getByText } = mount();
-    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
-    fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
-    fireEvent.click(container.querySelector('.specificity-modal__row')!);
-    await waitFor(() => getByTestId('modal-back'));
-    fireEvent.click(getByTestId('modal-back'));
-    await waitFor(() => {
-      expect(queryByTestId('mock-modal')).toBeNull();
-      expect(getByText('Done')).toBeDefined();
-    });
-  });
-
-  it('delete from edit removes tier and returns to manage', async () => {
+  it('delete from edit removes tier and closes modal', async () => {
     deleteHeaderTierMock.mockResolvedValue({});
     listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByTestId } = mount();
-    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
-    fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
-    fireEvent.click(container.querySelector('.specificity-modal__row')!);
+    const { getByTestId, queryByTestId } = mount();
+    await waitFor(() => expect(getByTestId('edit-ht-1')).toBeDefined());
+    fireEvent.click(getByTestId('edit-ht-1'));
     await waitFor(() => getByTestId('modal-delete'));
     fireEvent.click(getByTestId('modal-delete'));
     await waitFor(() => {
       expect(deleteHeaderTierMock).toHaveBeenCalledWith('my-agent', 'ht-1');
+      expect(queryByTestId('mock-modal')).toBeNull();
     });
   });
 
   it('delete handler toasts error on failure', async () => {
     deleteHeaderTierMock.mockRejectedValue(new Error('delete fail'));
     listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByTestId } = mount();
-    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
-    fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
-    fireEvent.click(container.querySelector('.specificity-modal__row')!);
+    const { getByTestId } = mount();
+    await waitFor(() => expect(getByTestId('edit-ht-1')).toBeDefined());
+    fireEvent.click(getByTestId('edit-ht-1'));
     await waitFor(() => getByTestId('modal-delete'));
     fireEvent.click(getByTestId('modal-delete'));
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('delete fail'));
@@ -449,18 +435,16 @@ describe('RoutingHeaderTiersSection', () => {
     listHeaderTiersMock.mockResolvedValue([disabledTier]);
     const { container } = mount();
     await waitFor(() => {
-      expect(container.textContent).toContain('No custom tier yet');
+      expect(container.textContent).toContain('No custom tiers activated');
       expect(container.textContent).toContain('Manage custom routing');
     });
   });
 
   it('edit modal onSaved from edit mode does not open snippet modal', async () => {
     listHeaderTiersMock.mockResolvedValue([baseTier]);
-    const { container, getByTestId, queryByTestId } = mount();
-    await waitFor(() => expect(container.textContent).toContain('Manage custom routing'));
-    fireEvent.click(container.querySelector('.routing-section__cta')!);
-    await waitFor(() => expect(container.querySelector('.specificity-modal__row')).not.toBeNull());
-    fireEvent.click(container.querySelector('.specificity-modal__row')!);
+    const { getByTestId, queryByTestId } = mount();
+    await waitFor(() => expect(getByTestId('edit-ht-1')).toBeDefined());
+    fireEvent.click(getByTestId('edit-ht-1'));
     await waitFor(() => getByTestId('modal-saved'));
     listHeaderTiersMock.mockResolvedValue([baseTier]);
     fireEvent.click(getByTestId('modal-saved'));

--- a/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
@@ -134,14 +134,14 @@ describe('RoutingSpecificitySection', () => {
     expect(screen.getByText('Task-specific routing')).toBeDefined();
     expect(
       screen.getByText(
-        'Send specific kinds of work (coding, trading, image gen…) to dedicated models. Overrides everything else.',
+        'Send specific tasks (coding, trading, image gen…) to dedicated models. Overrides default and complexity routing when a task matches.',
       ),
     ).toBeDefined();
   });
 
   it('shows "Enable specificity tiers" button when no tiers are active', () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
-    const buttons = screen.getAllByText('Enable task-specific routing');
+    const buttons = screen.getAllByText('Add a task-specific tier');
     // One in the header, one in the empty state
     expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
@@ -167,9 +167,9 @@ describe('RoutingSpecificitySection', () => {
     expect(screen.getByText('Manage task-specific routing')).toBeDefined();
   });
 
-  it('shows empty state with "No task-specific rules yet" when nothing active', () => {
+  it('shows empty state with "No task-specific tiers yet" when nothing active', () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
-    expect(screen.getByText('No task-specific rules yet')).toBeDefined();
+    expect(screen.getByText('No task-specific tiers yet')).toBeDefined();
     expect(screen.getByText('Route specialized tasks to dedicated models.')).toBeDefined();
   });
 
@@ -213,7 +213,7 @@ describe('RoutingSpecificitySection', () => {
   it('opens modal on header button click and shows all SPECIFICITY_STAGES with toggles', async () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
     // Click the header "Enable specific tiers" button (first one found)
-    const headerBtn = screen.getAllByText('Enable task-specific routing')[0];
+    const headerBtn = screen.getAllByText('Add a task-specific tier')[0];
     fireEvent.click(headerBtn);
     await waitFor(() => {
       expect(screen.getByText('Manage task-specific routing')).toBeDefined();
@@ -232,7 +232,7 @@ describe('RoutingSpecificitySection', () => {
   it('opens modal on empty-state button click', async () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
     // The empty-state also has an "Enable specific tiers" button
-    const buttons = screen.getAllByText('Enable task-specific routing');
+    const buttons = screen.getAllByText('Add a task-specific tier');
     fireEvent.click(buttons[buttons.length - 1]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
@@ -241,7 +241,7 @@ describe('RoutingSpecificitySection', () => {
 
   it('closes modal on "Done" button click', async () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -253,7 +253,7 @@ describe('RoutingSpecificitySection', () => {
 
   it('closes modal on Escape key', async () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -266,7 +266,7 @@ describe('RoutingSpecificitySection', () => {
 
   it('closes modal on overlay click (e.target === e.currentTarget)', async () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -280,7 +280,7 @@ describe('RoutingSpecificitySection', () => {
 
   it('does NOT close modal when clicking inside the dialog card', async () => {
     render(() => <RoutingSpecificitySection {...makeProps()} />);
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -298,7 +298,7 @@ describe('RoutingSpecificitySection', () => {
     render(() => <RoutingSpecificitySection {...props} />);
 
     // Open modal
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -359,7 +359,7 @@ describe('RoutingSpecificitySection', () => {
     const props = makeProps();
     render(() => <RoutingSpecificitySection {...props} />);
 
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -377,7 +377,7 @@ describe('RoutingSpecificitySection', () => {
     });
     render(() => <RoutingSpecificitySection {...props} />);
 
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -408,7 +408,7 @@ describe('RoutingSpecificitySection', () => {
     render(() => <RoutingSpecificitySection {...props} />);
 
     // Open modal and toggle -- should use refetchSpecificity
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -429,7 +429,7 @@ describe('RoutingSpecificitySection', () => {
     render(() => <RoutingSpecificitySection {...props} />);
 
     // Open modal and toggle -- should fallback to refetchAll
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -451,7 +451,7 @@ describe('RoutingSpecificitySection', () => {
     });
     render(() => <RoutingSpecificitySection {...props} />);
 
-    fireEvent.click(screen.getAllByText('Enable task-specific routing')[0]);
+    fireEvent.click(screen.getAllByText('Add a task-specific tier')[0]);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
@@ -502,13 +502,13 @@ describe('RoutingSpecificitySection', () => {
   it('handles undefined assignments gracefully', () => {
     const props = makeProps({ assignments: () => undefined });
     render(() => <RoutingSpecificitySection {...props} />);
-    expect(screen.getByText('No task-specific rules yet')).toBeDefined();
+    expect(screen.getByText('No task-specific tiers yet')).toBeDefined();
   });
 
   it('handles empty assignments array', () => {
     const props = makeProps({ assignments: () => [] });
     render(() => <RoutingSpecificitySection {...props} />);
-    expect(screen.getByText('No task-specific rules yet')).toBeDefined();
+    expect(screen.getByText('No task-specific tiers yet')).toBeDefined();
   });
 
   it('handles assignments with inactive tiers', () => {
@@ -531,9 +531,9 @@ describe('RoutingSpecificitySection', () => {
     render(() => <RoutingSpecificitySection {...props} />);
     // No tier card should be rendered since coding is not active
     expect(screen.queryByTestId('tier-card-coding')).toBeNull();
-    expect(screen.getByText('No task-specific rules yet')).toBeDefined();
+    expect(screen.getByText('No task-specific tiers yet')).toBeDefined();
     // Header button should say "Enable" not "Manage" since none are active
-    expect(screen.getAllByText('Enable task-specific routing').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Add a task-specific tier').length).toBeGreaterThanOrEqual(1);
   });
 
   /* ---- RoutingTierCard prop callbacks ---- */


### PR DESCRIPTION
## Summary

- Rewrite tier descriptions and pipeline help text for clarity and grammatical consistency ("if matches", "allows to identify", "analyses" → "analyzes", "the eventual fallback models", etc.).
- Always show the "How routing works" button; the modal now explains routing in general and reflects the user's current configuration.
- In the custom-routing manage modal, clicking a tier row toggles it on/off. Editing a tier now happens via a new pen icon directly on the card.
- Pluralize empty-state titles ("No custom tiers activated", "No task-specific tiers yet", "No fallbacks") and sentence-case the "Enable routing" / "Disable routing" buttons.
- Update HeaderTierModal placeholders ("My custom tier", "custom-value") and subtitle wording.

## Test plan

- [ ] Frontend unit: `npx vitest run` — 2537/2537
- [ ] Backend unit: `npm test --workspace=manifest-backend` — 4199/4199
- [ ] Backend e2e: `npm run test:e2e --workspace=manifest-backend` — 136/136
- [ ] TypeScript: `npx tsc --noEmit` in both `packages/frontend` and `packages/backend` — clean
- [ ] Manually verify routing page at `/agents/:agent/routing`: default/complexity/task-specific/custom tabs; "How routing works" button visible even with no layers enabled; toggle tiers by clicking the manage-modal row; edit tiers from the card's pen icon.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Routing page copy and interactions to make routing clearer and quicker to manage. Always show “How routing works,” streamline custom-tier toggling, and tighten empty states, labels, and button casing.

- **New Features**
  - Always show “How routing works”; the modal explains routing and mirrors the current setup, showing the Default step when other layers are off.
  - Manage custom routing faster: click a tier row to toggle it; edit a tier from a new pen icon on its card.
  - Copy polish across the page: clearer subtitles; pluralized empty states (“No custom tiers activated,” “No task-specific tiers yet,” “No fallbacks”); sentence‑case “Enable routing”/“Disable routing”; updated HeaderTierModal placeholders (“My custom tier,” “custom-value”) and subtitle.

<sup>Written for commit cdec19f7331aa32edea47a6dded7ffd37387ddc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

