### PR TITLE
fix: address OWASP security audit findings

### DIFF
--- a/.changeset/security-audit-fixes.md
+++ b/.changeset/security-audit-fixes.md
@@ -1,0 +1,16 @@
+---
+"manifest": patch
+---
+
+Security audit fixes (OWASP review).
+
+- Auth: SessionGuard and AgentKeyAuthGuard now read `request.socket.remoteAddress` for the loopback bypass decision instead of `request.ip`, which is forgeable via `X-Forwarded-For` when `trust proxy` is enabled. The production `trust proxy` setting is narrowed to `loopback, linklocal, uniquelocal` (override with `TRUST_PROXY` env).
+- Proxy: custom-provider and subscription endpoint URLs are revalidated against the SSRF allowlist immediately before each forward (DNS-rebinding defense). All proxy `fetch()` calls now use `redirect: 'error'` to block redirect-based escalation.
+- Auth rate limiting: added per-endpoint limits for `sign-up`, `forget-password` / `forgot-password` / `reset-password`, and `verify-email` / `send-verification-email` (Better Auth runs outside NestJS so `ThrottlerGuard` doesn't apply).
+- ApiKeyGuard: DB-API-key path now populates `request.user`, so user-scoped controllers no longer crash with a 500. `@CurrentUser()` fails closed with a 401 when no user is attached.
+- Crypto: AES-GCM IV length set to the standard 12 bytes (was 16), scrypt-derived keys cached per (secret, salt) to remove the per-call ~50ms cost on the proxy hot path. Boots warns once when `MANIFEST_ENCRYPTION_KEY` falls back to `BETTER_AUTH_SECRET` in production.
+- OAuth: `backendUrl` is validated against the allowlist at storage time instead of being trusted on the way out.
+- Telemetry: `routing_tier` and `auth_type` buckets are whitelisted against the shared enums; unknown values collapse to `"other"` instead of leaking verbatim.
+- Frontend: 401 responses no longer force a redirect to `/login` for per-endpoint auth failures. Only session-shaped 401s log the user out.
+- HSTS: warns at boot when production runs without HSTS on a non-loopback bind. Silence with `MANIFEST_DISABLE_HSTS=1`.
+- Dev CORS: defaults to a single origin (`http://localhost:3000`); set `CORS_ORIGIN` for anything else.

--- a/packages/backend/src/auth/current-user.decorator.spec.ts
+++ b/packages/backend/src/auth/current-user.decorator.spec.ts
@@ -2,7 +2,7 @@
 // metadata below. NestJS normally does this transitively, but this spec
 // exercises the decorator in isolation.
 import 'reflect-metadata';
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { CurrentUser } from './current-user.decorator';
 
@@ -36,8 +36,10 @@ describe('@CurrentUser()', () => {
     expect(factory(undefined, createContext(user))).toBe(user);
   });
 
-  it('returns undefined when no user is attached to the request', () => {
-    expect(factory(undefined, createContext(undefined))).toBeUndefined();
+  it('throws UnauthorizedException when no user is attached to the request', () => {
+    // Without a user we can't filter analytics by tenant — fail closed with
+    // a 401 instead of letting controllers crash on `user.id`.
+    expect(() => factory(undefined, createContext(undefined))).toThrow(UnauthorizedException);
   });
 
   it('ignores the data argument (decorator is not field-scoped)', () => {

--- a/packages/backend/src/auth/current-user.decorator.ts
+++ b/packages/backend/src/auth/current-user.decorator.ts
@@ -1,9 +1,15 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { Request } from 'express';
 
-export const CurrentUser = createParamDecorator(
-  (_data: unknown, ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest<Request & { user: unknown }>();
-    return request.user;
-  },
-);
+export const CurrentUser = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest<Request & { user?: unknown }>();
+  // Without a user we can't filter analytics by tenant. Fail closed with a
+  // 401 instead of letting the controller crash with `Cannot read 'id' of
+  // undefined` (which would surface as a 500 + stack trace in dev).
+  if (!request.user) {
+    throw new UnauthorizedException(
+      'This endpoint requires a user-scoped credential (session cookie or per-user API key).',
+    );
+  }
+  return request.user;
+});

--- a/packages/backend/src/auth/session.guard.spec.ts
+++ b/packages/backend/src/auth/session.guard.spec.ts
@@ -21,8 +21,13 @@ function createMockContext(overrides: { ip?: string; headers?: Record<string, st
   context: ExecutionContext;
   request: Record<string, unknown>;
 } {
+  // The guard reads request.socket.remoteAddress (the actual TCP peer) for
+  // its loopback decision. Mirror the test's `ip` field onto the socket so
+  // existing assertions still describe the scenario they intend to.
+  const peerIp = overrides.ip ?? '127.0.0.1';
   const request: Record<string, unknown> = {
-    ip: overrides.ip ?? '127.0.0.1',
+    ip: peerIp,
+    socket: { remoteAddress: peerIp },
     headers: overrides.headers ?? {},
   };
 

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -4,7 +4,7 @@ import { Request } from 'express';
 import { fromNodeHeaders } from 'better-auth/node';
 import { auth } from './auth.instance';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
-import { isLoopbackIp } from '../common/utils/local-ip';
+import { isLoopbackPeer } from '../common/utils/local-ip';
 import { isSelfHosted } from '../common/utils/detect-self-hosted';
 
 @Injectable()
@@ -44,8 +44,13 @@ export class SessionGuard implements CanActivate {
     }
 
     // In the self-hosted version, fall back to a synthetic user for loopback
-    // requests without a session (e.g. curl, programmatic access)
-    if (isSelfHosted() && request.ip && isLoopbackIp(request.ip)) {
+    // requests without a session (e.g. curl, programmatic access).
+    //
+    // Use the TCP peer address (request.socket.remoteAddress) — request.ip
+    // honors `trust proxy` and X-Forwarded-For, which a remote attacker can
+    // forge when the backend is reachable directly or sits behind a proxy
+    // that fails to strip XFF. The socket address cannot be spoofed.
+    if (isSelfHosted() && isLoopbackPeer(request)) {
       (request as Request & { user: unknown }).user = {
         id: 'local',
         name: 'Local User',

--- a/packages/backend/src/common/guards/api-key.guard.ts
+++ b/packages/backend/src/common/guards/api-key.guard.ts
@@ -51,6 +51,13 @@ export class ApiKeyGuard implements CanActivate {
     const found = candidates.find((c) => verifyKey(apiKey, c.key_hash));
 
     if (found) {
+      // Populate request.user so @CurrentUser-scoped controllers work the
+      // same way they do for cookie sessions. We only know the user_id from
+      // the api_keys row — name/email aren't joined here, but every analytics
+      // path keys off `user.id` via addTenantFilter, so the minimal shape is
+      // sufficient.
+      (request as Request & { user: { id: string } }).user = { id: String(found.user_id) };
+      (request as Request & { authMethod: string }).authMethod = 'api_key';
       (request as Request & { apiKeyUserId: string }).apiKeyUserId = String(found.user_id);
       this.apiKeyRepo
         .createQueryBuilder()
@@ -62,9 +69,13 @@ export class ApiKeyGuard implements CanActivate {
       return true;
     }
 
-    // Fall back to env-based API key (for simple setups)
+    // Fall back to env-based API key (for simple setups). The env key is a
+    // shared operator credential not tied to any user; controllers that
+    // depend on @CurrentUser will reject the request when `request.user`
+    // is unset (see CurrentUser decorator).
     const validKey = this.configService.get<string>('app.apiKey', '');
     if (validKey && this.safeCompare(apiKey, validKey)) {
+      (request as Request & { authMethod: string }).authMethod = 'env_api_key';
       return true;
     }
 

--- a/packages/backend/src/common/utils/crypto.util.ts
+++ b/packages/backend/src/common/utils/crypto.util.ts
@@ -1,18 +1,58 @@
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
+import { Logger as NestLogger } from '@nestjs/common';
 
 const ALGORITHM = 'aes-256-gcm';
-const IV_LENGTH = 16;
+// AES-GCM standard nonce length per NIST SP 800-38D §5.2.1.1. New ciphertexts
+// use 12 bytes; legacy 16-byte IVs from older versions still decrypt fine.
+const IV_LENGTH = 12;
 const SALT_LENGTH = 16;
 const KEY_LENGTH = 32;
 
+const logger = new NestLogger('crypto.util');
+let warnedAboutSecretReuse = false;
+
+// scrypt is deliberately CPU-expensive (~50ms+ per derivation with default
+// params). Calling it on every encrypt/decrypt — which happens on the proxy
+// hot path for provider keys — turns into a meaningful DoS amplifier under
+// load. Cache the derived key per (secret, salt) pair: AES-GCM with random
+// IVs remains safe (the (key, IV) pair is unique per ciphertext).
+const keyCache = new Map<string, Buffer>();
+const KEY_CACHE_MAX = 1024;
+
 function deriveKey(secret: string, salt: Buffer): Buffer {
-  return scryptSync(secret, salt, KEY_LENGTH);
+  const cacheKey = `${secret.length}:${secret}:${salt.toString('base64')}`;
+  const cached = keyCache.get(cacheKey);
+  if (cached) return cached;
+  const derived = scryptSync(secret, salt, KEY_LENGTH);
+  if (keyCache.size >= KEY_CACHE_MAX) {
+    const firstKey = keyCache.keys().next().value;
+    if (firstKey) keyCache.delete(firstKey);
+  }
+  keyCache.set(cacheKey, derived);
+  return derived;
 }
 
 export function getEncryptionSecret(): string {
-  const key = process.env['MANIFEST_ENCRYPTION_KEY'] || process.env['BETTER_AUTH_SECRET'];
-  if (key && key.length >= 32) {
-    return key;
+  const dedicated = process.env['MANIFEST_ENCRYPTION_KEY'];
+  if (dedicated && dedicated.length >= 32) {
+    return dedicated;
+  }
+
+  // Falling back to BETTER_AUTH_SECRET means a single secret leak compromises
+  // both session signing and stored provider/OAuth keys. Warn once at boot so
+  // operators have a clear remediation path: set MANIFEST_ENCRYPTION_KEY to a
+  // separate 32+ char secret.
+  const sessionSecret = process.env['BETTER_AUTH_SECRET'];
+  if (sessionSecret && sessionSecret.length >= 32) {
+    if (!warnedAboutSecretReuse && process.env['NODE_ENV'] === 'production') {
+      warnedAboutSecretReuse = true;
+      logger.warn(
+        'MANIFEST_ENCRYPTION_KEY not set — falling back to BETTER_AUTH_SECRET for at-rest ' +
+          'encryption. Set MANIFEST_ENCRYPTION_KEY to a separate 32+ char secret so a session-' +
+          'signing leak does not also decrypt stored provider/OAuth keys.',
+      );
+    }
+    return sessionSecret;
   }
 
   throw new Error(

--- a/packages/backend/src/common/utils/local-ip.ts
+++ b/packages/backend/src/common/utils/local-ip.ts
@@ -1,3 +1,22 @@
+import type { Request } from 'express';
+
 export function isLoopbackIp(ip: string): boolean {
   return ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1';
+}
+
+/**
+ * Returns the actual TCP peer address from the request socket.
+ *
+ * `request.ip` honors `trust proxy` and follows `X-Forwarded-For`, which is
+ * spoofable when the server is reachable directly (no proxy in front, or a
+ * proxy that fails to strip XFF). Auth bypasses gated on "is this loopback?"
+ * must use the socket address — it cannot be forged by a remote attacker.
+ */
+export function getSocketRemoteAddress(request: Request): string | undefined {
+  return request.socket?.remoteAddress ?? undefined;
+}
+
+export function isLoopbackPeer(request: Request): boolean {
+  const peer = getSocketRemoteAddress(request);
+  return !!peer && isLoopbackIp(peer);
 }

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -53,8 +53,13 @@ export async function bootstrap() {
 
   const isDev = process.env['NODE_ENV'] !== 'production';
   if (isDev) {
+    // Default to a single origin (the Vite dev server). Operators that need
+    // a different origin must set CORS_ORIGIN explicitly. Previously the
+    // fallback regex allowed http+https on both 3000 and 3001 with
+    // credentials, letting any locally-bound process on those ports read
+    // session cookies cross-origin.
     app.enableCors({
-      origin: process.env['CORS_ORIGIN'] || /^https?:\/\/(localhost|127\.0\.0\.1):(3000|3001)$/,
+      origin: process.env['CORS_ORIGIN'] || 'http://localhost:3000',
       credentials: true,
     });
   }
@@ -73,11 +78,19 @@ export async function bootstrap() {
   // Trust reverse proxy (Railway, Render, Traefik, Nginx, etc.) so Express
   // sees the real client IP from X-Forwarded-For headers. Enabled in
   // production deployments only — dev runs on loopback with no proxy.
+  //
+  // Restrict the trust to loopback / link-local / private subnets so a
+  // remote attacker cannot forge an X-Forwarded-For value to make Express
+  // think the request originated from a trusted IP. Operators with proxies
+  // outside these ranges should set TRUST_PROXY explicitly.
   if (!isDev) {
-    expressApp.set('trust proxy', 1);
+    const trustProxy = process.env['TRUST_PROXY'] ?? 'loopback, linklocal, uniquelocal';
+    expressApp.set('trust proxy', trustProxy);
   }
 
-  // Rate limit login attempts (Better Auth runs outside NestJS, so ThrottlerGuard doesn't apply)
+  // Rate limit auth endpoints (Better Auth runs outside NestJS, so
+  // ThrottlerGuard doesn't apply). Each endpoint gets its own limiter so
+  // sign-in attempts don't share a budget with sign-up / password-reset.
   const { default: rateLimit } = await import('express-rate-limit');
   const loginLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
@@ -86,7 +99,36 @@ export async function bootstrap() {
     legacyHeaders: false,
     message: { error: 'Too many login attempts. Try again later.' },
   });
+  const signupLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many sign-up attempts. Try again later.' },
+  });
+  // forget-password is the worst offender: each request sends an email and
+  // can be used for account enumeration via timing differences. Tight cap.
+  const forgetPasswordLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many password reset requests. Try again later.' },
+  });
+  const verifyEmailLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many verification requests. Try again later.' },
+  });
   expressApp.use('/api/auth/sign-in', loginLimiter);
+  expressApp.use('/api/auth/sign-up', signupLimiter);
+  expressApp.use('/api/auth/forget-password', forgetPasswordLimiter);
+  expressApp.use('/api/auth/forgot-password', forgetPasswordLimiter);
+  expressApp.use('/api/auth/reset-password', forgetPasswordLimiter);
+  expressApp.use('/api/auth/verify-email', verifyEmailLimiter);
+  expressApp.use('/api/auth/send-verification-email', verifyEmailLimiter);
 
   // Mount Better Auth handler (needs raw body, before express.json)
   const { toNodeHandler } = await import('better-auth/node');
@@ -105,6 +147,24 @@ export async function bootstrap() {
     logger.warn(
       `Development mode with BIND_ADDRESS=${host} — auth guards are relaxed for loopback IPs. ` +
         'Ensure this server is not exposed to untrusted networks.',
+    );
+  }
+
+  // Warn loudly when HSTS is silently disabled in production. Operators
+  // running behind an HTTPS reverse proxy without setting BETTER_AUTH_URL
+  // (or with an http:// value) will otherwise lose HSTS protection
+  // without realizing it.
+  if (
+    !isDev &&
+    !hstsEnabled &&
+    host !== '127.0.0.1' &&
+    host !== 'localhost' &&
+    host !== '::1' &&
+    process.env['MANIFEST_DISABLE_HSTS'] !== '1'
+  ) {
+    logger.warn(
+      'HSTS is disabled. Set BETTER_AUTH_URL to your https:// origin to enable it, or set ' +
+        'MANIFEST_DISABLE_HSTS=1 to silence this warning for HTTP-only LAN deployments.',
     );
   }
 

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -84,7 +84,18 @@ export async function bootstrap() {
   // think the request originated from a trusted IP. Operators with proxies
   // outside these ranges should set TRUST_PROXY explicitly.
   if (!isDev) {
-    const trustProxy = process.env['TRUST_PROXY'] ?? 'loopback, linklocal, uniquelocal';
+    // Env values are always strings, but Express's `trust proxy` treats
+    // numbers (hop count) and booleans differently from their string
+    // equivalents — `"1"` is parsed as a CIDR / IP literal, not "trust
+    // first hop". Coerce numeric and bool-shaped values explicitly.
+    const rawTrustProxy = process.env['TRUST_PROXY'] ?? 'loopback, linklocal, uniquelocal';
+    const trustProxy: string | number | boolean = /^\d+$/.test(rawTrustProxy)
+      ? Number(rawTrustProxy)
+      : rawTrustProxy === 'true'
+        ? true
+        : rawTrustProxy === 'false'
+          ? false
+          : rawTrustProxy;
     expressApp.set('trust proxy', trustProxy);
   }
 

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -9,7 +9,10 @@ function testCacheKey(token: string): string {
 }
 
 function makeContext(headers: Record<string, string | undefined>, ip = '203.0.113.1') {
-  const request: Record<string, unknown> = { headers, ip };
+  // The guard reads request.socket.remoteAddress for its loopback decision
+  // (request.ip is spoofable via X-Forwarded-For when trust proxy is set).
+  // Mirror the test's `ip` onto the socket so existing scenarios still hold.
+  const request: Record<string, unknown> = { headers, ip, socket: { remoteAddress: ip } };
   return {
     req: request,
     ctx: {
@@ -331,7 +334,7 @@ describe('AgentKeyAuthGuard', () => {
   });
 
   it('handles request.ip being undefined without crashing', async () => {
-    const request: Record<string, unknown> = { headers: {}, ip: undefined };
+    const request: Record<string, unknown> = { headers: {}, ip: undefined, socket: {} };
     const ctx = {
       switchToHttp: () => ({
         getRequest: () => request,

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -15,7 +15,7 @@ import { AgentApiKey } from '../../entities/agent-api-key.entity';
 import { IngestionContext } from '../interfaces/ingestion-context.interface';
 import { verifyKey, keyPrefix as computePrefix } from '../../common/utils/hash.util';
 import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
-import { isLoopbackIp } from '../../common/utils/local-ip';
+import { isLoopbackPeer } from '../../common/utils/local-ip';
 const MIN_TOKEN_LENGTH = 12;
 
 function cacheKey(token: string): string {
@@ -58,9 +58,10 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
     const request = context.switchToHttp().getRequest<Request>();
     const authHeader = request.headers['authorization'];
 
-    const ip = request.ip ?? '';
+    // Use socket.remoteAddress (TCP peer) — request.ip honors X-Forwarded-For
+    // and is spoofable when `trust proxy` is enabled.
     const isDevLoopback =
-      this.configService.get<string>('app.nodeEnv') === 'development' && isLoopbackIp(ip);
+      this.configService.get<string>('app.nodeEnv') === 'development' && isLoopbackPeer(request);
 
     if (!authHeader) {
       if (await this.handleDevLoopback(request, isDevLoopback)) return true;

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -49,11 +49,15 @@ export class OpenaiOauthService {
     const state = randomBytes(32).toString('hex');
     const verifier = randomBytes(32).toString('base64url');
     const challenge = createHash('sha256').update(verifier).digest('base64url');
+    // Validate the redirect target now (at storage time) instead of trusting
+    // it on the way out. The callback server only ever redirects to
+    // localhost-shaped origins, so anything else is dropped here.
+    const safeBackendUrl = backendUrl && this.isAllowedRedirectOrigin(backendUrl) ? backendUrl : '';
     this.pending.set(state, {
       verifier,
       agentId,
       userId,
-      backendUrl: backendUrl ?? '',
+      backendUrl: safeBackendUrl,
       expiresAt: Date.now() + STATE_TTL_MS,
     });
     if (this.useCallbackServer) {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './provider-endpoints';
+import { validatePublicUrl } from '../../common/utils/url-validation';
+import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { resolveSubscriptionEndpointKey } from './provider-hooks';
 import { injectOpenRouterCacheControl } from './cache-injection';
 import {
@@ -104,6 +106,19 @@ export class ProviderClient {
     const finalHeaders = extraHeaders ? { ...headers, ...extraHeaders } : headers;
 
     this.logger.debug(`Forwarding to ${endpointKey}: ${url.replace(/key=[^&]+/, 'key=***')}`);
+
+    // SSRF defense in depth for user-supplied endpoint URLs (custom providers,
+    // subscription resource URLs). validatePublicUrl was called when the URL
+    // was stored, but DNS for the hostname may have rebound to a private or
+    // cloud-metadata address since then. Re-resolve and re-check now.
+    if (endpoint.requiresSsrfRevalidation) {
+      try {
+        await validatePublicUrl(url, { allowPrivate: isSelfHosted() });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Refusing to forward to disallowed URL: ${message}`);
+      }
+    }
 
     return this.executeFetch(url, finalHeaders, requestBody, signal, {
       isGoogle,
@@ -253,6 +268,9 @@ export class ProviderClient {
         headers,
         body: JSON.stringify(requestBody),
         signal: fetchSignal,
+        // Block redirect-based SSRF escalation: a hostile upstream could 302
+        // to a private/metadata endpoint after our pre-fetch validation.
+        redirect: 'error',
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -8,6 +8,15 @@ export interface ProviderEndpoint {
   buildHeaders: (apiKey: string, authType?: string) => Record<string, string>;
   buildPath: (model: string) => string;
   format: 'openai' | 'google' | 'anthropic' | 'chatgpt';
+  /**
+   * Set to `true` for endpoints whose `baseUrl` is user-supplied (custom
+   * providers, subscription resource URLs). The proxy re-runs SSRF
+   * validation against this URL immediately before each forward to defend
+   * against DNS rebinding — the hostname might have resolved to a public
+   * IP at registration time but rebinds to a private/metadata address at
+   * forward time.
+   */
+  requiresSsrfRevalidation?: boolean;
 }
 
 const openaiHeaders = (apiKey: string) => ({
@@ -212,6 +221,7 @@ export function buildCustomEndpoint(
       buildHeaders: anthropicHeaders,
       buildPath: () => '/v1/messages',
       format: 'anthropic',
+      requiresSsrfRevalidation: true,
     };
   }
   return {
@@ -219,6 +229,7 @@ export function buildCustomEndpoint(
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    requiresSsrfRevalidation: true,
   };
 }
 
@@ -230,6 +241,10 @@ export function buildEndpointOverride(baseUrl: string, templateKey: string): Pro
   return {
     ...template,
     baseUrl: normalizeProviderBaseUrl(baseUrl),
+    // The base URL came from a user-supplied source (Qwen region selector,
+    // MiniMax OAuth resource URL). Treat it as an SSRF candidate and
+    // re-validate before each forward.
+    requiresSsrfRevalidation: true,
   };
 }
 

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -1,11 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { AUTH_TYPES, TIER_SLOTS } from 'manifest-shared';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import type { TelemetryPayloadV1 } from './dto/telemetry-payload';
 import { TELEMETRY_SCHEMA_VERSION } from './telemetry.config';
+
+const TIER_WHITELIST: ReadonlySet<string> = new Set<string>(TIER_SLOTS);
+const AUTH_TYPE_WHITELIST: ReadonlySet<string> = new Set<string>(AUTH_TYPES);
 
 interface ProviderAggregateRow {
   provider: string | null;
@@ -54,8 +58,12 @@ export class PayloadBuilderService {
       manifest_version: manifestVersion,
       messages_total: Number(totals.total),
       messages_by_provider: this.collapseProviders(providerRows),
-      messages_by_tier: this.bucketsToRecord(tierRows, 'unknown'),
-      messages_by_auth_type: this.bucketsToRecord(authRows, 'unknown'),
+      // Defense in depth: whitelist tier and auth_type values against the
+      // shared enums. If a future write path inserts an unexpected string,
+      // it collapses to `"other"` instead of leaking verbatim to the
+      // telemetry endpoint.
+      messages_by_tier: this.bucketsToRecord(tierRows, 'unknown', TIER_WHITELIST),
+      messages_by_auth_type: this.bucketsToRecord(authRows, 'unknown', AUTH_TYPE_WHITELIST),
       tokens_input_total: Number(totals.input_tokens ?? 0),
       tokens_output_total: Number(totals.output_tokens ?? 0),
       agents_total: agentsTotal,
@@ -131,10 +139,17 @@ export class PayloadBuilderService {
     return entry ? entry.id : 'custom';
   }
 
-  private bucketsToRecord(rows: BucketRow[], nullLabel: string): Record<string, number> {
+  private bucketsToRecord(
+    rows: BucketRow[],
+    nullLabel: string,
+    whitelist?: ReadonlySet<string>,
+  ): Record<string, number> {
     const out: Record<string, number> = {};
     for (const row of rows) {
-      const key = row.bucket ?? nullLabel;
+      let key = row.bucket ?? nullLabel;
+      if (whitelist && row.bucket !== null && !whitelist.has(row.bucket)) {
+        key = 'other';
+      }
       out[key] = (out[key] ?? 0) + Number(row.count);
     }
     return out;

--- a/packages/frontend/src/services/api/core.ts
+++ b/packages/frontend/src/services/api/core.ts
@@ -15,11 +15,20 @@ export async function fetchJson<T>(
 
   const res = await fetch(url.toString(), { credentials: 'include', cache: 'no-store' });
   if (res.status === 401) {
-    // Session expired or user logged out — silently redirect to login
-    if (window.location.pathname !== '/login') {
-      window.location.href = '/login';
+    // Only redirect to /login when the 401 looks like a real session
+    // expiry. Per-endpoint 401s (e.g. an endpoint that requires a
+    // user-scoped credential when called with a shared API key) shouldn't
+    // log the user out.
+    const body = await res.text().catch(() => '');
+    const looksLikeSessionExpiry =
+      !body || /session|cookie|unauthenticated|not authenticated/i.test(body);
+    if (looksLikeSessionExpiry) {
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
+      throw new Error('Session expired');
     }
-    throw new Error('Session expired');
+    throw new Error(body || 'Unauthorized');
   }
   if (!res.ok) {
     const body = await res.text().catch(() => '');

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -1414,7 +1414,7 @@ describe('fetchJson 401 redirect', () => {
   it('redirects to /login on 401 response and throws', async () => {
     const loc = { origin: 'http://localhost:3000', pathname: '/overview', href: '' };
     vi.stubGlobal('location', loc);
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401, text: async () => '' });
 
     await expect(getHealth()).rejects.toThrow('Session expired');
     expect(loc.href).toBe('/login');
@@ -1423,7 +1423,7 @@ describe('fetchJson 401 redirect', () => {
   it('does not redirect if already on /login but still throws', async () => {
     const loc = { origin: 'http://localhost:3000', pathname: '/login', href: '' };
     vi.stubGlobal('location', loc);
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401, text: async () => '' });
 
     await expect(getHealth()).rejects.toThrow('Session expired');
     expect(loc.href).toBe('');


### PR DESCRIPTION
### What changed

- Auth guards: use `socket.remoteAddress` (TCP peer) for the loopback bypass instead of `request.ip`, which `X-Forwarded-For` can spoof when `trust proxy` is set. Production trust proxy narrowed to loopback/linklocal/uniquelocal (override via `TRUST_PROXY`).
- Proxy: revalidate custom-provider and subscription URLs against the SSRF allowlist immediately before each forward (DNS rebinding defense). All proxy `fetch()` set `redirect: 'error'`.
- Auth rate limits: per-endpoint limiters for sign-up, password reset, and email verification (Better Auth runs outside Nest, so `ThrottlerGuard` doesn't apply).
- `ApiKeyGuard` now populates `request.user`. `@CurrentUser()` fails closed with 401 instead of letting controllers crash.
- AES-GCM IV length 16 -> 12 (NIST standard). Cache scrypt-derived keys per (secret, salt) so the proxy hot path stops paying ~50ms per call.
- Warn at boot when `MANIFEST_ENCRYPTION_KEY` falls back to `BETTER_AUTH_SECRET` in production.
- OAuth `backendUrl` validated at storage time, not on the way out.
- Telemetry: whitelist `routing_tier` and `auth_type` against the shared enums; unknown values collapse to `"other"`.
- Frontend: only redirect to `/login` when a 401 looks like a session expiry. Per-endpoint 401s throw with the body intact.
- HSTS: warn at boot when production runs without HSTS on a non-loopback bind. Silence with `MANIFEST_DISABLE_HSTS=1`.
- Dev CORS default tightened to `http://localhost:3000`.

### Why

OWASP audit on the current branch surfaced 4 highs (loopback bypass via XFF, recoverable agent keys, DNS-rebinding SSRF in the proxy, auth endpoints with no rate limit) and 8 mediums. This PR fixes the loopback bypass, the DNS rebinding gap, the rate-limit gap, and all 8 mediums.

### For operators

- If you front this server with a proxy whose IPs are not in `loopback/linklocal/uniquelocal`, set `TRUST_PROXY` (Express `trust proxy` syntax) so XFF resolution still works for your setup.
- Set `MANIFEST_ENCRYPTION_KEY` to a separate 32+ char secret. The fallback to `BETTER_AUTH_SECRET` still works but logs a warning in production.
- HTTP-only LAN deployments: silence the new HSTS warning with `MANIFEST_DISABLE_HSTS=1`.
- Dev frontends on a non-default origin must set `CORS_ORIGIN` explicitly.

### Notes

- One audit High not addressed here: agent `mnfst_*` keys are still stored encrypted-and-hashed (recoverable via a leaked encryption secret + DB). Tracked separately, since dropping the encrypted column is a UX/migration change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens auth and the proxy per OWASP findings: fixes loopback/XFF bypass, blocks DNS‑rebinding SSRF, and adds per-endpoint auth rate limits. Also tightens crypto defaults, telemetry buckets, HSTS/CORS posture, and frontend 401 handling.

- **Bug Fixes**
  - Loopback bypass: guards now use `socket.remoteAddress` (not `request.ip`); production `trust proxy` narrowed to `loopback, linklocal, uniquelocal` and `TRUST_PROXY` values are parsed as number/boolean or string as needed.
  - SSRF: revalidate custom-provider/subscription URLs just before forwarding; proxy `fetch()` uses `redirect: 'error'`.
  - Rate limiting: per-endpoint limits for sign-up, forgot/reset password, and verify-email (`better-auth` runs outside Nest, so `@nestjs/throttler` didn’t apply).
  - Auth flow: `ApiKeyGuard` populates `request.user`; `@CurrentUser()` returns 401 when missing to avoid controller crashes.
  - Crypto: AES-GCM IV set to 12 bytes; cache scrypt-derived keys; warn in prod if `MANIFEST_ENCRYPTION_KEY` falls back to `BETTER_AUTH_SECRET`.
  - OAuth: validate `backendUrl` at write time, not on response.
  - Telemetry: whitelist `routing_tier` and `auth_type`; unknowns collapse to `"other"`.
  - Frontend: only redirect to `/login` when a 401 looks like a session expiry; otherwise throw with response body.
  - Ops defaults: warn in prod when HSTS is off on a non-loopback bind (silence with `MANIFEST_DISABLE_HSTS=1`); dev CORS default tightened to `http://localhost:3000`.

- **Migration**
  - Set `TRUST_PROXY` if your reverse proxy IPs aren’t in loopback/link-local/private ranges.
  - Set a dedicated 32+ char `MANIFEST_ENCRYPTION_KEY` (separate from `BETTER_AUTH_SECRET`).
  - For HTTP-only LAN setups, silence the HSTS warning with `MANIFEST_DISABLE_HSTS=1`; otherwise set `BETTER_AUTH_URL` to your `https://` origin.
  - If your dev frontend runs on a non-default origin, set `CORS_ORIGIN`.

<sup>Written for commit c1aeb853be17fd4d10e15f1ea090d78b118bc80d. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1744?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

