### PR TITLE
🐛 fix: auth forms accessibility and content polish

### DIFF
--- a/.changeset/auth-forms-a11y-quick-wins.md
+++ b/.changeset/auth-forms-a11y-quick-wins.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Polish auth flow accessibility and a few content fixes from a UX audit. Login, Register, and Reset Password inputs now have proper label/`for` association, `autocomplete` attributes for password-manager autofill, and `aria-describedby` linking errors to inputs. The cooldown intervals on resend buttons clean up on unmount. The Register page now links to real Terms and Privacy URLs (was `href="#"`). Section titles on Settings and Account use `<h2>` instead of `<h3>` to fix a heading hierarchy skip. Dark-variant logos use empty alt text so screen readers don't read "Manifest" twice. The Limits "Create rule" button uses the same plus icon as Workspace's "Connect Agent" button.

--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -21,11 +21,7 @@ const AuthGuard: ParentComponent = (props) => {
           <div class="auth-card" style="text-align: center;">
             <div class="auth-logo">
               <img src="/logo.svg" alt="Manifest" class="auth-logo__img auth-logo__img--light" />
-              <img
-                src="/logo-white.svg"
-                alt="Manifest"
-                class="auth-logo__img auth-logo__img--dark"
-              />
+              <img src="/logo-white.svg" alt="" class="auth-logo__img auth-logo__img--dark" />
             </div>
             <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm);">
               Loading...

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -108,7 +108,7 @@ const Header: Component = () => {
           />
           <img
             src="/logo-white.svg"
-            alt="Manifest"
+            alt=""
             width="152"
             class="header__logo-img header__logo-img--dark"
           />

--- a/packages/frontend/src/layouts/AuthLayout.tsx
+++ b/packages/frontend/src/layouts/AuthLayout.tsx
@@ -1,4 +1,4 @@
-import type { ParentComponent } from "solid-js";
+import type { ParentComponent } from 'solid-js';
 
 const AuthLayout: ParentComponent = (props) => {
   return (
@@ -7,7 +7,7 @@ const AuthLayout: ParentComponent = (props) => {
         <div class="auth-logo">
           <a href="https://manifest.build" class="auth-logo__link">
             <img src="/logo.svg" alt="Manifest" class="auth-logo__img auth-logo__img--light" />
-            <img src="/logo-white.svg" alt="Manifest" class="auth-logo__img auth-logo__img--dark" />
+            <img src="/logo-white.svg" alt="" class="auth-logo__img auth-logo__img--dark" />
           </a>
         </div>
         {props.children}

--- a/packages/frontend/src/pages/Account.tsx
+++ b/packages/frontend/src/pages/Account.tsx
@@ -66,7 +66,7 @@ const Account: Component = () => {
         </div>
 
         {/* Profile Information */}
-        <h3 class="settings-section__title">Profile information</h3>
+        <h2 class="settings-section__title">Profile information</h2>
 
         <div class="settings-card">
           <div class="settings-card__row">
@@ -109,7 +109,7 @@ const Account: Component = () => {
         </div>
 
         {/* Workspace ID */}
-        <h3 class="settings-section__title">Workspace</h3>
+        <h2 class="settings-section__title">Workspace</h2>
 
         <div class="settings-card">
           <div class="settings-card__body">
@@ -161,7 +161,7 @@ const Account: Component = () => {
         </div>
 
         {/* Appearance */}
-        <h3 class="settings-section__title">Appearance</h3>
+        <h2 class="settings-section__title">Appearance</h2>
 
         <div class="settings-card">
           <div class="settings-card__body">

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -144,7 +144,21 @@ const Limits: Component = () => {
             setShowModal(true);
           }}
         >
-          + Create rule
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          Create rule
         </button>
       </div>
 

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { A, useSearchParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
-import { type Component, createSignal, onMount, Show } from 'solid-js';
+import { type Component, createSignal, createUniqueId, onCleanup, onMount, Show } from 'solid-js';
 import SocialButtons from '../components/SocialButtons.jsx';
 import { authClient } from '../services/auth-client.js';
 import { checkSocialProviders } from '../services/setup-status.js';
@@ -16,6 +16,9 @@ const Login: Component = () => {
   const [resendCooldown, setResendCooldown] = createSignal(0);
   const [socialProviders, setSocialProviders] = createSignal<string[]>([]);
   const [searchParams] = useSearchParams();
+  const emailId = createUniqueId();
+  const passwordId = createUniqueId();
+  const errorId = createUniqueId();
 
   onMount(async () => {
     if (searchParams.error) {
@@ -24,18 +27,26 @@ const Login: Component = () => {
     setSocialProviders(await checkSocialProviders());
   });
 
+  let cooldownInterval: ReturnType<typeof setInterval> | undefined;
+
   const startCooldown = () => {
     setResendCooldown(RESEND_COOLDOWN_SECONDS);
-    const interval = setInterval(() => {
+    if (cooldownInterval) clearInterval(cooldownInterval);
+    cooldownInterval = setInterval(() => {
       setResendCooldown((prev) => {
         if (prev <= 1) {
-          clearInterval(interval);
+          clearInterval(cooldownInterval);
+          cooldownInterval = undefined;
           return 0;
         }
         return prev - 1;
       });
     }, 1000);
   };
+
+  onCleanup(() => {
+    if (cooldownInterval) clearInterval(cooldownInterval);
+  });
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -103,7 +114,7 @@ const Login: Component = () => {
 
       <form class="auth-form" onSubmit={handleSubmit}>
         {error() && (
-          <div class="auth-form__error" role="alert">
+          <div id={errorId} class="auth-form__error" role="alert">
             {error()}
           </div>
         )}
@@ -117,26 +128,32 @@ const Login: Component = () => {
             {resendCooldown() > 0 ? `Resend in ${resendCooldown()}s` : 'Resend verification email'}
           </button>
         </Show>
-        <label class="auth-form__label">
+        <label class="auth-form__label" for={emailId}>
           Email
           <input
+            id={emailId}
             class="auth-form__input"
             type="email"
+            autocomplete="email"
             placeholder="you@example.com"
             value={email()}
             onInput={(e) => setEmail(e.currentTarget.value)}
             required
+            aria-describedby={error() ? errorId : undefined}
           />
         </label>
-        <label class="auth-form__label">
+        <label class="auth-form__label" for={passwordId}>
           Password
           <input
+            id={passwordId}
             class="auth-form__input"
             type="password"
+            autocomplete="current-password"
             placeholder="Enter your password"
             value={password()}
             onInput={(e) => setPassword(e.currentTarget.value)}
             required
+            aria-describedby={error() ? errorId : undefined}
           />
         </label>
         <div class="auth-form__actions">

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -1,6 +1,6 @@
 import { A } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
-import { type Component, createSignal, onMount, Show } from 'solid-js';
+import { type Component, createSignal, createUniqueId, onCleanup, onMount, Show } from 'solid-js';
 import SocialButtons from '../components/SocialButtons.jsx';
 import { authClient } from '../services/auth-client.js';
 import { checkSocialProviders } from '../services/setup-status.js';
@@ -17,23 +17,35 @@ const Register: Component = () => {
   const [alreadyExists, setAlreadyExists] = createSignal(false);
   const [resendCooldown, setResendCooldown] = createSignal(0);
   const [socialProviders, setSocialProviders] = createSignal<string[]>([]);
+  const nameId = createUniqueId();
+  const emailId = createUniqueId();
+  const passwordId = createUniqueId();
+  const errorId = createUniqueId();
 
   onMount(async () => {
     setSocialProviders(await checkSocialProviders());
   });
 
+  let cooldownInterval: ReturnType<typeof setInterval> | undefined;
+
   const startCooldown = () => {
     setResendCooldown(RESEND_COOLDOWN_SECONDS);
-    const interval = setInterval(() => {
+    if (cooldownInterval) clearInterval(cooldownInterval);
+    cooldownInterval = setInterval(() => {
       setResendCooldown((prev) => {
         if (prev <= 1) {
-          clearInterval(interval);
+          clearInterval(cooldownInterval);
+          cooldownInterval = undefined;
           return 0;
         }
         return prev - 1;
       });
     }, 1000);
   };
+
+  onCleanup(() => {
+    if (cooldownInterval) clearInterval(cooldownInterval);
+  });
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -108,7 +120,7 @@ const Register: Component = () => {
 
             <form class="auth-form" onSubmit={handleSubmit}>
               <Show when={alreadyExists()}>
-                <div class="auth-form__error" role="alert">
+                <div id={errorId} class="auth-form__error" role="alert">
                   An account with this email already exists.{' '}
                   <A href="/login" class="auth-form__error-link">
                     Sign in
@@ -121,42 +133,51 @@ const Register: Component = () => {
                 </div>
               </Show>
               <Show when={error() && !alreadyExists()}>
-                <div class="auth-form__error" role="alert">
+                <div id={errorId} class="auth-form__error" role="alert">
                   {error()}
                 </div>
               </Show>
-              <label class="auth-form__label">
+              <label class="auth-form__label" for={nameId}>
                 Name
                 <input
+                  id={nameId}
                   class="auth-form__input"
                   type="text"
+                  autocomplete="name"
                   placeholder="Your name"
                   value={name()}
                   onInput={(e) => setName(e.currentTarget.value)}
                   required
+                  aria-describedby={error() ? errorId : undefined}
                 />
               </label>
-              <label class="auth-form__label">
+              <label class="auth-form__label" for={emailId}>
                 Email
                 <input
+                  id={emailId}
                   class="auth-form__input"
                   type="email"
+                  autocomplete="email"
                   placeholder="you@example.com"
                   value={email()}
                   onInput={(e) => setEmail(e.currentTarget.value)}
                   required
+                  aria-describedby={error() ? errorId : undefined}
                 />
               </label>
-              <label class="auth-form__label">
+              <label class="auth-form__label" for={passwordId}>
                 Password
                 <input
+                  id={passwordId}
                   class="auth-form__input"
                   type="password"
+                  autocomplete="new-password"
                   placeholder="Create a password"
                   value={password()}
                   onInput={(e) => setPassword(e.currentTarget.value)}
                   required
                   minLength={8}
+                  aria-describedby={error() ? errorId : undefined}
                 />
               </label>
               <button class="auth-form__submit" type="submit" disabled={loading()}>
@@ -165,11 +186,21 @@ const Register: Component = () => {
             </form>
             <p class="auth-terms">
               By signing up, you agree to our{' '}
-              <a href="#" class="auth-terms__link">
+              <a
+                href="https://manifest.build/terms"
+                class="auth-terms__link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Terms
               </a>{' '}
               and{' '}
-              <a href="#" class="auth-terms__link">
+              <a
+                href="https://manifest.build/privacy"
+                class="auth-terms__link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Privacy Policy
               </a>
             </p>

--- a/packages/frontend/src/pages/ResetPassword.tsx
+++ b/packages/frontend/src/pages/ResetPassword.tsx
@@ -1,6 +1,6 @@
 import { A, useSearchParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
-import { type Component, createSignal, Show } from 'solid-js';
+import { type Component, createSignal, createUniqueId, Show } from 'solid-js';
 import { authClient } from '../services/auth-client.js';
 
 const RequestResetForm: Component = () => {
@@ -8,6 +8,8 @@ const RequestResetForm: Component = () => {
   const [sent, setSent] = createSignal(false);
   const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
+  const emailId = createUniqueId();
+  const errorId = createUniqueId();
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -42,16 +44,23 @@ const RequestResetForm: Component = () => {
 
       <Show when={!sent()}>
         <form class="auth-form" onSubmit={handleSubmit}>
-          {error() && <div class="auth-form__error" role="alert">{error()}</div>}
-          <label class="auth-form__label">
+          {error() && (
+            <div id={errorId} class="auth-form__error" role="alert">
+              {error()}
+            </div>
+          )}
+          <label class="auth-form__label" for={emailId}>
             Email
             <input
+              id={emailId}
               class="auth-form__input"
               type="email"
+              autocomplete="email"
               placeholder="you@example.com"
               value={email()}
               onInput={(e) => setEmail(e.currentTarget.value)}
               required
+              aria-describedby={error() ? errorId : undefined}
             />
           </label>
           <button class="auth-form__submit" type="submit" disabled={loading()}>
@@ -75,6 +84,9 @@ const SetNewPasswordForm: Component<{ token: string }> = (props) => {
   const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
   const [success, setSuccess] = createSignal(false);
+  const passwordId = createUniqueId();
+  const confirmId = createUniqueId();
+  const errorId = createUniqueId();
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -129,29 +141,39 @@ const SetNewPasswordForm: Component<{ token: string }> = (props) => {
         }
       >
         <form class="auth-form" onSubmit={handleSubmit}>
-          {error() && <div class="auth-form__error" role="alert">{error()}</div>}
-          <label class="auth-form__label">
+          {error() && (
+            <div id={errorId} class="auth-form__error" role="alert">
+              {error()}
+            </div>
+          )}
+          <label class="auth-form__label" for={passwordId}>
             New password
             <input
+              id={passwordId}
               class="auth-form__input"
               type="password"
+              autocomplete="new-password"
               placeholder="Enter new password"
               value={password()}
               onInput={(e) => setPassword(e.currentTarget.value)}
               required
               minLength={8}
+              aria-describedby={error() ? errorId : undefined}
             />
           </label>
-          <label class="auth-form__label">
+          <label class="auth-form__label" for={confirmId}>
             Confirm password
             <input
+              id={confirmId}
               class="auth-form__input"
               type="password"
+              autocomplete="new-password"
               placeholder="Confirm new password"
               value={confirmPassword()}
               onInput={(e) => setConfirmPassword(e.currentTarget.value)}
               required
               minLength={8}
+              aria-describedby={error() ? errorId : undefined}
             />
           </label>
           <button class="auth-form__submit" type="submit" disabled={loading()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,7 +182,7 @@ const Settings: Component = () => {
       </div>
 
       {/* -- Agent Type (read-only + change modal) --- */}
-      <h3 class="settings-section__title">Agent type</h3>
+      <h2 class="settings-section__title">Agent type</h2>
       <div class="settings-card">
         <div class="settings-card__row">
           <div class="settings-card__label">
@@ -229,7 +229,7 @@ const Settings: Component = () => {
           />
         )}
       >
-        <h3 class="settings-section__title">API Key</h3>
+        <h2 class="settings-section__title">API Key</h2>
         <div class="settings-card">
           <div class="settings-card__body">
             <span class="settings-card__label-title">Agent API key</span>
@@ -296,7 +296,7 @@ const Settings: Component = () => {
         </div>
 
         {/* -- Setup Instructions ---------------------- */}
-        <h3 class="settings-section__title">Setup</h3>
+        <h2 class="settings-section__title">Setup</h2>
         <Show
           when={!apiKeyData.loading}
           fallback={<div class="skeleton skeleton--rect" style="width: 100%; height: 200px;" />}
@@ -320,7 +320,7 @@ const Settings: Component = () => {
       </ErrorBoundary>
 
       {/* -- Danger Zone -------------------------------- */}
-      <h3 class="settings-section__title settings-section__title--danger">Danger zone</h3>
+      <h2 class="settings-section__title settings-section__title--danger">Danger zone</h2>
       <div class="settings-card settings-card--danger">
         <div class="settings-card__row">
           <div class="settings-card__label">

--- a/packages/frontend/tests/pages/Limits-interactions.test.tsx
+++ b/packages/frontend/tests/pages/Limits-interactions.test.tsx
@@ -63,7 +63,7 @@ describe("Limits page interactions", () => {
     const { toast } = await import("../../src/services/toast-store.js");
 
     render(() => <Limits />);
-    fireEvent.click(screen.getByText("+ Create rule"));
+    fireEvent.click(screen.getByText("Create rule"));
     fireEvent.click(screen.getByTestId("mock-save"));
 
     await vi.waitFor(() => {
@@ -181,7 +181,7 @@ describe("Limits page interactions", () => {
     (createNotificationRule as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("fail"));
 
     render(() => <Limits />);
-    fireEvent.click(screen.getByText("+ Create rule"));
+    fireEvent.click(screen.getByText("Create rule"));
     fireEvent.click(screen.getByTestId("mock-save"));
 
     // Should not throw — error is caught

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -74,7 +74,7 @@ describe("Limits page", () => {
 
   it("renders Create rule button", () => {
     render(() => <Limits />);
-    expect(screen.getByText("+ Create rule")).toBeDefined();
+    expect(screen.getByText("Create rule")).toBeDefined();
   });
 
   it("renders empty state when no rules", async () => {
@@ -517,7 +517,7 @@ describe("Limits page", () => {
     render(() => <Limits />);
 
     // Open the create rule modal
-    fireEvent.click(screen.getByText("+ Create rule"));
+    fireEvent.click(screen.getByText("Create rule"));
     await vi.waitFor(() => {
       const modal = screen.getByTestId("limit-modal");
       expect(modal.getAttribute("data-open")).toBe("true");


### PR DESCRIPTION
### ✨ What changed
- Login, Register, ResetPassword: id/for label association + autocomplete + aria-describedby for errors.
- Login, Register: clear resend cooldown setInterval on unmount.
- Register: real Terms / Privacy URLs (was href="#").
- Settings, Account: top section uses h2 instead of h3 (fixes h1->h3 skip).
- AuthLayout, Header, AuthGuard: alt="" on dark logo so screen readers don't read "Manifest" twice.
- Limits: "Create rule" button uses the plus SVG (matches Workspace).

### 💭 Why
First batch of quick wins from a recent UX/a11y audit. All low-risk attribute/copy/markup edits, no logic changes.

### 👤 For users
Password managers can autofill the auth forms. Screen readers announce labels and errors correctly. Terms and Privacy links work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve auth form accessibility and small UI polish across the app. Labels and errors are announced correctly, autofill works, and the Limits button uses a proper plus icon.

- **Bug Fixes**
  - Auth forms (Login/Register/Reset Password): add label/for, autocomplete, and aria-describedby for errors.
  - Login/Register: clear resend cooldown interval on unmount.
  - Register: replace placeholder Terms/Privacy links with real URLs (new tab).
  - Settings/Account: fix heading hierarchy (use h2).
  - AuthLayout/Header/AuthGuard: set alt="" on dark logos to avoid duplicate screen reader text.
  - Limits: replace “+” with SVG plus icon on “Create rule”; update tests.

<sup>Written for commit f5c9af8ec8e50d64ec3048ed551a05512790d8e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

