### PR TITLE
chore(docker): bump runtime to Node 24 LTS

### DIFF
--- a/.changeset/node-24-lts.md
+++ b/.changeset/node-24-lts.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bump Docker runtime to Node 24 LTS (`gcr.io/distroless/nodejs24-debian13`). Active LTS through April 2028, replacing Node 22 (Maintenance LTS, EOL April 2027). Build and prod-deps stages move to `node:24-alpine` and `node:24-slim` to keep install and runtime majors aligned. CI and release workflows updated to Node 24. Dependabot is now pinned to ignore Node major bumps so non-LTS Current releases (Node 23, 25, 27…) won't open noisy PRs — LTS upgrades happen on a deliberate cadence.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
     directory: /docker
     schedule:
       interval: weekly
+    # Ignore Node major bumps. Dependabot opens majors indiscriminately
+    # (e.g. PR #1736 proposed Node 25, a non-LTS release). Manifest
+    # tracks Node LTS only and picks the next LTS major manually
+    # (currently Node 24, next Node 26 in October 2026). Digest and
+    # minor/patch bumps still flow through automatically.
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "gcr.io/distroless/nodejs*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build --workspace=packages/shared
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build --workspace=packages/shared
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build --workspace=packages/shared
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - name: Check changeset status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The `AgentKeyAuthGuard` accepts any non-`mnfst_*` token from loopback IPs in the
 
 - **Backend**: NestJS 11, TypeORM 0.3, PostgreSQL 16, Better Auth, class-validator, class-transformer, Helmet
 - **Frontend**: SolidJS, Vite, uPlot (charts), Better Auth client, custom CSS theme
-- **Runtime**: TypeScript 5.x (strict mode), Node.js 22.x
+- **Runtime**: TypeScript 5.x (strict mode), Node.js 24.x
 - **Monorepo**: npm workspaces + Turborepo
 - **Release**: Changesets for version management + GitHub Actions for npm publishing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The full NestJS + SolidJS stack runs locally against PostgreSQL, and the same da
 
 ## Prerequisites
 
-- Node.js 22.x (LTS)
+- Node.js 24.x (LTS)
 - npm 10.x
 
 ## Repository Structure

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
-# Runtime is gcr.io/distroless/nodejs22-debian13 (no shell, no package
-# manager, just node). Prod deps are staged on node:22-slim; the prod
+# Runtime is gcr.io/distroless/nodejs24-debian13 (no shell, no package
+# manager, just node). Prod deps are staged on node:24-slim; the prod
 # install uses --ignore-scripts so no native modules are compiled,
 # which means the runtime's glibc version is invisible to node_modules.
-# Build/dev stages stay on node:22-alpine — smallest base that still has
+# Build/dev stages stay on node:24-alpine — smallest base that still has
 # a shell, which the build (turbo, nest) needs. All base images are
 # pinned by digest.
 
 # Stage 1: Install all dependencies (including dev deps) for the build.
-FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS deps
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS deps
 WORKDIR /app
 COPY package.json package-lock.json turbo.json ./
 COPY packages/shared/package.json packages/shared/
@@ -26,7 +26,7 @@ RUN npx turbo build --filter=manifest-backend --filter=manifest-frontend --filte
 # Stage 3: Production dependencies only. npm ci runs with --ignore-scripts
 # so nothing is compiled — all runtime deps are pure JS, making the glibc
 # of this stage irrelevant to the final image.
-FROM node:22-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c AS prod-deps
+FROM node:24-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS prod-deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY packages/shared/package.json packages/shared/
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/root/.npm \
 
 # Stage 4: Distroless runtime. Runs as the built-in `nonroot` user (UID
 # 65532) by default. No shell, no apk/apt, minimal CVE surface.
-FROM gcr.io/distroless/nodejs22-debian13:nonroot@sha256:559b13edb698d652d7852597747ebd691569d110f0a76132b870067b290e30bd AS runtime
+FROM gcr.io/distroless/nodejs24-debian13:nonroot@sha256:f16acace4aa70086d4a2caad6c716f01e3e2fe0dd8274c4530c7c17d987bdb1a AS runtime
 WORKDIR /app
 
 LABEL org.opencontainers.image.title="Manifest" \
@@ -63,8 +63,8 @@ LABEL org.opencontainers.image.title="Manifest" \
       org.opencontainers.image.source="https://github.com/mnfst/manifest" \
       org.opencontainers.image.vendor="MNFST Inc." \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.base.name="gcr.io/distroless/nodejs22-debian13:nonroot" \
-      org.opencontainers.image.base.digest="sha256:559b13edb698d652d7852597747ebd691569d110f0a76132b870067b290e30bd"
+      org.opencontainers.image.base.name="gcr.io/distroless/nodejs24-debian13:nonroot" \
+      org.opencontainers.image.base.digest="sha256:f16acace4aa70086d4a2caad6c716f01e3e2fe0dd8274c4530c7c17d987bdb1a"
 
 ENV NODE_ENV=production
 ENV BIND_ADDRESS=0.0.0.0


### PR DESCRIPTION
### What changed
- Bumped `docker/Dockerfile` (4 Node refs + header comment + OCI labels) from Node 22 to Node 24 LTS, with new digests for `node:24-alpine`, `node:24-slim`, and `gcr.io/distroless/nodejs24-debian13:nonroot`.
- Bumped `node-version` in `.github/workflows/ci.yml` (5 jobs) and `release.yml` to `24`.
- Updated Node version references in `CONTRIBUTING.md` and `CLAUDE.md`.
- Added `ignore` rules in `.github/dependabot.yml` for major Node bumps (`node` and `gcr.io/distroless/nodejs*`).
- Added a patch changeset.

### Why
PR #1736 was a Dependabot bump to Node 25 that only updated 2 of the 4 Node refs in the Dockerfile, leaving install on Node 25 and runtime on Node 22. It also targeted a non-LTS release (Node 25, EOL ~June 2026). This PR moves to Node 24 instead (Active LTS through April 2028) and updates every reference at once. The dependabot rule keeps future odd-major Node PRs from auto-opening.

### For users
Self-hosters pulling new `manifestdotbuild/manifest` tags after the next release will run on Node 24. Drop-in replacement, no config changes.

### For operators
None. Distroless runtime image, same `nonroot` user (UID 65532), same entrypoint, same healthcheck.

### Notes
- Validated locally on Node 24.15.0: shared tests pass, frontend tests pass (2597/2597), backend unit tests pass (4288/4288), backend + frontend `tsc --noEmit` clean. Backend e2e and Docker image build deferred to CI (Postgres + Docker not running locally).
- Closes the trajectory of #1736 (already closed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Node to 24 LTS across Docker, CI/release, and docs. Keeps build and runtime in sync and avoids noisy non‑LTS major bumps.

- **Dependencies**
  - Docker: move all stages to Node 24 LTS (`node:24-alpine`, `node:24-slim`, `gcr.io/distroless/nodejs24-debian13:nonroot`) and update OCI labels/digests.
  - CI/CD: set `node-version: 24` in CI and release workflows.
  - Tooling: add Dependabot ignore rules for Node majors (`node`, `gcr.io/distroless/nodejs*`).
  - Docs/changeset: update Node refs in docs and add a patch changeset.

<sup>Written for commit 31733369728a6adf9f26840faefd841182eec590. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1738?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

