### PR TITLE
fix(railway): bump healthcheck timeout from 120s to 300s

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ buildCommand = "npm run build"
 [deploy]
 startCommand = "npm start"
 healthcheckPath = "/api/v1/health"
-healthcheckTimeout = 120
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
### What changed
- `healthcheckTimeout` in `railway.toml`: `120` → `300`.

### Why
On the last multi-region rolling deploy, one of four replicas spent ~92s loading startup data and missed the 120s healthcheck window by ~4s. The same commit deployed cleanly on a parallel rollout, confirming the app is healthy. 300s is what Railway support recommended to give the slowest replica enough headroom.

### For operators
None. Healthy instances continue to pass healthcheck in under a second. The longer timeout only changes how long Railway will wait before declaring a slow-starting replica unhealthy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Railway healthcheck timeout from 120s to 300s to prevent false failures during multi‑region rolling deploys. Healthy instances are unaffected; this only extends the grace period for slow‑starting replicas.

<sup>Written for commit a1d580dd9e37718f5376dea16aa73769e5822716. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1741?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

