### PR TITLE
feat: add vision capability filter for model routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.3.1",
         "prettier": "^3.8.1",
+        "ts-jest": "^29.4.9",
         "turbo": "^2"
       }
     },
@@ -469,7 +470,7 @@
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -481,7 +482,7 @@
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
@@ -1319,7 +1320,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1337,7 +1338,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1359,7 +1360,7 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1385,7 +1386,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1406,7 +1407,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1427,7 +1428,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2207,7 +2207,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2233,7 +2233,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2247,7 +2247,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3177,14 +3177,6 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.40.0",
       "license": "Apache-2.0",
@@ -3504,7 +3496,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3518,7 +3509,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3532,7 +3522,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3546,7 +3535,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3560,7 +3548,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3574,7 +3561,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3588,7 +3574,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3602,7 +3587,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3616,7 +3600,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3630,7 +3613,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3644,7 +3626,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3658,7 +3639,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3672,7 +3652,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3686,7 +3665,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3700,7 +3678,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3714,7 +3691,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3726,7 +3702,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3738,7 +3713,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3752,7 +3726,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3766,7 +3739,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3780,7 +3752,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3794,7 +3765,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3808,7 +3778,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3822,7 +3791,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4211,6 +4179,8 @@
     },
     "node_modules/@types/jest": {
       "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4857,7 +4827,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6029,7 +5999,7 @@
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -6045,7 +6015,7 @@
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -6076,7 +6046,7 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -7352,7 +7322,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7446,19 +7415,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -7657,7 +7613,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -7727,7 +7683,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -7739,7 +7695,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7983,7 +7939,7 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -8154,6 +8110,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9071,7 +9029,7 @@
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
@@ -9872,7 +9830,7 @@
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -10104,7 +10062,7 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -10115,7 +10073,7 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -10499,7 +10457,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10732,16 +10690,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "dev": true,
@@ -10854,7 +10802,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10881,7 +10828,7 @@
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -10937,7 +10884,7 @@
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -11346,12 +11293,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/sql.js": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "dev": true,
@@ -11602,7 +11543,7 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -11634,7 +11575,7 @@
     },
     "node_modules/terser": {
       "version": "5.46.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -11744,12 +11685,12 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11757,7 +11698,7 @@
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11884,7 +11825,7 @@
     },
     "node_modules/tldts": {
       "version": "6.1.86",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -11895,7 +11836,7 @@
     },
     "node_modules/tldts-core": {
       "version": "6.1.86",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -11951,7 +11892,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -11962,7 +11903,7 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -11983,17 +11924,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -12010,7 +11953,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -12124,84 +12067,6 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
-    },
-    "node_modules/tsx": {
-      "version": "4.21.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.27.4",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
-      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -12544,7 +12409,7 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -12693,7 +12558,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12823,7 +12687,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -12862,7 +12726,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -13011,7 +12875,7 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -13022,7 +12886,7 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13033,7 +12897,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13041,7 +12905,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -13218,7 +13082,7 @@
     },
     "node_modules/ws": {
       "version": "8.20.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13238,7 +13102,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -13246,7 +13110,7 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -13270,7 +13134,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -13380,7 +13244,7 @@
         "@nestjs/testing": "^11.0.0",
         "@types/express": "^5.0.6",
         "@types/helmet": "^0.0.48",
-        "@types/jest": "^29.5.0",
+        "@types/jest": "^29.5.14",
         "@types/node": "^22.0.0",
         "@types/pg": "^8.16.0",
         "@types/react": "^19.2.14",
@@ -13389,7 +13253,7 @@
         "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.2.0",
+        "ts-jest": "^29.4.9",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.0"
       }
