### PR TITLE
fix(db): make DropComplexityRoutingFlag idempotent

### DIFF
--- a/packages/backend/src/database/migrations/1780000000000-DropComplexityRoutingFlag.spec.ts
+++ b/packages/backend/src/database/migrations/1780000000000-DropComplexityRoutingFlag.spec.ts
@@ -15,23 +15,26 @@ describe('DropComplexityRoutingFlag1780000000000', () => {
   });
 
   describe('up', () => {
-    it('drops the complexity_routing_enabled column', async () => {
+    it('drops the complexity_routing_enabled column idempotently', async () => {
       await migration.up(queryRunner as unknown as QueryRunner);
 
       const sqls = queryRunner.query.mock.calls.map((c) => c[0] as string);
       expect(sqls).toHaveLength(1);
-      expect(sqls[0]).toContain('ALTER TABLE "agents" DROP COLUMN "complexity_routing_enabled"');
+      expect(sqls[0]).toContain(
+        'ALTER TABLE "agents" DROP COLUMN IF EXISTS "complexity_routing_enabled"',
+      );
     });
   });
 
   describe('down', () => {
-    it('restores the column with DEFAULT true (always-on semantic)', async () => {
+    it('restores the column idempotently with DEFAULT true (always-on semantic)', async () => {
       await migration.down(queryRunner as unknown as QueryRunner);
 
       const sqls = queryRunner.query.mock.calls.map((c) => c[0] as string);
       expect(sqls).toHaveLength(1);
       expect(sqls[0]).toContain('ALTER TABLE "agents"');
-      expect(sqls[0]).toContain('"complexity_routing_enabled" boolean NOT NULL DEFAULT true');
+      expect(sqls[0]).toContain('ADD COLUMN IF NOT EXISTS "complexity_routing_enabled"');
+      expect(sqls[0]).toContain('boolean NOT NULL DEFAULT true');
     });
   });
 });

--- a/packages/backend/src/database/migrations/1780000000000-DropComplexityRoutingFlag.ts
+++ b/packages/backend/src/database/migrations/1780000000000-DropComplexityRoutingFlag.ts
@@ -1,10 +1,29 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
+/**
+ * The idempotent `IF EXISTS` / `IF NOT EXISTS` guards protect two real
+ * scenarios we've seen on production instances:
+ *
+ *   1. DB snapshot restored to a pre-1777100000000 state while the
+ *      TypeORM `migrations` table keeps this entry recorded — without
+ *      the guard, boot would succeed silently but `up()` would re-run
+ *      on any subsequent migrationsRun and crash when the column is
+ *      already missing.
+ *   2. A fresh self-hosted install where `migrationsRun: true` plays
+ *      the whole chain top-to-bottom but for unrelated reasons the
+ *      1777100000000 add never actually committed (mid-transaction
+ *      abort, etc.) — the drop would then 42703 on an absent column.
+ *
+ * The mirror `down()` guard keeps reversals safe if someone rolls back
+ * on a DB where the column was never dropped in the first place.
+ */
 export class DropComplexityRoutingFlag1780000000000 implements MigrationInterface {
   name = 'DropComplexityRoutingFlag1780000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "agents" DROP COLUMN "complexity_routing_enabled"`);
+    await queryRunner.query(
+      `ALTER TABLE "agents" DROP COLUMN IF EXISTS "complexity_routing_enabled"`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
@@ -13,7 +32,7 @@ export class DropComplexityRoutingFlag1780000000000 implements MigrationInterfac
     // column with DEFAULT false and then UPDATEd existing rows to true;
     // repeating that dance on rollback would flip new agents back to off).
     await queryRunner.query(
-      `ALTER TABLE "agents" ADD COLUMN "complexity_routing_enabled" boolean NOT NULL DEFAULT true`,
+      `ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "complexity_routing_enabled" boolean NOT NULL DEFAULT true`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- `DropComplexityRoutingFlag.up()` now uses `DROP COLUMN IF EXISTS`; `down()` uses `ADD COLUMN IF NOT EXISTS`. Running the migration against a DB that doesn't have the column (or runs the revert against one that already lacks it) is now a safe no-op instead of a 42703 that crashes boot.
- Spec updated to pin the new SQL.

## Why

Two production scenarios hit this:

1. A DB snapshot is restored to a state that predates `1777100000000-AddComplexityRoutingFlag`, but the TypeORM `migrations` table keeps this drop entry recorded. On the next boot `migrationsRun: true` sees the name recorded, does nothing — good — but any operator who re-plays the migration (via `migration:run` against a fresh DB, or via a rebuild that clears the `migrations` table) gets a boot crash.
2. A fresh self-hosted install where the original add migration hit a mid-transaction abort on a prior boot, recorded itself, but never actually committed the column. The follow-up drop then fails the same way.

`ALTER TABLE ... IF [NOT] EXISTS` lets both cases converge to the intended end state without operator intervention.

## Test plan

- [x] `npx jest src/database/migrations/1780000000000-DropComplexityRoutingFlag.spec.ts` — 3/3 pass, pins the new SQL
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke on a staging DB that already has the column dropped — second `up()` invocation should be a no-op instead of throwing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `DropComplexityRoutingFlag` migration idempotent to prevent 42703 boot crashes. The migration now no-ops if the column state already matches the target.

- **Bug Fixes**
  - Use `DROP COLUMN IF EXISTS` in `up()` and `ADD COLUMN IF NOT EXISTS` with `DEFAULT true` in `down()`.
  - Covers two cases: a snapshot older than the add migration but with this drop recorded, and installs where the add never committed.
  - Updated the unit spec to pin the new SQL.

<sup>Written for commit 9ba57c7982c5b52e9ce49c6b84fb2d68f9cd677f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

