### PR TITLE
fix(ui): routing page polish and local provider fixes

### DIFF
--- a/.changeset/ui-fixes-batch-2.md
+++ b/.changeset/ui-fixes-batch-2.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix agent duplication not copying routing mode, local provider models missing from model picker, and local provider toggle errors

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -200,6 +200,7 @@ describe('AgentDuplicationService', () => {
           description: 'a desc',
           agent_category: 'personal',
           agent_platform: 'openclaw',
+          complexity_routing_enabled: true,
         })
         .mockResolvedValueOnce(null);
 
@@ -278,6 +279,7 @@ describe('AgentDuplicationService', () => {
       expect(agentRow['name']).toBe('source-copy');
       expect(agentRow['tenant_id']).toBe('t1');
       expect(agentRow['agent_category']).toBe('personal');
+      expect(agentRow['complexity_routing_enabled']).toBe(true);
 
       expect(insertedRows['AgentApiKey']).toHaveLength(1);
       const [apiKeyRow] = insertedRows['AgentApiKey'] as Array<Record<string, unknown>>;

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -114,6 +114,7 @@ export class AgentDuplicationService {
         description: source.description,
         agent_category: source.agent_category,
         agent_platform: source.agent_platform,
+        complexity_routing_enabled: source.complexity_routing_enabled,
         is_active: true,
         tenant_id: source.tenant_id,
       });

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -115,8 +115,20 @@ describe('TimeseriesQueriesService', () => {
   describe('getCostByModel', () => {
     it('computes share_pct for each model', async () => {
       mockGetRawMany.mockResolvedValue([
-        { model: 'claude-opus-4-6', tokens: 700, estimated_cost: 10.0, auth_type: 'subscription' },
-        { model: 'gpt-4o', tokens: 300, estimated_cost: 5.0, auth_type: 'api_key' },
+        {
+          model: 'claude-opus-4-6',
+          tokens: 700,
+          estimated_cost: 10.0,
+          auth_type: 'subscription',
+          provider: 'anthropic',
+        },
+        {
+          model: 'gpt-4o',
+          tokens: 300,
+          estimated_cost: 5.0,
+          auth_type: 'api_key',
+          provider: 'openai',
+        },
       ]);
 
       const result = await service.getCostByModel('7d', 'u1');
@@ -125,6 +137,8 @@ describe('TimeseriesQueriesService', () => {
       expect(result[1].share_pct).toBe(30);
       expect(result[0].auth_type).toBe('subscription');
       expect(result[1].auth_type).toBe('api_key');
+      expect(result[0].provider).toBe('anthropic');
+      expect(result[1].provider).toBe('openai');
     });
 
     it('returns display_name from model_pricing when available', async () => {
@@ -135,6 +149,7 @@ describe('TimeseriesQueriesService', () => {
           tokens: 500,
           estimated_cost: 2.0,
           auth_type: null,
+          provider: 'openai',
         },
       ]);
 
@@ -144,7 +159,13 @@ describe('TimeseriesQueriesService', () => {
 
     it('falls back to model slug when display_name is missing', async () => {
       mockGetRawMany.mockResolvedValue([
-        { model: 'custom-model', tokens: 100, estimated_cost: 1.0, auth_type: null },
+        {
+          model: 'custom-model',
+          tokens: 100,
+          estimated_cost: 1.0,
+          auth_type: null,
+          provider: null,
+        },
       ]);
 
       const result = await service.getCostByModel('7d', 'u1');
@@ -152,11 +173,14 @@ describe('TimeseriesQueriesService', () => {
     });
 
     it('returns 0 share_pct when total tokens is 0', async () => {
-      mockGetRawMany.mockResolvedValue([{ model: 'test', tokens: 0, estimated_cost: 0 }]);
+      mockGetRawMany.mockResolvedValue([
+        { model: 'test', tokens: 0, estimated_cost: 0, provider: null },
+      ]);
 
       const result = await service.getCostByModel('7d', 'u1');
       expect(result[0].share_pct).toBe(0);
       expect(result[0].auth_type).toBeNull();
+      expect(result[0].provider).toBeNull();
     });
   });
 

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -137,6 +137,7 @@ export class TimeseriesQueriesService {
       .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
       .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'estimated_cost')
       .addSelect('at.auth_type', 'auth_type')
+      .addSelect('at.provider', 'provider')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL')
       .andWhere("at.model != ''");
@@ -144,6 +145,7 @@ export class TimeseriesQueriesService {
     const rows = await qb
       .groupBy('at.model')
       .addGroupBy('at.auth_type')
+      .addGroupBy('at.provider')
       .orderBy('tokens', 'DESC')
       .getRawMany();
 
@@ -159,6 +161,7 @@ export class TimeseriesQueriesService {
         totalTokens === 0 ? 0 : Math.round((Number(r['tokens'] ?? 0) / totalTokens) * 1000) / 10,
       estimated_cost: Number(r['estimated_cost'] ?? 0),
       auth_type: r['auth_type'] ? String(r['auth_type']) : null,
+      provider: r['provider'] ? String(r['provider']) : null,
     }));
   }
 

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -430,6 +430,23 @@ describe('ModelDiscoveryService', () => {
       expect(result[1].displayName).toBe('custom-llm');
     });
 
+    it('should inherit auth_type from user_providers row for custom provider models', async () => {
+      const providers = [
+        makeProvider({
+          provider: 'custom:cp-1',
+          auth_type: 'local',
+          cached_models: null,
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([makeCustomProvider()]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].authType).toBe('local');
+    });
+
     it('should deduplicate models by id', async () => {
       const providers = [
         makeProvider({

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -228,6 +228,14 @@ export class ModelDiscoveryService {
       }
     }
 
+    // Build auth_type lookup for custom providers from their user_providers rows
+    const customAuthTypes = new Map<string, AuthType>();
+    for (const p of providers) {
+      if (p.provider.startsWith('custom:')) {
+        customAuthTypes.set(p.provider, p.auth_type);
+      }
+    }
+
     // Merge custom provider models
     const customProviders = await this.customProviderRepo.find({
       where: { agent_id: agentId },
@@ -251,6 +259,7 @@ export class ModelDiscoveryService {
           id: modelKey,
           displayName: m.model_name,
           provider: cpKey,
+          authType: customAuthTypes.get(cpKey) ?? 'api_key',
           contextWindow: m.context_window ?? 128000,
           inputPricePerToken: inputPerToken,
           outputPricePerToken: outputPerToken,

--- a/packages/frontend/src/components/CostByModelTable.tsx
+++ b/packages/frontend/src/components/CostByModelTable.tsx
@@ -6,8 +6,10 @@ import { getModelDisplayName } from '../services/model-display.js';
 import {
   inferProviderFromModel,
   inferProviderName,
+  resolveProviderId,
   stripCustomPrefix,
 } from '../services/routing-utils.js';
+import { PROVIDERS } from '../services/providers.js';
 
 interface CostByModelRow {
   model: string;
@@ -16,11 +18,29 @@ interface CostByModelRow {
   share_pct: number;
   estimated_cost: number;
   auth_type: string | null;
+  provider?: string | null;
 }
 
 interface CostByModelTableProps {
   rows: CostByModelRow[];
   customProviderName: (model: string) => string | undefined;
+}
+
+function resolveRowProvider(row: CostByModelRow): string | undefined {
+  if (row.provider) {
+    const resolved = resolveProviderId(row.provider);
+    if (resolved) return resolved;
+  }
+  if (row.model) return inferProviderFromModel(row.model);
+  return undefined;
+}
+
+function resolveRowProviderName(row: CostByModelRow): string | undefined {
+  const id = resolveRowProvider(row);
+  if (!id) return undefined;
+  return (
+    PROVIDERS.find((p) => p.id === id)?.name ?? (row.model ? inferProviderName(row.model) : id)
+  );
 }
 
 const CostByModelTable: Component<CostByModelTableProps> = (props) => {
@@ -49,8 +69,11 @@ const CostByModelTable: Component<CostByModelTableProps> = (props) => {
               <tr>
                 <td style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
                   <span style="display: inline-flex; align-items: center; gap: 4px;">
-                    {row.model && inferProviderFromModel(row.model) === 'custom' ? (
-                      (() => {
+                    {(() => {
+                      const provId = resolveRowProvider(row);
+                      const isCustom =
+                        provId === 'custom' || provId?.startsWith('custom:') === true;
+                      if (row.model && isCustom) {
                         const provName = props.customProviderName(row.model);
                         const logo = customProviderLogo(
                           provName ?? '',
@@ -78,17 +101,21 @@ const CostByModelTable: Component<CostByModelTableProps> = (props) => {
                             {letter}
                           </span>
                         );
-                      })()
-                    ) : row.model && inferProviderFromModel(row.model) ? (
-                      <span
-                        title={`${inferProviderName(row.model)} (${authLabel(row.auth_type)})`}
-                        style="display: inline-flex; flex-shrink: 0; position: relative;"
-                      >
-                        {/* v8 ignore next 2 */}
-                        {providerIcon(inferProviderFromModel(row.model)!, 14)}
-                        {authBadgeFor(row.auth_type, 8)}
-                      </span>
-                    ) : null}
+                      }
+                      if (provId) {
+                        const provName = resolveRowProviderName(row);
+                        return (
+                          <span
+                            title={`${provName ?? provId} (${authLabel(row.auth_type)})`}
+                            style="display: inline-flex; flex-shrink: 0; position: relative;"
+                          >
+                            {providerIcon(provId, 14)}
+                            {authBadgeFor(row.auth_type, 8)}
+                          </span>
+                        );
+                      }
+                      return null;
+                    })()}
                     {row.model
                       ? row.model.startsWith('custom:')
                         ? `custom:${props.customProviderName(row.model) ?? 'Custom'}/${stripCustomPrefix(row.model)}`

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -143,14 +143,13 @@ const DuplicateAgentModal: Component<Props> = (props) => {
             disabled={submitting()}
           />
 
-          <details class="duplicate-agent__details">
-            <summary>
-              What's copied
+          <div class="duplicate-agent__section">
+            <div class="duplicate-agent__section-header">
+              What is copied
               <Show when={preview()}>
-                {' '}
                 <span class="duplicate-agent__badge">{totalCopied()}</span>
               </Show>
-            </summary>
+            </div>
             <Show
               when={preview()}
               fallback={<div class="skeleton skeleton--rect" style="width: 100%; height: 80px;" />}
@@ -173,12 +172,18 @@ const DuplicateAgentModal: Component<Props> = (props) => {
                   <strong>{preview()!.copied.specificityAssignments}</strong> specificity override
                   {preview()!.copied.specificityAssignments === 1 ? '' : 's'}
                 </li>
-                <li class="duplicate-agent__skipped">
-                  Not copied: messages, logs, notification rules
-                </li>
               </ul>
             </Show>
-          </details>
+          </div>
+
+          <div class="duplicate-agent__section">
+            <div class="duplicate-agent__section-header">What is not copied</div>
+            <ul class="duplicate-agent__list">
+              <li>Messages</li>
+              <li>Logs</li>
+              <li>Notification rules</li>
+            </ul>
+          </div>
 
           <div class="modal-card__footer">
             <button class="btn btn--ghost btn--sm" onClick={requestClose} type="button">

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { authClient } from '../services/auth-client.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import { agentPlatformIcon } from '../services/agent-platform-store.js';
 import { checkIsSelfHosted } from '../services/setup-status.js';
+import DuplicateAgentModal from './DuplicateAgentModal.jsx';
 
 const GITHUB_REPO = 'mnfst/manifest';
 const STAR_DISMISSED_KEY = 'github-star-dismissed';
@@ -16,6 +17,8 @@ const Header: Component = () => {
   const getAgentName = useAgentName();
   const location = useLocation();
   const [menuOpen, setMenuOpen] = createSignal(false);
+  const [gearOpen, setGearOpen] = createSignal(false);
+  const [duplicateOpen, setDuplicateOpen] = createSignal(false);
   const [starCount, setStarCount] = createSignal<number | null>(null);
   const [starDismissed, setStarDismissed] = createSignal(
     sessionStorage.getItem(STAR_DISMISSED_KEY) === 'true',
@@ -81,10 +84,13 @@ const Header: Component = () => {
     if (!target.closest('.header__user')) {
       setMenuOpen(false);
     }
+    if (!target.closest('.header__gear')) {
+      setGearOpen(false);
+    }
   };
 
   createEffect(() => {
-    if (menuOpen()) {
+    if (menuOpen() || gearOpen()) {
       document.addEventListener('click', handleClickOutside);
       onCleanup(() => document.removeEventListener('click', handleClickOutside));
     }
@@ -130,6 +136,73 @@ const Header: Component = () => {
             </Show>
             {agentDisplayName() ?? getAgentName()}
           </span>
+          <div class="header__gear" style="position: relative;">
+            <button
+              class="header__gear-btn"
+              onClick={() => setGearOpen(!gearOpen())}
+              aria-label="Agent actions"
+              aria-haspopup="menu"
+              aria-expanded={gearOpen()}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4m0 6c-1.08 0-2-.92-2-2s.92-2 2-2 2 .92 2 2-.92 2-2 2" />
+                <path d="m20.42 13.4-.51-.29c.05-.37.08-.74.08-1.11s-.03-.74-.08-1.11l.51-.29c.96-.55 1.28-1.78.73-2.73l-1-1.73a2.006 2.006 0 0 0-2.73-.73l-.53.31c-.58-.46-1.22-.83-1.9-1.11v-.6c0-1.1-.9-2-2-2h-2c-1.1 0-2 .9-2 2v.6c-.67.28-1.31.66-1.9 1.11l-.53-.31c-.96-.55-2.18-.22-2.73.73l-1 1.73c-.55.96-.22 2.18.73 2.73l.51.29c-.05.37-.08.74-.08 1.11s.03.74.08 1.11l-.51.29c-.96.55-1.28 1.78-.73 2.73l1 1.73c.55.95 1.77 1.28 2.73.73l.53-.31c.58.46 1.22.83 1.9 1.11v.6c0 1.1.9 2 2 2h2c1.1 0 2-.9 2-2v-.6a8.7 8.7 0 0 0 1.9-1.11l.53.31c.95.55 2.18.22 2.73-.73l1-1.73c.55-.96.22-2.18-.73-2.73m-2.59-2.78c.11.45.17.92.17 1.38s-.06.92-.17 1.38a1 1 0 0 0 .47 1.11l1.12.65-1 1.73-1.14-.66c-.38-.22-.87-.16-1.19.14-.68.65-1.51 1.13-2.38 1.4-.42.13-.71.52-.71.96v1.3h-2v-1.3c0-.44-.29-.83-.71-.96-.88-.27-1.7-.75-2.38-1.4a1.01 1.01 0 0 0-1.19-.15l-1.14.66-1-1.73 1.12-.65c.39-.22.58-.68.47-1.11-.11-.45-.17-.92-.17-1.38s.06-.93.17-1.38A1 1 0 0 0 5.7 9.5l-1.12-.65 1-1.73 1.14.66c.38.22.87.16 1.19-.14.68-.65 1.51-1.13 2.38-1.4.42-.13.71-.52.71-.96v-1.3h2v1.3c0 .44.29.83.71.96.88.27 1.7.75 2.38 1.4.32.31.81.36 1.19.14l1.14-.66 1 1.73-1.12.65c-.39.22-.58.68-.47 1.11Z" />
+              </svg>
+            </button>
+            <Show when={gearOpen()}>
+              <div class="header__dropdown" role="menu" style="left: 0; right: auto;">
+                <A
+                  href={`/agents/${encodeURIComponent(getAgentName()!)}/settings`}
+                  class="header__dropdown-item"
+                  role="menuitem"
+                  onClick={() => setGearOpen(false)}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                  </svg>
+                  Settings
+                </A>
+                <button
+                  class="header__dropdown-item"
+                  role="menuitem"
+                  onClick={() => {
+                    setGearOpen(false);
+                    setDuplicateOpen(true);
+                  }}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M20 2H10c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m0 12H10V4h10z" />
+                    <path d="M4 22h10c1.1 0 2-.9 2-2v-2h-2v2H4V10h2V8H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2m10-10h2v-2h2V8h-2V6h-2v2h-2v2h2z" />
+                  </svg>
+                  Duplicate agent
+                </button>
+              </div>
+            </Show>
+          </div>
         </Show>
       </div>
       <div class="header__right">
@@ -263,6 +336,11 @@ const Header: Component = () => {
           </Show>
         </div>
       </div>
+      <DuplicateAgentModal
+        open={duplicateOpen()}
+        sourceName={getAgentName() ?? ''}
+        onClose={() => setDuplicateOpen(false)}
+      />
     </header>
   );
 };

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -134,75 +134,75 @@ const Header: Component = () => {
                 class="header__breadcrumb-icon"
               />
             </Show>
-            {agentDisplayName() ?? getAgentName()}
-          </span>
-          <div class="header__gear" style="position: relative;">
-            <button
-              class="header__gear-btn"
-              onClick={() => setGearOpen(!gearOpen())}
-              aria-label="Agent actions"
-              aria-haspopup="menu"
-              aria-expanded={gearOpen()}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+            <span>{agentDisplayName() ?? getAgentName()}</span>
+            <div class="header__gear" style="position: relative;">
+              <button
+                class="header__gear-btn"
+                onClick={() => setGearOpen(!gearOpen())}
+                aria-label="Agent actions"
+                aria-haspopup="menu"
+                aria-expanded={gearOpen()}
               >
-                <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4m0 6c-1.08 0-2-.92-2-2s.92-2 2-2 2 .92 2 2-.92 2-2 2" />
-                <path d="m20.42 13.4-.51-.29c.05-.37.08-.74.08-1.11s-.03-.74-.08-1.11l.51-.29c.96-.55 1.28-1.78.73-2.73l-1-1.73a2.006 2.006 0 0 0-2.73-.73l-.53.31c-.58-.46-1.22-.83-1.9-1.11v-.6c0-1.1-.9-2-2-2h-2c-1.1 0-2 .9-2 2v.6c-.67.28-1.31.66-1.9 1.11l-.53-.31c-.96-.55-2.18-.22-2.73.73l-1 1.73c-.55.96-.22 2.18.73 2.73l.51.29c-.05.37-.08.74-.08 1.11s.03.74.08 1.11l-.51.29c-.96.55-1.28 1.78-.73 2.73l1 1.73c.55.95 1.77 1.28 2.73.73l.53-.31c.58.46 1.22.83 1.9 1.11v.6c0 1.1.9 2 2 2h2c1.1 0 2-.9 2-2v-.6a8.7 8.7 0 0 0 1.9-1.11l.53.31c.95.55 2.18.22 2.73-.73l1-1.73c.55-.96.22-2.18-.73-2.73m-2.59-2.78c.11.45.17.92.17 1.38s-.06.92-.17 1.38a1 1 0 0 0 .47 1.11l1.12.65-1 1.73-1.14-.66c-.38-.22-.87-.16-1.19.14-.68.65-1.51 1.13-2.38 1.4-.42.13-.71.52-.71.96v1.3h-2v-1.3c0-.44-.29-.83-.71-.96-.88-.27-1.7-.75-2.38-1.4a1.01 1.01 0 0 0-1.19-.15l-1.14.66-1-1.73 1.12-.65c.39-.22.58-.68.47-1.11-.11-.45-.17-.92-.17-1.38s.06-.93.17-1.38A1 1 0 0 0 5.7 9.5l-1.12-.65 1-1.73 1.14.66c.38.22.87.16 1.19-.14.68-.65 1.51-1.13 2.38-1.4.42-.13.71-.52.71-.96v-1.3h2v1.3c0 .44.29.83.71.96.88.27 1.7.75 2.38 1.4.32.31.81.36 1.19.14l1.14-.66 1 1.73-1.12.65c-.39.22-.58.68-.47 1.11Z" />
-              </svg>
-            </button>
-            <Show when={gearOpen()}>
-              <div class="header__dropdown" role="menu" style="left: 0; right: auto;">
-                <A
-                  href={`/agents/${encodeURIComponent(getAgentName()!)}/settings`}
-                  class="header__dropdown-item"
-                  role="menuitem"
-                  onClick={() => setGearOpen(false)}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
                 >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    aria-hidden="true"
+                  <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4m0 6c-1.08 0-2-.92-2-2s.92-2 2-2 2 .92 2 2-.92 2-2 2" />
+                  <path d="m20.42 13.4-.51-.29c.05-.37.08-.74.08-1.11s-.03-.74-.08-1.11l.51-.29c.96-.55 1.28-1.78.73-2.73l-1-1.73a2.006 2.006 0 0 0-2.73-.73l-.53.31c-.58-.46-1.22-.83-1.9-1.11v-.6c0-1.1-.9-2-2-2h-2c-1.1 0-2 .9-2 2v.6c-.67.28-1.31.66-1.9 1.11l-.53-.31c-.96-.55-2.18-.22-2.73.73l-1 1.73c-.55.96-.22 2.18.73 2.73l.51.29c-.05.37-.08.74-.08 1.11s.03.74.08 1.11l-.51.29c-.96.55-1.28 1.78-.73 2.73l1 1.73c.55.95 1.77 1.28 2.73.73l.53-.31c.58.46 1.22.83 1.9 1.11v.6c0 1.1.9 2 2 2h2c1.1 0 2-.9 2-2v-.6a8.7 8.7 0 0 0 1.9-1.11l.53.31c.95.55 2.18.22 2.73-.73l1-1.73c.55-.96.22-2.18-.73-2.73m-2.59-2.78c.11.45.17.92.17 1.38s-.06.92-.17 1.38a1 1 0 0 0 .47 1.11l1.12.65-1 1.73-1.14-.66c-.38-.22-.87-.16-1.19.14-.68.65-1.51 1.13-2.38 1.4-.42.13-.71.52-.71.96v1.3h-2v-1.3c0-.44-.29-.83-.71-.96-.88-.27-1.7-.75-2.38-1.4a1.01 1.01 0 0 0-1.19-.15l-1.14.66-1-1.73 1.12-.65c.39-.22.58-.68.47-1.11-.11-.45-.17-.92-.17-1.38s.06-.93.17-1.38A1 1 0 0 0 5.7 9.5l-1.12-.65 1-1.73 1.14.66c.38.22.87.16 1.19-.14.68-.65 1.51-1.13 2.38-1.4.42-.13.71-.52.71-.96v-1.3h2v1.3c0 .44.29.83.71.96.88.27 1.7.75 2.38 1.4.32.31.81.36 1.19.14l1.14-.66 1 1.73-1.12.65c-.39.22-.58.68-.47 1.11Z" />
+                </svg>
+              </button>
+              <Show when={gearOpen()}>
+                <div class="header__dropdown" role="menu" style="left: 0; right: auto;">
+                  <A
+                    href={`/agents/${encodeURIComponent(getAgentName()!)}/settings`}
+                    class="header__dropdown-item"
+                    role="menuitem"
+                    onClick={() => setGearOpen(false)}
                   >
-                    <circle cx="12" cy="12" r="3" />
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                  </svg>
-                  Settings
-                </A>
-                <button
-                  class="header__dropdown-item"
-                  role="menuitem"
-                  onClick={() => {
-                    setGearOpen(false);
-                    setDuplicateOpen(true);
-                  }}
-                >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    aria-hidden="true"
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <circle cx="12" cy="12" r="3" />
+                      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                    </svg>
+                    Settings
+                  </A>
+                  <button
+                    class="header__dropdown-item"
+                    role="menuitem"
+                    onClick={() => {
+                      setGearOpen(false);
+                      setDuplicateOpen(true);
+                    }}
                   >
-                    <path d="M20 2H10c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m0 12H10V4h10z" />
-                    <path d="M4 22h10c1.1 0 2-.9 2-2v-2h-2v2H4V10h2V8H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2m10-10h2v-2h2V8h-2V6h-2v2h-2v2h2z" />
-                  </svg>
-                  Duplicate agent
-                </button>
-              </div>
-            </Show>
-          </div>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path d="M20 2H10c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m0 12H10V4h10z" />
+                      <path d="M4 22h10c1.1 0 2-.9 2-2v-2h-2v2H4V10h2V8H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2m10-10h2v-2h2V8h-2V6h-2v2h-2v2h2z" />
+                    </svg>
+                    Duplicate agent
+                  </button>
+                </div>
+              </Show>
+            </div>
+          </span>
         </Show>
       </div>
       <div class="header__right">

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -487,7 +487,7 @@ const ModelPickerModal: Component<Props> = (props) => {
                   : isSub()
                     ? 'No subscription providers connected. Connect a provider to see models.'
                     : isLocal()
-                      ? 'No local providers connected. Connect Ollama or LM Studio to see models.'
+                      ? 'No local providers connected. Connect a local provider to see models.'
                       : 'No API key providers connected. Connect a provider to see models.'}
               <Show when={!search().trim() && !showFreeOnly() && props.onConnectProviders}>
                 <button

--- a/packages/frontend/src/components/ProviderLocalTab.tsx
+++ b/packages/frontend/src/components/ProviderLocalTab.tsx
@@ -82,15 +82,15 @@ const ProviderLocalTab: Component<Props> = (props) => {
               const providerKey = `custom:${cp.id}`;
               const connected = () => props.isConnected(providerKey);
               const handleClick = () => {
-                // When the provider is connected, a click on the tile
-                // disconnects it — same UX as the Subscription tab.
-                // Editing the base_url / model list happens from the
-                // routing card in the main page, not here.
+                props.onEditCustom(cp);
+              };
+              const handleToggle = (e: MouseEvent) => {
+                e.stopPropagation();
                 if (connected()) {
                   props.onToggle(providerKey);
-                  return;
+                } else {
+                  props.onEditCustom(cp);
                 }
-                props.onEditCustom(cp);
               };
               return (
                 <button class="provider-toggle" disabled={props.busy()} onClick={handleClick}>
@@ -110,6 +110,7 @@ const ProviderLocalTab: Component<Props> = (props) => {
                   <span
                     class="provider-toggle__switch"
                     classList={{ 'provider-toggle__switch--on': connected() }}
+                    onClick={handleToggle}
                   >
                     <span class="provider-toggle__switch-thumb" />
                   </span>
@@ -122,15 +123,19 @@ const ProviderLocalTab: Component<Props> = (props) => {
             const hasLocalPort = () => prov.defaultLocalPort !== undefined;
 
             const handleClick = () => {
-              if (connected()) {
-                props.onToggle(prov.id);
-                return;
-              }
               if (hasLocalPort()) {
                 props.onOpenLocalServer(prov);
                 return;
               }
               props.onOpenDetail(prov.id, 'local');
+            };
+            const handleToggle = (e: MouseEvent) => {
+              e.stopPropagation();
+              if (connected()) {
+                props.onToggle(prov.id);
+              } else {
+                handleClick();
+              }
             };
 
             return (
@@ -148,6 +153,7 @@ const ProviderLocalTab: Component<Props> = (props) => {
                 <span
                   class="provider-toggle__switch"
                   classList={{ 'provider-toggle__switch--on': connected() }}
+                  onClick={handleToggle}
                 >
                   <span class="provider-toggle__switch-thumb" />
                 </span>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -63,6 +63,7 @@ interface OverviewData {
     share_pct: number;
     estimated_cost: number;
     auth_type: string | null;
+    provider?: string | null;
   }>;
   recent_activity: MessageRow[];
   active_skills: Array<{

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -6,7 +6,6 @@ import ErrorState from '../components/ErrorState.jsx';
 import AgentTypeGrid from '../components/AgentTypeGrid.jsx';
 import SetupStepAddProvider from '../components/SetupStepAddProvider.jsx';
 import SetupModal from '../components/SetupModal.jsx';
-import DuplicateAgentModal from '../components/DuplicateAgentModal.jsx';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import {
   deleteAgent,
@@ -45,7 +44,6 @@ const Settings: Component = () => {
   );
   const [showTypeModal, setShowTypeModal] = createSignal(false);
   const [showSetupModal, setShowSetupModal] = createSignal(false);
-  const [showDuplicateModal, setShowDuplicateModal] = createSignal(false);
   const [modalCategory, setModalCategory] = createSignal<AgentCategory | null>(null);
   const [modalPlatform, setModalPlatform] = createSignal<AgentPlatform | null>(null);
   const [savingType, setSavingType] = createSignal(false);
@@ -321,25 +319,6 @@ const Settings: Component = () => {
         </Show>
       </ErrorBoundary>
 
-      {/* -- Duplicate ---------------------------------- */}
-      <h3 class="settings-section__title">Duplicate</h3>
-      <div class="settings-card">
-        <div class="settings-card__row">
-          <div class="settings-card__label">
-            <span class="settings-card__label-title">Duplicate this agent</span>
-            <span class="settings-card__label-desc">
-              Creates a new agent with the same providers, routing tiers, and specificity overrides.
-              A fresh API key is generated. Messages and history stay with this agent.
-            </span>
-          </div>
-          <div class="settings-card__control">
-            <button class="btn btn--outline btn--sm" onClick={() => setShowDuplicateModal(true)}>
-              Duplicate agent
-            </button>
-          </div>
-        </div>
-      </div>
-
       {/* -- Danger Zone -------------------------------- */}
       <h3 class="settings-section__title settings-section__title--danger">Danger zone</h3>
       <div class="settings-card settings-card--danger">
@@ -511,12 +490,6 @@ const Settings: Component = () => {
         agentCategory={currentCategory()}
         onClose={() => setShowSetupModal(false)}
         onDone={() => setShowSetupModal(false)}
-      />
-
-      <DuplicateAgentModal
-        open={showDuplicateModal()}
-        sourceName={agentName()}
-        onClose={() => setShowDuplicateModal(false)}
       />
     </div>
   );

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -291,7 +291,7 @@ export interface StageDef {
 export const DEFAULT_STAGE: StageDef = {
   id: 'default',
   step: 0,
-  label: 'Default model',
+  label: 'Regular',
   desc: 'Handles every request.',
 };
 

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -130,47 +130,20 @@
 }
 
 /* ── Duplicate Agent Modal ─────────────────────────── */
-.duplicate-agent__details {
+.duplicate-agent__section {
   margin-top: var(--gap-md);
-  padding: 10px 12px;
-  background: hsl(var(--muted) / 0.4);
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
   font-size: var(--font-size-sm);
 }
 
-.duplicate-agent__details > summary {
-  cursor: pointer;
+.duplicate-agent__section-header {
   font-weight: 500;
   color: hsl(var(--foreground));
-  list-style: none;
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-.duplicate-agent__details > summary::-webkit-details-marker {
-  display: none;
-}
-
-.duplicate-agent__details > summary::before {
-  content: '';
-  display: inline-block;
-  width: 0;
-  height: 0;
-  margin-right: 4px;
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  border-left: 5px solid hsl(var(--muted-foreground));
-  transition: transform var(--transition-fast);
-}
-
-.duplicate-agent__details[open] > summary::before {
-  transform: rotate(90deg);
-}
-
 .duplicate-agent__badge {
-  margin-left: auto;
   padding: 1px 8px;
   background: hsl(var(--accent));
   color: hsl(var(--foreground));
@@ -195,14 +168,8 @@
   font-weight: 500;
 }
 
-.duplicate-agent__skipped {
-  list-style: none;
-  margin-left: -18px;
-  padding-top: 6px;
-  margin-top: 4px;
-  border-top: 1px dashed hsl(var(--border));
-  font-size: var(--font-size-xs);
-  color: hsl(var(--muted-foreground));
+.duplicate-agent__section + .duplicate-agent__section {
+  margin-top: var(--gap-sm);
 }
 
 .agent-card__top {

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -511,6 +511,28 @@
   background: hsl(var(--accent));
 }
 
+/* ── Gear Button ─────────────────────────────────── */
+.header__gear-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.header__gear-btn:hover {
+  color: hsl(var(--foreground));
+  background: hsl(var(--accent));
+}
+
 /* ── Docs Link ───────────────────────────────────── */
 .header__docs-link {
   display: inline-flex;

--- a/packages/frontend/tests/components/CostByModelTable.test.tsx
+++ b/packages/frontend/tests/components/CostByModelTable.test.tsx
@@ -117,4 +117,28 @@ describe('CostByModelTable', () => {
     // Tooltip on the outer wrapper reflects the auth label.
     expect(providerCell?.innerHTML).toContain('Subscription');
   });
+
+  it('prefers the stored provider over model-name inference', () => {
+    // Model name starts with "minimax-" which would infer MiniMax,
+    // but the stored provider is "ollama" — icon tooltip should say Ollama.
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[row({ model: 'minimax-chat', provider: 'ollama', auth_type: 'api_key' })]}
+        customProviderName={() => undefined}
+      />
+    ));
+    const providerSpan = container.querySelector('tbody tr td span[title]');
+    expect(providerSpan?.getAttribute('title')).toContain('Ollama');
+  });
+
+  it('falls back to model-name inference when provider is null', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[row({ model: 'claude-opus-4', provider: null, auth_type: 'api_key' })]}
+        customProviderName={() => undefined}
+      />
+    ));
+    const providerSpan = container.querySelector('tbody tr td span[title]');
+    expect(providerSpan?.getAttribute('title')).toContain('Anthropic');
+  });
 });

--- a/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
+++ b/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
@@ -64,21 +64,34 @@ describe('DuplicateAgentModal', () => {
     });
   });
 
-  it('shows counts in the details disclosure', async () => {
+  it('shows copied and not-copied sections without an accordion', async () => {
     render(() => (
       <DuplicateAgentModal open={true} sourceName="my-agent" onClose={vi.fn()} />
     ));
 
     await waitFor(() => {
-      const list = qa('.duplicate-agent__list li');
-      expect(list.length).toBeGreaterThan(0);
+      const allItems = qa('.duplicate-agent__list li');
+      // Wait for the copied section to render (more than just the 3 "not copied" items)
+      expect(allItems.length).toBeGreaterThan(3);
     });
 
+    // "What is copied" items
     const list = qa('.duplicate-agent__list li').map((li) => li.textContent);
     expect(list.some((t) => t?.includes('3') && t?.includes('provider credential'))).toBe(true);
     expect(list.some((t) => t?.includes('1') && t?.includes('custom provider'))).toBe(true);
     expect(list.some((t) => t?.includes('4') && t?.includes('tier override'))).toBe(true);
     expect(list.some((t) => t?.includes('2') && t?.includes('specificity override'))).toBe(true);
+
+    // "What is not copied" items are always visible (no accordion)
+    const headers = qa('.duplicate-agent__section-header').map((h) => h.textContent?.trim());
+    expect(headers.some((h) => h?.includes("What is copied"))).toBe(true);
+    expect(headers.some((h) => h?.includes("What is not copied"))).toBe(true);
+    expect(list.some((t) => t === 'Messages')).toBe(true);
+    expect(list.some((t) => t === 'Logs')).toBe(true);
+    expect(list.some((t) => t === 'Notification rules')).toBe(true);
+
+    // No <details> elements — content is always visible
+    expect(document.querySelector('details')).toBeNull();
   });
 
   it('calls duplicateAgent, shows toast, and navigates on success', async () => {

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -25,6 +25,19 @@ vi.mock("../../src/services/routing.js", () => ({
   useAgentName: () => () => mockAgentName,
 }));
 
+vi.mock("../../src/services/api.js", () => ({
+  duplicateAgent: vi.fn(),
+  getDuplicatePreview: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../src/services/recent-agents.js", () => ({
+  markAgentCreated: vi.fn(),
+}));
+
+vi.mock("../../src/services/toast-store.js", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
 let mockAgentDisplayName: string | null = null;
 vi.mock("../../src/services/agent-display-name.js", () => ({
   agentDisplayName: () => mockAgentDisplayName,
@@ -264,6 +277,45 @@ describe("Header - breadcrumb", () => {
     mockAgentName = "my-agent";
     render(() => <Header />);
     expect(screen.getByText("Workspace")).toBeDefined();
+  });
+});
+
+describe("Header - gear dropdown", () => {
+  it("shows gear button when on an agent page", () => {
+    mockAgentName = "my-agent";
+    render(() => <Header />);
+    expect(screen.getByLabelText("Agent actions")).toBeDefined();
+  });
+
+  it("does not show gear button when not on an agent page", () => {
+    mockAgentName = null;
+    render(() => <Header />);
+    expect(screen.queryByLabelText("Agent actions")).toBeNull();
+  });
+
+  it("opens dropdown with Settings and Duplicate items", async () => {
+    mockAgentName = "my-agent";
+    render(() => <Header />);
+    await fireEvent.click(screen.getByLabelText("Agent actions"));
+    expect(screen.getByText("Settings")).toBeDefined();
+    expect(screen.getByText("Duplicate agent")).toBeDefined();
+  });
+
+  it("Settings links to the agent settings page", async () => {
+    mockAgentName = "my-agent";
+    const { container } = render(() => <Header />);
+    await fireEvent.click(screen.getByLabelText("Agent actions"));
+    const settingsLink = container.querySelector('a[href="/agents/my-agent/settings"]');
+    expect(settingsLink).not.toBeNull();
+  });
+
+  it("closes gear dropdown when clicking outside", async () => {
+    mockAgentName = "my-agent";
+    render(() => <Header />);
+    await fireEvent.click(screen.getByLabelText("Agent actions"));
+    expect(screen.getByText("Settings")).toBeDefined();
+    await fireEvent.click(document.body);
+    expect(screen.queryByText("Duplicate agent")).toBeNull();
   });
 });
 

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -652,7 +652,7 @@ describe("ModelPickerModal", () => {
       />
     ));
     expect(
-      screen.getByText(/No local providers connected\. Connect Ollama or LM Studio to see models\./),
+      screen.getByText(/No local providers connected\. Connect a local provider to see models\./),
     ).toBeDefined();
   });
 

--- a/packages/frontend/tests/components/ProviderLocalTab.test.tsx
+++ b/packages/frontend/tests/components/ProviderLocalTab.test.tsx
@@ -144,10 +144,9 @@ describe('ProviderLocalTab', () => {
     expect(container.querySelector('.provider-toggle__switch--on')).not.toBeNull();
   });
 
-  it('disconnects a connected standard tile on click instead of reopening the detail view', () => {
+  it('navigates to detail view when clicking a connected standard tile', () => {
     const onToggle = vi.fn();
     const onOpenDetail = vi.fn();
-    const onOpenLocalServer = vi.fn();
     render(() => (
       <ProviderLocalTab
         {...baseProps}
@@ -156,16 +155,32 @@ describe('ProviderLocalTab', () => {
         isConnected={() => true}
         onToggle={onToggle}
         onOpenDetail={onOpenDetail}
-        onOpenLocalServer={onOpenLocalServer}
       />
     ));
     fireEvent.click(document.querySelector('button.provider-toggle') as HTMLButtonElement);
-    expect(onToggle).toHaveBeenCalledWith('ollama');
-    expect(onOpenDetail).not.toHaveBeenCalled();
-    expect(onOpenLocalServer).not.toHaveBeenCalled();
+    expect(onOpenDetail).toHaveBeenCalledWith('ollama', 'local');
+    expect(onToggle).not.toHaveBeenCalled();
   });
 
-  it('disconnects a connected custom tile via its custom:<uuid> provider key', () => {
+  it('disconnects a connected standard tile when clicking the toggle switch', () => {
+    const onToggle = vi.fn();
+    const onOpenDetail = vi.fn();
+    render(() => (
+      <ProviderLocalTab
+        {...baseProps}
+        localProviders={[provider({ id: 'ollama', name: 'Ollama' })]}
+        customProviders={[]}
+        isConnected={() => true}
+        onToggle={onToggle}
+        onOpenDetail={onOpenDetail}
+      />
+    ));
+    fireEvent.click(document.querySelector('.provider-toggle__switch') as HTMLElement);
+    expect(onToggle).toHaveBeenCalledWith('ollama');
+    expect(onOpenDetail).not.toHaveBeenCalled();
+  });
+
+  it('opens edit for a connected custom tile on click', () => {
     const onToggle = vi.fn();
     const onEditCustom = vi.fn();
     render(() => (
@@ -186,8 +201,76 @@ describe('ProviderLocalTab', () => {
       />
     ));
     fireEvent.click(document.querySelector('button.provider-toggle') as HTMLButtonElement);
+    expect(onEditCustom).toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('disconnects a connected custom tile when clicking the toggle switch', () => {
+    const onToggle = vi.fn();
+    const onEditCustom = vi.fn();
+    render(() => (
+      <ProviderLocalTab
+        {...baseProps}
+        localProviders={[]}
+        customProviders={[
+          {
+            id: 'cp-lms',
+            name: 'LM Studio',
+            base_url: 'http://localhost:1234/v1',
+            models: [],
+          } as never,
+        ]}
+        isConnected={(key) => key === 'custom:cp-lms'}
+        onToggle={onToggle}
+        onEditCustom={onEditCustom}
+      />
+    ));
+    fireEvent.click(document.querySelector('.provider-toggle__switch') as HTMLElement);
     expect(onToggle).toHaveBeenCalledWith('custom:cp-lms');
     expect(onEditCustom).not.toHaveBeenCalled();
+  });
+
+  it('opens connect flow when clicking the toggle on a disconnected standard tile', () => {
+    const onToggle = vi.fn();
+    const onOpenDetail = vi.fn();
+    render(() => (
+      <ProviderLocalTab
+        {...baseProps}
+        localProviders={[provider({ id: 'ollama', name: 'Ollama' })]}
+        customProviders={[]}
+        isConnected={() => false}
+        onToggle={onToggle}
+        onOpenDetail={onOpenDetail}
+      />
+    ));
+    fireEvent.click(document.querySelector('.provider-toggle__switch') as HTMLElement);
+    expect(onOpenDetail).toHaveBeenCalledWith('ollama', 'local');
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('opens edit when clicking the toggle on a disconnected custom tile', () => {
+    const onToggle = vi.fn();
+    const onEditCustom = vi.fn();
+    render(() => (
+      <ProviderLocalTab
+        {...baseProps}
+        localProviders={[]}
+        customProviders={[
+          {
+            id: 'cp-lms',
+            name: 'LM Studio',
+            base_url: 'http://localhost:1234/v1',
+            models: [],
+          } as never,
+        ]}
+        isConnected={() => false}
+        onToggle={onToggle}
+        onEditCustom={onEditCustom}
+      />
+    ));
+    fireEvent.click(document.querySelector('.provider-toggle__switch') as HTMLElement);
+    expect(onEditCustom).toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
   });
 
   it('disables all tiles while busy is true', () => {

--- a/packages/frontend/tests/components/ProviderSelectContent.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectContent.test.tsx
@@ -166,8 +166,9 @@ describe("ProviderSelectContent", () => {
       return t;
     });
     // Toggle should be ON since the provider is connected with auth_type='local'
-    expect(ollamaTile.querySelector(".provider-toggle__switch--on")).not.toBeNull();
-    fireEvent.click(ollamaTile);
+    const toggle = ollamaTile.querySelector(".provider-toggle__switch") as HTMLElement;
+    expect(toggle.classList.contains("provider-toggle__switch--on")).toBe(true);
+    fireEvent.click(toggle);
     await waitFor(() => expect(disconnect).toHaveBeenCalledWith("test-agent", "ollama", "local"));
     await waitFor(() => expect(onUpdateLocal).toHaveBeenCalled());
   });
@@ -203,7 +204,8 @@ describe("ProviderSelectContent", () => {
       if (!t) throw new Error("Ollama tile not found");
       return t;
     });
-    fireEvent.click(ollamaTile);
+    const toggle = ollamaTile.querySelector(".provider-toggle__switch") as HTMLElement;
+    fireEvent.click(toggle);
     await waitFor(() => expect(disconnect).toHaveBeenCalled());
     expect(onUpdateLocal).not.toHaveBeenCalled();
   });

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -113,9 +113,9 @@ describe("Routing — enabled state (providers active)", () => {
       { id: "5", user_id: "u1", tier: "default", override_model: null, override_provider: null, auto_assigned_model: null, fallback_models: null, updated_at: "2025-01-01" },
     ]);
     render(() => <Routing />);
-    // Default tab is active by default — wait for the single "Default model" card to render
+    // Default tab is active by default — wait for the single "Regular" card to render
     await waitFor(() => {
-      expect(screen.getAllByText("Default model").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Regular").length).toBeGreaterThan(0);
     });
     // The "+ Add model" button on the default card triggers onDropdownOpen lambda
     const addBtns = screen.getAllByText("+ Add model");

--- a/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
@@ -5,7 +5,7 @@ vi.mock('../../src/services/providers.js', () => ({
   DEFAULT_STAGE: {
     id: 'default',
     step: 0,
-    label: 'Default model',
+    label: 'Regular',
     desc: 'Handles every request.',
   },
   STAGES: [


### PR DESCRIPTION
## Summary

- **Agent duplication**: copy `complexity_routing_enabled` so the routing mode (regular vs complexity) is preserved
- **Tier card label**: rename "Default model" to "Regular" in the default routing tab
- **Local provider models**: set `authType` on custom provider models so they appear in the Local tab of the model picker instead of being lost under API Keys
- **Local provider UX**: clicking a connected local provider tile navigates to the edit view instead of disconnecting; toggle switch handles connect/disconnect; disconnected toggle opens connect flow instead of erroring
- **Empty state copy**: genericize "No local providers connected" message to not enumerate specific providers

## Test plan

- [ ] Duplicate an agent that has complexity routing enabled — verify the copy also has it enabled
- [ ] Open Routing page in default mode — verify the tier card says "Regular" not "Default model"
- [ ] Connect LM Studio, open model picker on the Local tab — verify models appear
- [ ] Click a connected local provider tile — verify it opens Edit provider, not toggles off
- [ ] Click the toggle switch on a disconnected local provider — verify it opens the connect flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Routing page and Local providers UX, added an agent header gear menu (Settings/Duplicate) aligned in the breadcrumb, and made cost analytics use the stored provider for accurate icons/tooltips. Duplication now preserves routing mode, and local models show in the picker.

- **New Features**
  - Added header gear menu on agent pages (Settings, Duplicate) aligned in the breadcrumb; Duplicate modal shows “What is copied” and “What is not copied”.
  - Cost by model table prefers the stored provider for icons/tooltips; backend now includes `provider` in cost rows.

- **Bug Fixes**
  - Agent duplication copies `complexity_routing_enabled`.
  - Custom provider models inherit `authType` so they appear in the Local tab.
  - Local provider tiles: click opens Edit; toggle handles connect/disconnect; toggling a disconnected tile opens connect/edit instead of erroring.
  - Default routing tier label changed from “Default model” to “Regular”.
  - Genericized “No local providers connected” empty state text.

<sup>Written for commit 4c2a15df311694fd5ae47f0c037268cba25e9706. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