@@ -13606,7 +13470,7 @@
     },
     "packages/frontend/node_modules/@types/node": {
       "version": "22.19.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.3.1",
     "prettier": "^3.8.1",
+    "ts-jest": "^29.4.9",
     "turbo": "^2"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,7 +18,6 @@
     "migration:create": "typeorm-ts-node-commonjs migration:create"
   },
   "dependencies": {
-    "manifest-shared": "*",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",
@@ -38,6 +37,7 @@
     "compression": "^1.8.1",
     "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
+    "manifest-shared": "*",
     "pg": "^8.13.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -52,7 +52,7 @@
     "@nestjs/testing": "^11.0.0",
     "@types/express": "^5.0.6",
     "@types/helmet": "^0.0.48",
-    "@types/jest": "^29.5.0",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.16.0",
     "@types/react": "^19.2.14",
@@ -61,7 +61,7 @@
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.2.0",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.0"
   },

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
@@ -11,6 +11,7 @@ function makeModel(id: string): DiscoveredModel {
     outputPricePerToken: null,
     capabilityReasoning: false,
     capabilityCode: false,
+    capabilityVision: false,
     qualityScore: 3,
   };
 }

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -16,6 +16,7 @@ function makeModel(id: string, provider = 'test'): DiscoveredModel {
     outputPricePerToken: null,
     capabilityReasoning: false,
     capabilityCode: false,
+    capabilityVision: false,
     qualityScore: 3,
   };
 }

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -37,6 +37,7 @@ function makeModel(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
     outputPricePerToken: null,
     capabilityReasoning: false,
     capabilityCode: false,
+    capabilityVision: false,
     qualityScore: 3,
     ...overrides,
   };

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -252,6 +252,7 @@ export class ModelDiscoveryService {
           outputPricePerToken: outputPerToken,
           capabilityReasoning: false,
           capabilityCode: false,
+          capabilityVision: false,
           qualityScore: 2,
         });
       }

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -300,6 +300,7 @@ describe('supplementWithKnownModels', () => {
         outputPricePerToken: 0.02,
         capabilityReasoning: false,
         capabilityCode: false,
+        capabilityVision: false,
         qualityScore: 3,
       },
     ];
@@ -321,6 +322,7 @@ describe('supplementWithKnownModels', () => {
         outputPricePerToken: 0.075,
         capabilityReasoning: false,
         capabilityCode: false,
+        capabilityVision: false,
         qualityScore: 3,
       },
     ];

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -1,4 +1,5 @@
 import { DiscoveredModel } from './model-fetcher';
+import { detectVisionCapability } from './provider-model-fetcher.service';
 import {
   OPENROUTER_PREFIX_TO_PROVIDER,
   PROVIDER_BY_ID_OR_ALIAS,
@@ -160,6 +161,7 @@ export function buildModelsDevFallback(
     outputPricePerToken: e.outputPricePerToken,
     capabilityReasoning: e.reasoning ?? false,
     capabilityCode: e.toolCall ?? false,
+    capabilityVision: false,
     qualityScore: 3,
   }));
 }
@@ -204,6 +206,7 @@ export function buildFallbackModels(
       outputPricePerToken: entry.output,
       capabilityReasoning: false,
       capabilityCode: false,
+      capabilityVision: detectVisionCapability(modelId, providerId),
       qualityScore: 3,
     });
   }
@@ -255,6 +258,7 @@ export function buildSubscriptionFallbackModels(
         outputPricePerToken: entry.output,
         capabilityReasoning: false,
         capabilityCode: false,
+        capabilityVision: detectVisionCapability(modelId, providerId),
         qualityScore: 3,
       });
     }
@@ -280,6 +284,7 @@ export function buildSubscriptionFallbackModels(
       outputPricePerToken: 0,
       capabilityReasoning: false,
       capabilityCode: false,
+      capabilityVision: detectVisionCapability(modelId, providerId),
       qualityScore: 3,
     });
   }
@@ -319,6 +324,7 @@ export function supplementWithKnownModels(
       outputPricePerToken: 0,
       capabilityReasoning: false,
       capabilityCode: false,
+      capabilityVision: detectVisionCapability(modelId, providerId),
       qualityScore: 3,
     });
   }

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -15,6 +15,8 @@ export interface DiscoveredModel {
   outputPricePerToken: number | null;
   capabilityReasoning: boolean;
   capabilityCode: boolean;
+  capabilityVision: boolean;
+  capabilityVision: boolean;
   qualityScore: number;
   authType?: 'api_key' | 'subscription';
 }

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -11,6 +11,33 @@ const ANTHROPIC_DEFAULT_CONTEXT = 200000;
 const GEMINI_DEFAULT_CONTEXT = 1000000;
 const MINIMAX_SUBSCRIPTION_MODELS_URL = 'https://api.minimax.io/anthropic/v1/models?limit=100';
 
