### PR TITLE
♻️ refactor(messages): rename timing column "Duration" → "Latency"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
 
 Every request to `manifest/auto` goes through a 23-dimension scoring algorithm (runs in under 2ms). The scorer picks a tier (simple, standard, complex, or reasoning) and routes to the best model in that tier from your connected providers.
 
-All routing data (tokens, costs, model, duration) is recorded automatically. You see it in the dashboard. No extra setup.
+All routing data (tokens, costs, model, latency) is recorded automatically. You see it in the dashboard. No extra setup.
 
 ## Manifest vs OpenRouter
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14074,7 +14074,7 @@
       }
     },
     "packages/manifest": {
-      "version": "5.50.1"
+      "version": "5.53.0"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/frontend/src/components/MessageDetails.tsx
+++ b/packages/frontend/src/components/MessageDetails.tsx
@@ -286,7 +286,7 @@ export default function MessageDetails(props: MessageDetailsProps): JSX.Element 
                           <th>Response Model</th>
                           <th>Input</th>
                           <th>Output</th>
-                          <th>Duration</th>
+                          <th>Latency</th>
                           <th>TTFT</th>
                         </tr>
                       </thead>
@@ -309,7 +309,7 @@ export default function MessageDetails(props: MessageDetailsProps): JSX.Element 
                       <thead>
                         <tr>
                           <th>Tool</th>
-                          <th>Duration</th>
+                          <th>Latency</th>
                           <th>Status</th>
                           <th>Error</th>
                         </tr>

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -114,7 +114,7 @@ const HEADER_LABELS: Record<MessageColumnKey, string> = {
   output: 'Output',
   model: 'Model',
   cache: 'Cache',
-  duration: 'Duration',
+  duration: 'Latency',
   status: 'Status',
   feedback: '',
 };

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -301,7 +301,7 @@ const MessageLog: Component = () => {
                     <th>Output</th>
                     <th>Model</th>
                     <th>Cache</th>
-                    <th>Duration</th>
+                    <th>Latency</th>
                     <th>Status</th>
                   </tr>
                 </thead>

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -144,7 +144,7 @@ describe('MessageTable', () => {
       expect(headers[3]!.textContent).toContain('Message');
       expect(headers[5]!.textContent).toContain('Total Tokens');
       expect(headers[8]!.textContent).toContain('Cache');
-      expect(headers[9]!.textContent).toContain('Duration');
+      expect(headers[9]!.textContent).toContain('Latency');
       expect(headers[10]!.textContent).toContain('Status');
       // Tooltips should be present for token columns
       const tooltips = container.querySelectorAll('[data-testid="info-tooltip"]');
@@ -781,7 +781,7 @@ describe('MessageTable', () => {
       expect(headers[0]!.textContent).toContain('Date');
       expect(headers[1]!.textContent).toContain('Cost');
       expect(headers[2]!.textContent).toContain('Tokens');
-      expect(headers[3]!.textContent).toContain('Duration');
+      expect(headers[3]!.textContent).toContain('Latency');
       expect(headers[4]!.textContent).toContain('Status');
     });
   });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -166,7 +166,7 @@ describe("MessageLog", () => {
       expect(container.textContent).toContain("Total Tokens");
       expect(container.textContent).toContain("Model");
       expect(container.textContent).toContain("Cache");
-      expect(container.textContent).toContain("Duration");
+      expect(container.textContent).toContain("Latency");
       expect(container.textContent).toContain("Status");
     });
   });


### PR DESCRIPTION
### ✨ What changed
- Messages table and detail modal columns now read "Latency" instead of "Duration".
- README description updated to match.
- Lockfile drift synced (`packages/manifest` 5.50.1 → 5.53.0).

### 💭 Why
LLM tooling (OpenAI, Anthropic, Langfuse, Helicone) labels request timing as "Latency". The previous "Duration" wording was correct but unfamiliar to users coming from those tools.

### 👤 For users
The Messages page, Overview recent-messages panel, and message detail modal (both LLM Calls and Tool Executions tables) show "Latency" where they used to show "Duration". Values render identically.

### 📝 Notes
- DB column `duration_ms`, API DTO fields, and the `formatDuration()` helper are unchanged, so no migration and no API contract break.
- If a TTFT metric is ever exposed as a first-class column, it will need a distinct label since "Latency" is now taken for total request time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the timing column from “Duration” to “Latency” across the Messages UI to match common LLM tooling. No behavior, data, or API changes.

- **Refactors**
  - Replaced “Duration” with “Latency” in Messages tables and message details; updated README and tests.
  - Timing still comes from `duration_ms` and uses `formatDuration()`; values render the same.

- **Dependencies**
  - Synced lockfile drift: `packages/manifest` 5.50.1 → 5.53.0.

<sup>Written for commit fa25e555121d0063aee21bb839d09678ebc653dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

