### PR TITLE
fix(duplication): remap custom provider refs when duplicating agents

### DIFF
--- a/.changeset/fix-agent-duplication-providers.md
+++ b/.changeset/fix-agent-duplication-providers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix agent duplication not copying local/custom providers correctly

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -227,6 +227,7 @@ describe('AgentDuplicationService', () => {
             user_id: 'u1',
             name: 'local',
             base_url: 'http://x',
+            api_kind: 'openai',
             models: [],
           },
         ],
@@ -292,6 +293,280 @@ describe('AgentDuplicationService', () => {
       expect(userProviderRow['id']).not.toBe('up1');
 
       expect(mockInvalidateAgent).toHaveBeenCalledWith(agentRow['id']);
+    });
+
+    it('copies api_kind field for custom providers', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
+        .mockResolvedValueOnce(null);
+
+      repoRows = {
+        CustomProvider: [
+          {
+            id: 'cp1',
+            agent_id: 'src-1',
+            user_id: 'u1',
+            name: 'my-server',
+            base_url: 'http://x',
+            api_kind: 'anthropic',
+            models: [{ model_name: 'test' }],
+          },
+        ],
+      };
+
+      await service.duplicate('user-1', 'source', {
+        name: 'copy',
+        displayName: 'copy',
+      });
+
+      const cpRow = (insertedRows['CustomProvider'] as Array<Record<string, unknown>>)[0];
+      expect(cpRow['api_kind']).toBe('anthropic');
+    });
+
+    it('remaps custom:<uuid> references in user providers to new custom provider IDs', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
+        .mockResolvedValueOnce(null);
+
+      repoRows = {
+        CustomProvider: [
+          {
+            id: 'old-cp-uuid',
+            agent_id: 'src-1',
+            user_id: 'u1',
+            name: 'LM Studio',
+            base_url: 'http://localhost:1234',
+            api_kind: 'openai',
+            models: [],
+          },
+        ],
+        UserProvider: [
+          {
+            id: 'up1',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'custom:old-cp-uuid',
+            api_key_encrypted: null,
+            key_prefix: null,
+            auth_type: 'local',
+            region: null,
+            is_active: true,
+            cached_models: null,
+            models_fetched_at: null,
+          },
+        ],
+      };
+
+      await service.duplicate('user-1', 'source', {
+        name: 'copy',
+        displayName: 'copy',
+      });
+
+      const cpRow = (insertedRows['CustomProvider'] as Array<Record<string, unknown>>)[0];
+      const newCpId = cpRow['id'] as string;
+      expect(newCpId).not.toBe('old-cp-uuid');
+
+      const upRow = (insertedRows['UserProvider'] as Array<Record<string, unknown>>)[0];
+      expect(upRow['provider']).toBe(`custom:${newCpId}`);
+      expect(upRow['auth_type']).toBe('local');
+    });
+
+    it('duplicates canonical local providers (ollama, lmstudio) as-is', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
+        .mockResolvedValueOnce(null);
+
+      repoRows = {
+        UserProvider: [
+          {
+            id: 'up-ollama',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'ollama',
+            api_key_encrypted: null,
+            key_prefix: null,
+            auth_type: 'local',
+            region: null,
+            is_active: true,
+            cached_models: [{ id: 'llama3' }],
+            models_fetched_at: '2025-01-01',
+          },
+          {
+            id: 'up-lmstudio',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'lmstudio',
+            api_key_encrypted: null,
+            key_prefix: null,
+            auth_type: 'local',
+            region: null,
+            is_active: true,
+            cached_models: null,
+            models_fetched_at: null,
+          },
+        ],
+      };
+
+      const result = await service.duplicate('user-1', 'source', {
+        name: 'copy',
+        displayName: 'copy',
+      });
+
+      expect(result.copied.providers).toBe(2);
+      const ups = insertedRows['UserProvider'] as Array<Record<string, unknown>>;
+      expect(ups).toHaveLength(2);
+      expect(ups[0]['provider']).toBe('ollama');
+      expect(ups[0]['auth_type']).toBe('local');
+      expect(ups[0]['cached_models']).toEqual([{ id: 'llama3' }]);
+      expect(ups[1]['provider']).toBe('lmstudio');
+      expect(ups[1]['auth_type']).toBe('local');
+    });
+
+    it('duplicates subscription providers alongside api_key providers', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
+        .mockResolvedValueOnce(null);
+
+      repoRows = {
+        UserProvider: [
+          {
+            id: 'up-sub',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'anthropic',
+            api_key_encrypted: 'enc-sub',
+            key_prefix: null,
+            auth_type: 'subscription',
+            region: null,
+            is_active: true,
+            cached_models: null,
+            models_fetched_at: null,
+          },
+          {
+            id: 'up-key',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'openai',
+            api_key_encrypted: 'enc-key',
+            key_prefix: 'sk-',
+            auth_type: 'api_key',
+            region: null,
+            is_active: true,
+            cached_models: null,
+            models_fetched_at: null,
+          },
+        ],
+      };
+
+      const result = await service.duplicate('user-1', 'source', {
+        name: 'copy',
+        displayName: 'copy',
+      });
+
+      expect(result.copied.providers).toBe(2);
+      const ups = insertedRows['UserProvider'] as Array<Record<string, unknown>>;
+      expect(ups).toHaveLength(2);
+      const sub = ups.find((u) => u['auth_type'] === 'subscription');
+      const key = ups.find((u) => u['auth_type'] === 'api_key');
+      expect(sub!['provider']).toBe('anthropic');
+      expect(sub!['api_key_encrypted']).toBe('enc-sub');
+      expect(key!['provider']).toBe('openai');
+      expect(key!['api_key_encrypted']).toBe('enc-key');
+    });
+
+    it('remaps multiple custom providers correctly', async () => {
+      mockAgentGetOne
+        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
+        .mockResolvedValueOnce(null);
+
+      repoRows = {
+        CustomProvider: [
+          {
+            id: 'cp-lms',
+            agent_id: 'src-1',
+            user_id: 'u1',
+            name: 'LM Studio',
+            base_url: 'http://localhost:1234',
+            api_kind: 'openai',
+            models: [],
+          },
+          {
+            id: 'cp-llama',
+            agent_id: 'src-1',
+            user_id: 'u1',
+            name: 'llama.cpp',
+            base_url: 'http://localhost:8080',
+            api_kind: 'openai',
+            models: [{ model_name: 'mistral' }],
+          },
+        ],
+        UserProvider: [
+          {
+            id: 'up1',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'custom:cp-lms',
+            api_key_encrypted: null,
+            key_prefix: null,
+            auth_type: 'local',
+            region: null,
+            is_active: true,
+            cached_models: null,
+            models_fetched_at: null,
+          },
+          {
+            id: 'up2',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'custom:cp-llama',
+            api_key_encrypted: null,
+            key_prefix: null,
+            auth_type: 'local',
+            region: null,
+            is_active: true,
+            cached_models: null,
+            models_fetched_at: null,
+          },
+          {
+            id: 'up3',
+            user_id: 'u1',
+            agent_id: 'src-1',
+            provider: 'anthropic',
+            api_key_encrypted: 'enc',
+            key_prefix: 'sk-',
+            auth_type: 'api_key',
+            region: null,
+            is_active: true,
+            cached_models: null,
+            models_fetched_at: null,
+          },
+        ],
+      };
+
+      await service.duplicate('user-1', 'source', {
+        name: 'copy',
+        displayName: 'copy',
+      });
+
+      const cps = insertedRows['CustomProvider'] as Array<Record<string, unknown>>;
+      expect(cps).toHaveLength(2);
+      const lmsNewId = cps.find((c) => c['name'] === 'LM Studio')!['id'];
+      const llamaNewId = cps.find((c) => c['name'] === 'llama.cpp')!['id'];
+
+      const ups = insertedRows['UserProvider'] as Array<Record<string, unknown>>;
+      expect(ups).toHaveLength(3);
+
+      const lmsUp = ups.find((u) => (u['provider'] as string).includes(lmsNewId as string));
+      expect(lmsUp).toBeDefined();
+      expect(lmsUp!['provider']).toBe(`custom:${lmsNewId}`);
+
+      const llamaUp = ups.find((u) => (u['provider'] as string).includes(llamaNewId as string));
+      expect(llamaUp).toBeDefined();
+      expect(llamaUp!['provider']).toBe(`custom:${llamaNewId}`);
+
+      const anthUp = ups.find((u) => u['provider'] === 'anthropic');
+      expect(anthUp).toBeDefined();
+      expect(anthUp!['provider']).toBe('anthropic');
     });
 
     it('skips insert batches when source has no rows', async () => {

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -38,8 +38,17 @@ export class AgentDuplicationService {
     private readonly routingCache: RoutingCacheService,
   ) {}
 
+  private static readonly CUSTOM_PREFIX = 'custom:';
+
   private generateOtlpKey(): string {
     return API_KEY_PREFIX + randomBytes(32).toString('base64url');
+  }
+
+  private remapCustomProviderRef(provider: string, idMap: Map<string, string>): string {
+    if (!provider.startsWith(AgentDuplicationService.CUSTOM_PREFIX)) return provider;
+    const oldId = provider.slice(AgentDuplicationService.CUSTOM_PREFIX.length);
+    const newId = idMap.get(oldId);
+    return newId ? `${AgentDuplicationService.CUSTOM_PREFIX}${newId}` : provider;
   }
 
   private async findOwnedAgent(userId: string, agentName: string): Promise<Agent | null> {
@@ -130,6 +139,28 @@ export class AgentDuplicationService {
         is_active: true,
       });
 
+      const customProviders = await manager
+        .getRepository(CustomProvider)
+        .find({ where: { agent_id: source.id } });
+      const customProviderIdMap = new Map<string, string>();
+      if (customProviders.length > 0) {
+        const newCustomProviders = customProviders.map((cp) => {
+          const newId = uuidv4();
+          customProviderIdMap.set(cp.id, newId);
+          return {
+            id: newId,
+            agent_id: newAgentId,
+            user_id: cp.user_id,
+            name: cp.name,
+            base_url: cp.base_url,
+            api_kind: cp.api_kind,
+            models: cp.models,
+            created_at: now,
+          };
+        });
+        await manager.getRepository(CustomProvider).insert(newCustomProviders);
+      }
+
       const providers = await manager
         .getRepository(UserProvider)
         .find({ where: { agent_id: source.id } });
@@ -139,7 +170,7 @@ export class AgentDuplicationService {
             id: uuidv4(),
             user_id: p.user_id,
             agent_id: newAgentId,
-            provider: p.provider,
+            provider: this.remapCustomProviderRef(p.provider, customProviderIdMap),
             api_key_encrypted: p.api_key_encrypted,
             key_prefix: p.key_prefix,
             auth_type: p.auth_type,
@@ -149,23 +180,6 @@ export class AgentDuplicationService {
             updated_at: now,
             cached_models: p.cached_models,
             models_fetched_at: p.models_fetched_at,
-          })),
-        );
-      }
-
-      const customProviders = await manager
-        .getRepository(CustomProvider)
-        .find({ where: { agent_id: source.id } });
-      if (customProviders.length > 0) {
-        await manager.getRepository(CustomProvider).insert(
-          customProviders.map((cp) => ({
-            id: uuidv4(),
-            agent_id: newAgentId,
-            user_id: cp.user_id,
-            name: cp.name,
-            base_url: cp.base_url,
-            models: cp.models,
-            created_at: now,
           })),
         );
       }