+/* ── Vision capability detection ── */
+
+/**
+ * Per-provider rules for detecting vision capability from a model id.
+ * Keyed by the config key used in PROVIDER_CONFIGS. Providers not listed
+ * here default to false (vision cannot be determined reliably without
+ * per-model metadata).
+ */
+const VISION_PATTERNS: Record<string, RegExp> = {
+  openai: /(?:^gpt-4o|^gpt-4-turbo|^gpt-4-.*-vision)/i,
+  anthropic: /(?:^claude-3|^claude-4|^opus-4)/i,
+  deepseek: /(?:^deepseek-vl2|^deepseek-v3)/i,
+  mistral: /(?:^mistral-large|pixtral)/i,
+  xai: /(?:^grok-2-vision|^grok-3)/i,
+  qwen: /(?:qwen-vl|^qvq|^qwq)/i,
+  zai: /(?:^glm-4v|^cogview)/i,
+};
+
+export function detectVisionCapability(modelId: string, provider: string): boolean {
+  // Gemini: all models accept images.
+  if (provider === 'gemini') return true;
+  // Normalize subscription variants to base provider key.
+  const base = provider.replace(/-subscription$/, '');
+  const pattern = VISION_PATTERNS[base];
+  return pattern ? pattern.test(modelId) : false;
+}
+
 /* ── Generic parser factory ── */
 
 interface ModelParserConfig<T> {
@@ -22,6 +49,7 @@ interface ModelParserConfig<T> {
   inputPricePerToken?: number | null;
   outputPricePerToken?: number | null;
   capabilityCode?: boolean;
+  capabilityVision?: boolean;
   qualityScore?: number;
 }
 
@@ -46,6 +74,7 @@ function createModelParser<T>(
           outputPricePerToken: config.outputPricePerToken ?? null,
           capabilityReasoning: false,
           capabilityCode: config.capabilityCode ?? false,
+          capabilityVision: detectVisionCapability(id, provider),
           qualityScore: config.qualityScore ?? 3,
         };
       });
@@ -210,6 +239,7 @@ function parseGemini(body: unknown, provider: string): DiscoveredModel[] {
         outputPricePerToken: null,
         capabilityReasoning: false,
         capabilityCode: false,
+        capabilityVision: detectVisionCapability(id, provider),
         qualityScore: 3,
       };
     });
@@ -260,6 +290,7 @@ function parseOpenRouter(body: unknown, provider: string): DiscoveredModel[] {
           completion !== null && Number.isFinite(completion) && completion >= 0 ? completion : null,
         capabilityReasoning: false,
         capabilityCode: false,
+        capabilityVision: false,
         qualityScore: 3,
       };
     });
@@ -520,6 +551,7 @@ export class ProviderModelFetcherService {
       outputPricePerToken: 0,
       capabilityReasoning: true,
       capabilityCode: true,
+      capabilityVision: false,
       qualityScore: 3,
     }));
   }

