### PR TITLE
feat(routing): merge complexity into default tab with toggle

### DIFF
--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -77,6 +77,7 @@ import { AddSpecificityMiscategorized1777000000000 } from './migrations/17770000
 import { AddComplexityRoutingFlag1777100000000 } from './migrations/1777100000000-AddComplexityRoutingFlag';
 import { AddHeaderTierEnabled1777100000000 } from './migrations/1777100000000-AddHeaderTierEnabled';
 import { DropComplexityRoutingFlag1780000000000 } from './migrations/1780000000000-DropComplexityRoutingFlag';
+import { ReAddComplexityRoutingFlag1781000000000 } from './migrations/1781000000000-ReAddComplexityRoutingFlag';
 
 const entities = [
   AgentMessage,
@@ -155,6 +156,7 @@ const migrations = [
   AddComplexityRoutingFlag1777100000000,
   AddHeaderTierEnabled1777100000000,
   DropComplexityRoutingFlag1780000000000,
+  ReAddComplexityRoutingFlag1781000000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1781000000000-ReAddComplexityRoutingFlag.spec.ts
+++ b/packages/backend/src/database/migrations/1781000000000-ReAddComplexityRoutingFlag.spec.ts
@@ -1,0 +1,26 @@
+import { ReAddComplexityRoutingFlag1781000000000 } from './1781000000000-ReAddComplexityRoutingFlag';
+
+describe('ReAddComplexityRoutingFlag1781000000000', () => {
+  const migration = new ReAddComplexityRoutingFlag1781000000000();
+  const queries: string[] = [];
+  const queryRunner = { query: jest.fn(async (sql: string) => queries.push(sql)) } as never;
+
+  beforeEach(() => {
+    queries.length = 0;
+    (queryRunner as { query: jest.Mock }).query.mockClear();
+  });
+
+  it('up adds the column with DEFAULT true then alters to DEFAULT false', async () => {
+    await migration.up(queryRunner);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain('ADD COLUMN');
+    expect(queries[0]).toContain('DEFAULT true');
+    expect(queries[1]).toContain('SET DEFAULT false');
+  });
+
+  it('down drops the column', async () => {
+    await migration.down(queryRunner);
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).toContain('DROP COLUMN');
+  });
+});

--- a/packages/backend/src/database/migrations/1781000000000-ReAddComplexityRoutingFlag.ts
+++ b/packages/backend/src/database/migrations/1781000000000-ReAddComplexityRoutingFlag.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ReAddComplexityRoutingFlag1781000000000 implements MigrationInterface {
+  name = 'ReAddComplexityRoutingFlag1781000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add with DEFAULT true so existing agents keep complexity routing on.
+    await queryRunner.query(
+      `ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "complexity_routing_enabled" boolean NOT NULL DEFAULT true`,
+    );
+    // Change default to false so new agents start with simple routing.
+    await queryRunner.query(
+      `ALTER TABLE "agents" ALTER COLUMN "complexity_routing_enabled" SET DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agents" DROP COLUMN IF EXISTS "complexity_routing_enabled"`,
+    );
+  }
+}

--- a/packages/backend/src/entities/agent.entity.ts
+++ b/packages/backend/src/entities/agent.entity.ts
@@ -27,6 +27,9 @@ export class Agent {
   @Column('boolean', { default: true })
   is_active!: boolean;
 
+  @Column('boolean', { default: false })
+  complexity_routing_enabled!: boolean;
+
   @ManyToOne(() => Tenant, (t) => t.agents, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'tenant_id' })
   tenant!: Tenant;

--- a/packages/backend/src/routing/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve.service.spec.ts
@@ -1,3 +1,4 @@
+import { Repository } from 'typeorm';
 import { ResolveService } from './resolve/resolve.service';
 import { TierService } from './routing-core/tier.service';
 import { ProviderKeyService } from './routing-core/provider-key.service';
@@ -6,6 +7,7 @@ import { SpecificityPenaltyService } from './routing-core/specificity-penalty.se
 import { HeaderTierService } from './header-tiers/header-tier.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