--- a/packages/backend/test/agent-duplication.e2e-spec.ts
+++ b/packages/backend/test/agent-duplication.e2e-spec.ts
@@ -153,6 +153,101 @@ describe('Agent Duplication (e2e)', () => {
     expect(newSpec[0].category).toBe('coding');
   });
 
+  it('POST /agents/:name/duplicate remaps custom:<uuid> provider references', async () => {
+    const now = new Date().toISOString();
+    const srcAgentId = 'src-remap-agent';
+    await ds.getRepository(Agent).insert({
+      id: srcAgentId,
+      name: 'remap-source',
+      display_name: 'Remap Source',
+      is_active: true,
+      tenant_id: TEST_TENANT_ID,
+    });
+    await ds.getRepository(AgentApiKey).insert({
+      id: 'ak-remap',
+      key: 'enc-placeholder',
+      key_hash: 'hash-remap',
+      key_prefix: 'mnfst_remap',
+      label: 'remap key',
+      tenant_id: TEST_TENANT_ID,
+      agent_id: srcAgentId,
+      is_active: true,
+    });
+
+    await ds.getRepository(CustomProvider).insert({
+      id: 'cp-lmstudio-e2e',
+      agent_id: srcAgentId,
+      user_id: 'test-user-001',
+      name: 'LM Studio',
+      base_url: 'http://localhost:1234/v1',
+      api_kind: 'openai',
+      models: [{ model_name: 'nvidia/nemotron' }],
+      created_at: now,
+    });
+    await ds.getRepository(UserProvider).insert({
+      id: 'up-lmstudio-e2e',
+      user_id: 'test-user-001',
+      agent_id: srcAgentId,
+      provider: 'custom:cp-lmstudio-e2e',
+      api_key_encrypted: null,
+      key_prefix: null,
+      auth_type: 'local',
+      region: null,
+      is_active: true,
+      connected_at: now,
+      updated_at: now,
+      cached_models: null,
+      models_fetched_at: null,
+    });
+
+    await ds.getRepository(UserProvider).insert({
+      id: 'up-ollama-e2e',
+      user_id: 'test-user-001',
+      agent_id: srcAgentId,
+      provider: 'ollama',
+      api_key_encrypted: null,
+      key_prefix: null,
+      auth_type: 'local',
+      region: null,
+      is_active: true,
+      connected_at: now,
+      updated_at: now,
+      cached_models: null,
+      models_fetched_at: null,
+    });
+
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/agents/remap-source/duplicate')
+      .set(headers)
+      .send({ name: 'remap-copy' })
+      .expect(201);
+
+    const newAgentId = res.body.agent.id;
+
+    const newCustom = await ds
+      .getRepository(CustomProvider)
+      .find({ where: { agent_id: newAgentId } });
+    expect(newCustom).toHaveLength(1);
+    expect(newCustom[0].name).toBe('LM Studio');
+    expect(newCustom[0].api_kind).toBe('openai');
+    expect(newCustom[0].id).not.toBe('cp-lmstudio-e2e');
+
+    const newProviders = await ds
+      .getRepository(UserProvider)
+      .find({ where: { agent_id: newAgentId } });
+    expect(newProviders).toHaveLength(2);
+
+    const customUp = newProviders.find((p) => p.provider.startsWith('custom:'));
+    expect(customUp).toBeDefined();
+    expect(customUp!.provider).toBe(`custom:${newCustom[0].id}`);
+    expect(customUp!.provider).not.toContain('cp-lmstudio-e2e');
+    expect(customUp!.auth_type).toBe('local');
+
+    const ollamaUp = newProviders.find((p) => p.provider === 'ollama');
+    expect(ollamaUp).toBeDefined();
+    expect(ollamaUp!.auth_type).toBe('local');
+  });
+
   it('POST /agents/:name/duplicate returns 409 when target name already exists', async () => {
     await request(app.getHttpServer())
       .post(`/api/v1/agents/${sourceAgent}/duplicate`)


### PR DESCRIPTION
## Summary

- Fixed agent duplication not correctly copying custom/local providers (LM Studio, llama.cpp, etc.)
- Custom providers stored as `custom:<uuid>` in `user_providers` were not remapped to new UUIDs, causing broken provider references in the duplicated agent (showing a mysterious "C" icon instead of the real provider)
- Added missing `api_kind` field copy for custom providers
- Reordered transaction to duplicate custom providers before user providers so the old-to-new UUID map is available for remapping

## Test plan

- [x] Unit tests: 6 new tests covering api_kind copy, custom:uuid remapping, canonical local providers, subscription providers, and multiple custom provider remapping
- [x] E2E test: new test verifying full round-trip duplication of LM Studio custom provider + Ollama canonical provider with correct UUID remapping
- [x] TypeScript compilation passes
- [x] Lint passes
- [x] All 15 unit tests pass
- [x] All 7 e2e tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent duplication so custom/local provider references are remapped and stay valid. Also copies `api_kind` for custom providers.

- **Bug Fixes**
  - Remaps `custom:<uuid>` in `user_providers` to new custom provider IDs.
  - Copies `api_kind` when duplicating `CustomProvider`.
  - Duplicates custom providers before user providers to build the old→new ID map.
  - Keeps canonical locals (`ollama`, `lmstudio`) and subscription/api-key providers unchanged.
  - Adds unit and e2e tests covering remapping and round-trip duplication.

<sup>Written for commit 52867ba552f141a526705e2db00dc5a2c341ed0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