--- a/packages/backend/src/model-discovery/vision-capability.spec.ts
+++ b/packages/backend/src/model-discovery/vision-capability.spec.ts
@@ -1,0 +1,141 @@
+import { detectVisionCapability } from './provider-model-fetcher.service';
+
+describe('detectVisionCapability', () => {
+  describe('openai', () => {
+    it('returns true for gpt-4o family', () => {
+      expect(detectVisionCapability('gpt-4o', 'openai')).toBe(true);
+      expect(detectVisionCapability('gpt-4o-mini', 'openai')).toBe(true);
+      expect(detectVisionCapability('gpt-4o-2024-08-06', 'openai')).toBe(true);
+    });
+
+    it('returns true for gpt-4-turbo family', () => {
+      expect(detectVisionCapability('gpt-4-turbo', 'openai')).toBe(true);
+      expect(detectVisionCapability('gpt-4-turbo-preview', 'openai')).toBe(true);
+    });
+
+    it('returns true for gpt-4-vision variants', () => {
+      expect(detectVisionCapability('gpt-4-1106-vision-preview', 'openai')).toBe(true);
+    });
+
+    it('returns false for non-vision OpenAI models', () => {
+      expect(detectVisionCapability('gpt-3.5-turbo', 'openai')).toBe(false);
+      expect(detectVisionCapability('o1-mini', 'openai')).toBe(false);
+      expect(detectVisionCapability('o3', 'openai')).toBe(false);
+    });
+  });
+
+  describe('anthropic', () => {
+    it('returns true for claude-3 family', () => {
+      expect(detectVisionCapability('claude-3-opus-20240229', 'anthropic')).toBe(true);
+      expect(detectVisionCapability('claude-3-5-sonnet-20241022', 'anthropic')).toBe(true);
+      expect(detectVisionCapability('claude-3-haiku', 'anthropic')).toBe(true);
+      expect(detectVisionCapability('claude-3.7-sonnet', 'anthropic')).toBe(true);
+    });
+
+    it('returns true for claude-4 family', () => {
+      expect(detectVisionCapability('claude-4-opus', 'anthropic')).toBe(true);
+      expect(detectVisionCapability('opus-4-0', 'anthropic')).toBe(true);
+    });
+
+    it('returns false for older Anthropic models', () => {
+      expect(detectVisionCapability('claude-2.1', 'anthropic')).toBe(false);
+      expect(detectVisionCapability('claude-instant-1.2', 'anthropic')).toBe(false);
+    });
+  });
+
+  describe('gemini', () => {
+    it('returns true for every gemini model', () => {
+      expect(detectVisionCapability('gemini-2.5-pro', 'gemini')).toBe(true);
+      expect(detectVisionCapability('gemini-flash', 'gemini')).toBe(true);
+      expect(detectVisionCapability('anything', 'gemini')).toBe(true);
+    });
+  });
+
+  describe('deepseek', () => {
+    it('returns true for deepseek-vl2 and deepseek-v3', () => {
+      expect(detectVisionCapability('deepseek-vl2', 'deepseek')).toBe(true);
+      expect(detectVisionCapability('deepseek-v3', 'deepseek')).toBe(true);
+    });
+
+    it('returns false for other deepseek models', () => {
+      expect(detectVisionCapability('deepseek-chat', 'deepseek')).toBe(false);
+      expect(detectVisionCapability('deepseek-reasoner', 'deepseek')).toBe(false);
+    });
+  });
+
+  describe('mistral', () => {
+    it('returns true for mistral-large and pixtral', () => {
+      expect(detectVisionCapability('mistral-large-latest', 'mistral')).toBe(true);
+      expect(detectVisionCapability('pixtral-12b-2409', 'mistral')).toBe(true);
+    });
+
+    it('returns false for other mistral models', () => {
+      expect(detectVisionCapability('mistral-small-latest', 'mistral')).toBe(false);
+      expect(detectVisionCapability('codestral-latest', 'mistral')).toBe(false);
+    });
+  });
+
+  describe('xai', () => {
+    it('returns true for grok-2-vision and all grok-3 variants', () => {
+      expect(detectVisionCapability('grok-2-vision-1212', 'xai')).toBe(true);
+      expect(detectVisionCapability('grok-3', 'xai')).toBe(true);
+      expect(detectVisionCapability('grok-3-mini', 'xai')).toBe(true);
+    });
+
+    it('returns false for grok-2 without vision and grok-beta', () => {
+      expect(detectVisionCapability('grok-2-1212', 'xai')).toBe(false);
+      expect(detectVisionCapability('grok-beta', 'xai')).toBe(false);
+    });
+  });
+
+  describe('qwen', () => {
+    it('returns true for qwen-vl, qvq, and qwq', () => {
+      expect(detectVisionCapability('qwen-vl-max', 'qwen')).toBe(true);
+      expect(detectVisionCapability('qvq-72b-preview', 'qwen')).toBe(true);
+      expect(detectVisionCapability('qwq-32b', 'qwen')).toBe(true);
+    });
+
+    it('returns false for other qwen models', () => {
+      expect(detectVisionCapability('qwen2.5-72b-instruct', 'qwen')).toBe(false);
+    });
+  });
+
+  describe('zai', () => {
+    it('returns true for glm-4v and cogview', () => {
+      expect(detectVisionCapability('glm-4v', 'zai')).toBe(true);
+      expect(detectVisionCapability('cogview-3', 'zai')).toBe(true);
+    });
+
+    it('returns false for other zai models', () => {
+      expect(detectVisionCapability('glm-4-plus', 'zai')).toBe(false);
+    });
+  });
+
+  describe('providers without vision', () => {
+    it('returns false for moonshot', () => {
+      expect(detectVisionCapability('moonshot-v1-8k', 'moonshot')).toBe(false);
+    });
+
+    it('returns false for minimax native models', () => {
+      expect(detectVisionCapability('MiniMax-M1.1', 'minimax')).toBe(false);
+      expect(detectVisionCapability('MiniMax-M2', 'minimax')).toBe(false);
+    });
+
+    it('returns false for openrouter (metadata unavailable)', () => {
+      expect(detectVisionCapability('anthropic/claude-3.5-sonnet', 'openrouter')).toBe(false);
+    });
+
+    it('returns false for ollama and ollama-cloud', () => {
+      expect(detectVisionCapability('llama3.2:11b', 'ollama')).toBe(false);
+      expect(detectVisionCapability('gpt-oss:120b', 'ollama-cloud')).toBe(false);
+    });
+
+    it('returns false for copilot', () => {
+      expect(detectVisionCapability('gpt-4', 'copilot')).toBe(false);
+    });
+
+    it('returns false for unknown providers', () => {
+      expect(detectVisionCapability('some-model', 'unknown-provider')).toBe(false);
+    });
+  });
+});

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -22,6 +22,7 @@ function makeDiscovered(overrides: Partial<DiscoveredModel> = {}): DiscoveredMod
     outputPricePerToken: 0.00001,
     capabilityReasoning: false,
     capabilityCode: true,