+import { Agent } from '../entities/agent.entity';
 
 describe('ResolveService', () => {
   let service: ResolveService;
@@ -15,6 +17,7 @@ describe('ResolveService', () => {
   let mockPricingCache: Record<string, jest.Mock>;
   let mockDiscoveryService: Record<string, jest.Mock>;
   let mockPenaltyService: Record<string, jest.Mock>;
+  let mockAgentRepo: Record<string, jest.Mock>;
 
   beforeEach(() => {
     mockTierService = {
@@ -44,6 +47,9 @@ describe('ResolveService', () => {
     mockPenaltyService = {
       getPenaltiesForAgent: jest.fn().mockResolvedValue(new Map()),
     };
+    mockAgentRepo = {
+      findOne: jest.fn().mockResolvedValue({ complexity_routing_enabled: true }),
+    };
 
     service = new ResolveService(
       mockTierService as unknown as TierService,
@@ -53,6 +59,7 @@ describe('ResolveService', () => {
       mockDiscoveryService as unknown as ModelDiscoveryService,
       mockPenaltyService as unknown as SpecificityPenaltyService,
       { list: jest.fn().mockResolvedValue([]) } as unknown as HeaderTierService,
+      mockAgentRepo as unknown as Repository<Agent>,
     );
   });
 

--- a/packages/backend/src/routing/resolve/resolve.default.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.default.spec.ts
@@ -4,6 +4,7 @@ jest.mock('../../scoring', () => {
   return { scoreRequest, scanMessages };
 });
 
+import { Repository } from 'typeorm';
 import { ResolveService } from './resolve.service';
 import { TierService } from '../routing-core/tier.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
@@ -12,6 +13,7 @@ import { SpecificityPenaltyService } from '../routing-core/specificity-penalty.s
 import { HeaderTierService } from '../header-tiers/header-tier.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { Agent } from '../../entities/agent.entity';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const scoring = require('../../scoring');
 
@@ -55,6 +57,9 @@ function buildService(opts: {
     {
       list: jest.fn().mockResolvedValue([]),
     } as unknown as HeaderTierService,
+    {
+      findOne: jest.fn().mockResolvedValue({ complexity_routing_enabled: true }),
+    } as unknown as Repository<Agent>,
   );
 }
 

--- a/packages/backend/src/routing/resolve/resolve.default.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.default.spec.ts
@@ -150,4 +150,58 @@ describe('ResolveService — default tier catch-all', () => {
     expect(out.model).toBeNull();
     expect(out.provider).toBeNull();
   });
+
+  it('skips complexity scoring and uses default tier when complexity_routing_enabled is false', async () => {
+    scoring.scanMessages.mockReturnValue(null);
+    scoring.scoreRequest.mockReturnValue({
+      tier: 'complex',
+      confidence: 1,
+      score: 80,
+      reason: 'scored',
+    });
+
+    const tierService = {
+      getTiers: jest.fn().mockResolvedValue([
+        {
+          tier: 'default',
+          override_model: 'openai/gpt-4o-mini',
+          auto_assigned_model: null,
+          override_provider: null,
+          override_auth_type: null,
+        },
+      ]),
+    } as unknown as TierService;
+
+    const providerKeyService = {
+      getEffectiveModel: jest.fn().mockResolvedValue('openai/gpt-4o-mini'),
+      getAuthType: jest.fn().mockResolvedValue('api_key'),
+      hasActiveProvider: jest.fn().mockResolvedValue(true),
+      isModelAvailable: jest.fn().mockResolvedValue(true),
+    } as unknown as ProviderKeyService;
+
+    const svc = new ResolveService(
+      tierService,
+      providerKeyService,
+      { getActiveAssignments: jest.fn().mockResolvedValue([]) } as unknown as SpecificityService,
+      {
+        getByModel: jest.fn().mockReturnValue({ provider: 'OpenAI' }),
+      } as unknown as ModelPricingCacheService,
+      { getModelForAgent: jest.fn().mockResolvedValue(null) } as unknown as ModelDiscoveryService,
+      {
+        getPenaltiesForAgent: jest.fn().mockResolvedValue(new Map()),
+      } as unknown as SpecificityPenaltyService,
+      { list: jest.fn().mockResolvedValue([]) } as unknown as HeaderTierService,
+      {
+        findOne: jest.fn().mockResolvedValue({ complexity_routing_enabled: false }),
+      } as unknown as Repository<Agent>,
+    );
+
+    const out = await svc.resolve('agent-1', [
+      { role: 'user', content: 'build a complex React app' },
+    ]);
+
+    expect(scoring.scoreRequest).not.toHaveBeenCalled();
+    expect(out.tier).toBe('default');
+    expect(out.reason).toBe('default');
+  });
 });

--- a/packages/backend/src/routing/resolve/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.spec.ts
@@ -4,6 +4,7 @@ jest.mock('../../scoring', () => {
   return { scoreRequest, scanMessages };
 });
 
+import { Repository } from 'typeorm';
 import { ResolveService } from './resolve.service';
 import { TierService } from '../routing-core/tier.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
@@ -12,6 +13,7 @@ import { SpecificityPenaltyService } from '../routing-core/specificity-penalty.s
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { HeaderTierService } from '../header-tiers/header-tier.service';
+import { Agent } from '../../entities/agent.entity';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const scoring = require('../../scoring');
 
@@ -57,6 +59,10 @@ function makeService(overrides: {
     list: jest.fn().mockResolvedValue(overrides.headerTiers ?? []),
   } as unknown as HeaderTierService;
 
+  const agentRepo: Repository<Agent> = {
+    findOne: jest.fn().mockResolvedValue({ complexity_routing_enabled: true }),
+  } as unknown as Repository<Agent>;
+
   const svc = new ResolveService(
     tierService,
     providerKeyService,
@@ -65,6 +71,7 @@ function makeService(overrides: {
     discoveryService,
     penaltyService,
     headerTierService,
+    agentRepo,
   );
   return {
     svc,

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import type { IncomingHttpHeaders } from 'http';
 import { TierService } from '../routing-core/tier.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
@@ -10,6 +12,7 @@ import { ModelDiscoveryService } from '../../model-discovery/model-discovery.ser
 import { scoreRequest, ScorerInput, MomentumInput, scanMessages } from '../../scoring';
 import { ResolveResponse } from '../dto/resolve-response';
 import { inferProviderFromModelName } from '../../common/utils/provider-aliases';
+import { Agent } from '../../entities/agent.entity';
 import type { SpecificityCategory, TierSlot } from 'manifest-shared';
 import type { HeaderTier } from '../../entities/header-tier.entity';
 
@@ -37,6 +40,8 @@ export class ResolveService {
     private readonly discoveryService: ModelDiscoveryService,
     private readonly penaltyService: SpecificityPenaltyService,
     private readonly headerTierService: HeaderTierService,
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
   ) {}
 
   async resolve(
@@ -53,6 +58,11 @@ export class ResolveService {
     if (headers) {
       const headerTierResult = await this.resolveHeaderTier(agentId, headers);
       if (headerTierResult) return headerTierResult;
+    }
+
+    const agent = await this.agentRepo.findOne({ where: { id: agentId } });
+    if (agent && !agent.complexity_routing_enabled) {
+      return this.resolveForTier(agentId, 'default', 'default');
     }
 
     const specificityResult = await this.resolveSpecificity(

--- a/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
@@ -88,4 +88,18 @@ describe('ResolveAgentService', () => {
     expect(await svc.resolve('user-B', 'agent')).toBe(agentB);
     expect(findOne).toHaveBeenCalledTimes(2);
   });
+
+  it('invalidate removes the cached entry so the next resolve re-queries', async () => {
+    const agent = { id: 'agent-1', name: 'demo-agent' } as Agent;
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(agent);
+
+    await svc.resolve('user-1', 'demo-agent');
+    expect(findOne).toHaveBeenCalledTimes(1);
+
+    svc.invalidate('tenant-1', 'demo-agent');
+
+    await svc.resolve('user-1', 'demo-agent');
+    expect(findOne).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/backend/src/routing/routing-core/resolve-agent.service.ts
+++ b/packages/backend/src/routing/routing-core/resolve-agent.service.ts
@@ -44,4 +44,8 @@ export class ResolveAgentService {
     this.cache.set(cacheKey, { agent, expiresAt: Date.now() + TTL_MS });
     return agent;
   }
+
+  invalidate(tenantId: string, agentName: string): void {
+    this.cache.delete(`${tenantId}:${agentName}`);
+  }
 }

--- a/packages/backend/src/routing/tier.controller.spec.ts
+++ b/packages/backend/src/routing/tier.controller.spec.ts
@@ -113,4 +113,18 @@ describe('TierController', () => {
       BadRequestException,
     );
   });
+
+  it('GET complexity/status returns the current flag', async () => {
+    const result = await controller.getComplexityStatus(user, 'demo');
+    expect(result).toEqual({ enabled: true });
+  });
+
+  it('POST complexity/toggle flips the flag and invalidates cache', async () => {
+    const result = await controller.toggleComplexity(user, 'demo');
+    expect(result).toEqual({ enabled: false });
+    expect(agentRepo.update).toHaveBeenCalledWith('agent-1', {
+      complexity_routing_enabled: false,
+    });
+    expect(resolveAgentService.invalidate).toHaveBeenCalledWith('tenant-1', 'demo');
+  });
 });

--- a/packages/backend/src/routing/tier.controller.spec.ts
+++ b/packages/backend/src/routing/tier.controller.spec.ts
@@ -1,14 +1,22 @@
 import { BadRequestException } from '@nestjs/common';
+import { Repository } from 'typeorm';
 import { TierController } from './tier.controller';
 import { TierService } from './routing-core/tier.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
+import { Agent } from '../entities/agent.entity';
 import type { AuthUser } from '../auth/auth.instance';
 
 describe('TierController', () => {
   const user = { id: 'user-1' } as AuthUser;
-  const agent = { id: 'agent-1', name: 'demo' };
+  const agent = {
+    id: 'agent-1',
+    name: 'demo',
+    tenant_id: 'tenant-1',
+    complexity_routing_enabled: true,
+  };
   let tierService: jest.Mocked<Partial<TierService>>;
-  let resolveAgentService: { resolve: jest.Mock };
+  let resolveAgentService: { resolve: jest.Mock; invalidate: jest.Mock };
+  let agentRepo: jest.Mocked<Partial<Repository<Agent>>>;
   let controller: TierController;
 
   beforeEach(() => {
@@ -21,10 +29,17 @@ describe('TierController', () => {
       setFallbacks: jest.fn().mockResolvedValue([]),
       clearFallbacks: jest.fn().mockResolvedValue(undefined),
     };
-    resolveAgentService = { resolve: jest.fn().mockResolvedValue(agent) };
+    resolveAgentService = {
+      resolve: jest.fn().mockResolvedValue(agent),
+      invalidate: jest.fn(),
+    };
+    agentRepo = {
+      update: jest.fn().mockResolvedValue(undefined),
+    };
     controller = new TierController(
       tierService as unknown as TierService,
       resolveAgentService as unknown as ResolveAgentService,
+      agentRepo as unknown as Repository<Agent>,
     );
   });
 

--- a/packages/backend/src/routing/tier.controller.ts
+++ b/packages/backend/src/routing/tier.controller.ts
@@ -8,18 +8,23 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { TIER_SLOTS } from 'manifest-shared';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
 import { TierService } from './routing-core/tier.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { AgentNameParamDto, SetOverrideDto, SetFallbacksDto } from './dto/routing.dto';
+import { Agent } from '../entities/agent.entity';
 
 @Controller('api/v1/routing')
 export class TierController {
   constructor(
     private readonly tierService: TierService,
     private readonly resolveAgentService: ResolveAgentService,
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
   ) {}
 
   @Get(':agentName/tiers')
@@ -99,6 +104,21 @@ export class TierController {
     const agent = await this.resolveAgentService.resolve(user.id, agentName);
     await this.tierService.clearFallbacks(agent.id, tier);
     return { ok: true };
+  }
+
+  @Get(':agentName/complexity/status')
+  async getComplexityStatus(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
+    const agent = await this.resolveAgentService.resolve(user.id, agentName);
+    return { enabled: agent.complexity_routing_enabled };
+  }
+
+  @Post(':agentName/complexity/toggle')
+  async toggleComplexity(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
+    const agent = await this.resolveAgentService.resolve(user.id, agentName);
+    const newValue = !agent.complexity_routing_enabled;
+    await this.agentRepo.update(agent.id, { complexity_routing_enabled: newValue });
+    this.resolveAgentService.invalidate(agent.tenant_id, agentName);
+    return { enabled: newValue };
   }
 
   private validateTier(tier: string): void {

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -191,7 +191,7 @@ export async function createTestApp(): Promise<INestApplication> {
       [TEST_TENANT_ID, TEST_USER_ID, 'Test Org', now, now],
     );
     await ds.query(
-      `INSERT INTO agents (id, name, display_name, description, is_active, tenant_id, created_at, updated_at) VALUES ($1,$2,$3,$4,true,$5,$6,$7)`,
+      `INSERT INTO agents (id, name, display_name, description, is_active, complexity_routing_enabled, tenant_id, created_at, updated_at) VALUES ($1,$2,$3,$4,true,true,$5,$6,$7)`,
       [TEST_AGENT_ID, 'test-agent', 'Test Agent', 'Test agent', TEST_TENANT_ID, now, now],
     );
     await ds.query(

--- a/packages/backend/test/smoke-test.e2e-spec.ts
+++ b/packages/backend/test/smoke-test.e2e-spec.ts
@@ -149,6 +149,13 @@ describe('ST-03: Seed agent data', () => {
 
     const tenantId = agents[0].tenant_id;
     const agentId = agents[0].id;
+
+    // Enable complexity routing so ST-05 tier routing tests can score requests
+    await ds.query(
+      `UPDATE agents SET complexity_routing_enabled = true WHERE id = $1`,
+      [agentId],
+    );
+
     // Use a timestamp 60s in the past so period boundary comparisons are safe
     const past = new Date(Date.now() - 60_000).toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 

--- a/packages/frontend/public/icons/azure.svg
+++ b/packages/frontend/public/icons/azure.svg
@@ -1,0 +1,23 @@
+<svg width="150" height="150" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="e399c19f-b68f-429d-b176-18c2117ff73c" x1="-1032.172" x2="-1059.213" y1="145.312" y2="65.426" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#114a8b"/>
+            <stop offset="1" stop-color="#0669bc"/>
+        </linearGradient>
+        <linearGradient id="ac2a6fc2-ca48-4327-9a3c-d4dcc3256e15" x1="-1023.725" x2="-1029.98" y1="108.083" y2="105.968" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-opacity=".3"/>
+            <stop offset=".071" stop-opacity=".2"/>
+            <stop offset=".321" stop-opacity=".1"/>
+            <stop offset=".623" stop-opacity=".05"/>
+            <stop offset="1" stop-opacity="0"/>
+        </linearGradient>
+        <linearGradient id="a7fee970-a784-4bb1-af8d-63d18e5f7db9" x1="-1027.165" x2="-997.482" y1="147.642" y2="68.561" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#3ccbf4"/>
+            <stop offset="1" stop-color="#2892df"/>
+        </linearGradient>
+    </defs>
+    <path fill="url(#e399c19f-b68f-429d-b176-18c2117ff73c)" d="M33.338 6.544h26.038l-27.03 80.087a4.152 4.152 0 0 1-3.933 2.824H8.149a4.145 4.145 0 0 1-3.928-5.47L29.404 9.368a4.152 4.152 0 0 1 3.934-2.825z"/>
+    <path fill="#0078d4" d="M71.175 60.261h-41.29a1.911 1.911 0 0 0-1.305 3.309l26.532 24.764a4.171 4.171 0 0 0 2.846 1.121h23.38z"/>
+    <path fill="url(#ac2a6fc2-ca48-4327-9a3c-d4dcc3256e15)" d="M33.338 6.544a4.118 4.118 0 0 0-3.943 2.879L4.252 83.917a4.14 4.14 0 0 0 3.908 5.538h20.787a4.443 4.443 0 0 0 3.41-2.9l5.014-14.777 17.91 16.705a4.237 4.237 0 0 0 2.666.972H81.24L71.024 60.261l-29.781.007L59.47 6.544z"/>
+    <path fill="url(#a7fee970-a784-4bb1-af8d-63d18e5f7db9)" d="M66.595 9.364a4.145 4.145 0 0 0-3.928-2.82H33.648a4.146 4.146 0 0 1 3.928 2.82l25.184 74.62a4.146 4.146 0 0 1-3.928 5.472h29.02a4.146 4.146 0 0 0 3.927-5.472z"/>
+</svg>

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -7,6 +7,7 @@ import type {
 } from '../services/api.js';
 import {
   type HeaderTier,
+  resetHeaderTier,
   setHeaderTierFallbacks,
   clearHeaderTierFallbacks,
 } from '../services/api/header-tiers.js';
@@ -44,12 +45,15 @@ interface Props {
   onOverride: (model: string, provider: string, authType?: AuthType) => void | Promise<void>;
   onFallbacksUpdate: (fallbacks: string[]) => void;
   onEdit?: () => void;
+  onDisable?: () => void;
 }
 
 const HeaderTierCard: Component<Props> = (props) => {
   type PickerMode = 'primary' | 'fallback' | null;
   const [pickerMode, setPickerMode] = createSignal<PickerMode>(null);
   const [snippetOpen, setSnippetOpen] = createSignal(false);
+  const [menuOpen, setMenuOpen] = createSignal(false);
+  const [resetting, setResetting] = createSignal(false);
 
   const currentModel = (): string | null => props.tier.override_model;
   const fallbacks = (): string[] => props.tier.fallback_models ?? [];
@@ -116,37 +120,30 @@ const HeaderTierCard: Component<Props> = (props) => {
     }
   };
 
+  const handleReset = async () => {
+    setResetting(true);
+    try {
+      await resetHeaderTier(props.agentName, props.tier.id);
+      props.onFallbacksUpdate([]);
+    } catch {
+      // silent
+    } finally {
+      setResetting(false);
+    }
+  };
+
   return (
     <div class="routing-card routing-card--header-tier">
       <div class="routing-card__header">
         <span class="routing-card__tier header-tier-card__title">
           <span class="header-tier-card__name">{props.tier.name}</span>
-          <button
-            type="button"
-            class="header-tier-card__icon-btn"
-            onClick={() => setSnippetOpen(true)}
-            aria-label={`How to send the header for ${props.tier.name}`}
-            title="How to send this header from your app"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4m0 6c-1.08 0-2-.92-2-2s.92-2 2-2 2 .92 2 2-.92 2-2 2" />
-              <path d="m20.42 13.4-.51-.29c.05-.37.08-.74.08-1.11s-.03-.74-.08-1.11l.51-.29c.96-.55 1.28-1.78.73-2.73l-1-1.73a2.006 2.006 0 0 0-2.73-.73l-.53.31c-.58-.46-1.22-.83-1.9-1.11v-.6c0-1.1-.9-2-2-2h-2c-1.1 0-2 .9-2 2v.6c-.67.28-1.31.66-1.9 1.11l-.53-.31c-.96-.55-2.18-.22-2.73.73l-1 1.73c-.55.96-.22 2.18.73 2.73l.51.29c-.05.37-.08.74-.08 1.11s.03.74.08 1.11l-.51.29c-.96.55-1.28 1.78-.73 2.73l1 1.73c.55.95 1.78 1.28 2.73.73l.53-.31c.58.46 1.22.83 1.9 1.11v.6c0 1.1.9 2 2 2h2c1.1 0 2-.9 2-2v-.6a8.7 8.7 0 0 0 1.9-1.11l.53.31c.95.55 2.18.22 2.73-.73l1-1.73c.55-.96.22-2.18-.73-2.73m-2.59-2.78c.11.45.17.92.17 1.38s-.06.92-.17 1.38a1 1 0 0 0 .47 1.11l1.12.65-1 1.73-1.14-.66c-.38-.22-.87-.16-1.19.14-.68.65-1.51 1.13-2.38 1.4-.42.13-.71.52-.71.96v1.3h-2v-1.3c0-.44-.29-.83-.71-.96-.88-.27-1.7-.75-2.38-1.4a1.01 1.01 0 0 0-1.19-.15l-1.14.66-1-1.73 1.12-.65c.39-.22.58-.68.47-1.11-.11-.45-.17-.92-.17-1.38s.06-.93.17-1.38A1 1 0 0 0 5.7 9.5l-1.12-.65 1-1.73 1.14.66c.38.22.87.16 1.19-.14.68-.65 1.51-1.13 2.38-1.4.42-.13.71-.52.71-.96v-1.3h2v1.3c0 .44.29.83.71.96.88.27 1.7.75 2.38 1.4.32.31.81.36 1.19.14l1.14-.66 1 1.73-1.12.65c-.39.22-.58.68-.47 1.11Z" />
-            </svg>
-          </button>
-          <Show when={props.onEdit}>
+          <div class="header-tier-card__kebab">
             <button
               type="button"
               class="header-tier-card__icon-btn"
-              onClick={() => props.onEdit?.()}
-              aria-label={`Edit ${props.tier.name}`}
-              title="Edit tier"
+              onClick={() => setMenuOpen(!menuOpen())}
+              aria-label={`Options for ${props.tier.name}`}
+              title="Options"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -156,14 +153,78 @@ const HeaderTierCard: Component<Props> = (props) => {
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
-                <path d="M4 22h16v-2H4zM20.71 5.63l-2.34-2.34a1 1 0 0 0-1.41 0l-1.84 1.84 3.75 3.75 1.84-1.84a1 1 0 0 0 0-1.41zM3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" />
+                <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4m0 6c-1.08 0-2-.92-2-2s.92-2 2-2 2 .92 2 2-.92 2-2 2" />
+                <path d="m20.42 13.4-.51-.29c.05-.37.08-.74.08-1.11s-.03-.74-.08-1.11l.51-.29c.96-.55 1.28-1.78.73-2.73l-1-1.73a2.006 2.006 0 0 0-2.73-.73l-.53.31c-.58-.46-1.22-.83-1.9-1.11v-.6c0-1.1-.9-2-2-2h-2c-1.1 0-2 .9-2 2v.6c-.67.28-1.31.66-1.9 1.11l-.53-.31c-.96-.55-2.18-.22-2.73.73l-1 1.73c-.55.96-.22 2.18.73 2.73l.51.29c-.05.37-.08.74-.08 1.11s.03.74.08 1.11l-.51.29c-.96.55-1.28 1.78-.73 2.73l1 1.73c.55.95 1.78 1.28 2.73.73l.53-.31c.58.46 1.22.83 1.9 1.11v.6c0 1.1.9 2 2 2h2c1.1 0 2-.9 2-2v-.6a8.7 8.7 0 0 0 1.9-1.11l.53.31c.95.55 2.18.22 2.73-.73l1-1.73c.55-.96.22-2.18-.73-2.73m-2.59-2.78c.11.45.17.92.17 1.38s-.06.92-.17 1.38a1 1 0 0 0 .47 1.11l1.12.65-1 1.73-1.14-.66c-.38-.22-.87-.16-1.19.14-.68.65-1.51 1.13-2.38 1.4-.42.13-.71.52-.71.96v1.3h-2v-1.3c0-.44-.29-.83-.71-.96-.88-.27-1.7-.75-2.38-1.4a1.01 1.01 0 0 0-1.19-.15l-1.14.66-1-1.73 1.12-.65c.39-.22.58-.68.47-1.11-.11-.45-.17-.92-.17-1.38s.06-.93.17-1.38A1 1 0 0 0 5.7 9.5l-1.12-.65 1-1.73 1.14.66c.38.22.87.16 1.19-.14.68-.65 1.51-1.13 2.38-1.4.42-.13.71-.52.71-.96v-1.3h2v1.3c0 .44.29.83.71.96.88.27 1.7.75 2.38 1.4.32.31.81.36 1.19.14l1.14-.66 1 1.73-1.12.65c-.39.22-.58.68-.47 1.11Z" />
               </svg>
             </button>
-          </Show>
+            <Show when={menuOpen()}>
+              <div class="header-tier-card__menu" onMouseLeave={() => setMenuOpen(false)}>
+                <button
+                  type="button"
+                  class="header-tier-card__menu-item"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    setSnippetOpen(true);
+                  }}
+                >
+                  Send this header
+                </button>
+                <Show when={props.onEdit}>
+                  <button
+                    type="button"
+                    class="header-tier-card__menu-item"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      props.onEdit?.();
+                    }}
+                  >
+                    Edit tier
+                  </button>
+                </Show>
+                <Show when={props.onDisable}>
+                  <button
+                    type="button"
+                    class="header-tier-card__menu-item header-tier-card__menu-item--danger"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      props.onDisable?.();
+                    }}
+                  >
+                    Disable
+                  </button>
+                </Show>
+              </div>
+            </Show>
+          </div>
         </span>
-        <Show when={!currentModel()}>
-          <button class="routing-card__header-add" onClick={() => setPickerMode('primary')}>
-            + Add model
+        <Show
+          when={currentModel()}
+          fallback={
+            <button class="routing-card__header-add" onClick={() => setPickerMode('primary')}>
+              + Add model
+            </button>
+          }
+        >
+          <button
+            class="routing-card__header-action routing-card__header-action--danger"
+            onClick={handleReset}
+            disabled={resetting()}
+          >
+            {resetting() ? (
+              <span class="spinner" style="width: 12px; height: 12px;" />
+            ) : (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="12"
+                height="12"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path d="m7.77,12.97c.49.41,1.23.06,1.23-.58v-2.4h6c2.21,0,4,1.79,4,4v5c0,.55.45,1,1,1s1-.45,1-1v-5c0-3.31-2.69-6-6-6h-6v-2.4c0-.64-.74-.98-1.23-.58l-4.08,3.4c-.36.3-.36.85,0,1.15l4.08,3.4Z" />
+              </svg>
+            )}
+            Reset
           </button>
         </Show>
       </div>

--- a/packages/frontend/src/components/ProviderIcon.tsx
+++ b/packages/frontend/src/components/ProviderIcon.tsx
@@ -344,6 +344,9 @@ export function providerIcon(id: string, size: number = 20): JSX.Element | null 
 }
 
 const CUSTOM_PROVIDER_LOGOS: Record<string, string> = {
+  azure: '/icons/azure.svg',
+  'azure openai': '/icons/azure.svg',
+  'microsoft azure': '/icons/azure.svg',
   cerebras: '/icons/cerebras.svg',
   'cloudflare workers ai': '/icons/workersai.svg',
   cohere: '/icons/cohere.svg',
@@ -370,6 +373,7 @@ const CUSTOM_PROVIDER_LOGOS: Record<string, string> = {
 };
 
 const BASE_URL_TO_PROVIDER: [RegExp, string][] = [
+  [/\.azure\.com|azure\.openai\.com|openai\.azure\.com/i, 'azure'],
   [/api\.cerebras\.ai/i, 'cerebras'],
   [/api\.cloudflare\.com|workers\.ai/i, 'cloudflare workers ai'],
   [/cohere\.ai/i, 'cohere'],

--- a/packages/frontend/src/components/RoutingPipelineCard.tsx
+++ b/packages/frontend/src/components/RoutingPipelineCard.tsx
@@ -2,14 +2,18 @@ import type { JSX } from 'solid-js';
 
 interface PipelineStep {
   num: number;
-  name: string;
+  name: JSX.Element;
   desc: string;
 }
 
 /**
  * Builds the pipeline help modal content.
  */
-export function buildPipelineHelp(specificity: boolean, custom: boolean): JSX.Element {
+export function buildPipelineHelp(
+  specificity: boolean,
+  custom: boolean,
+  complexity: boolean,
+): JSX.Element {
   const steps: PipelineStep[] = [];
   let n = 1;
 
@@ -30,15 +34,19 @@ export function buildPipelineHelp(specificity: boolean, custom: boolean): JSX.El
   }
 
   steps.push({
-    num: n++,
-    name: 'Complexity routing',
-    desc: 'Manifest semantically analyzes the query, scores its complexity, and assigns it to a tier ranging from \u201csimple\u201d to \u201creasoning\u201d.',
-  });
-
-  steps.push({
     num: n,
-    name: 'Default routing',
-    desc: 'Catch-all for any query that has no matching tier assignment \u2014 falls back to the default model and its fallbacks.',
+    name: complexity ? (
+      <>
+        Default routing: <i>complexity</i>
+      </>
+    ) : (
+      <>
+        Default routing: <i>regular</i>
+      </>
+    ),
+    desc: complexity
+      ? 'Manifest semantically analyzes the query, scores its complexity, and assigns it to a tier ranging from \u201csimple\u201d to \u201creasoning\u201d.'
+      : 'All remaining requests go to the default model and its fallbacks.',
   });
 
   return (

--- a/packages/frontend/src/components/RoutingTabs.tsx
+++ b/packages/frontend/src/components/RoutingTabs.tsx
@@ -1,6 +1,6 @@
 import { createSignal, Show, type Component, type JSX } from 'solid-js';
 
-export type RoutingTabId = 'default' | 'complexity' | 'specificity' | 'custom';
+export type RoutingTabId = 'default' | 'specificity' | 'custom';
 
 interface Tab {
   id: RoutingTabId;
@@ -14,7 +14,6 @@ export interface RoutingTabsProps {
   pipelineHelp?: () => JSX.Element | null;
   children: {
     default: JSX.Element;
-    complexity: JSX.Element;
     specificity: JSX.Element;
     custom: JSX.Element;
   };
@@ -26,7 +25,6 @@ const RoutingTabs: Component<RoutingTabsProps> = (props) => {
 
   const tabs: Tab[] = [
     { id: 'default', label: 'Default', dot: () => true },
-    { id: 'complexity', label: 'Complexity', dot: () => true },
     { id: 'specificity', label: 'Task-specific', dot: () => props.specificityEnabled() },
     { id: 'custom', label: 'Custom', dot: () => props.customEnabled() },
   ];
@@ -88,7 +86,6 @@ const RoutingTabs: Component<RoutingTabsProps> = (props) => {
         aria-labelledby={`routing-tab-${activeTab()}`}
       >
         <Show when={activeTab() === 'default'}>{props.children.default}</Show>
-        <Show when={activeTab() === 'complexity'}>{props.children.complexity}</Show>
         <Show when={activeTab() === 'specificity'}>{props.children.specificity}</Show>
         <Show when={activeTab() === 'custom'}>{props.children.custom}</Show>
       </div>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -7,7 +7,6 @@ import RoutingTabs from '../components/RoutingTabs.js';
 import { toast } from '../services/toast-store.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import RoutingDefaultTierSection from './RoutingDefaultTierSection.js';
-import RoutingComplexitySection from './RoutingComplexitySection.js';
 import RoutingSpecificitySection from './RoutingSpecificitySection.js';
 import RoutingHeaderTiersSection from './RoutingHeaderTiersSection.js';
 import { RoutingLoadingSkeleton, ActiveProviderIcons, RoutingFooter } from './RoutingPanels.js';
@@ -24,6 +23,8 @@ import {
   refreshModels,
   getPricingHealth,
   refreshPricing,
+  getComplexityStatus,
+  toggleComplexity,
 } from '../services/api.js';
 import { parseCustomProviderParams, parseProviderDeepLink } from '../services/routing-params.js';
 
@@ -60,6 +61,23 @@ const Routing: Component = () => {
     () => agentName(),
     (name) => listHeaderTiers(name).catch(() => [] as HeaderTier[]),
   );
+  const [complexityStatus, { refetch: refetchComplexityStatus, mutate: mutateComplexityStatus }] =
+    createResource(() => agentName(), getComplexityStatus);
+  const [togglingComplexity, setTogglingComplexity] = createSignal(false);
+  const complexityEnabled = () => complexityStatus()?.enabled ?? true;
+
+  const handleToggleComplexity = async () => {
+    setTogglingComplexity(true);
+    try {
+      const result = await toggleComplexity(agentName());
+      mutateComplexityStatus(result);
+    } catch {
+      toast.error('Failed to toggle complexity routing');
+    } finally {
+      setTogglingComplexity(false);
+    }
+  };
+
   const hasCustomTiersEnabled = () => headerTiers()?.some((t) => t.enabled) ?? false;
   const [dropdownTier, setDropdownTier] = createSignal<string | null>(null);
   const [specificityDropdown, setSpecificityDropdown] = createSignal<string | null>(null);
@@ -278,7 +296,13 @@ const Routing: Component = () => {
         <RoutingTabs
           specificityEnabled={hasAnySpecificityActive}
           customEnabled={hasCustomTiersEnabled}
-          pipelineHelp={() => buildPipelineHelp(hasAnySpecificityActive(), hasCustomTiersEnabled())}
+          pipelineHelp={() =>
+            buildPipelineHelp(
+              hasAnySpecificityActive(),
+              hasCustomTiersEnabled(),
+              complexityEnabled(),
+            )
+          }
         >
           {{
             default: (
@@ -300,29 +324,10 @@ const Routing: Component = () => {
                 onFallbackUpdate={actions.handleFallbackUpdate}
                 onAddFallback={(tierId) => setFallbackPickerTier(tierId)}
                 getFallbacksFor={actions.getFallbacksFor}
-                embedded
-              />
-            ),
-            complexity: (
-              <RoutingComplexitySection
-                agentName={agentName}
-                tiers={() => tiers() ?? []}
-                models={() => models() ?? []}
-                customProviders={() => customProviders() ?? []}
-                activeProviders={activeProviders}
-                connectedProviders={() => connectedProviders() ?? []}
-                tiersLoading={tiers.loading}
-                changingTier={actions.changingTier}
-                resettingTier={actions.resettingTier}
-                resettingAll={actions.resettingAll}
-                addingFallback={actions.addingFallback}
-                onDropdownOpen={(tierId) => setDropdownTier(tierId)}
-                onOverride={handleOverride}
-                onReset={actions.handleReset}
-                onFallbackUpdate={actions.handleFallbackUpdate}
-                onAddFallback={(tierId) => setFallbackPickerTier(tierId)}
-                getFallbacksFor={actions.getFallbacksFor}
                 getTier={actions.getTier}
+                complexityEnabled={complexityEnabled}
+                togglingComplexity={togglingComplexity}
+                onToggleComplexity={handleToggleComplexity}
                 embedded
               />
             ),

--- a/packages/frontend/src/pages/RoutingComplexitySection.tsx
+++ b/packages/frontend/src/pages/RoutingComplexitySection.tsx
@@ -1,4 +1,4 @@
-import { For, type Component } from 'solid-js';
+import { For, Show, type Component } from 'solid-js';
 import { STAGES } from '../services/providers.js';
 import RoutingTierCard from './RoutingTierCard.js';
 import type {
@@ -28,6 +28,9 @@ export interface RoutingComplexitySectionProps {
   onAddFallback: (tierId: string) => void;
   getFallbacksFor: (tierId: string) => string[];
   getTier: (tierId: string) => TierAssignment | undefined;
+  complexityEnabled: () => boolean;
+  togglingComplexity: () => boolean;
+  onToggleComplexity: () => void;
   embedded?: boolean;
 }
 
@@ -61,28 +64,66 @@ const RoutingComplexitySection: Component<RoutingComplexitySectionProps> = (prop
     </div>
   );
 
+  const toggle = () => (
+    <button
+      class="routing-switch"
+      classList={{ 'routing-switch--on': props.complexityEnabled() }}
+      disabled={props.togglingComplexity()}
+      onClick={() => props.onToggleComplexity()}
+      aria-pressed={props.complexityEnabled()}
+    >
+      <span class="routing-switch__label">
+        {props.complexityEnabled() ? 'Enabled' : 'Disabled'}
+      </span>
+      <span class="routing-switch__track">
+        <span class="routing-switch__thumb" />
+      </span>
+    </button>
+  );
+
+  const emptyState = () => (
+    <div class="complexity-empty">
+      <span class="complexity-empty__title">Complexity routing is off</span>
+      <span class="complexity-empty__desc">
+        All requests go through the default tier. Enable complexity routing to score each request
+        and route it to a matching tier.
+      </span>
+    </div>
+  );
+
   if (props.embedded) {
     return (
       <div>
-        <div class="routing-section__header" style="margin-bottom: 16px;">
+        <div
+          class="routing-section__header routing-section__header--with-control"
+          style="margin-bottom: 16px;"
+        >
           <span class="routing-section__subtitle">
             Analyzes the complexity of each request on the fly and routes it to the matching tier.
           </span>
+          {toggle()}
         </div>
-        {tierCards()}
+        <Show when={props.complexityEnabled()} fallback={emptyState()}>
+          {tierCards()}
+        </Show>
       </div>
     );
   }
 
   return (
     <div class="routing-section">
-      <div class="routing-section__header">
-        <span class="routing-section__title">Complexity routing</span>
-        <span class="routing-section__subtitle">
-          Analyzes the complexity of each request on the fly and routes it to the matching tier.
-        </span>
+      <div class="routing-section__header routing-section__header--with-control">
+        <div>
+          <span class="routing-section__title">Complexity routing</span>
+          <span class="routing-section__subtitle">
+            Analyzes the complexity of each request on the fly and routes it to the matching tier.
+          </span>
+        </div>
+        {toggle()}
       </div>
-      {tierCards()}
+      <Show when={props.complexityEnabled()} fallback={emptyState()}>
+        {tierCards()}
+      </Show>
     </div>
   );
 };

--- a/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
+++ b/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
@@ -1,4 +1,4 @@
-import { Show, type Component } from 'solid-js';
+import { For, Show, type Component } from 'solid-js';
 import type {
   AuthType,
   AvailableModel,
@@ -6,7 +6,7 @@ import type {
   RoutingProvider,
   TierAssignment,
 } from '../services/api.js';
-import { DEFAULT_STAGE } from '../services/providers.js';
+import { DEFAULT_STAGE, STAGES } from '../services/providers.js';
 import RoutingTierCard from './RoutingTierCard.js';
 
 export interface RoutingDefaultTierSectionProps {
@@ -27,14 +27,15 @@ export interface RoutingDefaultTierSectionProps {
   onFallbackUpdate: (tierId: string, fallbacks: string[]) => void;
   onAddFallback: (tierId: string) => void;
   getFallbacksFor: (tierId: string) => string[];
+  getTier: (tierId: string) => TierAssignment | undefined;
+  complexityEnabled: () => boolean;
+  togglingComplexity: () => boolean;
+  onToggleComplexity: () => void;
   embedded?: boolean;
 }
 
 const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (props) => {
-  const subtitle = () =>
-    'Acts as a safety net and handles requests that complexity routing can\u2019t resolve';
-
-  const card = () => (
+  const defaultCard = () => (
     <div
       class="routing-cards"
       classList={{
@@ -65,28 +66,86 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
     </div>
   );
 
+  const complexityCards = () => (
+    <div class="routing-cards">
+      <For each={STAGES}>
+        {(stage) => (
+          <RoutingTierCard
+            stage={stage}
+            tier={() => props.getTier(stage.id)}
+            models={props.models}
+            customProviders={props.customProviders}
+            activeProviders={props.activeProviders}
+            tiersLoading={props.tiersLoading}
+            changingTier={props.changingTier}
+            resettingTier={props.resettingTier}
+            resettingAll={props.resettingAll}
+            addingFallback={props.addingFallback}
+            agentName={props.agentName}
+            onDropdownOpen={props.onDropdownOpen}
+            onOverride={props.onOverride}
+            onReset={props.onReset}
+            onFallbackUpdate={props.onFallbackUpdate}
+            onAddFallback={props.onAddFallback}
+            getFallbacksFor={props.getFallbacksFor}
+            connectedProviders={props.connectedProviders}
+          />
+        )}
+      </For>
+    </div>
+  );
+
+  const switchButton = () => (
+    <button
+      class="routing-switch"
+      classList={{ 'routing-switch--on': props.complexityEnabled() }}
+      disabled={props.togglingComplexity()}
+      onClick={() => props.onToggleComplexity()}
+    >
+      <span class="routing-switch__label">Route by complexity</span>
+      <span class="routing-switch__track">
+        <span class="routing-switch__thumb" />
+      </span>
+    </button>
+  );
+
+  const subtitle = () =>
+    props.complexityEnabled()
+      ? 'Analyzes the complexity of each request on the fly and routes it to the matching tier.'
+      : 'Pick one model and up to 5 fallbacks as your default routing.';
+
   if (props.embedded) {
     return (
       <div>
-        <Show when={!props.tiersLoading}>
-          <span class="routing-section__subtitle" style="margin-bottom: 16px;">
-            {subtitle()}
-          </span>
+        <div
+          class="routing-section__header routing-section__header--with-control"
+          style="margin-bottom: 16px;"
+        >
+          <span class="routing-section__subtitle">{subtitle()}</span>
+          {switchButton()}
+        </div>
+        <Show
+          when={props.complexityEnabled()}
+          fallback={<div class="routing-cards-backdrop">{defaultCard()}</div>}
+        >
+          {complexityCards()}
         </Show>
-        <div class="routing-cards-backdrop">{card()}</div>
       </div>
     );
   }
 
   return (
-    <div class="routing-section routing-section--dimmed">
-      <div class="routing-section__header">
-        <span class="routing-section__title">Default model</span>
-        <Show when={!props.tiersLoading}>
+    <div class="routing-section">
+      <div class="routing-section__header routing-section__header--with-control">
+        <div>
+          <span class="routing-section__title">Default routing</span>
           <span class="routing-section__subtitle">{subtitle()}</span>
-        </Show>
+        </div>
+        {switchButton()}
       </div>
-      {card()}
+      <Show when={props.complexityEnabled()} fallback={defaultCard()}>
+        {complexityCards()}
+      </Show>
     </div>
   );
 };

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -146,6 +146,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 onOverride={(m, p, a) => handleOverride(tier.id, m, p, a)}
                 onFallbacksUpdate={() => refetch()}
                 onEdit={() => setModalTier(tier)}
+                onDisable={() => handleToggle(tier.id, false)}
               />
             )}
           </For>

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -88,6 +88,22 @@ export async function copilotPollToken(agentName: string, deviceCode: string) {
   return res.json() as Promise<{ status: CopilotPollStatus }>;
 }
 
+/* -- Routing: Complexity Toggle -- */
+
+export interface ComplexityStatus {
+  enabled: boolean;
+}
+
+export function getComplexityStatus(agentName: string) {
+  return fetchJson<ComplexityStatus>(routingPath(agentName, 'complexity/status'));
+}
+
+export function toggleComplexity(agentName: string) {
+  return fetchMutate<ComplexityStatus>(routingPath(agentName, 'complexity/toggle'), {
+    method: 'POST',
+  });
+}
+
 /* -- Routing: Tier Assignments -- */
 
 export interface TierAssignment {

--- a/packages/frontend/src/styles/routing-header-tiers.css
+++ b/packages/frontend/src/styles/routing-header-tiers.css
@@ -87,8 +87,7 @@
   gap: 6px;
   min-width: 0;
   flex: 1 1 auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow: visible;
   white-space: nowrap;
 }
 
@@ -128,8 +127,9 @@
   color: hsl(var(--foreground));
 }
 .header-tier-card__icon-btn:focus-visible {
-  outline: 2px solid hsl(var(--ring));
-  outline-offset: 2px;
+  outline: none;
+  background: hsl(var(--muted) / 0.8);
+  color: hsl(var(--foreground));
 }
 
 /* Right: Reset / + Add model + kebab, all in one inline cluster mirroring

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -289,7 +289,7 @@
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .dark .routing-card {

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -434,6 +434,17 @@ describe('HeaderTierCard', () => {
     expect(onDisable).toHaveBeenCalledTimes(1);
   });
 
+  it('swallows errors thrown by resetHeaderTier without crashing', async () => {
+    resetHeaderTierMock.mockRejectedValue(new Error('reset boom'));
+    const { getByText } = mount();
+    const resetBtn = getByText('Reset');
+    expect(resetBtn).toBeDefined();
+    fireEvent.click(resetBtn);
+    await waitFor(() => expect(resetHeaderTierMock).toHaveBeenCalled());
+    // Component must still be in the DOM after the error
+    expect(getByText('Reset')).toBeDefined();
+  });
+
   it('falls back to the provider db-id when the model name has no recognizable prefix', () => {
     // model name has no known vendor prefix but the model entry still resolves
     // to a known provider via its `provider` field — we should fall back to it.

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -4,6 +4,7 @@ import type { HeaderTier } from '../../src/services/api/header-tiers';
 
 const setHeaderTierFallbacksMock = vi.fn();
 const clearHeaderTierFallbacksMock = vi.fn();
+const resetHeaderTierMock = vi.fn();
 
 vi.mock('../../src/services/api/header-tiers.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -11,6 +12,7 @@ vi.mock('../../src/services/api/header-tiers.js', async (importOriginal) => {
     ...actual,
     setHeaderTierFallbacks: (...args: unknown[]) => setHeaderTierFallbacksMock(...args),
     clearHeaderTierFallbacks: (...args: unknown[]) => clearHeaderTierFallbacksMock(...args),
+    resetHeaderTier: (...args: unknown[]) => resetHeaderTierMock(...args),
   };
 });
 
@@ -99,6 +101,17 @@ vi.mock('../../src/components/AuthBadge.js', () => ({
     t ? <span data-testid={`auth-${t}`} /> : null,
 }));
 
+vi.mock('../../src/components/HeaderTierSnippetModal.js', () => ({
+  default: (props: { tier: { name: string }; onClose: () => void }) => (
+    <div data-testid="mock-snippet-modal">
+      <span>Snippet for {props.tier.name}</span>
+      <button data-testid="snippet-close" onClick={props.onClose}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
 import HeaderTierCard from '../../src/components/HeaderTierCard';
 
 const baseTier: HeaderTier = {
@@ -126,12 +139,14 @@ interface MountOptions {
   onOverride?: ReturnType<typeof vi.fn>;
   onFallbacksUpdate?: ReturnType<typeof vi.fn>;
   onEdit?: ReturnType<typeof vi.fn>;
+  onDisable?: ReturnType<typeof vi.fn>;
 }
 
 function mount(opts: MountOptions = {}) {
   const onOverride = opts.onOverride ?? vi.fn();
   const onFallbacksUpdate = opts.onFallbacksUpdate ?? vi.fn();
   const onEdit = opts.onEdit;
+  const onDisable = opts.onDisable;
   const result = render(() => (
     <HeaderTierCard
       agentName="my-agent"
@@ -153,9 +168,10 @@ function mount(opts: MountOptions = {}) {
       onOverride={onOverride}
       onFallbacksUpdate={onFallbacksUpdate}
       onEdit={onEdit}
+      onDisable={onDisable}
     />
   ));
-  return { ...result, onOverride, onFallbacksUpdate, onEdit };
+  return { ...result, onOverride, onFallbacksUpdate, onEdit, onDisable };
 }
 
 describe('HeaderTierCard', () => {
@@ -194,9 +210,12 @@ describe('HeaderTierCard', () => {
     expect(onOverride).toHaveBeenCalledWith('gpt-4o-mini', 'OpenAI', 'api_key');
   });
 
-  it('renders gear icon button for snippet modal', () => {
-    const { container } = mount();
-    expect(container.querySelector('.header-tier-card__icon-btn')).not.toBeNull();
+  it('renders gear icon button that opens a dropdown menu', () => {
+    const { container, getByText } = mount();
+    const gearBtn = container.querySelector('.header-tier-card__icon-btn');
+    expect(gearBtn).not.toBeNull();
+    fireEvent.click(gearBtn!);
+    expect(getByText('Send this header')).toBeDefined();
   });
 
   it('renders the FallbackList when a primary model is set', () => {
@@ -235,11 +254,6 @@ describe('HeaderTierCard', () => {
     const { getByTestId, onFallbacksUpdate } = mount();
     fireEvent.click(getByTestId('fallback-update'));
     expect(onFallbacksUpdate).toHaveBeenCalledWith(['mock-removed']);
-  });
-
-  it('renders gear icon button for snippet modal', () => {
-    const { container } = mount();
-    expect(container.querySelector('.header-tier-card__icon-btn')).not.toBeNull();
   });
 
   it('infers the provider id from the model prefix when override_provider is absent', () => {
@@ -346,31 +360,78 @@ describe('HeaderTierCard', () => {
     expect(container.querySelector('[data-testid="provider-icon"]')).toBeNull();
   });
 
-  it('gear icon button opens the SDK snippet modal', async () => {
-    const { container, getByText } = mount();
+  it('gear icon button opens the SDK snippet modal via "Send this header" menu item', async () => {
+    const { container, getByText, getByTestId } = mount();
     const gearBtn = container.querySelector('.header-tier-card__icon-btn');
     expect(gearBtn).not.toBeNull();
     fireEvent.click(gearBtn!);
-    await waitFor(() => expect(getByText(/Send the .* header/)).toBeDefined());
+    const sendItem = getByText('Send this header');
+    expect(sendItem).toBeDefined();
+    fireEvent.click(sendItem);
+    await waitFor(() => expect(getByTestId('mock-snippet-modal')).toBeDefined());
   });
 
-  it('renders the edit button only when onEdit is provided', () => {
+  it('renders "Edit tier" in dropdown only when onEdit is provided', () => {
     const onEdit = vi.fn();
-    const { container: withEdit } = mount({ onEdit });
-    expect(withEdit.querySelector(`button[aria-label="Edit ${baseTier.name}"]`)).not.toBeNull();
+    const { container: withEdit, getByText: withEditGetByText } = mount({ onEdit });
+    const gearBtn = withEdit.querySelector('.header-tier-card__icon-btn')!;
+    fireEvent.click(gearBtn);
+    expect(withEditGetByText('Edit tier')).toBeDefined();
 
     const { container: withoutEdit } = mount();
-    expect(withoutEdit.querySelector('button[aria-label^="Edit "]')).toBeNull();
+    const gearBtn2 = withoutEdit.querySelector('.header-tier-card__icon-btn')!;
+    fireEvent.click(gearBtn2);
+    expect(withoutEdit.querySelector('.header-tier-card__menu')).not.toBeNull();
+    expect(withoutEdit.textContent).not.toContain('Edit tier');
   });
 
-  it('calls onEdit when the edit button is clicked', () => {
+  it('calls onEdit when "Edit tier" menu item is clicked', () => {
     const onEdit = vi.fn();
-    const { container } = mount({ onEdit });
-    const editBtn = container.querySelector(
-      `button[aria-label="Edit ${baseTier.name}"]`,
-    ) as HTMLButtonElement;
-    fireEvent.click(editBtn);
+    const { container, getByText } = mount({ onEdit });
+    const gearBtn = container.querySelector('.header-tier-card__icon-btn')!;
+    fireEvent.click(gearBtn);
+    fireEvent.click(getByText('Edit tier'));
     expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Reset button when a model is assigned and calls resetHeaderTier on click', async () => {
+    resetHeaderTierMock.mockResolvedValue(undefined);
+    const { getByText, onFallbacksUpdate } = mount();
+    const resetBtn = getByText('Reset');
+    expect(resetBtn).toBeDefined();
+    fireEvent.click(resetBtn);
+    await waitFor(() =>
+      expect(resetHeaderTierMock).toHaveBeenCalledWith('my-agent', 'ht-1'),
+    );
+    expect(onFallbacksUpdate).toHaveBeenCalledWith([]);
+  });
+
+  it('does not render Reset button when no model is assigned', () => {
+    const emptyTier: HeaderTier = { ...baseTier, override_model: null };
+    const { queryByText } = mount({ tier: emptyTier });
+    expect(queryByText('Reset')).toBeNull();
+  });
+
+  it('renders "Disable" in dropdown only when onDisable is provided', () => {
+    const onDisable = vi.fn();
+    const { container: withDisable, getByText: withDisableGetByText } = mount({ onDisable });
+    const gearBtn = withDisable.querySelector('.header-tier-card__icon-btn')!;
+    fireEvent.click(gearBtn);
+    expect(withDisableGetByText('Disable')).toBeDefined();
+
+    const { container: withoutDisable } = mount();
+    const gearBtn2 = withoutDisable.querySelector('.header-tier-card__icon-btn')!;
+    fireEvent.click(gearBtn2);
+    expect(withoutDisable.textContent).not.toContain('Disable');
+  });
+
+  it('calls onDisable when "Disable" menu item is clicked', () => {
+    const onDisable = vi.fn();
+    const { container, getByText } = mount({ onDisable });
+    const gearBtn = container.querySelector('.header-tier-card__icon-btn')!;
+    fireEvent.click(gearBtn);
+    fireEvent.click(getByText('Disable'));
+    expect(onDisable).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to the provider db-id when the model name has no recognizable prefix', () => {

--- a/packages/frontend/tests/components/ProviderIcon.test.tsx
+++ b/packages/frontend/tests/components/ProviderIcon.test.tsx
@@ -92,6 +92,24 @@ describe("customProviderLogo", () => {
     expect(img!.getAttribute("src")).toBe("/icons/cohere.svg");
   });
 
+  it("resolves Azure by name", () => {
+    const { container } = render(() => (
+      <div>{customProviderLogo("Microsoft Azure")}</div>
+    ));
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("/icons/azure.svg");
+  });
+
+  it("resolves Azure by base URL", () => {
+    const { container } = render(() => (
+      <div>{customProviderLogo("my-provider", 16, "https://my-instance.openai.azure.com/v1")}</div>
+    ));
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("/icons/azure.svg");
+  });
+
   it("returns null when base URL does not match any pattern", () => {
     const { container } = render(() => (
       <div>{customProviderLogo("custom", 16, "https://api.example.com/v1")}</div>

--- a/packages/frontend/tests/components/RoutingPipelineCard.test.tsx
+++ b/packages/frontend/tests/components/RoutingPipelineCard.test.tsx
@@ -2,61 +2,86 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@solidjs/testing-library';
 import { buildPipelineHelp } from '../../src/components/RoutingPipelineCard';
 
-function renderHelp(specificity: boolean, custom: boolean) {
-  const content = buildPipelineHelp(specificity, custom);
+function renderHelp(specificity: boolean, custom: boolean, complexity: boolean) {
+  const content = buildPipelineHelp(specificity, custom, complexity);
   render(() => <div>{content}</div>);
   return true;
 }
 
 describe('buildPipelineHelp', () => {
-  it('always shows Complexity and Default steps even when no opt-in layers are enabled', () => {
-    renderHelp(false, false);
-    expect(screen.getByText('Complexity routing')).toBeDefined();
-    expect(screen.getByText('Default routing')).toBeDefined();
+  it('always shows Default routing even when no opt-in layers are enabled', () => {
+    renderHelp(false, false, false);
+    expect(screen.getByText('Default routing:')).toBeNull
+    expect(screen.queryByText('Complexity routing')).toBeNull();
     expect(screen.queryByText('Task-specific routing')).toBeNull();
     expect(screen.queryByText('Custom routing')).toBeNull();
   });
 
   it('shows all four steps when every opt-in layer is enabled', () => {
-    renderHelp(true, true);
+    renderHelp(true, true, true);
     expect(screen.getByText('Custom routing')).toBeDefined();
     expect(screen.getByText('Task-specific routing')).toBeDefined();
-    expect(screen.getByText('Complexity routing')).toBeDefined();
-    expect(screen.getByText('Default routing')).toBeDefined();
+    expect(screen.queryByText('Complexity routing')).toBeNull();
+    expect(screen.queryByText('Default routing:')).toBeDefined();
   });
 
-  it('shows Task-specific + Complexity + Default when only specificity is enabled', () => {
-    renderHelp(true, false);
+  it('shows Task-specific + Default when only specificity is enabled', () => {
+    renderHelp(true, false, false);
     expect(screen.getByText('Task-specific routing')).toBeDefined();
-    expect(screen.getByText('Complexity routing')).toBeDefined();
-    expect(screen.getByText('Default routing')).toBeDefined();
     expect(screen.queryByText('Custom routing')).toBeNull();
+    expect(screen.queryByText('Complexity routing')).toBeNull();
   });
 
-  it('shows Custom + Complexity + Default when only custom is enabled', () => {
-    renderHelp(false, true);
+  it('shows Custom + Default when only custom is enabled', () => {
+    renderHelp(false, true, false);
     expect(screen.getByText('Custom routing')).toBeDefined();
-    expect(screen.getByText('Complexity routing')).toBeDefined();
-    expect(screen.getByText('Default routing')).toBeDefined();
+    expect(screen.queryByText('Complexity routing')).toBeNull();
   });
 
-  it('numbers steps sequentially', () => {
-    renderHelp(true, true);
-    const nums = screen.getAllByText(/^[1-4]$/);
-    expect(nums.length).toBe(4);
+  it('numbers steps sequentially for three steps (custom + specificity + default)', () => {
+    renderHelp(true, true, true);
+    const nums = screen.getAllByText(/^[1-3]$/);
+    expect(nums.length).toBe(3);
     expect(nums[0].textContent).toBe('1');
     expect(nums[1].textContent).toBe('2');
     expect(nums[2].textContent).toBe('3');
-    expect(nums[3].textContent).toBe('4');
   });
 
-  it('describes Default as the catch-all tier', () => {
-    renderHelp(false, false);
-    expect(screen.getByText(/Catch-all for any query that has no matching tier assignment/)).toBeDefined();
+  it('numbers steps sequentially for two steps', () => {
+    renderHelp(false, false, false);
+    const nums = screen.getAllByText(/^[1-2]$/);
+    expect(nums.length).toBe(1);
+    expect(nums[0].textContent).toBe('1');
+  });
+
+  it('describes Default as catch-all when complexity=false', () => {
+    renderHelp(false, false, false);
+    expect(
+      screen.getByText('All remaining requests go to the default model and its fallbacks.'),
+    ).toBeDefined();
+  });
+
+  it('describes Default as complexity scoring when complexity=true', () => {
+    renderHelp(false, false, true);
+    expect(
+      screen.getByText(
+        /scores its complexity, and assigns it to a tier ranging from \u201csimple\u201d to \u201creasoning\u201d/,
+      ),
+    ).toBeDefined();
+  });
+
+  it('annotates default step name with "regular" when complexity=false', () => {
+    renderHelp(false, false, false);
+    expect(screen.getByText('regular')).toBeDefined();
+  });
+
+  it('annotates default step name with "complexity" when complexity=true', () => {
+    renderHelp(false, false, true);
+    expect(screen.getByText('complexity')).toBeDefined();
   });
 
   it('shows the summary line', () => {
-    renderHelp(false, false);
+    renderHelp(false, false, false);
     expect(screen.getByText(/intercept queries on the fly/i)).toBeDefined();
     expect(screen.getByText(/current configuration looks like/i)).toBeDefined();
   });

--- a/packages/frontend/tests/components/RoutingTabs.test.tsx
+++ b/packages/frontend/tests/components/RoutingTabs.test.tsx
@@ -15,7 +15,6 @@ function renderTabs(
     >
       {{
         default: <div data-testid="default-content">Default content</div>,
-        complexity: <div data-testid="complexity-content">Complexity content</div>,
         specificity: <div data-testid="specificity-content">Specificity content</div>,
         custom: <div data-testid="custom-content">Custom content</div>,
       }}
@@ -24,10 +23,9 @@ function renderTabs(
 }
 
 describe('RoutingTabs', () => {
-  it('renders all four tab labels', () => {
+  it('renders all three tab labels', () => {
     renderTabs();
     expect(screen.getByRole('tab', { name: /Default/ })).toBeDefined();
-    expect(screen.getByRole('tab', { name: /Complexity/ })).toBeDefined();
     expect(screen.getByRole('tab', { name: /Task-specific/ })).toBeDefined();
     expect(screen.getByRole('tab', { name: /Custom/ })).toBeDefined();
   });
@@ -40,16 +38,8 @@ describe('RoutingTabs', () => {
   it('shows default content by default', () => {
     renderTabs();
     expect(screen.getByTestId('default-content')).toBeDefined();
-    expect(screen.queryByTestId('complexity-content')).toBeNull();
     expect(screen.queryByTestId('specificity-content')).toBeNull();
     expect(screen.queryByTestId('custom-content')).toBeNull();
-  });
-
-  it('switches to complexity tab on click', () => {
-    renderTabs();
-    fireEvent.click(screen.getByRole('tab', { name: /Complexity/ }));
-    expect(screen.queryByTestId('default-content')).toBeNull();
-    expect(screen.getByTestId('complexity-content')).toBeDefined();
   });
 
   it('switches to specificity tab on click', () => {
@@ -71,16 +61,16 @@ describe('RoutingTabs', () => {
     const defaultTab = screen.getByRole('tab', { name: /Default/ });
     expect(defaultTab.getAttribute('aria-selected')).toBe('true');
 
-    const complexityTab = screen.getByRole('tab', { name: /Complexity/ });
-    expect(complexityTab.getAttribute('aria-selected')).toBe('false');
+    const specificityTab = screen.getByRole('tab', { name: /Task-specific/ });
+    expect(specificityTab.getAttribute('aria-selected')).toBe('false');
   });
 
   it('updates aria-selected on tab switch', () => {
     renderTabs();
-    fireEvent.click(screen.getByRole('tab', { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole('tab', { name: /Task-specific/ }));
 
     expect(screen.getByRole('tab', { name: /Default/ }).getAttribute('aria-selected')).toBe('false');
-    expect(screen.getByRole('tab', { name: /Complexity/ }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: /Task-specific/ }).getAttribute('aria-selected')).toBe('true');
   });
 
   it('renders tabpanel with correct role', () => {
@@ -91,23 +81,21 @@ describe('RoutingTabs', () => {
   it('shows green dot for enabled layers and gray for disabled', () => {
     const { container } = renderTabs({ specificityEnabled: false, customEnabled: true });
     const dots = container.querySelectorAll('.routing-tabs__dot');
-    // Default (always on), complexity (always on), specificity (off), custom (on)
+    // Default (always on), specificity (off), custom (on)
     expect(dots[0].classList.contains('routing-tabs__dot--on')).toBe(true);
-    expect(dots[1].classList.contains('routing-tabs__dot--on')).toBe(true);
-    expect(dots[2].classList.contains('routing-tabs__dot--off')).toBe(true);
-    expect(dots[3].classList.contains('routing-tabs__dot--on')).toBe(true);
+    expect(dots[1].classList.contains('routing-tabs__dot--off')).toBe(true);
+    expect(dots[2].classList.contains('routing-tabs__dot--on')).toBe(true);
   });
 
-  it('Default and Complexity tabs always have a green dot', () => {
+  it('Default tab always has a green dot; specificity and custom are off by default', () => {
     const { container } = renderTabs();
     const dots = container.querySelectorAll('.routing-tabs__dot');
-    expect(dots.length).toBe(4);
-    // Default and Complexity dots are always on
+    expect(dots.length).toBe(3);
+    // Default dot is always on
     expect(dots[0].classList.contains('routing-tabs__dot--on')).toBe(true);
-    expect(dots[1].classList.contains('routing-tabs__dot--on')).toBe(true);
     // Specificity and Custom are off by default
+    expect(dots[1].classList.contains('routing-tabs__dot--off')).toBe(true);
     expect(dots[2].classList.contains('routing-tabs__dot--off')).toBe(true);
-    expect(dots[3].classList.contains('routing-tabs__dot--off')).toBe(true);
   });
 
   it('applies active class to selected tab', () => {
@@ -128,7 +116,6 @@ describe('RoutingTabs', () => {
       >
         {{
           default: <div>Default</div>,
-          complexity: <div>Complexity</div>,
           specificity: <div>Specificity</div>,
           custom: <div>Custom</div>,
         }}
@@ -146,7 +133,6 @@ describe('RoutingTabs', () => {
       >
         {{
           default: <div>Default</div>,
-          complexity: <div>Complexity</div>,
           specificity: <div>Specificity</div>,
           custom: <div>Custom</div>,
         }}
@@ -164,7 +150,6 @@ describe('RoutingTabs', () => {
       >
         {{
           default: <div>Default</div>,
-          complexity: <div>Complexity</div>,
           specificity: <div>Specificity</div>,
           custom: <div>Custom</div>,
         }}
@@ -187,7 +172,6 @@ describe('RoutingTabs', () => {
       >
         {{
           default: <div>Default</div>,
-          complexity: <div>Complexity</div>,
           specificity: <div>Specificity</div>,
           custom: <div>Custom</div>,
         }}
@@ -208,7 +192,6 @@ describe('RoutingTabs', () => {
       >
         {{
           default: <div>Default</div>,
-          complexity: <div>Complexity</div>,
           specificity: <div>Specificity</div>,
           custom: <div>Custom</div>,
         }}
@@ -230,7 +213,6 @@ describe('RoutingTabs', () => {
       >
         {{
           default: <div>Default</div>,
-          complexity: <div>Complexity</div>,
           specificity: <div>Specificity</div>,
           custom: <div>Custom</div>,
         }}
@@ -252,7 +234,6 @@ describe('RoutingTabs', () => {
       >
         {{
           default: <div>Default</div>,
-          complexity: <div>Complexity</div>,
           specificity: <div>Specificity</div>,
           custom: <div>Custom</div>,
         }}

--- a/packages/frontend/tests/pages/Routing-deeplink.test.tsx
+++ b/packages/frontend/tests/pages/Routing-deeplink.test.tsx
@@ -77,6 +77,8 @@ vi.mock('../../src/services/api.js', () => ({
   overrideSpecificity: vi.fn().mockResolvedValue({}),
   getPricingHealth: vi.fn().mockResolvedValue({ model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
   refreshPricing: vi.fn().mockResolvedValue({ ok: true, model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
+  getComplexityStatus: vi.fn().mockResolvedValue({ enabled: true }),
+  toggleComplexity: vi.fn().mockResolvedValue({ enabled: false }),
 }));
 
 vi.mock('../../src/services/routing-utils.js', () => ({

--- a/packages/frontend/tests/pages/Routing-prefill.test.tsx
+++ b/packages/frontend/tests/pages/Routing-prefill.test.tsx
@@ -73,6 +73,8 @@ vi.mock('../../src/services/api.js', () => ({
   overrideSpecificity: vi.fn().mockResolvedValue({}),
   getPricingHealth: vi.fn().mockResolvedValue({ model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
   refreshPricing: vi.fn().mockResolvedValue({ ok: true, model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
+  getComplexityStatus: vi.fn().mockResolvedValue({ enabled: true }),
+  toggleComplexity: vi.fn().mockResolvedValue({ enabled: false }),
 }));
 
 vi.mock('../../src/services/routing-utils.js', () => ({

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -75,6 +75,8 @@ vi.mock("../../src/services/api.js", () => ({
   refreshModels: vi.fn().mockResolvedValue({ ok: true }),
   getPricingHealth: vi.fn().mockResolvedValue({ model_count: 100, last_fetched_at: "2026-04-13T00:00:00.000Z" }),
   refreshPricing: vi.fn().mockResolvedValue({ ok: true, model_count: 100, last_fetched_at: "2026-04-13T00:00:00.000Z" }),
+  getComplexityStatus: vi.fn().mockResolvedValue({ enabled: true }),
+  toggleComplexity: vi.fn().mockResolvedValue({ enabled: false }),
 }));
 
 import Routing from "../../src/pages/Routing";
@@ -100,8 +102,18 @@ describe("Routing — enabled state (providers active)", () => {
   });
 
   it("renders Default tab with tier card and exercises its interactions", async () => {
+    const { getComplexityStatus } = await import("../../src/services/api.js");
+    vi.mocked(getComplexityStatus).mockResolvedValueOnce({ enabled: false });
+    const { getTierAssignments } = await import("../../src/services/api.js");
+    vi.mocked(getTierAssignments).mockResolvedValueOnce([
+      { id: "1", user_id: "u1", tier: "simple", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+      { id: "2", user_id: "u1", tier: "standard", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+      { id: "3", user_id: "u1", tier: "complex", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+      { id: "4", user_id: "u1", tier: "reasoning", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
+      { id: "5", user_id: "u1", tier: "default", override_model: null, override_provider: null, auto_assigned_model: null, fallback_models: null, updated_at: "2025-01-01" },
+    ]);
     render(() => <Routing />);
-    // Default tab is active by default — wait for the card to render
+    // Default tab is active by default — wait for the single "Default model" card to render
     await waitFor(() => {
       expect(screen.getAllByText("Default model").length).toBeGreaterThan(0);
     });
@@ -118,7 +130,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("renders all four tier labels", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     expect(await screen.findByText("Simple")).toBeDefined();
     expect(screen.getByText("Standard")).toBeDefined();
     expect(screen.getByText("Complex")).toBeDefined();
@@ -128,7 +140,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("renders tier labels", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     expect(await screen.findByText("Simple")).toBeDefined();
     expect(screen.getByText("Standard")).toBeDefined();
     expect(screen.getByText("Complex")).toBeDefined();
@@ -138,7 +150,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("shows auto tag for non-override tiers", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const autoTags = await screen.findAllByText("auto");
     // simple, standard, reasoning are auto (3 tiers); complex has an override
     expect(autoTags.length).toBe(3);
@@ -147,7 +159,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("shows Change button for all tiers", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const editButtons = await screen.findAllByText("Change");
     expect(editButtons.length).toBe(4);
   });
@@ -155,7 +167,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("renders fallback empty state in tier cards", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const emptyStates = await screen.findAllByText("No fallbacks");
     expect(emptyStates.length).toBe(4); // one per tier
   });
@@ -196,7 +208,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("opens model picker when Change button is clicked", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const editButtons = await screen.findAllByText("Change");
     fireEvent.click(editButtons[0]);
     expect(await screen.findByText("Select a model")).toBeDefined();
@@ -205,7 +217,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("opens model picker when Change button is clicked on override tier", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const editButtons = await screen.findAllByText("Change");
     // complex tier (index 2) has an override
     fireEvent.click(editButtons[2]);
@@ -215,7 +227,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("shows tier label in model picker subtitle", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     // Click override for 'simple' tier
     fireEvent.click(overrideButtons[0]);
@@ -225,7 +237,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("closes model picker when close button is clicked", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
     expect(await screen.findByText("Select a model")).toBeDefined();
@@ -241,7 +253,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("closes model picker on overlay click", async () => {
     const { container } = render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
     expect(await screen.findByText("Select a model")).toBeDefined();
@@ -257,7 +269,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("closes model picker on Escape key", async () => {
     const { container } = render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
     expect(await screen.findByText("Select a model")).toBeDefined();
@@ -273,7 +285,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("shows search input in model picker", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
     expect(await screen.findByLabelText("Search models or providers")).toBeDefined();
@@ -282,7 +294,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("filters models by search query", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
 
@@ -298,7 +310,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("shows 'No models match' when search has no results", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
 
@@ -313,7 +325,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("selects a model and calls overrideTier", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
     await screen.findByText("Select a model");
@@ -333,7 +345,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("shows (recommended) label for auto-assigned model", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]); // simple tier, auto is gpt-4o-mini
 
@@ -345,7 +357,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("calls resetAllTiers when Reset all to auto is clicked", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const resetAllBtn = await screen.findByText("Reset all to auto");
     fireEvent.click(resetAllBtn);
 
@@ -362,7 +374,7 @@ describe("Routing — enabled state (providers active)", () => {
     vi.mocked(resetAllTiers).mockReturnValue(new Promise<void>((r) => { resolveResetAll = r; }) as any);
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const resetAllBtn = await screen.findByText("Reset all to auto") as HTMLButtonElement;
     fireEvent.click(resetAllBtn);
 
@@ -393,7 +405,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("displays model price labels", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     // gpt-4o-mini: input 0.00000015 * 1M = $0.15
     await waitFor(() => {
       const text = document.body.textContent || "";
@@ -412,7 +424,7 @@ describe("Routing — enabled state (providers active)", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const addButtons = await screen.findAllByText("+ Add model");
     // 4 complexity tiers visible in the active tab
     expect(addButtons.length).toBe(4);
@@ -435,7 +447,7 @@ describe("Routing — enabled state (providers active)", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     expect(await screen.findByText("Included in subscription")).toBeDefined();
   });
 
@@ -453,7 +465,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("shows Reset button only for edited tiers", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
     const resetButtons = screen.queryAllByText("Reset");
     // Only "complex" tier has override_model set
@@ -470,7 +482,7 @@ describe("Routing — enabled state (providers active)", () => {
     ]);
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
     // "simple" tier has fallbacks → Reset should appear
     const resetButtons = screen.queryAllByText("Reset");
@@ -480,7 +492,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("opens confirmation modal when Reset is clicked", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
     const resetBtn = screen.getByText("Reset");
     fireEvent.click(resetBtn);
@@ -492,7 +504,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("calls resetTier when confirmed", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
     const resetBtn = screen.getByText("Reset");
     fireEvent.click(resetBtn);
@@ -515,7 +527,7 @@ describe("Routing — enabled state (providers active)", () => {
   it("closes reset modal on Cancel", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
     const resetBtn = screen.getByText("Reset");
     fireEvent.click(resetBtn);
@@ -532,7 +544,7 @@ describe("Routing — enabled state (providers active)", () => {
     vi.mocked(resetTier).mockRejectedValueOnce(new Error("fail"));
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
     const resetBtn = screen.getByText("Reset");
     fireEvent.click(resetBtn);
@@ -616,7 +628,8 @@ describe("Routing — enabled state (providers active)", () => {
   });
 
   it("resets the default tier via its Reset button", async () => {
-    const { getTierAssignments } = await import("../../src/services/api.js");
+    const { getComplexityStatus, getTierAssignments } = await import("../../src/services/api.js");
+    vi.mocked(getComplexityStatus).mockResolvedValueOnce({ enabled: false });
     vi.mocked(getTierAssignments).mockResolvedValueOnce([
       { id: "1", user_id: "u1", tier: "simple", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
       { id: "2", user_id: "u1", tier: "standard", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
@@ -649,7 +662,8 @@ describe("Routing — enabled state (providers active)", () => {
   });
 
   it("opens default-tier picker from the + Add model button", async () => {
-    const { getTierAssignments } = await import("../../src/services/api.js");
+    const { getComplexityStatus, getTierAssignments } = await import("../../src/services/api.js");
+    vi.mocked(getComplexityStatus).mockResolvedValueOnce({ enabled: false });
     vi.mocked(getTierAssignments).mockResolvedValueOnce([
       { id: "1", user_id: "u1", tier: "simple", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
       { id: "2", user_id: "u1", tier: "standard", override_model: null, override_provider: null, auto_assigned_model: "gpt-4o-mini", fallback_models: null, updated_at: "2025-01-01" },
@@ -711,7 +725,7 @@ describe("Routing — pricing cache health banner", () => {
     vi.mocked(getPricingHealth).mockResolvedValue({ model_count: 100, last_fetched_at: "2026-04-13T00:00:00.000Z" });
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
     expect(screen.queryByText(/Pricing catalog is empty/)).toBeNull();
   });
@@ -769,7 +783,7 @@ describe("Routing — empty state (no active providers)", () => {
     // Tabs are visible by default
     expect(await screen.findByRole("tablist")).toBeDefined();
     expect(screen.getByRole("tab", { name: /Default/ })).toBeDefined();
-    expect(screen.getByRole("tab", { name: /Complexity/ })).toBeDefined();
+    expect(screen.getByRole("tab", { name: /Task-specific/ })).toBeDefined();
     // Footer setup instructions available
     expect(screen.getByText("Setup instructions")).toBeDefined();
   });
@@ -822,7 +836,7 @@ describe("Routing — helper functions", () => {
     vi.mocked(overrideTier).mockRejectedValueOnce(new Error("fail"));
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const overrideButtons = await screen.findAllByText("Change");
     fireEvent.click(overrideButtons[0]);
     await screen.findByText("Select a model");
@@ -840,7 +854,7 @@ describe("Routing — helper functions", () => {
     vi.mocked(resetAllTiers).mockRejectedValueOnce(new Error("fail"));
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const resetAllBtn = await screen.findByText("Reset all to auto");
     fireEvent.click(resetAllBtn);
 
@@ -858,7 +872,7 @@ describe("Routing — helper functions", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     // The model should still be found via PROVIDERS fallback (gpt-4o-mini is in OpenAI's model list)
     await waitFor(() => {
       expect(screen.getByText("Simple")).toBeDefined();
@@ -875,7 +889,7 @@ describe("Routing — helper functions", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     // The override model name should render (no provider icon since providerIdForModel returns undefined)
     await waitFor(() => {
       expect(screen.getByText("Simple")).toBeDefined();
@@ -897,7 +911,7 @@ describe("Routing — custom providers", () => {
 
     const { container } = render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await waitFor(() => {
       // Custom provider branch: renders a letter icon instead of an SVG provider icon
       const letter = container.querySelector(".routing-providers-info .provider-card__logo-letter");
@@ -925,7 +939,7 @@ describe("Routing — custom providers", () => {
 
     const { container } = render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await waitFor(() => {
       const letter = container.querySelector(".routing-card .provider-card__logo-letter");
       expect(letter).not.toBeNull();
@@ -951,7 +965,7 @@ describe("Routing — custom providers", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await waitFor(() => {
       // labelFor should produce "Groq / my-llama"
       expect(screen.getByText("Groq / my-llama")).toBeDefined();
@@ -976,7 +990,7 @@ describe("Routing — custom providers", () => {
 
     const { container } = render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await waitFor(() => {
       // null prices → pricePerM returns "—"
       expect(container.textContent).toContain("\u2014 in");
@@ -1208,7 +1222,7 @@ describe("Routing — fallback management", () => {
   it("opens fallback picker when Add fallback is clicked", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]);
     // The model picker modal should open
@@ -1218,7 +1232,7 @@ describe("Routing — fallback management", () => {
   it("calls setFallbacks when a fallback model is picked", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]); // simple tier
     await screen.findByText("Select a model");
@@ -1247,7 +1261,7 @@ describe("Routing — fallback management", () => {
     const { container } = render(() => <Routing />);
     // Simple tier has 1 fallback, so it shows the standalone "Add fallback" button (not inside empty state)
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findAllByText("Add fallback");
     const standaloneAddBtn = container.querySelector(".fallback-list__add:not(.fallback-list__empty .fallback-list__add)") as HTMLButtonElement;
     fireEvent.click(standaloneAddBtn);
@@ -1263,7 +1277,7 @@ describe("Routing — fallback management", () => {
     vi.mocked(setFallbacks).mockReturnValueOnce(new Promise<void>((r) => { resolveSetFallbacks = r; }) as any);
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]); // simple tier
     await screen.findByText("Select a model");
@@ -1284,7 +1298,7 @@ describe("Routing — fallback management", () => {
     vi.mocked(setFallbacks).mockRejectedValueOnce(new Error("fail"));
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]);
     await screen.findByText("Select a model");
@@ -1308,7 +1322,7 @@ describe("Routing — fallback management", () => {
 
     const { container } = render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await waitFor(() => {
       const fallbackCards = container.querySelectorAll(".fallback-list__card");
       expect(fallbackCards.length).toBe(1);
@@ -1333,7 +1347,7 @@ describe("Routing — fallback management", () => {
 
     const { container } = render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     // Wait for fallback list to render with custom provider fallback
     await waitFor(() => {
       const removeButtons = container.querySelectorAll(".fallback-list__remove");
@@ -1357,7 +1371,7 @@ describe("Routing — fallback management", () => {
   it("closes fallback picker when close button is clicked", async () => {
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]);
     expect(await screen.findByText("Select a model")).toBeDefined();
@@ -1396,7 +1410,7 @@ describe("Routing — effectiveAuth case-insensitive matching", () => {
     render(() => <Routing />);
     // Should show "Included in subscription" because effectiveAuth matches "Anthropic" provider case-insensitively
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     expect(await screen.findByText("Included in subscription")).toBeDefined();
   });
 
@@ -1417,7 +1431,7 @@ describe("Routing — effectiveAuth case-insensitive matching", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     expect(await screen.findByText("Included in subscription")).toBeDefined();
   });
 
@@ -1440,7 +1454,7 @@ describe("Routing — effectiveAuth case-insensitive matching", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     // providerIdForModel returns "qwen" via the PROVIDERS model list fallback (line 52)
     // labelFor can't find modelInfo (empty apiModels) so renders raw model name
     await waitFor(() => {
@@ -1469,7 +1483,7 @@ describe("Routing — effectiveAuth case-insensitive matching", () => {
 
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     // getModelLabel falls back to formatModelSlug: "my-unknown-model" → "My Unknown Model"
     await waitFor(() => {
       expect(screen.getByText("My Unknown Model")).toBeDefined();
@@ -1518,7 +1532,7 @@ describe("Routing — specificity routing", () => {
     ]);
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     await screen.findByText("Simple");
 
     // Switch to the Task-specific tab to see specificity content
@@ -1549,7 +1563,7 @@ describe("Routing — specificity routing", () => {
     vi.mocked(getSpecificityAssignments).mockResolvedValue([]);
     render(() => <Routing />);
     await screen.findByRole("tablist");
-    fireEvent.click(screen.getByRole("tab", { name: /Complexity/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
     const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]); // simple tier
     await screen.findByText("Select a model");

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -895,6 +895,37 @@ describe("Routing — helper functions", () => {
       expect(screen.getByText("Simple")).toBeDefined();
     });
   });
+
+  it("calls toggleComplexity and mutates state when Route by complexity toggle is clicked", async () => {
+    const { toggleComplexity } = await import("../../src/services/api.js");
+    vi.mocked(toggleComplexity).mockResolvedValueOnce({ enabled: false });
+
+    render(() => <Routing />);
+    await screen.findByRole("tablist");
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
+    // Wait for the toggle to appear
+    const toggle = await screen.findByRole("button", { name: /Route by complexity/i });
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(toggleComplexity).toHaveBeenCalledWith("test-agent");
+    });
+  });
+
+  it("shows an error toast when toggleComplexity rejects", async () => {
+    const { toggleComplexity } = await import("../../src/services/api.js");
+    vi.mocked(toggleComplexity).mockRejectedValueOnce(new Error("network error"));
+
+    render(() => <Routing />);
+    await screen.findByRole("tablist");
+    fireEvent.click(screen.getByRole("tab", { name: /Default/ }));
+    const toggle = await screen.findByRole("button", { name: /Route by complexity/i });
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to toggle complexity routing");
+    });
+  });
 });
 
 describe("Routing — custom providers", () => {

--- a/packages/frontend/tests/pages/RoutingComplexitySection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingComplexitySection.test.tsx
@@ -92,6 +92,9 @@ function makeProps(
     onAddFallback: vi.fn(),
     getFallbacksFor: () => [],
     getTier: () => undefined,
+    complexityEnabled: () => true,
+    togglingComplexity: () => false,
+    onToggleComplexity: vi.fn(),
     ...overrides,
   };
 }
@@ -121,19 +124,48 @@ describe('RoutingComplexitySection', () => {
     ).toBeDefined();
   });
 
-  it('always renders the four tier cards (complexity routing is always on)', () => {
-    render(() => <RoutingComplexitySection {...makeProps()} />);
+  it('renders the four tier cards when complexityEnabled is true', () => {
+    render(() => <RoutingComplexitySection {...makeProps({ complexityEnabled: () => true })} />);
     expect(screen.getByTestId('tier-card-simple')).toBeDefined();
     expect(screen.getByTestId('tier-card-standard')).toBeDefined();
     expect(screen.getByTestId('tier-card-complex')).toBeDefined();
     expect(screen.getByTestId('tier-card-reasoning')).toBeDefined();
   });
 
-  it('does not render any enable/disable toggle', () => {
-    render(() => <RoutingComplexitySection {...makeProps()} />);
-    expect(screen.queryByText(/enable complexity routing/i)).toBeNull();
-    expect(screen.queryByText(/disable complexity routing/i)).toBeNull();
-    expect(screen.queryByText(/complexity routing is off/i)).toBeNull();
+  it('renders the toggle button showing "Enabled" when complexityEnabled is true', () => {
+    render(() => <RoutingComplexitySection {...makeProps({ complexityEnabled: () => true })} />);
+    expect(screen.getByText('Enabled')).toBeDefined();
+    expect(screen.queryByText('Disabled')).toBeNull();
+  });
+
+  it('renders the toggle button showing "Disabled" when complexityEnabled is false', () => {
+    render(() => <RoutingComplexitySection {...makeProps({ complexityEnabled: () => false })} />);
+    expect(screen.getByText('Disabled')).toBeDefined();
+    expect(screen.queryByText('Enabled')).toBeNull();
+  });
+
+  it('shows the empty state and hides tier cards when complexityEnabled is false', () => {
+    render(() => <RoutingComplexitySection {...makeProps({ complexityEnabled: () => false })} />);
+    expect(screen.getByText('Complexity routing is off')).toBeDefined();
+    expect(screen.queryByTestId('tier-card-simple')).toBeNull();
+    expect(screen.queryByTestId('tier-card-standard')).toBeNull();
+    expect(screen.queryByTestId('tier-card-complex')).toBeNull();
+    expect(screen.queryByTestId('tier-card-reasoning')).toBeNull();
+  });
+
+  it('calls onToggleComplexity when the toggle button is clicked', () => {
+    const onToggleComplexity = vi.fn();
+    render(() => <RoutingComplexitySection {...makeProps({ onToggleComplexity })} />);
+    (screen.getByText('Enabled').closest('button') as HTMLButtonElement).click();
+    expect(onToggleComplexity).toHaveBeenCalledOnce();
+  });
+
+  it('disables the toggle button while togglingComplexity is true', () => {
+    render(() =>
+      <RoutingComplexitySection {...makeProps({ togglingComplexity: () => true })} />,
+    );
+    const btn = screen.getByText('Enabled').closest('button') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
   });
 
   it('forwards each tier-card handler to the parent', () => {

--- a/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
@@ -8,6 +8,12 @@ vi.mock('../../src/services/providers.js', () => ({
     label: 'Default model',
     desc: 'Handles every request.',
   },
+  STAGES: [
+    { id: 'simple', step: 1, label: 'Simple', desc: 'Simple requests.' },
+    { id: 'standard', step: 2, label: 'Standard', desc: 'Standard requests.' },
+    { id: 'complex', step: 3, label: 'Complex', desc: 'Complex requests.' },
+    { id: 'reasoning', step: 4, label: 'Reasoning', desc: 'Reasoning requests.' },
+  ],
 }));
 
 vi.mock('../../src/pages/RoutingTierCard.js', () => ({
@@ -91,48 +97,104 @@ function makeProps(
     onFallbackUpdate: vi.fn(),
     onAddFallback: vi.fn(),
     getFallbacksFor: () => [],
+    getTier: () => undefined,
+    complexityEnabled: () => false,
+    togglingComplexity: () => false,
+    onToggleComplexity: vi.fn(),
     ...overrides,
   };
 }
 
 describe('RoutingDefaultTierSection', () => {
-  it('renders the Default model title in the section header', () => {
-    render(() => <RoutingDefaultTierSection {...makeProps()} />);
-    const matches = screen.getAllByText('Default model');
-    // One in the section header, one in the reused tier-card mock stub
-    expect(matches.length).toBeGreaterThanOrEqual(1);
-    expect(matches.some((el) => el.classList.contains('routing-section__title'))).toBe(true);
+  it('renders the "Default routing" title in the section header', () => {
+    const { container } = render(() => <RoutingDefaultTierSection {...makeProps()} />);
+    const title = container.querySelector('.routing-section__title');
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toBe('Default routing');
   });
 
-  it('always describes the Default tier as a safety net (complexity routing is always on)', () => {
-    render(() => <RoutingDefaultTierSection {...makeProps()} />);
+  it('shows the simple-routing subtitle when complexity is disabled', () => {
+    render(() => <RoutingDefaultTierSection {...makeProps({ complexityEnabled: () => false })} />);
+    expect(
+      screen.getByText('Pick one model and up to 5 fallbacks as your default routing.'),
+    ).toBeDefined();
+  });
+
+  it('shows the complexity subtitle when complexity is enabled', () => {
+    render(() => <RoutingDefaultTierSection {...makeProps({ complexityEnabled: () => true })} />);
     expect(
       screen.getByText(
-        'Acts as a safety net and handles requests that complexity routing can\u2019t resolve',
+        'Analyzes the complexity of each request on the fly and routes it to the matching tier.',
       ),
     ).toBeDefined();
   });
 
-  it('always applies the dimmed class (complexity routing is always on)', () => {
+  it('does not apply a dimmed class', () => {
     const { container } = render(() => <RoutingDefaultTierSection {...makeProps()} />);
-    expect(container.querySelector('.routing-section--dimmed')).not.toBeNull();
+    expect(container.querySelector('.routing-section--dimmed')).toBeNull();
   });
 
-  it('renders a single default tier card', () => {
-    render(() => <RoutingDefaultTierSection {...makeProps()} />);
+  it('renders a single default tier card when complexity is disabled', () => {
+    render(() => <RoutingDefaultTierSection {...makeProps({ complexityEnabled: () => false })} />);
     expect(screen.getByTestId('tier-card-default')).toBeDefined();
+    expect(screen.queryByTestId('tier-card-simple')).toBeNull();
   });
 
-  it('skips subtitle while tiers are loading', () => {
-    render(() => <RoutingDefaultTierSection {...makeProps({ tiersLoading: true })} />);
-    expect(
-      screen.queryByText(
-        'Acts as a safety net and handles requests that complexity routing can\u2019t resolve',
-      ),
-    ).toBeNull();
+  it('renders complexity tier cards instead of the default card when complexity is enabled', () => {
+    render(() => <RoutingDefaultTierSection {...makeProps({ complexityEnabled: () => true })} />);
+    expect(screen.queryByTestId('tier-card-default')).toBeNull();
+    expect(screen.getByTestId('tier-card-simple')).toBeDefined();
+    expect(screen.getByTestId('tier-card-standard')).toBeDefined();
+    expect(screen.getByTestId('tier-card-complex')).toBeDefined();
+    expect(screen.getByTestId('tier-card-reasoning')).toBeDefined();
   });
 
-  it('forwards every handler prop to the inner tier card', () => {
+  it('wraps the default card in routing-cards-backdrop when embedded and complexity is disabled', () => {
+    const { container } = render(() =>
+      <RoutingDefaultTierSection
+        {...makeProps({ complexityEnabled: () => false, embedded: true })}
+      />,
+    );
+    const backdrop = container.querySelector('.routing-cards-backdrop');
+    expect(backdrop).not.toBeNull();
+    expect(backdrop!.querySelector('[data-testid="tier-card-default"]')).not.toBeNull();
+  });
+
+  it('renders the "Route by complexity" toggle button', () => {
+    render(() => <RoutingDefaultTierSection {...makeProps()} />);
+    expect(screen.getByText('Route by complexity')).toBeDefined();
+  });
+
+  it('calls onToggleComplexity when the toggle is clicked', () => {
+    const onToggleComplexity = vi.fn();
+    const { container } = render(() =>
+      <RoutingDefaultTierSection {...makeProps({ onToggleComplexity })} />,
+    );
+    const button = container.querySelector('.routing-switch') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    button.click();
+    expect(onToggleComplexity).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the toggle button while togglingComplexity is true', () => {
+    const { container } = render(() =>
+      <RoutingDefaultTierSection {...makeProps({ togglingComplexity: () => true })} />,
+    );
+    const button = container.querySelector('.routing-switch') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    expect(button.disabled).toBe(true);
+  });
+
+  it('adds routing-switch--on class when complexity is enabled', () => {
+    const { container } = render(() =>
+      <RoutingDefaultTierSection {...makeProps({ complexityEnabled: () => true })} />,
+    );
+    const button = container.querySelector('.routing-switch');
+    expect(button).not.toBeNull();
+    expect(button!.classList.contains('routing-switch--on')).toBe(true);
+  });
+
+  it('forwards every handler prop to the default tier card', () => {
     const onDropdownOpen = vi.fn();
     const onOverride = vi.fn();
     const onReset = vi.fn();

--- a/packages/frontend/tests/services/routing.test.ts
+++ b/packages/frontend/tests/services/routing.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { agentPath } from "../../src/services/routing";
+import { getComplexityStatus, toggleComplexity } from "../../src/services/api/routing";
 
 describe("agentPath", () => {
   it("builds path with agent name", () => {
@@ -10,5 +11,57 @@ describe("agentPath", () => {
   });
   it("returns root when agent is null", () => {
     expect(agentPath(null, "/overview")).toBe("/");
+  });
+});
+
+describe("getComplexityStatus", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls the correct endpoint and returns the parsed response", async () => {
+    const payload = { enabled: true };
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(payload),
+    } as Response);
+
+    const result = await getComplexityStatus("my-agent");
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/routing/my-agent/complexity/status"),
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(result).toEqual(payload);
+  });
+});
+
+describe("toggleComplexity", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls the correct endpoint with POST and returns the parsed response", async () => {
+    const payload = { enabled: false };
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(payload)),
+    } as Response);
+
+    const result = await toggleComplexity("my-agent");
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/routing/my-agent/complexity/toggle"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result).toEqual(payload);
   });
 });


### PR DESCRIPTION
## Summary

- Moves complexity routing inside the Default tab as a toggleable mode ("Route by complexity" toggle)
- Removes the standalone Complexity tab from routing
- New agents default to simple routing (single tier), existing agents keep their complexity setting
- Adds gear dropdown menu on custom tier cards with "Send this header", "Edit tier", and "Disable" actions
- Adds Reset button on custom tier cards when a model is assigned
- Updates "How routing works" modal to reflect the merged pipeline
- Adds Microsoft Azure as a recognized custom provider logo

Resolves MAN-37

## Test plan

- [ ] Toggle "Route by complexity" on/off in the Default tab
- [ ] Verify complexity tiers appear when enabled, single default card when disabled
- [ ] Check "How routing works" modal reflects the current mode
- [ ] Test custom tier gear dropdown menu (Send this header, Edit tier, Disable)
- [ ] Test Reset button on custom tier cards with assigned models
- [ ] Create a new agent and verify it defaults to simple routing
- [ ] Verify existing agents keep their complexity routing setting after migration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges complexity routing into the Default tab with a “Route by complexity” toggle, removing the separate Complexity tab. Persists a per‑agent flag with APIs; new agents default to simple routing while existing agents keep their setup. (Fulfills MAN-37.)

- **New Features**
  - Default tab gets a “Route by complexity” switch; UI shows one default card or four complexity tiers.
  - “How routing works” modal reflects the active mode.
  - Header tier cards add a gear menu: “Send this header”, “Edit tier”, “Disable”, plus a Reset button when a model is set.
  - Custom providers: add Microsoft Azure logo detection.
  - Backend: `complexity_routing_enabled` on agents; `GET /api/v1/routing/:agentName/complexity/status` and `POST /api/v1/routing/:agentName/complexity/toggle`; invalidate resolve‑agent cache on toggle; `ResolveService` skips complexity scoring when off.

- **Migration**
  - Re-adds `complexity_routing_enabled` with backfill: existing agents default to true; default then set to false for new agents.
  - No manual steps; run migrations and deploy.

<sup>Written for commit a3989da12902eb211d4f2dfe8fed2890255a5a4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