+    capabilityVision: false,
     qualityScore: 3,
     ...overrides,
   };

--- a/packages/backend/src/routing/resolve/resolve.default.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.default.spec.ts
@@ -1,7 +1,8 @@
 jest.mock('../../scoring', () => {
   const scoreRequest = jest.fn();
   const scanMessages = jest.fn();
-  return { scoreRequest, scanMessages };
+  const containsImage = jest.fn().mockReturnValue(false);
+  return { scoreRequest, scanMessages, containsImage };
 });
 
 import { ResolveService } from './resolve.service';

--- a/packages/backend/src/routing/resolve/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.spec.ts
@@ -1,7 +1,8 @@
 jest.mock('../../scoring', () => {
   const scoreRequest = jest.fn();
   const scanMessages = jest.fn();
-  return { scoreRequest, scanMessages };
+  const containsImage = jest.fn().mockReturnValue(false);
+  return { scoreRequest, scanMessages, containsImage };
 });
 
 import { ResolveService } from './resolve.service';

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -7,11 +7,26 @@ import { SpecificityPenaltyService } from '../routing-core/specificity-penalty.s
 import { HeaderTierService } from '../header-tiers/header-tier.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
-import { scoreRequest, ScorerInput, MomentumInput, scanMessages } from '../../scoring';
+import {
+  scoreRequest,
+  ScorerInput,
+  MomentumInput,
+  scanMessages,
+  containsImage,
+} from '../../scoring';
 import { ResolveResponse } from '../dto/resolve-response';
 import { inferProviderFromModelName } from '../../common/utils/provider-aliases';
 import type { SpecificityCategory, TierSlot } from 'manifest-shared';
 import type { HeaderTier } from '../../entities/header-tier.entity';
+import type { TierAssignment } from '../../entities/tier-assignment.entity';
+
+const TIER_RANK: Record<string, number> = {
+  simple: 0,
+  standard: 1,
+  complex: 2,
+  reasoning: 3,
+  default: -1,
+};
 
 /**
  * When specificity detection is below this confidence, skip specificity
@@ -83,7 +98,16 @@ export class ResolveService {
       return this.resolveForTier(agentId, 'default', 'default');
     }
 
-    const model = await this.providerKeyService.getEffectiveModel(agentId, assignment);
+    const scoredModel = await this.providerKeyService.getEffectiveModel(agentId, assignment);
+    const needsVision = containsImage(messages);
+    const { model, resolvedAssignment, resolvedTier } = await this.applyVisionFilter(
+      agentId,
+      tiers,
+      assignment,
+      result.tier,
+      scoredModel,
+      needsVision,
+    );
 
     if (!model) {
       this.logger.warn(
@@ -100,14 +124,14 @@ export class ResolveService {
       };
     }
 
-    const provider = await this.resolveProvider(agentId, assignment, model);
+    const provider = await this.resolveProvider(agentId, resolvedAssignment, model);
     const authType = provider
-      ? (assignment.override_auth_type ??
+      ? (resolvedAssignment.override_auth_type ??
         (await this.providerKeyService.getAuthType(agentId, provider)))
       : undefined;
 
     return {
-      tier: result.tier,
+      tier: resolvedTier,
       model,
       provider,
       confidence: result.confidence,
@@ -115,6 +139,54 @@ export class ResolveService {
       reason: result.reason,
       auth_type: authType,
     };
+  }
+
+  /**
+   * When the request contains images, fall up to the next higher tier with a
+   * vision-capable model. If no tier has one, the scored model is returned
+   * unchanged with a warning — the proxy may still forward the request, but
+   * without vision support the model response will be text-only.
+   */
+  private async applyVisionFilter(
+    agentId: string,
+    tiers: TierAssignment[],
+    scoredAssignment: TierAssignment,
+    scoredTier: TierSlot,
+    scoredModel: string | null,
+    needsVision: boolean,
+  ): Promise<{
+    model: string | null;
+    resolvedAssignment: TierAssignment;
+    resolvedTier: TierSlot;
+  }> {
+    if (!needsVision || !scoredModel) {
+      return { model: scoredModel, resolvedAssignment: scoredAssignment, resolvedTier: scoredTier };
+    }
+
+    const scoredDiscovered = await this.discoveryService.getModelForAgent(agentId, scoredModel);
+    if (scoredDiscovered?.capabilityVision) {
+      return { model: scoredModel, resolvedAssignment: scoredAssignment, resolvedTier: scoredTier };
+    }
+
+    const scoredRank = TIER_RANK[scoredTier];
+    const higher = tiers
+      .filter((t) => TIER_RANK[t.tier] > scoredRank)
+      .sort((a, b) => TIER_RANK[a.tier] - TIER_RANK[b.tier]);
+
+    const match = await this.providerKeyService.getVisionCapableModel(agentId, higher);
+    if (match) {
+      return {
+        model: match.model,
+        resolvedAssignment: match.assignment,
+        resolvedTier: match.assignment.tier as TierSlot,
+      };
+    }
+
+    this.logger.warn(
+      `Request contains images but no tier has a vision-capable model for agent=${agentId} ` +
+        `(scored tier=${scoredTier}, scored model=${scoredModel}); falling through to non-vision model`,
+    );
+    return { model: scoredModel, resolvedAssignment: scoredAssignment, resolvedTier: scoredTier };
   }
 
   async resolveForTier(

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -585,4 +585,64 @@ describe('ProviderKeyService', () => {
       expect(result).toBe('claude-3-haiku');
     });
   });
+
+  /* ── getVisionCapableModel ── */
+
+  describe('getVisionCapableModel', () => {
+    function assignment(overrides: Partial<TierAssignment> = {}): TierAssignment {
+      return {
+        override_model: null,
+        auto_assigned_model: null,
+        tier: 'standard',
+        ...overrides,
+      } as TierAssignment;
+    }
+
+    it('returns null when no tiers have an effective model', async () => {
+      const result = await service.getVisionCapableModel('agent-1', [assignment()]);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the only model has no vision capability', async () => {
+      discoveryService.getModelForAgent.mockResolvedValue({
+        id: 'gpt-3.5-turbo',
+        capabilityVision: false,
+      });
+
+      const result = await service.getVisionCapableModel('agent-1', [
+        assignment({ auto_assigned_model: 'gpt-3.5-turbo' }),
+      ]);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the first vision-capable tier in order', async () => {
+      const tiers = [
+        assignment({ tier: 'standard', auto_assigned_model: 'gpt-3.5-turbo' }),
+        assignment({ tier: 'complex', auto_assigned_model: 'gpt-4o' }),
+        assignment({ tier: 'reasoning', auto_assigned_model: 'claude-3-opus' }),
+      ];
+      discoveryService.getModelForAgent.mockImplementation(
+        async (_agentId: string, model: string) => {
+          if (model === 'gpt-4o') return { id: 'gpt-4o', capabilityVision: true };
+          if (model === 'claude-3-opus') return { id: 'claude-3-opus', capabilityVision: true };
+          return { id: model, capabilityVision: false };
+        },
+      );
+
+      const result = await service.getVisionCapableModel('agent-1', tiers);
+
+      expect(result).toEqual({ model: 'gpt-4o', assignment: tiers[1] });
+    });
+
+    it('skips assignments whose effective model is missing from discovery', async () => {
+      discoveryService.getModelForAgent.mockResolvedValue(null);
+
+      const result = await service.getVisionCapableModel('agent-1', [
+        assignment({ auto_assigned_model: 'phantom' }),
+      ]);
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -112,6 +112,27 @@ export class ProviderKeyService {
     return assignment.auto_assigned_model;
   }
 
+  /**
+   * Find the first vision-capable model across the supplied tier assignments,
+   * in order. Returns the first assignment whose effective model exists in
+   * the agent's discovered model list with `capabilityVision: true`, or null
+   * if none of the candidates can accept images.
+   */
+  async getVisionCapableModel(
+    agentId: string,
+    tiers: TierAssignment[],
+  ): Promise<{ model: string; assignment: TierAssignment } | null> {
+    for (const assignment of tiers) {
+      const model = await this.getEffectiveModel(agentId, assignment);
+      if (!model) continue;
+      const discovered = await this.discoveryService.getModelForAgent(agentId, model);
+      if (discovered?.capabilityVision) {
+        return { model, assignment };
+      }
+    }
+    return null;
+  }
+
   private async resolveProviderApiKey(
     agentId: string,
     provider: string,

--- a/packages/backend/src/routing/tier-auto-assign.service.spec.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.spec.ts
@@ -11,6 +11,7 @@ function makeModel(overrides: Partial<DiscoveredModel>): DiscoveredModel {
     outputPricePerToken: 0.00003,
     capabilityReasoning: false,
     capabilityCode: false,
+    capabilityVision: false,
     qualityScore: 3,
     ...overrides,
   };

--- a/packages/backend/src/scoring/__tests__/score-request.spec.ts
+++ b/packages/backend/src/scoring/__tests__/score-request.spec.ts
@@ -325,7 +325,7 @@ describe('scoreRequest — tier compatibility', () => {
     const result = scoreRequest({
       messages: [{ role: 'user', content: 'test request' }],
     });
-    expect(result.dimensions).toHaveLength(31);
+    expect(result.dimensions).toHaveLength(32);
   });
 });
 

--- a/packages/backend/src/scoring/__tests__/text-extractor.spec.ts
+++ b/packages/backend/src/scoring/__tests__/text-extractor.spec.ts
@@ -1,4 +1,9 @@
-import { extractUserTexts, countConversationMessages, combinedText } from '../text-extractor';
+import {
+  extractUserTexts,
+  countConversationMessages,
+  combinedText,
+  containsImage,
+} from '../text-extractor';
 
 describe('extractUserTexts', () => {
   it('returns empty for empty messages', () => {
@@ -192,5 +197,86 @@ describe('combinedText', () => {
 
   it('returns empty string for empty array', () => {
     expect(combinedText([])).toBe('');
+  });
+});
+
+describe('containsImage', () => {
+  it('returns false for empty messages', () => {
+    expect(containsImage([])).toBe(false);
+  });
+
+  it('returns false for string content', () => {
+    expect(containsImage([{ role: 'user', content: 'hello world' }])).toBe(false);
+  });
+
+  it('returns false for null or missing content', () => {
+    expect(containsImage([{ role: 'user', content: null }])).toBe(false);
+    expect(containsImage([{ role: 'user' }])).toBe(false);
+  });
+
+  it('detects OpenAI image_url content element', () => {
+    expect(
+      containsImage([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is this?' },
+            { type: 'image_url', image_url: { url: 'https://example.com/img.png' } },
+          ],
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it('detects Anthropic image content element', () => {
+    expect(
+      containsImage([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe' },
+            { type: 'image', source: { type: 'base64', data: 'abc' } },
+          ],
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns false for array content without image types', () => {
+    expect(
+      containsImage([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'just words' }],
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('ignores null and non-object elements inside the array', () => {
+    expect(
+      containsImage([
+        {
+          role: 'user',
+          content: [null, 'plain string', 42, { type: 'text', text: 'hi' }],
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('detects an image in any message, not just the last', () => {
+    expect(
+      containsImage([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'first' },
+            { type: 'image_url', image_url: { url: 'x' } },
+          ],
+        },
+        { role: 'assistant', content: 'reply' },
+        { role: 'user', content: 'second turn' },
+      ]),
+    ).toBe(true);
   });
 });

--- a/packages/backend/src/scoring/config.ts
+++ b/packages/backend/src/scoring/config.ts
@@ -92,6 +92,7 @@ export const DEFAULT_CONFIG: ScorerConfig = {
       keywords: DEFAULT_KEYWORDS.calendarManagement,
     },
     { name: 'trading', weight: 0, direction: 'up', keywords: DEFAULT_KEYWORDS.trading },
+    { name: 'visionInput', weight: 0.08, direction: 'up' },
     { name: 'tokenCount', weight: 0.05, direction: 'up' },
     { name: 'nestedListDepth', weight: 0.03, direction: 'up' },
     { name: 'conditionalLogic', weight: 0.03, direction: 'up' },

--- a/packages/backend/src/scoring/index.ts
+++ b/packages/backend/src/scoring/index.ts
@@ -13,6 +13,7 @@ import {
   extractUserTexts,
   countConversationMessages,
   combinedText,
+  containsImage,
   ExtractedText,
 } from './text-extractor';
 import {
@@ -43,6 +44,7 @@ export type { MomentumInput } from './momentum';
 export { detectSpecificity } from './specificity-detector';
 export type { SpecificityResult } from './specificity-detector';
 export { scanMessages } from './scan-messages';
+export { containsImage } from './text-extractor';
 
 let defaultTrie: KeywordTrie | null = null;
 
@@ -92,6 +94,7 @@ interface StructuralDimContext {
   tools?: ScorerInput['tools'];
   toolChoice?: unknown;
   conversationCount: number;
+  hasImage: boolean;
 }
 
 type StructuralScorer = (ctx: StructuralDimContext) => number;
@@ -106,6 +109,7 @@ const STRUCTURAL_SCORERS = new Map<string, StructuralScorer>([
   ['repetitionRequests', (ctx) => scoreRepetitionRequests(ctx.combined)],
   ['toolCount', (ctx) => scoreToolCount(ctx.tools, ctx.toolChoice)],
   ['conversationDepth', (ctx) => scoreConversationDepth(ctx.conversationCount)],
+  ['visionInput', (ctx) => (ctx.hasImage ? 1 : 0)],
 ]);
 
 function scoreStructuralDimension(dim: DimensionConfig, ctx: StructuralDimContext): number {
@@ -219,6 +223,7 @@ export function scoreRequest(
     tools,
     toolChoice: tool_choice,
     conversationCount,
+    hasImage: containsImage(messages),
   };
   const { dimensions, rawScore } = scoreDimensions(config, allMatches, extracted, ctx);
 

--- a/packages/backend/src/scoring/text-extractor.ts
+++ b/packages/backend/src/scoring/text-extractor.ts
@@ -72,3 +72,16 @@ export function countConversationMessages(messages: ScorerMessage[]): number {
 export function combinedText(extracted: ExtractedText[]): string {
   return extracted.map((e) => e.text).join('\n');
 }
+
+export function containsImage(messages: ScorerMessage[]): boolean {
+  for (const msg of messages) {
+    const content = msg.content;
+    if (!Array.isArray(content)) continue;
+    for (const element of content) {
+      if (!element || typeof element !== 'object') continue;
+      const type = (element as Record<string, unknown>).type;
+      if (type === 'image_url' || type === 'image') return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Vision Capability Filter for Model Routing

When a request contains images (image_url or image content elements), Manifest now routes only to models that support vision input.

### What changed

- **capabilityVision** added to DiscoveredModel interface, populated per-provider via \`detectVisionCapability()\` with patterns for all major providers
- **containsImage()** helper in text-extractor detects image blocks in multimodal messages
- **resolve.service.ts** falls up to next higher tier when scored model lacks vision capability but request has images
- **getVisionCapableModel()** in provider-key.service finds first vision-capable model across tier assignments
- **visionInput** scoring dimension (weight 0.08) boosts complexity for image-bearing requests

### Design decisions

- Vision is a **model capability filter at resolution time**, not a new specificity category. It composes with whatever tier or specificity won.
- No separate vision pricing fields — providers bill images as input tokens, which the existing pricing model already handles.
- When no tier has a vision model, falls through to the non-vision model (current behavior) rather than erroring.

### Test results

All tests pass (225/226 suites). The one failure (app.config.spec.ts) is pre-existing DATABASE_URL issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes image-bearing requests to vision-capable models and falls up tiers when needed, improving multimodal routing without breaking existing behavior.

- **New Features**
  - Added `capabilityVision` to `DiscoveredModel`; detected per provider via `detectVisionCapability()` (OpenAI: gpt-4o/4-turbo/4-vision; Anthropic: claude-3/4; Gemini: all; DeepSeek: vl2/v3; Mistral: large/pixtral; xAI: grok-2-vision/grok-3; Qwen: qwen-vl/qvq/qwq; Zai: glm-4v/cogview).
  - Added `containsImage()` to detect image blocks; when images are present, route to a vision-capable model or fall up to the next higher tier with one; if none exist, keep the scored model.
  - Added `getVisionCapableModel()` to find the first vision-capable model across tier assignments.
  - Added `visionInput` scoring dimension (weight 0.08) to reflect multimodal complexity.
  - Populated `capabilityVision` across discovery parsers and fallbacks.

- **Dependencies**
  - Bumped `ts-jest` to `^29.4.9` and `@types/jest` to `^29.5.14`.

<sup>Written for commit 102e50e91a8018cc8c74eac119f6af78f10c6f58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

