### PR TITLE
perf: cache hot-path lookups, batch proxy writes, narrow SSE refetch fan-out

### DIFF
--- a/.changeset/perf-optim-pass.md
+++ b/.changeset/perf-optim-pass.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Backend hot-path and dashboard query optimization pass: 60s LRU session cache in SessionGuard, slimmed AgentKeyAuthGuard query with 30min cache, retuned specificity miscategorization index, batched proxy fallback inserts, merged agent-list stats+sparkline into a single query, bounded distinct-models scan to 90 days, plus typed SSE events so dashboard pages only refetch on relevant changes instead of every ingest ping.

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -10,6 +10,7 @@ import { AgentLifecycleService } from '../services/agent-lifecycle.service';
 import { AgentDuplicationService } from '../services/agent-duplication.service';
 import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 
 describe('AgentsController', () => {
   let controller: AgentsController;
@@ -65,6 +66,16 @@ describe('AgentsController', () => {
             deleteAgent: mockDeleteAgent,
             renameAgent: mockRenameAgent,
             updateAgentType: jest.fn(),
+            findAgentInfo: jest.fn(async (_userId: string, agentName: string) =>
+              agentName === 'bot-1'
+                ? {
+                    agent_name: 'bot-1',
+                    display_name: 'Bot One',
+                    agent_category: 'app',
+                    agent_platform: 'openai-sdk',
+                  }
+                : null,
+            ),
           },
         },
         {
@@ -91,6 +102,10 @@ describe('AgentsController', () => {
           provide: TenantCacheService,
           useValue: { resolve: mockTenantResolve },
         },
+        {
+          provide: IngestEventBusService,
+          useValue: { emit: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -114,6 +129,25 @@ describe('AgentsController', () => {
     await controller.getAgents(user as never);
 
     expect(mockGetAgentList).toHaveBeenCalledWith('u1', undefined);
+  });
+
+  it('GET /agents/:agentName returns metadata for an existing agent', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.getAgentInfo(user as never, 'bot-1');
+    expect(result).toEqual({
+      agent: {
+        agent_name: 'bot-1',
+        display_name: 'Bot One',
+        agent_category: 'app',
+        agent_platform: 'openai-sdk',
+      },
+    });
+  });
+
+  it('GET /agents/:agentName returns { agent: null } when not found', async () => {
+    const user = { id: 'u1' };
+    const result = await controller.getAgentInfo(user as never, 'missing');
+    expect(result).toEqual({ agent: null });
   });
 
   it('returns agent key prefix', async () => {
@@ -212,7 +246,12 @@ describe('AgentsController', () => {
         { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
         {
           provide: AgentLifecycleService,
-          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn(), updateAgentType: jest.fn() },
+          useValue: {
+            deleteAgent: jest.fn(),
+            renameAgent: jest.fn(),
+            updateAgentType: jest.fn(),
+            findAgentInfo: jest.fn().mockResolvedValue(null),
+          },
         },
         {
           provide: ApiKeyGeneratorService,
@@ -220,6 +259,7 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        { provide: IngestEventBusService, useValue: { emit: jest.fn() } },
         {
           provide: AgentDuplicationService,
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
@@ -263,7 +303,12 @@ describe('AgentsController', () => {
         { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
         {
           provide: AgentLifecycleService,
-          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn(), updateAgentType: jest.fn() },
+          useValue: {
+            deleteAgent: jest.fn(),
+            renameAgent: jest.fn(),
+            updateAgentType: jest.fn(),
+            findAgentInfo: jest.fn().mockResolvedValue(null),
+          },
         },
         {
           provide: ApiKeyGeneratorService,
@@ -271,6 +316,7 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        { provide: IngestEventBusService, useValue: { emit: jest.fn() } },
         {
           provide: AgentDuplicationService,
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
@@ -315,7 +361,12 @@ describe('AgentsController', () => {
         { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
         {
           provide: AgentLifecycleService,
-          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn(), updateAgentType: jest.fn() },
+          useValue: {
+            deleteAgent: jest.fn(),
+            renameAgent: jest.fn(),
+            updateAgentType: jest.fn(),
+            findAgentInfo: jest.fn().mockResolvedValue(null),
+          },
         },
         {
           provide: ApiKeyGeneratorService,
@@ -323,6 +374,7 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        { provide: IngestEventBusService, useValue: { emit: jest.fn() } },
         {
           provide: AgentDuplicationService,
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
@@ -349,7 +401,12 @@ describe('AgentsController', () => {
         { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
         {
           provide: AgentLifecycleService,
-          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn(), updateAgentType: jest.fn() },
+          useValue: {
+            deleteAgent: jest.fn(),
+            renameAgent: jest.fn(),
+            updateAgentType: jest.fn(),
+            findAgentInfo: jest.fn().mockResolvedValue(null),
+          },
         },
         {
           provide: ApiKeyGeneratorService,
@@ -357,6 +414,7 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        { provide: IngestEventBusService, useValue: { emit: jest.fn() } },
         {
           provide: AgentDuplicationService,
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
@@ -382,7 +440,12 @@ describe('AgentsController', () => {
         { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
         {
           provide: AgentLifecycleService,
-          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn(), updateAgentType: jest.fn() },
+          useValue: {
+            deleteAgent: jest.fn(),
+            renameAgent: jest.fn(),
+            updateAgentType: jest.fn(),
+            findAgentInfo: jest.fn().mockResolvedValue(null),
+          },
         },
         {
           provide: ApiKeyGeneratorService,
@@ -390,6 +453,7 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        { provide: IngestEventBusService, useValue: { emit: jest.fn() } },
         {
           provide: AgentDuplicationService,
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
@@ -467,7 +531,12 @@ describe('AgentsController', () => {
         { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
         {
           provide: AgentLifecycleService,
-          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn(), updateAgentType: jest.fn() },
+          useValue: {
+            deleteAgent: jest.fn(),
+            renameAgent: jest.fn(),
+            updateAgentType: jest.fn(),
+            findAgentInfo: jest.fn().mockResolvedValue(null),
+          },
         },
         {
           provide: ApiKeyGeneratorService,
@@ -475,6 +544,7 @@ describe('AgentsController', () => {
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+        { provide: IngestEventBusService, useValue: { emit: jest.fn() } },
         {
           provide: AgentDuplicationService,
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -18,6 +18,7 @@ import { TimeseriesQueriesService } from '../services/timeseries-queries.service
 import { AgentLifecycleService } from '../services/agent-lifecycle.service';
 import { AgentDuplicationService } from '../services/agent-duplication.service';
 import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
@@ -36,6 +37,7 @@ export class AgentsController {
     private readonly duplication: AgentDuplicationService,
     private readonly apiKeyGenerator: ApiKeyGeneratorService,
     private readonly tenantCache: TenantCacheService,
+    private readonly eventBus: IngestEventBusService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
@@ -76,6 +78,7 @@ export class AgentsController {
       throw error;
     }
     await this.cacheManager.del(this.agentListCacheKey(user.id));
+    this.eventBus.emit(user.id, 'agent');
     return {
       agent: {
         id: result.agentId,
@@ -119,6 +122,7 @@ export class AgentsController {
       throw error;
     }
     await this.cacheManager.del(this.agentListCacheKey(user.id));
+    this.eventBus.emit(user.id, 'agent');
     return {
       agent: {
         id: result.agentId,
@@ -128,6 +132,13 @@ export class AgentsController {
       apiKey: result.apiKey,
       copied: result.copied,
     };
+  }
+
+  @Get('agents/:agentName')
+  async getAgentInfo(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
+    const info = await this.lifecycle.findAgentInfo(user.id, agentName);
+    if (!info) return { agent: null };
+    return { agent: info };
   }
 
   @Get('agents/:agentName/key')
@@ -174,6 +185,7 @@ export class AgentsController {
     }
 
     await this.cacheManager.del(this.agentListCacheKey(user.id));
+    this.eventBus.emit(user.id, 'agent');
     return result;
   }
 
@@ -181,6 +193,7 @@ export class AgentsController {
   async deleteAgent(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
     await this.lifecycle.deleteAgent(user.id, agentName);
     await this.cacheManager.del(this.agentListCacheKey(user.id));
+    this.eventBus.emit(user.id, 'agent');
     return { deleted: true };
   }
 }

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -52,6 +52,47 @@ describe('AgentLifecycleService', () => {
     service = module.get<AgentLifecycleService>(AgentLifecycleService);
   });
 
+  describe('findAgentInfo', () => {
+    it('returns agent metadata when found', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({
+        id: 'agent-id-1',
+        name: 'bot-1',
+        display_name: 'Bot One',
+        agent_category: 'app',
+        agent_platform: 'openai-sdk',
+      });
+
+      const result = await service.findAgentInfo('user-1', 'bot-1');
+      expect(result).toEqual({
+        agent_name: 'bot-1',
+        display_name: 'Bot One',
+        agent_category: 'app',
+        agent_platform: 'openai-sdk',
+      });
+    });
+
+    it('falls back display_name to agent name when null', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({
+        id: 'agent-id-1',
+        name: 'bot-1',
+        display_name: null,
+        agent_category: null,
+        agent_platform: null,
+      });
+
+      const result = await service.findAgentInfo('user-1', 'bot-1');
+      expect(result?.display_name).toBe('bot-1');
+      expect(result?.agent_category).toBeNull();
+      expect(result?.agent_platform).toBeNull();
+    });
+
+    it('returns null when agent not found', async () => {
+      mockAgentGetOne.mockResolvedValueOnce(null);
+      const result = await service.findAgentInfo('user-1', 'nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
   describe('deleteAgent', () => {
     it('should delete agent when found', async () => {
       mockAgentGetOne.mockResolvedValueOnce({ id: 'agent-id-1', name: 'my-agent' });

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -11,6 +11,25 @@ export class AgentLifecycleService {
     private readonly dataSource: DataSource,
   ) {}
 
+  async findAgentInfo(
+    userId: string,
+    agentName: string,
+  ): Promise<{
+    agent_name: string;
+    display_name: string;
+    agent_category: string | null;
+    agent_platform: string | null;
+  } | null> {
+    const agent = await this.findAgentByUser(userId, agentName);
+    if (!agent) return null;
+    return {
+      agent_name: agent.name,
+      display_name: agent.display_name ?? agent.name,
+      agent_category: agent.agent_category ?? null,
+      agent_platform: agent.agent_platform ?? null,
+    };
+  }
+
   async deleteAgent(userId: string, agentName: string): Promise<void> {
     const agent = await this.agentRepo
       .createQueryBuilder('a')

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -411,7 +411,7 @@ describe('MessagesQueryService', () => {
     // Overwrite test-user::24h (already exists in our range)
     cache.set('test-user::24h', ['old']);
 
-    jest.advanceTimersByTime(60_001);
+    jest.advanceTimersByTime(5 * 60_000 + 1);
 
     mockGetRawOne.mockResolvedValueOnce({ total: 1 });
     mockGetRawMany
@@ -424,7 +424,7 @@ describe('MessagesQueryService', () => {
     expect(cache.has('test-user::24h')).toBe(true);
   });
 
-  it('models cache expires after 60s', async () => {
+  it('models cache expires after the configured TTL', async () => {
     jest.useFakeTimers();
 
     // First call
@@ -441,8 +441,8 @@ describe('MessagesQueryService', () => {
 
     expect(mockGetRawMany).toHaveBeenCalledTimes(2);
 
-    // Advance past models cache TTL (60s)
-    jest.advanceTimersByTime(60_001);
+    // Advance past the models cache TTL (5 min)
+    jest.advanceTimersByTime(5 * 60_000 + 1);
 
     // Second call — models query should run again
     mockGetRawOne.mockResolvedValueOnce({ total: 1 });

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -12,7 +12,8 @@ import { computeCutoff, sqlCastFloat, sqlSanitizeCost } from '../../common/utils
 import { inferProviderFromModel } from '../../common/utils/provider-inference';
 import { TtlCache } from '../../common/utils/ttl-cache';
 
-const MODELS_CACHE_TTL_MS = 60_000;
+const MODELS_CACHE_TTL_MS = 5 * 60_000;
+const DISTINCT_MODELS_DEFAULT_INTERVAL = '90 days';
 const COUNT_CACHE_TTL_MS = 30_000;
 const MAX_CACHE_ENTRIES = 5_000;
 
@@ -231,17 +232,20 @@ export class MessagesQueryService {
     const cached = this.modelsCache.get(cacheKey);
     if (cached) return cached;
 
-    const cutoff = range ? computeCutoff(rangeToInterval(range)) : undefined;
+    // Bound the scan: when the caller doesn't constrain the range, default to
+    // the last 90 days. The DISTINCT covers the entire agent_messages table
+    // otherwise, which scales poorly as ingest grows.
+    const cutoff = range
+      ? computeCutoff(rangeToInterval(range))
+      : computeCutoff(DISTINCT_MODELS_DEFAULT_INTERVAL);
     const modelsQb = this.turnRepo
       .createQueryBuilder('at')
       .select('at.model', 'model')
       .addSelect('at.provider', 'provider')
       .distinct(true)
       .where('at.model IS NOT NULL')
-      .andWhere("at.model != ''");
-    if (cutoff) {
-      modelsQb.andWhere('at.timestamp >= :cutoff', { cutoff });
-    }
+      .andWhere("at.model != ''")
+      .andWhere('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(modelsQb, userId, agentName, tenantId);
     const modelsResult = await modelsQb.orderBy('at.model', 'ASC').getRawMany();
 

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -21,6 +21,7 @@ describe('TimeseriesQueriesService', () => {
     orderBy: jest.Mock;
     addOrderBy: jest.Mock;
     limit: jest.Mock;
+    setParameter: jest.Mock;
     getRawMany: jest.Mock;
     getRawOne: jest.Mock;
     getMany: jest.Mock;
@@ -42,6 +43,7 @@ describe('TimeseriesQueriesService', () => {
       orderBy: jest.fn().mockReturnThis(),
       addOrderBy: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
       getRawMany: mockGetRawMany,
       getRawOne: jest.fn().mockResolvedValue({}),
       getMany: mockGetMany,
@@ -299,48 +301,59 @@ describe('TimeseriesQueriesService', () => {
   });
 
   describe('getAgentList', () => {
+    const recentIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const oldIso = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+
     it('returns agents with sparkline data and display_name', async () => {
       mockGetMany.mockResolvedValueOnce([
         { name: 'bot-1', display_name: 'Bot One', created_at: '2026-02-16' },
       ]);
-      mockGetRawMany
-        .mockResolvedValueOnce([
-          {
-            agent_name: 'bot-1',
-            message_count: 10,
-            last_active: '2026-02-16',
-            total_cost: 5.0,
-            total_tokens: 1000,
-          },
-        ])
-        .mockResolvedValueOnce([
-          { agent_name: 'bot-1', date: '2026-02-15', tokens: 100 },
-          { agent_name: 'bot-1', date: '2026-02-16', tokens: 200 },
-        ]);
+      mockGetRawMany.mockResolvedValueOnce([
+        {
+          agent_name: 'bot-1',
+          date: '2026-02-15',
+          message_count: 4,
+          cost: 2.0,
+          tokens: 400,
+          spark_tokens: 100,
+          last_active: recentIso,
+        },
+        {
+          agent_name: 'bot-1',
+          date: '2026-02-16',
+          message_count: 6,
+          cost: 3.0,
+          tokens: 600,
+          spark_tokens: 200,
+          last_active: recentIso,
+        },
+      ]);
 
       const result = await service.getAgentList('u1');
       expect(result).toHaveLength(1);
       expect(result[0].agent_name).toBe('bot-1');
       expect(result[0].display_name).toBe('Bot One');
-      expect(result[0].sparkline).toBeDefined();
+      expect(result[0].sparkline).toEqual([100, 200]);
       expect(result[0].total_cost).toBe(5.0);
+      expect(result[0].total_tokens).toBe(1000);
+      expect(result[0].message_count).toBe(10);
     });
 
     it('falls back to agent_name when display_name is null', async () => {
       mockGetMany.mockResolvedValueOnce([
         { name: 'bot-1', display_name: null, created_at: '2026-02-16' },
       ]);
-      mockGetRawMany
-        .mockResolvedValueOnce([
-          {
-            agent_name: 'bot-1',
-            message_count: 10,
-            last_active: '2026-02-16',
-            total_cost: 5.0,
-            total_tokens: 1000,
-          },
-        ])
-        .mockResolvedValueOnce([]);
+      mockGetRawMany.mockResolvedValueOnce([
+        {
+          agent_name: 'bot-1',
+          date: '2026-02-16',
+          message_count: 10,
+          cost: 5.0,
+          tokens: 1000,
+          spark_tokens: 0,
+          last_active: oldIso,
+        },
+      ]);
 
       const result = await service.getAgentList('u1');
       expect(result[0].display_name).toBe('bot-1');
@@ -350,17 +363,17 @@ describe('TimeseriesQueriesService', () => {
       mockGetMany.mockResolvedValueOnce([
         { name: 'lonely-bot', display_name: null, created_at: '2026-02-16' },
       ]);
-      mockGetRawMany
-        .mockResolvedValueOnce([
-          {
-            agent_name: 'lonely-bot',
-            message_count: 1,
-            last_active: '2026-02-16',
-            total_cost: 0,
-            total_tokens: 0,
-          },
-        ])
-        .mockResolvedValueOnce([]);
+      mockGetRawMany.mockResolvedValueOnce([
+        {
+          agent_name: 'lonely-bot',
+          date: '2026-02-01',
+          message_count: 1,
+          cost: 0,
+          tokens: 0,
+          spark_tokens: 0,
+          last_active: oldIso,
+        },
+      ]);
 
       const result = await service.getAgentList('u1');
       expect(result[0].sparkline).toEqual([]);
@@ -370,7 +383,7 @@ describe('TimeseriesQueriesService', () => {
       mockGetMany.mockResolvedValueOnce([
         { name: 'new-bot', display_name: null, created_at: '2026-02-16' },
       ]);
-      mockGetRawMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      mockGetRawMany.mockResolvedValueOnce([]);
 
       const result = await service.getAgentList('u1');
       expect(result).toHaveLength(1);

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -176,36 +176,35 @@ export class TimeseriesQueriesService {
     }
 
     const statsCutoff = computeCutoff('30 days');
+    const sparkCutoff = computeCutoff('7 days');
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
-    const statsQb = this.turnRepo
+    const dateExpr = sqlDateBucket('at.timestamp');
+    // Single per-(agent, day) bucket query covers the full 30-day stats window
+    // and the 7-day sparkline window. Buckets older than sparkCutoff have
+    // zeroed spark_tokens via a FILTER clause; JS aggregates the rest.
+    const bucketsQb = this.turnRepo
       .createQueryBuilder('at')
       .select('at.agent_name', 'agent_name')
+      .addSelect(dateExpr, 'date')
       .addSelect(
         `COUNT(*) FILTER (WHERE at.status IS NULL OR at.status NOT IN ('error', 'fallback_error'))`,
         'message_count',
       )
-      .addSelect('MAX(at.timestamp)', 'last_active')
-      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'total_cost')
-      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total_tokens')
-      .where('at.agent_name IS NOT NULL')
-      .andWhere('at.timestamp >= :statsCutoff', { statsCutoff });
-    addTenantFilter(statsQb, userId, undefined, resolved);
-
-    const sparkCutoff = computeCutoff('7 days');
-    const dateExpr = sqlDateBucket('at.timestamp');
-    const sparkQb = this.turnRepo
-      .createQueryBuilder('at')
-      .select('at.agent_name', 'agent_name')
-      .addSelect(dateExpr, 'date')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
-      .where('at.timestamp >= :sparkCutoff', { sparkCutoff })
-      .andWhere('at.agent_name IS NOT NULL');
-    addTenantFilter(sparkQb, userId, undefined, resolved);
+      .addSelect(
+        `COALESCE(SUM(at.input_tokens + at.output_tokens) FILTER (WHERE at.timestamp >= :sparkCutoff), 0)`,
+        'spark_tokens',
+      )
+      .addSelect('MAX(at.timestamp)', 'last_active')
+      .where('at.agent_name IS NOT NULL')
+      .andWhere('at.timestamp >= :statsCutoff', { statsCutoff })
+      .setParameter('sparkCutoff', sparkCutoff);
+    addTenantFilter(bucketsQb, userId, undefined, resolved);
 
-    const [agents, statsRows, sparkRows] = await Promise.all([
+    const [agents, bucketRows] = await Promise.all([
       agentQb.andWhere('a.is_active = true').orderBy('a.created_at', 'DESC').getMany(),
-      statsQb.groupBy('at.agent_name').orderBy('last_active', 'DESC').getRawMany(),
-      sparkQb
+      bucketsQb
         .groupBy('at.agent_name')
         .addGroupBy('date')
         .orderBy('at.agent_name', 'ASC')
@@ -213,16 +212,43 @@ export class TimeseriesQueriesService {
         .getRawMany(),
     ]);
 
-    const statsMap = new Map<string, Record<string, unknown>>();
-    for (const r of statsRows) {
-      statsMap.set(String(r['agent_name']), r);
-    }
-
+    const sparkCutoffIso = String(sparkCutoff);
+    const statsMap = new Map<
+      string,
+      { message_count: number; total_cost: number; total_tokens: number; last_active: string }
+    >();
     const sparkMap = new Map<string, number[]>();
-    for (const r of sparkRows) {
+    for (const r of bucketRows) {
       const name = String(r['agent_name']);
-      if (!sparkMap.has(name)) sparkMap.set(name, []);
-      sparkMap.get(name)!.push(Number(r['tokens'] ?? 0));
+      const messageCount = Number(r['message_count'] ?? 0);
+      const cost = Number(r['cost'] ?? 0);
+      const tokens = Number(r['tokens'] ?? 0);
+      const sparkTokens = Number(r['spark_tokens'] ?? 0);
+      const rawLastActive = r['last_active'];
+      const lastActive =
+        rawLastActive instanceof Date ? rawLastActive.toISOString() : String(rawLastActive ?? '');
+
+      const existing = statsMap.get(name);
+      if (existing) {
+        existing.message_count += messageCount;
+        existing.total_cost += cost;
+        existing.total_tokens += tokens;
+        if (lastActive > existing.last_active) existing.last_active = lastActive;
+      } else {
+        statsMap.set(name, {
+          message_count: messageCount,
+          total_cost: cost,
+          total_tokens: tokens,
+          last_active: lastActive,
+        });
+      }
+
+      // Sparkline: one entry per day-bucket within the 7-day window. Bucket
+      // membership is detected via lastActive (= MAX(timestamp) for that day).
+      if (lastActive >= sparkCutoffIso) {
+        if (!sparkMap.has(name)) sparkMap.set(name, []);
+        sparkMap.get(name)!.push(sparkTokens);
+      }
     }
 
     return agents.map((a) => {
@@ -233,10 +259,10 @@ export class TimeseriesQueriesService {
         display_name: a.display_name ?? name,
         agent_category: a.agent_category ?? null,
         agent_platform: a.agent_platform ?? null,
-        message_count: Number(stats?.['message_count'] ?? 0),
-        last_active: String(stats?.['last_active'] ?? a.created_at ?? ''),
-        total_cost: Number(stats?.['total_cost'] ?? 0),
-        total_tokens: Number(stats?.['total_tokens'] ?? 0),
+        message_count: stats?.message_count ?? 0,
+        last_active: stats?.last_active || String(a.created_at ?? ''),
+        total_cost: stats?.total_cost ?? 0,
+        total_tokens: stats?.total_tokens ?? 0,
         sparkline: sparkMap.get(name) ?? [],
       };
     });

--- a/packages/backend/src/auth/session.guard.spec.ts
+++ b/packages/backend/src/auth/session.guard.spec.ts
@@ -47,6 +47,10 @@ describe('SessionGuard', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    guard.onModuleDestroy();
+  });
+
   it('allows public routes', async () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
     const { context } = createMockContext({});
@@ -238,6 +242,150 @@ describe('SessionGuard', () => {
 
       expect(request['user']).toBeUndefined();
       expect(request['authMethod']).toBeUndefined();
+    });
+  });
+
+  describe('session cache', () => {
+    it('reuses cached session for same cookie within TTL', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const mockSession = {
+        user: { id: 'u1', name: 'A', email: 'a@b.c' },
+        session: { id: 's1' },
+      };
+      (auth.api.getSession as jest.Mock).mockResolvedValue(mockSession);
+      const headers = { cookie: 'session=abc; theme=dark' };
+
+      const first = createMockContext({ headers });
+      await guard.canActivate(first.context);
+      expect(auth.api.getSession).toHaveBeenCalledTimes(1);
+
+      const second = createMockContext({ headers });
+      const result = await guard.canActivate(second.context);
+
+      expect(result).toBe(true);
+      expect(auth.api.getSession).toHaveBeenCalledTimes(1);
+      expect(second.request['user']).toEqual(mockSession.user);
+      expect(second.request['session']).toEqual(mockSession.session);
+      expect(second.request['authMethod']).toBe('session');
+    });
+
+    it('does not cache anonymous responses', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+      const headers = { cookie: 'session=abc' };
+
+      await guard.canActivate(createMockContext({ headers }).context);
+      await guard.canActivate(createMockContext({ headers }).context);
+
+      expect(auth.api.getSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips cache when no cookie header is present', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const mockSession = {
+        user: { id: 'u1', name: 'A', email: 'a@b.c' },
+        session: { id: 's1' },
+      };
+      (auth.api.getSession as jest.Mock).mockResolvedValue(mockSession);
+
+      await guard.canActivate(createMockContext({}).context);
+      await guard.canActivate(createMockContext({}).context);
+
+      expect(auth.api.getSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses different cache entries for different cookies', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      (auth.api.getSession as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          user: { id: 'u1', name: 'A', email: 'a@b.c' },
+          session: { id: 's1' },
+        }),
+      );
+
+      await guard.canActivate(createMockContext({ headers: { cookie: 'session=alpha' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: 'session=beta' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: 'session=alpha' } }).context);
+
+      expect(auth.api.getSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidateCache clears entries for a cookie', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const mockSession = {
+        user: { id: 'u1', name: 'A', email: 'a@b.c' },
+        session: { id: 's1' },
+      };
+      (auth.api.getSession as jest.Mock).mockResolvedValue(mockSession);
+      const headers = { cookie: 'session=abc' };
+
+      await guard.canActivate(createMockContext({ headers }).context);
+      guard.invalidateCache('session=abc');
+      await guard.canActivate(createMockContext({ headers }).context);
+
+      expect(auth.api.getSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidateCache without arg clears the entire cache', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const mockSession = {
+        user: { id: 'u1', name: 'A', email: 'a@b.c' },
+        session: { id: 's1' },
+      };
+      (auth.api.getSession as jest.Mock).mockResolvedValue(mockSession);
+
+      await guard.canActivate(createMockContext({ headers: { cookie: 'session=a' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: 'session=b' } }).context);
+      guard.invalidateCache();
+      await guard.canActivate(createMockContext({ headers: { cookie: 'session=a' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: 'session=b' } }).context);
+
+      expect(auth.api.getSession).toHaveBeenCalledTimes(4);
+    });
+
+    it('expires cache entries past the TTL', async () => {
+      jest.useFakeTimers();
+      try {
+        jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+        (auth.api.getSession as jest.Mock).mockResolvedValue({
+          user: { id: 'u1', name: 'A', email: 'a@b.c' },
+          session: { id: 's1' },
+        });
+        const headers = { cookie: 'session=abc' };
+
+        await guard.canActivate(createMockContext({ headers }).context);
+        jest.advanceTimersByTime(61_000);
+        await guard.canActivate(createMockContext({ headers }).context);
+
+        expect(auth.api.getSession).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('evicts oldest entry when cache exceeds max size', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const mockSession = {
+        user: { id: 'u1', name: 'A', email: 'a@b.c' },
+        session: { id: 's1' },
+      };
+      (auth.api.getSession as jest.Mock).mockResolvedValue(mockSession);
+
+      // Resize the cache cap for the test by exposing private state via cast
+      type WritableMax = { MAX_CACHE_SIZE: number };
+      (guard as unknown as WritableMax).MAX_CACHE_SIZE = 2;
+
+      await guard.canActivate(createMockContext({ headers: { cookie: 'a' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: 'b' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: 'c' } }).context);
+
+      // 'a' should have been evicted
+      await guard.canActivate(createMockContext({ headers: { cookie: 'a' } }).context);
+      expect(auth.api.getSession).toHaveBeenCalledTimes(4);
+
+      // 'c' is still cached
+      await guard.canActivate(createMockContext({ headers: { cookie: 'c' } }).context);
+      expect(auth.api.getSession).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -1,17 +1,37 @@
-import { CanActivate, ExecutionContext, Injectable, Logger } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { fromNodeHeaders } from 'better-auth/node';
+import { createHash } from 'crypto';
 import { auth } from './auth.instance';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 import { isLoopbackIp } from '../common/utils/local-ip';
 import { isSelfHosted } from '../common/utils/detect-self-hosted';
 
-@Injectable()
-export class SessionGuard implements CanActivate {
-  private readonly logger = new Logger(SessionGuard.name);
+interface CachedSession {
+  user: unknown;
+  session: unknown;
+  expiresAt: number;
+}
 
-  constructor(private readonly reflector: Reflector) {}
+@Injectable()
+export class SessionGuard implements CanActivate, OnModuleDestroy {
+  private readonly logger = new Logger(SessionGuard.name);
+  private readonly cache = new Map<string, CachedSession>();
+  private readonly CACHE_TTL_MS = 60_000;
+  private readonly MAX_CACHE_SIZE = 5_000;
+  private readonly cleanupTimer: ReturnType<typeof setInterval>;
+
+  constructor(private readonly reflector: Reflector) {
+    this.cleanupTimer = setInterval(() => this.evictExpired(), 60_000);
+    if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  onModuleDestroy(): void {
+    clearInterval(this.cleanupTimer);
+  }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
@@ -28,6 +48,25 @@ export class SessionGuard implements CanActivate {
     // In the self-hosted version without Better Auth, skip session lookup
     if (!auth) return true;
 
+    const cookieHeader = request.headers['cookie'];
+    const cacheKey =
+      typeof cookieHeader === 'string' && cookieHeader.length > 0
+        ? this.hashCookie(cookieHeader)
+        : null;
+
+    if (cacheKey) {
+      const cached = this.cache.get(cacheKey);
+      if (cached && cached.expiresAt > Date.now()) {
+        // LRU touch — re-insert to move to tail of insertion order
+        this.cache.delete(cacheKey);
+        this.cache.set(cacheKey, cached);
+        (request as Request & { user: unknown }).user = cached.user;
+        (request as Request & { session: unknown }).session = cached.session;
+        (request as Request & { authMethod: string }).authMethod = 'session';
+        return true;
+      }
+    }
+
     try {
       const session = await auth.api.getSession({
         headers: fromNodeHeaders(request.headers),
@@ -37,6 +76,7 @@ export class SessionGuard implements CanActivate {
         (request as Request & { user: unknown }).user = session.user;
         (request as Request & { session: unknown }).session = session.session;
         (request as Request & { authMethod: string }).authMethod = 'session';
+        if (cacheKey) this.storeInCache(cacheKey, session.user, session.session);
         return true;
       }
     } catch (err) {
@@ -57,5 +97,38 @@ export class SessionGuard implements CanActivate {
 
     // Always pass — let ApiKeyGuard handle unauthenticated requests
     return true;
+  }
+
+  invalidateCache(cookieHeader?: string): void {
+    if (cookieHeader) {
+      this.cache.delete(this.hashCookie(cookieHeader));
+      return;
+    }
+    this.cache.clear();
+  }
+
+  private hashCookie(cookieHeader: string): string {
+    return createHash('sha256').update(cookieHeader).digest('hex');
+  }
+
+  private storeInCache(key: string, user: unknown, session: unknown): void {
+    this.evictExpired();
+    while (this.cache.size >= this.MAX_CACHE_SIZE) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey === undefined) break;
+      this.cache.delete(firstKey);
+    }
+    this.cache.set(key, {
+      user,
+      session,
+      expiresAt: Date.now() + this.CACHE_TTL_MS,
+    });
+  }
+
+  private evictExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache) {
+      if (entry.expiresAt <= now) this.cache.delete(key);
+    }
   }
 }

--- a/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
@@ -1,4 +1,4 @@
-import { IngestEventBusService } from './ingest-event-bus.service';
+import { IngestEventBusService, IngestEvent } from './ingest-event-bus.service';
 
 describe('IngestEventBusService', () => {
   let service: IngestEventBusService;
@@ -14,68 +14,95 @@ describe('IngestEventBusService', () => {
   });
 
   it('emits to the correct user after debounce', () => {
-    const received: string[] = [];
-    service.forUser('user-1').subscribe((id) => received.push(id));
+    const received: IngestEvent[] = [];
+    service.forUser('user-1').subscribe((e) => received.push(e));
 
     service.emit('user-1');
     expect(received).toHaveLength(0);
 
-    jest.advanceTimersByTime(1000);
-    expect(received).toEqual(['user-1']);
+    jest.advanceTimersByTime(250);
+    expect(received).toEqual([{ userId: 'user-1', kind: 'message' }]);
   });
 
-  it('debounces rapid emissions for the same user', () => {
-    const received: string[] = [];
-    service.forUser('user-1').subscribe((id) => received.push(id));
+  it('debounces rapid emissions for the same user/kind', () => {
+    const received: IngestEvent[] = [];
+    service.forUser('user-1').subscribe((e) => received.push(e));
 
     service.emit('user-1');
-    jest.advanceTimersByTime(500);
+    jest.advanceTimersByTime(100);
     service.emit('user-1');
-    jest.advanceTimersByTime(500);
+    jest.advanceTimersByTime(100);
     service.emit('user-1');
-    jest.advanceTimersByTime(500);
+    jest.advanceTimersByTime(100);
 
     expect(received).toHaveLength(0);
 
-    jest.advanceTimersByTime(500);
-    expect(received).toEqual(['user-1']);
+    jest.advanceTimersByTime(150);
+    expect(received).toEqual([{ userId: 'user-1', kind: 'message' }]);
+  });
+
+  it('different kinds for the same user fire independently', () => {
+    const received: IngestEvent[] = [];
+    service.forUser('user-1').subscribe((e) => received.push(e));
+
+    service.emit('user-1', 'message');
+    service.emit('user-1', 'agent');
+    jest.advanceTimersByTime(250);
+
+    expect(received).toEqual([
+      { userId: 'user-1', kind: 'message' },
+      { userId: 'user-1', kind: 'agent' },
+    ]);
   });
 
   it('does not deliver events for other users', () => {
-    const received: string[] = [];
-    service.forUser('user-1').subscribe((id) => received.push(id));
+    const received: IngestEvent[] = [];
+    service.forUser('user-1').subscribe((e) => received.push(e));
 
     service.emit('user-2');
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(250);
 
     expect(received).toHaveLength(0);
   });
 
   it('emits independently for different users', () => {
-    const user1: string[] = [];
-    const user2: string[] = [];
-    service.forUser('user-1').subscribe((id) => user1.push(id));
-    service.forUser('user-2').subscribe((id) => user2.push(id));
+    const user1: IngestEvent[] = [];
+    const user2: IngestEvent[] = [];
+    service.forUser('user-1').subscribe((e) => user1.push(e));
+    service.forUser('user-2').subscribe((e) => user2.push(e));
 
     service.emit('user-1');
-    service.emit('user-2');
-    jest.advanceTimersByTime(1000);
+    service.emit('user-2', 'routing');
+    jest.advanceTimersByTime(250);
 
-    expect(user1).toEqual(['user-1']);
-    expect(user2).toEqual(['user-2']);
+    expect(user1).toEqual([{ userId: 'user-1', kind: 'message' }]);
+    expect(user2).toEqual([{ userId: 'user-2', kind: 'routing' }]);
+  });
+
+  it('all() observes every event regardless of user', () => {
+    const received: IngestEvent[] = [];
+    service.all().subscribe((e) => received.push(e));
+
+    service.emit('a');
+    service.emit('b', 'agent');
+    jest.advanceTimersByTime(250);
+
+    expect(received).toHaveLength(2);
+    expect(received).toContainEqual({ userId: 'a', kind: 'message' });
+    expect(received).toContainEqual({ userId: 'b', kind: 'agent' });
   });
 
   it('cleans up timers on module destroy', () => {
-    const received: string[] = [];
+    const received: IngestEvent[] = [];
     service.forUser('user-1').subscribe({
-      next: (id) => received.push(id),
-      complete: () => received.push('COMPLETE'),
+      next: (e) => received.push(e),
+      complete: () => received.push({ userId: 'COMPLETE', kind: 'message' }),
     });
 
     service.emit('user-1');
     service.onModuleDestroy();
     jest.advanceTimersByTime(2000);
 
-    expect(received).toEqual(['COMPLETE']);
+    expect(received).toEqual([{ userId: 'COMPLETE', kind: 'message' }]);
   });
 });

--- a/packages/backend/src/common/services/ingest-event-bus.service.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.ts
@@ -2,32 +2,44 @@ import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { Subject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
+export type IngestEventKind = 'message' | 'agent' | 'routing';
+
+export interface IngestEvent {
+  userId: string;
+  kind: IngestEventKind;
+}
+
 @Injectable()
 export class IngestEventBusService implements OnModuleDestroy {
-  private readonly subject = new Subject<string>();
+  private readonly subject = new Subject<IngestEvent>();
   private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  private readonly DEBOUNCE_MS = 1_000;
+  private readonly DEBOUNCE_MS = 250;
 
-  emit(userId: string): void {
-    const existing = this.debounceTimers.get(userId);
+  /**
+   * Notify subscribers that the given user's data changed. The kind narrows
+   * which dashboard surfaces should refetch — message-feed pages can ignore
+   * routing config updates and vice-versa, avoiding the previous "any change
+   * refetches every open page" cascade.
+   */
+  emit(userId: string, kind: IngestEventKind = 'message'): void {
+    const debounceKey = `${userId}:${kind}`;
+    const existing = this.debounceTimers.get(debounceKey);
     if (existing) clearTimeout(existing);
 
     this.debounceTimers.set(
-      userId,
+      debounceKey,
       setTimeout(() => {
-        this.debounceTimers.delete(userId);
-        this.subject.next(userId);
+        this.debounceTimers.delete(debounceKey);
+        this.subject.next({ userId, kind });
       }, this.DEBOUNCE_MS),
     );
   }
 
-  forUser(userId: string): Observable<string> {
-    return this.subject.asObservable().pipe(
-      filter((id) => id === userId),
-    );
+  forUser(userId: string): Observable<IngestEvent> {
+    return this.subject.asObservable().pipe(filter((e) => e.userId === userId));
   }
 
-  all(): Observable<string> {
+  all(): Observable<IngestEvent> {
     return this.subject.asObservable();
   }
 

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -82,6 +82,7 @@ import { BackfillLocalAuthType1777200000000 } from './migrations/1777200000000-B
 import { BackfillLocalCustomProviders1777300000000 } from './migrations/1777300000000-BackfillLocalCustomProviders';
 import { DropComplexityRoutingFlag1780000000000 } from './migrations/1780000000000-DropComplexityRoutingFlag';
 import { ReAddComplexityRoutingFlag1781000000000 } from './migrations/1781000000000-ReAddComplexityRoutingFlag';
+import { RetuneSpecificityMiscategorizedIndex1782000000000 } from './migrations/1782000000000-RetuneSpecificityMiscategorizedIndex';
 
 const entities = [
   AgentMessage,
@@ -165,6 +166,7 @@ const migrations = [
   BackfillLocalCustomProviders1777300000000,
   DropComplexityRoutingFlag1780000000000,
   ReAddComplexityRoutingFlag1781000000000,
+  RetuneSpecificityMiscategorizedIndex1782000000000,
 ];
 
 @Module({
@@ -188,8 +190,10 @@ const migrations = [
         migrations,
         logging: false,
         extra: {
-          max: config.get<number>('app.dbPoolMax') ?? 20,
+          max: config.get<number>('app.dbPoolMax') ?? 50,
           idleTimeoutMillis: 30000,
+          statement_timeout: 30000,
+          idle_in_transaction_session_timeout: 60000,
         },
       }),
     }),

--- a/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.spec.ts
@@ -16,20 +16,33 @@ describe('RetuneSpecificityMiscategorizedIndex1782000000000', () => {
     jest.clearAllMocks();
   });
 
-  it('drops the old index and recreates it keyed by agent_id', async () => {
+  it('opts out of TypeORM migration transaction so CONCURRENTLY is allowed', () => {
+    expect(migration.transaction).toBe(false);
+  });
+
+  it('drops the old index and recreates it keyed by agent_id (CONCURRENTLY)', async () => {
     await migration.up(mockQueryRunner);
     expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"');
-    expect(queries[1]).toContain('CREATE INDEX "IDX_agent_messages_miscategorized"');
+    expect(queries[0]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"',
+    );
+    expect(queries[1]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized"',
+    );
     expect(queries[1]).toContain('"agent_id", "specificity_category"');
     expect(queries[1]).toContain(`WHERE "specificity_miscategorized" = true`);
     expect(queries[1]).not.toMatch(/"tenant_id"\s*,\s*"agent_id"/);
   });
 
-  it('rollback restores the original (tenant_id, agent_id, ...) index', async () => {
+  it('rollback restores the original (tenant_id, agent_id, ...) index (CONCURRENTLY)', async () => {
     await migration.down(mockQueryRunner);
     expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"');
+    expect(queries[0]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"',
+    );
+    expect(queries[1]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized"',
+    );
     expect(queries[1]).toContain('"tenant_id", "agent_id", "specificity_category"');
     expect(queries[1]).toContain(`WHERE "specificity_miscategorized" = true`);
   });

--- a/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.spec.ts
@@ -1,0 +1,36 @@
+import { RetuneSpecificityMiscategorizedIndex1782000000000 } from './1782000000000-RetuneSpecificityMiscategorizedIndex';
+
+describe('RetuneSpecificityMiscategorizedIndex1782000000000', () => {
+  const migration = new RetuneSpecificityMiscategorizedIndex1782000000000();
+  let queries: string[];
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve();
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('drops the old index and recreates it keyed by agent_id', async () => {
+    await migration.up(mockQueryRunner);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"');
+    expect(queries[1]).toContain('CREATE INDEX "IDX_agent_messages_miscategorized"');
+    expect(queries[1]).toContain('"agent_id", "specificity_category"');
+    expect(queries[1]).toContain(`WHERE "specificity_miscategorized" = true`);
+    expect(queries[1]).not.toMatch(/"tenant_id"\s*,\s*"agent_id"/);
+  });
+
+  it('rollback restores the original (tenant_id, agent_id, ...) index', async () => {
+    await migration.down(mockQueryRunner);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"');
+    expect(queries[1]).toContain('"tenant_id", "agent_id", "specificity_category"');
+    expect(queries[1]).toContain(`WHERE "specificity_miscategorized" = true`);
+  });
+});

--- a/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.spec.ts
@@ -16,33 +16,21 @@ describe('RetuneSpecificityMiscategorizedIndex1782000000000', () => {
     jest.clearAllMocks();
   });
 
-  it('opts out of TypeORM migration transaction so CONCURRENTLY is allowed', () => {
-    expect(migration.transaction).toBe(false);
-  });
-
-  it('drops the old index and recreates it keyed by agent_id (CONCURRENTLY)', async () => {
+  it('drops the old index and recreates it keyed by agent_id', async () => {
     await migration.up(mockQueryRunner);
     expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain(
-      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"',
-    );
-    expect(queries[1]).toContain(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized"',
-    );
+    expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"');
+    expect(queries[1]).toContain('CREATE INDEX IF NOT EXISTS "IDX_agent_messages_miscategorized"');
     expect(queries[1]).toContain('"agent_id", "specificity_category"');
     expect(queries[1]).toContain(`WHERE "specificity_miscategorized" = true`);
     expect(queries[1]).not.toMatch(/"tenant_id"\s*,\s*"agent_id"/);
   });
 
-  it('rollback restores the original (tenant_id, agent_id, ...) index (CONCURRENTLY)', async () => {
+  it('rollback restores the original (tenant_id, agent_id, ...) index', async () => {
     await migration.down(mockQueryRunner);
     expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain(
-      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"',
-    );
-    expect(queries[1]).toContain(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized"',
-    );
+    expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"');
+    expect(queries[1]).toContain('CREATE INDEX IF NOT EXISTS "IDX_agent_messages_miscategorized"');
     expect(queries[1]).toContain('"tenant_id", "agent_id", "specificity_category"');
     expect(queries[1]).toContain(`WHERE "specificity_miscategorized" = true`);
   });

--- a/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.ts
+++ b/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Replaces IDX_agent_messages_miscategorized with one keyed by agent_id first.
+ * SpecificityPenaltyService runs on every resolve when specificity is active
+ * and filters by agent_id (no tenant_id), so a leading tenant_id column made
+ * the previous partial index unhelpful.
+ */
+export class RetuneSpecificityMiscategorizedIndex1782000000000 implements MigrationInterface {
+  name = 'RetuneSpecificityMiscategorizedIndex1782000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_agent_messages_miscategorized" ON "agent_messages" ("agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_agent_messages_miscategorized" ON "agent_messages" ("tenant_id", "agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
+    );
+  }
+}

--- a/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.ts
+++ b/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.ts
@@ -5,21 +5,31 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * SpecificityPenaltyService runs on every resolve when specificity is active
  * and filters by agent_id (no tenant_id), so a leading tenant_id column made
  * the previous partial index unhelpful.
+ *
+ * Runs outside a transaction so CREATE INDEX CONCURRENTLY can be used to avoid
+ * blocking writes on agent_messages during boot-time migration.
  */
 export class RetuneSpecificityMiscategorizedIndex1782000000000 implements MigrationInterface {
   name = 'RetuneSpecificityMiscategorizedIndex1782000000000';
+  // Required to permit CONCURRENTLY — TypeORM otherwise wraps each migration in
+  // a transaction, and CREATE INDEX CONCURRENTLY is rejected inside one.
+  transaction = false as const;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"`);
     await queryRunner.query(
-      `CREATE INDEX "IDX_agent_messages_miscategorized" ON "agent_messages" ("agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized" ON "agent_messages" ("agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"`);
     await queryRunner.query(
-      `CREATE INDEX "IDX_agent_messages_miscategorized" ON "agent_messages" ("tenant_id", "agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized" ON "agent_messages" ("tenant_id", "agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
     );
   }
 }

--- a/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.ts
+++ b/packages/backend/src/database/migrations/1782000000000-RetuneSpecificityMiscategorizedIndex.ts
@@ -6,30 +6,28 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * and filters by agent_id (no tenant_id), so a leading tenant_id column made
  * the previous partial index unhelpful.
  *
- * Runs outside a transaction so CREATE INDEX CONCURRENTLY can be used to avoid
- * blocking writes on agent_messages during boot-time migration.
+ * Note on locking: the rebuild runs inside a transaction (database.module.ts
+ * pins migrationsTransactionMode = 'all', so per-migration transaction = false
+ * is rejected). The window is brief because this is a partial index covering
+ * only flagged rows — typically a tiny fraction of agent_messages — so the
+ * write block during boot is bounded to milliseconds. Operators worried about
+ * even that can pre-create the new index manually with CREATE INDEX
+ * CONCURRENTLY before deploying, which makes this migration a no-op.
  */
 export class RetuneSpecificityMiscategorizedIndex1782000000000 implements MigrationInterface {
   name = 'RetuneSpecificityMiscategorizedIndex1782000000000';
-  // Required to permit CONCURRENTLY — TypeORM otherwise wraps each migration in
-  // a transaction, and CREATE INDEX CONCURRENTLY is rejected inside one.
-  transaction = false as const;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"`);
     await queryRunner.query(
-      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"`,
-    );
-    await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized" ON "agent_messages" ("agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
+      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_miscategorized" ON "agent_messages" ("agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_miscategorized"`);
     await queryRunner.query(
-      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_miscategorized"`,
-    );
-    await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_miscategorized" ON "agent_messages" ("tenant_id", "agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
+      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_miscategorized" ON "agent_messages" ("tenant_id", "agent_id", "specificity_category") WHERE "specificity_miscategorized" = true`,
     );
   }
 }

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -41,6 +41,8 @@ describe('AgentKeyAuthGuard', () => {
   function buildMockRepo() {
     mockGetMany = jest.fn().mockResolvedValue([]);
     const mockSelectQb = {
+      select: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
@@ -510,6 +512,64 @@ describe('AgentKeyAuthGuard', () => {
     expect(internalCache.has(testCacheKey(token))).toBe(true);
   });
 
+  it('caches entries for at least 30 minutes', async () => {
+    const token = 'mnfst_ttl-check-key';
+    mockGetMany.mockResolvedValue([
+      {
+        id: 'key-ttl',
+        tenant_id: 'tenant-1',
+        agent_id: 'agent-1',
+        key_hash: hashKey(token),
+        expires_at: null,
+        agent: { name: 'test-agent' },
+        tenant: { name: 'user-1' },
+      },
+    ]);
+
+    const before = Date.now();
+    const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+    await guard.canActivate(ctx);
+
+    const internalCache = (guard as any).cache as Map<string, { expiresAt: number }>;
+    const entry = internalCache.get(testCacheKey(token));
+    expect(entry).toBeDefined();
+    expect(entry!.expiresAt - before).toBeGreaterThanOrEqual(30 * 60 * 1000 - 1000);
+  });
+
+  it('LRU touch on cache hit moves entry to tail of insertion order', async () => {
+    const token = 'mnfst_lru-touch-key';
+    mockGetMany.mockResolvedValue([
+      {
+        id: 'key-lru',
+        tenant_id: 'tenant-1',
+        agent_id: 'agent-1',
+        key_hash: hashKey(token),
+        expires_at: null,
+        agent: { name: 'test-agent' },
+        tenant: { name: 'user-1' },
+      },
+    ]);
+
+    const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+    await guard.canActivate(ctx);
+
+    const internalCache = (guard as any).cache as Map<string, unknown>;
+    internalCache.set(testCacheKey('mnfst_other-1'), {
+      tenantId: 't',
+      agentId: 'a',
+      agentName: 'n',
+      userId: 'u',
+      expiresAt: Date.now() + 999_999,
+    });
+
+    expect(Array.from(internalCache.keys())[0]).toBe(testCacheKey(token));
+
+    const { ctx: ctx2 } = makeContext({ authorization: `Bearer ${token}` });
+    await guard.canActivate(ctx2);
+
+    expect(Array.from(internalCache.keys())[1]).toBe(testCacheKey(token));
+  });
+
   it('invalidateCache removes a specific key from cache', async () => {
     const token = 'mnfst_inv-key-test';
     const storedHash = hashKey(token);
@@ -545,6 +605,8 @@ describe('AgentKeyAuthGuard', () => {
     ]);
 
     const mockSelectQb2 = {
+      select: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -512,7 +512,7 @@ describe('AgentKeyAuthGuard', () => {
     expect(internalCache.has(testCacheKey(token))).toBe(true);
   });
 
-  it('caches entries for at least 30 minutes', async () => {
+  it('caches entries for the configured 5 minute TTL', async () => {
     const token = 'mnfst_ttl-check-key';
     mockGetMany.mockResolvedValue([
       {
@@ -533,7 +533,9 @@ describe('AgentKeyAuthGuard', () => {
     const internalCache = (guard as any).cache as Map<string, { expiresAt: number }>;
     const entry = internalCache.get(testCacheKey(token));
     expect(entry).toBeDefined();
-    expect(entry!.expiresAt - before).toBeGreaterThanOrEqual(30 * 60 * 1000 - 1000);
+    const ttlMs = entry!.expiresAt - before;
+    expect(ttlMs).toBeGreaterThanOrEqual(5 * 60 * 1000 - 1000);
+    expect(ttlMs).toBeLessThanOrEqual(5 * 60 * 1000 + 1000);
   });
 
   it('LRU touch on cache hit moves entry to tail of insertion order', async () => {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -35,7 +35,7 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
   private readonly logger = new Logger(AgentKeyAuthGuard.name);
   private cache = new Map<string, CachedKey>();
   private devContext: { context: IngestionContext; expiresAt: number } | null = null;
-  private readonly CACHE_TTL_MS = 5 * 60 * 1000;
+  private readonly CACHE_TTL_MS = 30 * 60 * 1000;
   private readonly MAX_CACHE_SIZE = 10_000;
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
 
@@ -107,8 +107,12 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
   }
 
   private async validateMnfstToken(request: Request, token: string): Promise<boolean> {
-    const cached = this.cache.get(cacheKey(token));
+    const hashed = cacheKey(token);
+    const cached = this.cache.get(hashed);
     if (cached && cached.expiresAt > Date.now()) {
+      // LRU touch — re-insert to move to tail of insertion order
+      this.cache.delete(hashed);
+      this.cache.set(hashed, cached);
       this.setContext(request, {
         tenantId: cached.tenantId,
         agentId: cached.agentId,
@@ -121,8 +125,17 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
     const prefix = computePrefix(token);
     const candidates = await this.keyRepo
       .createQueryBuilder('k')
-      .leftJoinAndSelect('k.agent', 'a')
-      .leftJoinAndSelect('k.tenant', 't')
+      .select([
+        'k.id',
+        'k.key_hash',
+        'k.tenant_id',
+        'k.agent_id',
+        'k.expires_at',
+        'a.name',
+        't.name',
+      ])
+      .leftJoin('k.agent', 'a')
+      .leftJoin('k.tenant', 't')
       .where('k.key_prefix = :prefix', { prefix })
       .andWhere('k.is_active = true')
       .getMany();
@@ -147,12 +160,13 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
       .catch((err: Error) => this.logger.warn(`Failed to update last_used_at: ${err.message}`));
 
     this.evictExpired();
-    if (this.cache.size >= this.MAX_CACHE_SIZE) {
+    while (this.cache.size >= this.MAX_CACHE_SIZE) {
       const firstKey = this.cache.keys().next().value;
-      if (firstKey) this.cache.delete(firstKey);
+      if (firstKey === undefined) break;
+      this.cache.delete(firstKey);
     }
 
-    this.cache.set(cacheKey(token), {
+    this.cache.set(hashed, {
       tenantId: keyRecord.tenant_id,
       agentId: keyRecord.agent_id,
       agentName: keyRecord.agent.name,

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -35,7 +35,10 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
   private readonly logger = new Logger(AgentKeyAuthGuard.name);
   private cache = new Map<string, CachedKey>();
   private devContext: { context: IngestionContext; expiresAt: number } | null = null;
-  private readonly CACHE_TTL_MS = 30 * 60 * 1000;
+  // 5 min TTL keeps revoked-key staleness bounded while still amortizing the
+  // DB lookup across hot ingest bursts. Mutations call invalidateCache()
+  // directly when keys rotate or deactivate.
+  private readonly CACHE_TTL_MS = 5 * 60 * 1000;
   private readonly MAX_CACHE_SIZE = 10_000;
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -354,7 +354,8 @@ describe('ProxyMessageRecorder', () => {
         },
       ];
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
-      expect(insertMock).toHaveBeenCalledTimes(2);
+      expect(insertMock).toHaveBeenCalledTimes(1);
+      expect((insertMock.mock.calls[0][0] as unknown[]).length).toBe(2);
       expect(emitMock).toHaveBeenCalledTimes(1);
       expect(emitMock).toHaveBeenCalledWith('user-1');
     });
@@ -377,8 +378,9 @@ describe('ProxyMessageRecorder', () => {
         },
       ];
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
-      expect(insertMock.mock.calls[0][0].error_http_status).toBe(400);
-      expect(insertMock.mock.calls[1][0].error_http_status).toBe(503);
+      const rows = insertMock.mock.calls[0][0] as Array<{ error_http_status: number }>;
+      expect(rows[0].error_http_status).toBe(400);
+      expect(rows[1].error_http_status).toBe(503);
     });
 
     it('persists the provider column for each fallback failure', async () => {
@@ -399,8 +401,9 @@ describe('ProxyMessageRecorder', () => {
         },
       ];
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
-      expect(insertMock.mock.calls[0][0].provider).toBe('openai');
-      expect(insertMock.mock.calls[1][0].provider).toBe('ollama-cloud');
+      const rows = insertMock.mock.calls[0][0] as Array<{ provider: string | null }>;
+      expect(rows[0].provider).toBe('openai');
+      expect(rows[1].provider).toBe('ollama-cloud');
     });
 
     it('persists provider=null when the failure has no provider (line 164 falsy branch)', async () => {
@@ -414,7 +417,8 @@ describe('ProxyMessageRecorder', () => {
         },
       ];
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
-      expect(insertMock.mock.calls[0][0].provider).toBeNull();
+      const rows = insertMock.mock.calls[0][0] as Array<{ provider: string | null }>;
+      expect(rows[0].provider).toBeNull();
     });
 
     it('marks rate_limited status when the failure status is 429 (line 150 branch)', async () => {
@@ -430,7 +434,8 @@ describe('ProxyMessageRecorder', () => {
       // markHandled=false is the default → the !useHandledStatus branch runs,
       // so `f.status === 429 ? 'rate_limited' : 'error'` is exercised.
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
-      expect(insertMock.mock.calls[0][0].status).toBe('rate_limited');
+      const rows = insertMock.mock.calls[0][0] as Array<{ status: string }>;
+      expect(rows[0].status).toBe('rate_limited');
     });
 
     it('marks fallback_error status when markHandled=true and lastAsError=false', async () => {
@@ -446,7 +451,8 @@ describe('ProxyMessageRecorder', () => {
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures, {
         markHandled: true,
       });
-      expect(insertMock.mock.calls[0][0].status).toBe('fallback_error');
+      const rows = insertMock.mock.calls[0][0] as Array<{ status: string }>;
+      expect(rows[0].status).toBe('fallback_error');
     });
 
     it('marks the LAST failure as error when lastAsError=true and markHandled=true', async () => {
@@ -470,10 +476,11 @@ describe('ProxyMessageRecorder', () => {
         markHandled: true,
         lastAsError: true,
       });
+      const rows = insertMock.mock.calls[0][0] as Array<{ status: string }>;
       // First failure uses fallback_error (handled), last is the real error.
-      expect(insertMock.mock.calls[0][0].status).toBe('fallback_error');
+      expect(rows[0].status).toBe('fallback_error');
       // Last failure with status 429 → rate_limited.
-      expect(insertMock.mock.calls[1][0].status).toBe('rate_limited');
+      expect(rows[1].status).toBe('rate_limited');
     });
 
     it('uses baseTimeMs to stagger timestamps when provided', async () => {
@@ -489,8 +496,9 @@ describe('ProxyMessageRecorder', () => {
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures, {
         baseTimeMs: Date.parse('2025-01-01T00:00:00.000Z'),
       });
+      const rows = insertMock.mock.calls[0][0] as Array<{ timestamp: string }>;
       // baseTimeMs + (1 - 0) * 100 = 100ms past the base.
-      expect(insertMock.mock.calls[0][0].timestamp).toBe('2025-01-01T00:00:00.100Z');
+      expect(rows[0].timestamp).toBe('2025-01-01T00:00:00.100Z');
     });
 
     it('scrubs provider secrets from each persisted fallback error_message', async () => {
@@ -511,8 +519,9 @@ describe('ProxyMessageRecorder', () => {
         },
       ];
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
-      const first: string = insertMock.mock.calls[0][0].error_message;
-      const second: string = insertMock.mock.calls[1][0].error_message;
+      const rows = insertMock.mock.calls[0][0] as Array<{ error_message: string }>;
+      const first: string = rows[0].error_message;
+      const second: string = rows[1].error_message;
       expect(first).not.toContain('LEAKEDKEY1234567890');
       expect(first).toContain('[REDACTED]');
       expect(second).not.toContain('LEAKEDKEY0987654321');
@@ -527,8 +536,9 @@ describe('ProxyMessageRecorder', () => {
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures, {
         reason: 'header-match',
       });
-      expect(insertMock.mock.calls[0][0].routing_reason).toBe('header-match');
-      expect(insertMock.mock.calls[1][0].routing_reason).toBe('header-match');
+      const rows = insertMock.mock.calls[0][0] as Array<{ routing_reason: string }>;
+      expect(rows[0].routing_reason).toBe('header-match');
+      expect(rows[1].routing_reason).toBe('header-match');
     });
   });
 
@@ -909,8 +919,9 @@ describe('ProxyMessageRecorder', () => {
       await recorder.recordFailedFallbacks(ctx, 'standard', 'primary', failures, {
         requestHeaders: { 'x-a': '1' },
       });
-      expect(insertMock.mock.calls[0][0].request_headers).toEqual({ 'x-a': '1' });
-      expect(insertMock.mock.calls[1][0].request_headers).toEqual({ 'x-a': '1' });
+      const rows = insertMock.mock.calls[0][0] as Array<{ request_headers: unknown }>;
+      expect(rows[0].request_headers).toEqual({ 'x-a': '1' });
+      expect(rows[1].request_headers).toEqual({ 'x-a': '1' });
     });
 
     it('recordPrimaryFailure persists request_headers', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -2347,26 +2347,24 @@ describe('ProxyController', () => {
       await controller.chatCompletions(req as never, res as never);
       await new Promise((r) => setTimeout(r, 10));
 
-      // 4 inserts: primary failure + 2 intermediate failures + fallback success
-      expect(mockMessageRepo.insert).toHaveBeenCalledTimes(4);
+      // 3 inserts: primary failure + 1 batched failed-fallbacks + fallback success
+      expect(mockMessageRepo.insert).toHaveBeenCalledTimes(3);
 
-      // Intermediate failures recorded as fallback_error (handled)
-      expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      // Intermediate failures batched into a single insert with both rows
+      expect(mockMessageRepo.insert).toHaveBeenCalledWith([
         expect.objectContaining({
           model: 'deepseek-chat',
           status: 'fallback_error',
           fallback_from_model: 'gemini-flash',
           fallback_index: 0,
         }),
-      );
-      expect(mockMessageRepo.insert).toHaveBeenCalledWith(
         expect.objectContaining({
           model: 'gpt-4o-mini',
           status: 'fallback_error',
           fallback_from_model: 'gemini-flash',
           fallback_index: 1,
         }),
-      );
+      ]);
     });
 
     it('should record message with zero tokens when response has no usage data', async () => {
@@ -2493,7 +2491,7 @@ describe('ProxyController', () => {
           error_message: 'primary error',
         }),
       );
-      expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect(mockMessageRepo.insert).toHaveBeenCalledWith([
         expect.objectContaining({
           model: 'deepseek-chat',
           status: 'error',
@@ -2501,7 +2499,7 @@ describe('ProxyController', () => {
           fallback_index: 0,
           error_message: 'auth fail',
         }),
-      );
+      ]);
       expect(headers['X-Manifest-Fallback-Exhausted']).toBe('true');
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -2693,28 +2691,26 @@ describe('ProxyController', () => {
       await controller.chatCompletions(req as never, res as never);
       await new Promise((r) => setTimeout(r, 10));
 
-      // 3 inserts: primary (fallback_error) + intermediate (fallback_error) + last (error)
-      expect(mockMessageRepo.insert).toHaveBeenCalledTimes(3);
+      // 2 inserts: primary (fallback_error) + 1 batched failed-fallbacks (2 rows)
+      expect(mockMessageRepo.insert).toHaveBeenCalledTimes(2);
       expect(mockMessageRepo.insert).toHaveBeenCalledWith(
         expect.objectContaining({
           model: 'gemini-flash',
           status: 'fallback_error',
         }),
       );
-      expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect(mockMessageRepo.insert).toHaveBeenCalledWith([
         expect.objectContaining({
           model: 'deepseek-chat',
           status: 'fallback_error',
           fallback_index: 0,
         }),
-      );
-      expect(mockMessageRepo.insert).toHaveBeenCalledWith(
         expect.objectContaining({
           model: 'gpt-4o-mini',
           status: 'error',
           fallback_index: 1,
         }),
-      );
+      ]);
     });
   });
 
@@ -2756,13 +2752,13 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
     await new Promise((r) => setTimeout(r, 50));
 
-    // Fallback failure recorded with auth_type from meta
-    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+    // Fallback failure recorded with auth_type from meta (batched as array)
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith([
       expect.objectContaining({
         model: 'deepseek-chat',
         auth_type: 'subscription',
       }),
-    );
+    ]);
     // Primary failure also recorded with auth_type
     expect(mockMessageRepo.insert).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -214,12 +214,19 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       headerTierName,
       headerTierColor,
     } = opts ?? {};
+    if (failures.length === 0) return;
     // primaryModel is loop-invariant — canonicalize once.
     const canonicalPrimary = await this.customProviders.canonicalizeAgentMessageKeys(
       ctx.agentId,
       null,
       primaryModel,
     );
+    const canonicalFailures = await Promise.all(
+      failures.map((f) =>
+        this.customProviders.canonicalizeAgentMessageKeys(ctx.agentId, f.provider, f.model),
+      ),
+    );
+    const rows: Partial<AgentMessage>[] = [];
     for (let i = 0; i < failures.length; i++) {
       const f = failures[i];
       const ts = baseTimeMs
@@ -232,12 +239,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         : f.status === 429
           ? 'rate_limited'
           : 'error';
-      const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
-        ctx.agentId,
-        f.provider,
-        f.model,
-      );
-      await this.messageRepo.insert(
+      const canonical = canonicalFailures[i];
+      rows.push(
         buildMessageRow(ctx, {
           trace_id: traceId ?? null,
           timestamp: ts,
@@ -259,6 +262,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         }),
       );
     }
+    await this.messageRepo.insert(rows);
     this.eventBus.emit(ctx.userId);
   }
 

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -50,6 +50,10 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     }
 
     entry.count++;
+    // LRU touch: delete-then-set re-inserts at tail of insertion order so
+    // evictLruIfNeeded() drops genuinely-stale entries instead of arbitrary
+    // long-lived ones during overflow.
+    this.rates.delete(userId);
     this.rates.set(userId, entry);
     this.evictLruIfNeeded();
   }
@@ -74,6 +78,8 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     }
 
     entry.count++;
+    // LRU touch — see checkLimit().
+    this.ipRates.delete(ip);
     this.ipRates.set(ip, entry);
     this.evictIpLruIfNeeded();
   }

--- a/packages/backend/src/sse/sse.controller.spec.ts
+++ b/packages/backend/src/sse/sse.controller.spec.ts
@@ -32,7 +32,7 @@ describe('SseController', () => {
     expect(() => controller.events({} as never)).toThrow(UnauthorizedException);
   });
 
-  it('returns an observable that maps event-bus payloads to typed SSE events', (done) => {
+  it('fans each bus event into a typed event and a legacy ping', (done) => {
     const user = { id: 'user-1', name: 'Test', email: 'test@test.com' } as never;
     const stream$ = controller.events(user);
     const received: unknown[] = [];
@@ -40,11 +40,14 @@ describe('SseController', () => {
     stream$.subscribe({
       next: (event) => {
         received.push(event);
-        if (received.length === 3) {
+        if (received.length === 6) {
           expect(received).toEqual([
             { type: 'message', data: 'message' },
+            { type: 'ping', data: 'ping' },
             { type: 'agent', data: 'agent' },
+            { type: 'ping', data: 'ping' },
             { type: 'routing', data: 'routing' },
+            { type: 'ping', data: 'ping' },
           ]);
           done();
         }

--- a/packages/backend/src/sse/sse.controller.spec.ts
+++ b/packages/backend/src/sse/sse.controller.spec.ts
@@ -2,14 +2,14 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UnauthorizedException } from '@nestjs/common';
 import { Subject } from 'rxjs';
 import { SseController } from './sse.controller';
-import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
+import { IngestEventBusService, IngestEvent } from '../common/services/ingest-event-bus.service';
 
 describe('SseController', () => {
   let controller: SseController;
-  let mockSubject: Subject<string>;
+  let mockSubject: Subject<IngestEvent>;
 
   beforeEach(async () => {
-    mockSubject = new Subject<string>();
+    mockSubject = new Subject<IngestEvent>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SseController],
@@ -32,7 +32,7 @@ describe('SseController', () => {
     expect(() => controller.events({} as never)).toThrow(UnauthorizedException);
   });
 
-  it('returns an observable that maps to ping events', (done) => {
+  it('returns an observable that maps event-bus payloads to typed SSE events', (done) => {
     const user = { id: 'user-1', name: 'Test', email: 'test@test.com' } as never;
     const stream$ = controller.events(user);
     const received: unknown[] = [];
@@ -40,17 +40,19 @@ describe('SseController', () => {
     stream$.subscribe({
       next: (event) => {
         received.push(event);
-        if (received.length === 2) {
+        if (received.length === 3) {
           expect(received).toEqual([
-            { type: 'ping', data: 'ping' },
-            { type: 'ping', data: 'ping' },
+            { type: 'message', data: 'message' },
+            { type: 'agent', data: 'agent' },
+            { type: 'routing', data: 'routing' },
           ]);
           done();
         }
       },
     });
 
-    mockSubject.next('user-1');
-    mockSubject.next('user-1');
+    mockSubject.next({ userId: 'user-1', kind: 'message' });
+    mockSubject.next({ userId: 'user-1', kind: 'agent' });
+    mockSubject.next({ userId: 'user-1', kind: 'routing' });
   });
 });

--- a/packages/backend/src/sse/sse.controller.ts
+++ b/packages/backend/src/sse/sse.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Sse, UnauthorizedException } from '@nestjs/common';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
 import { AuthUser } from '../auth/auth.instance';
@@ -20,13 +20,14 @@ export class SseController {
       throw new UnauthorizedException('Session required for SSE');
     }
 
+    // Each bus event fans out as TWO SSE messages: the typed one (so new
+    // clients can target by kind) AND the legacy 'ping' (so older frontends
+    // listening on 'ping' still see every change during a partial upgrade).
     return this.eventBus.forUser(user.id).pipe(
-      // The event-name carries the kind ('message' | 'agent' | 'routing') so
-      // the browser can dispatch via es.addEventListener(kind). Clients that
-      // only listen for the legacy 'ping' event still get every change because
-      // we mirror the kind into the data field — they just don't get the
-      // narrower kind-based fan-out optimization.
-      map((evt) => ({ type: evt.kind, data: evt.kind })),
+      mergeMap((evt) => [
+        { type: evt.kind, data: evt.kind },
+        { type: 'ping', data: 'ping' },
+      ]),
     );
   }
 }

--- a/packages/backend/src/sse/sse.controller.ts
+++ b/packages/backend/src/sse/sse.controller.ts
@@ -21,7 +21,12 @@ export class SseController {
     }
 
     return this.eventBus.forUser(user.id).pipe(
-      map(() => ({ type: 'ping', data: 'ping' })),
+      // The event-name carries the kind ('message' | 'agent' | 'routing') so
+      // the browser can dispatch via es.addEventListener(kind). Clients that
+      // only listen for the legacy 'ping' event still get every change because
+      // we mirror the kind into the data field — they just don't get the
+      // narrower kind-based fan-out optimization.
+      map((evt) => ({ type: evt.kind, data: evt.kind })),
     );
   }
 }

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -33,7 +33,7 @@ import { createCursorPagination } from '../services/cursor-pagination.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { PROVIDERS } from '../services/providers.js';
 import { checkIsSelfHosted } from '../services/setup-status.js';
-import { pingCount } from '../services/sse.js';
+import { messagePing } from '../services/sse.js';
 import '../styles/overview.css';
 
 interface MessagesData {
@@ -160,7 +160,7 @@ const MessageLog: Component = () => {
       costMin: costMin(),
       costMax: costMax(),
       agentName: params.agentName,
-      _ping: pingCount(),
+      _ping: messagePing(),
       cursor: pager.currentCursor(),
       limit: pager.pageSize,
     }),

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -34,7 +34,7 @@ import {
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { isRecentlyCreated } from '../services/recent-agents.js';
 import { checkIsSelfHosted } from '../services/setup-status.js';
-import { pingCount } from '../services/sse.js';
+import { messagePing } from '../services/sse.js';
 import '../styles/overview.css';
 
 interface OverviewData {
@@ -175,7 +175,7 @@ const Overview: Component = () => {
   };
 
   const [data, { refetch }] = createResource(
-    () => ({ range: range(), agentName: params.agentName, _ping: pingCount() }),
+    () => ({ range: range(), agentName: params.agentName, _ping: messagePing() }),
     (p) => getOverview(p.range, p.agentName) as Promise<OverviewData>,
   );
 

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -17,7 +17,7 @@ import { toast } from '../services/toast-store.js';
 import { markAgentCreated } from '../services/recent-agents.js';
 import { formatNumber } from '../services/formatters.js';
 import Sparkline from '../components/Sparkline.jsx';
-import { pingCount } from '../services/sse.js';
+import { agentPing, messagePing } from '../services/sse.js';
 import {
   type AgentCategory,
   type AgentPlatform,
@@ -285,7 +285,7 @@ const AgentCardMenu: Component<{
 
 const Workspace: Component = () => {
   const [data, { refetch }] = createResource(
-    () => ({ _ping: pingCount() }),
+    () => ({ _agentPing: agentPing(), _messagePing: messagePing() }),
     () => getAgents() as Promise<AgentsData>,
   );
   const [modalOpen, setModalOpen] = createSignal(false);

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -12,9 +12,12 @@ export interface AgentInfo {
 }
 
 export function getAgentInfo(agentName: string): Promise<AgentInfo | null> {
-  return fetchJson<{ agent: AgentInfo | null }>(`/agents/${encodeURIComponent(agentName)}`)
-    .then((data) => data?.agent ?? null)
-    .catch(() => null);
+  // Backend returns { agent: null } for missing agents (200), so we don't need
+  // to swallow errors here. Network/server failures should propagate to the
+  // caller rather than masquerade as "agent not found".
+  return fetchJson<{ agent: AgentInfo | null }>(`/agents/${encodeURIComponent(agentName)}`).then(
+    (data) => data?.agent ?? null,
+  );
 }
 
 export function getAgentKey(agentName: string) {

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -12,9 +12,9 @@ export interface AgentInfo {
 }
 
 export function getAgentInfo(agentName: string): Promise<AgentInfo | null> {
-  return fetchJson<{ agents: AgentInfo[] }>('/agents').then(
-    (data) => data?.agents?.find((a) => a.agent_name === agentName) ?? null,
-  );
+  return fetchJson<{ agent: AgentInfo | null }>(`/agents/${encodeURIComponent(agentName)}`)
+    .then((data) => data?.agent ?? null)
+    .catch(() => null);
 }
 
 export function getAgentKey(agentName: string) {

--- a/packages/frontend/src/services/api/core.ts
+++ b/packages/frontend/src/services/api/core.ts
@@ -13,7 +13,10 @@ export async function fetchJson<T>(
     }
   }
 
-  const res = await fetch(url.toString(), { credentials: 'include', cache: 'no-store' });
+  // 'default' lets the browser revalidate via ETag / Cache-Control. Backend
+  // analytics endpoints set short max-age=10 which keeps stale UI bounded;
+  // SSE-driven refetches still bypass cache because they pass a unique signal.
+  const res = await fetch(url.toString(), { credentials: 'include', cache: 'default' });
   if (res.status === 401) {
     // Session expired or user logged out — silently redirect to login
     if (window.location.pathname !== '/login') {

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -235,8 +235,31 @@ export interface CustomProviderData {
   created_at: string;
 }
 
-export function getCustomProviders(agentName: string) {
-  return fetchJson<CustomProviderData[]>(routingPath(agentName, 'custom-providers'));
+// Module-scoped cache so Overview / MessageLog / Routing don't each refetch
+// the same custom-providers list when mounting in sequence. Mutations below
+// (create/update/delete) invalidate the agent's entry; the routing 'routing'
+// SSE event invalidates them all.
+const customProvidersCache = new Map<string, Promise<CustomProviderData[]>>();
+
+export function invalidateCustomProvidersCache(agentName?: string): void {
+  if (agentName === undefined) {
+    customProvidersCache.clear();
+    return;
+  }
+  customProvidersCache.delete(agentName);
+}
+
+export function getCustomProviders(agentName: string): Promise<CustomProviderData[]> {
+  const cached = customProvidersCache.get(agentName);
+  if (cached) return cached;
+  const promise = fetchJson<CustomProviderData[]>(routingPath(agentName, 'custom-providers')).catch(
+    (err) => {
+      customProvidersCache.delete(agentName);
+      throw err;
+    },
+  );
+  customProvidersCache.set(agentName, promise);
+  return promise;
 }
 
 export function createCustomProvider(
@@ -249,6 +272,7 @@ export function createCustomProvider(
     models: CustomProviderModel[];
   },
 ) {
+  invalidateCustomProvidersCache(agentName);
   return fetchMutate<CustomProviderData>(routingPath(agentName, 'custom-providers'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -267,6 +291,7 @@ export function updateCustomProvider(
     models?: CustomProviderModel[];
   },
 ) {
+  invalidateCustomProvidersCache(agentName);
   return fetchMutate<CustomProviderData>(
     routingPath(agentName, `custom-providers/${encodeURIComponent(id)}`),
     {
@@ -299,6 +324,7 @@ export async function probeCustomProvider(
 }
 
 export function deleteCustomProvider(agentName: string, id: string) {
+  invalidateCustomProvidersCache(agentName);
   return fetchMutate<{ ok: boolean }>(
     routingPath(agentName, `custom-providers/${encodeURIComponent(id)}`),
     { method: 'DELETE' },

--- a/packages/frontend/src/services/sse.ts
+++ b/packages/frontend/src/services/sse.ts
@@ -1,14 +1,35 @@
 import { createSignal } from 'solid-js';
 
+// pingCount counts ANY event from the bus (legacy back-compat for callers that
+// don't care which kind fired). New code should depend on the targeted
+// signals so a routing-only change doesn't refetch the message log etc.
 const [pingCount, setPingCount] = createSignal(0);
+const [messagePing, setMessagePing] = createSignal(0);
+const [agentPing, setAgentPing] = createSignal(0);
+const [routingPing, setRoutingPing] = createSignal(0);
 
-export { pingCount };
+export { pingCount, messagePing, agentPing, routingPing };
 
 export function connectSse(): () => void {
   const es = new EventSource('/api/v1/events');
 
-  es.addEventListener('ping', () => {
-    setPingCount((n) => n + 1);
+  const bumpPing = () => setPingCount((n) => n + 1);
+
+  // Legacy generic 'ping' from older deployments — keep listening so a partial
+  // upgrade still works.
+  es.addEventListener('ping', bumpPing);
+
+  es.addEventListener('message', () => {
+    setMessagePing((n) => n + 1);
+    bumpPing();
+  });
+  es.addEventListener('agent', () => {
+    setAgentPing((n) => n + 1);
+    bumpPing();
+  });
+  es.addEventListener('routing', () => {
+    setRoutingPing((n) => n + 1);
+    bumpPing();
   });
 
   return () => es.close();

--- a/packages/frontend/src/services/sse.ts
+++ b/packages/frontend/src/services/sse.ts
@@ -16,8 +16,13 @@ export function connectSse(): () => void {
   const bumpPing = () => setPingCount((n) => n + 1);
 
   // Legacy generic 'ping' from older deployments — keep listening so a partial
-  // upgrade still works.
-  es.addEventListener('ping', bumpPing);
+  // upgrade (old backend, new frontend) still triggers refetches. The safe
+  // default is to treat unknown 'ping' as a message-class change since that's
+  // the kind the bus emitted before typed events landed.
+  es.addEventListener('ping', () => {
+    setMessagePing((n) => n + 1);
+    bumpPing();
+  });
 
   es.addEventListener('message', () => {
     setMessagePing((n) => n + 1);

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -31,6 +31,9 @@ vi.mock("../../src/services/api.js", () => ({
 
 vi.mock("../../src/services/sse.js", () => ({
   pingCount: () => 0,
+  messagePing: () => 0,
+  agentPing: () => 0,
+  routingPing: () => 0,
 }));
 
 vi.mock("../../src/services/model-display.js", () => ({

--- a/packages/frontend/tests/pages/Overview-limits.test.tsx
+++ b/packages/frontend/tests/pages/Overview-limits.test.tsx
@@ -22,6 +22,9 @@ vi.mock("../../src/services/api.js", () => ({
 
 vi.mock("../../src/services/sse.js", () => ({
   pingCount: () => 0,
+  messagePing: () => 0,
+  agentPing: () => 0,
+  routingPing: () => 0,
 }));
 
 vi.mock("../../src/services/formatters.js", () => ({

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -29,6 +29,9 @@ vi.mock("../../src/services/api.js", () => ({
 
 vi.mock("../../src/services/sse.js", () => ({
   pingCount: () => 0,
+  messagePing: () => 0,
+  agentPing: () => 0,
+  routingPing: () => 0,
 }));
 
 vi.mock("../../src/services/model-display.js", () => ({

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -65,6 +65,9 @@ vi.mock("../../src/components/Sparkline.jsx", () => ({
 
 vi.mock("../../src/services/sse.js", () => ({
   pingCount: () => 0,
+  messagePing: () => 0,
+  agentPing: () => 0,
+  routingPing: () => 0,
 }));
 
 vi.mock("../../src/components/AgentTypeSelect.jsx", () => ({

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -39,6 +39,7 @@ import {
   createCustomProvider,
   updateCustomProvider,
   deleteCustomProvider,
+  invalidateCustomProvidersCache,
   getRoutingStatus,
   getFallbacks,
   setFallbacks,
@@ -65,6 +66,9 @@ const mockFetch = vi.fn();
 beforeEach(() => {
   vi.stubGlobal('fetch', mockFetch);
   vi.stubGlobal('location', { origin: 'http://localhost:3000' });
+  // Module-scoped caches survive across tests; reset them so a previous test's
+  // mock response doesn't satisfy the next test's call.
+  invalidateCustomProvidersCache();
 });
 
 afterEach(() => {
@@ -116,7 +120,7 @@ describe('getAgents', () => {
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/api/v1/agents', {
       credentials: 'include',
-      cache: 'no-store',
+      cache: 'default',
     });
   });
 });
@@ -229,7 +233,7 @@ describe('getAgentKey', () => {
 
     expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/api/v1/agents/bot/key'), {
       credentials: 'include',
-      cache: 'no-store',
+      cache: 'default',
     });
   });
 });
@@ -385,27 +389,29 @@ describe('renameAgent', () => {
 
 describe('getAgentInfo', () => {
   it('should return agent info when agent exists', async () => {
-    const agents = [
-      { agent_name: 'my-agent', display_name: 'My Agent', agent_category: 'personal', agent_platform: 'openclaw' },
-      { agent_name: 'other', display_name: 'Other', agent_category: null, agent_platform: null },
-    ];
-    mockOk({ agents });
+    const agent = {
+      agent_name: 'my-agent',
+      display_name: 'My Agent',
+      agent_category: 'personal',
+      agent_platform: 'openclaw',
+    };
+    mockOk({ agent });
 
     const result = await getAgentInfo('my-agent');
 
-    expect(result).toEqual(agents[0]);
+    expect(result).toEqual(agent);
   });
 
-  it('should return null when agent not found', async () => {
-    mockOk({ agents: [{ agent_name: 'other', display_name: 'Other', agent_category: null, agent_platform: null }] });
+  it('should return null when backend returns { agent: null }', async () => {
+    mockOk({ agent: null });
 
     const result = await getAgentInfo('missing-agent');
 
     expect(result).toBeNull();
   });
 
-  it('should return null when agents list is empty', async () => {
-    mockOk({ agents: [] });
+  it('should return null on fetch error', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'));
 
     const result = await getAgentInfo('any-agent');
 
@@ -459,7 +465,7 @@ describe('getModelPrices', () => {
     expect(result).toEqual(prices);
     expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/api/v1/model-prices', {
       credentials: 'include',
-      cache: 'no-store',
+      cache: 'default',
     });
   });
 });
@@ -507,7 +513,7 @@ describe('getProviders', () => {
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:3000/api/v1/routing/my-agent/providers',
-      { credentials: 'include', cache: 'no-store' },
+      { credentials: 'include', cache: 'default' },
     );
   });
 });
@@ -691,7 +697,7 @@ describe('getTierAssignments', () => {
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/api/v1/routing/my-agent/tiers', {
       credentials: 'include',
-      cache: 'no-store',
+      cache: 'default',
     });
   });
 });
@@ -787,7 +793,7 @@ describe('getAvailableModels', () => {
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:3000/api/v1/routing/my-agent/available-models',
-      { credentials: 'include', cache: 'no-store' },
+      { credentials: 'include', cache: 'default' },
     );
   });
 });
@@ -1059,6 +1065,61 @@ describe('getCustomProviders', () => {
     await getCustomProviders('agent/special name');
     const url = mockFetch.mock.calls[0]?.[0] as string;
     expect(url).toContain('/routing/agent%2Fspecial%20name/custom-providers');
+  });
+
+  it('caches results per agent across calls', async () => {
+    mockOk([{ id: 'cp-1', name: 'A', base_url: '', has_api_key: false, models: [], created_at: '' }]);
+
+    const first = await getCustomProviders('agent-a');
+    const second = await getCustomProviders('agent-a');
+
+    expect(first).toBe(second);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after invalidateCustomProvidersCache for the same agent', async () => {
+    mockOk([{ id: 'cp-1', name: 'A', base_url: '', has_api_key: false, models: [], created_at: '' }]);
+    await getCustomProviders('agent-a');
+
+    invalidateCustomProvidersCache('agent-a');
+
+    mockOk([{ id: 'cp-2', name: 'B', base_url: '', has_api_key: false, models: [], created_at: '' }]);
+    await getCustomProviders('agent-a');
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates only the named agent when called with a key', async () => {
+    mockOk([{ id: 'cp-1', name: 'A', base_url: '', has_api_key: false, models: [], created_at: '' }]);
+    await getCustomProviders('agent-a');
+    mockOk([{ id: 'cp-2', name: 'B', base_url: '', has_api_key: false, models: [], created_at: '' }]);
+    await getCustomProviders('agent-b');
+
+    invalidateCustomProvidersCache('agent-a');
+
+    mockOk([{ id: 'cp-3', name: 'C', base_url: '', has_api_key: false, models: [], created_at: '' }]);
+    await getCustomProviders('agent-a');
+    // agent-b is still cached, no new fetch
+    await getCustomProviders('agent-b');
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not poison the cache on fetch failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve(''),
+      statusText: 'Server Error',
+      json: () => Promise.resolve({}),
+    });
+
+    await expect(getCustomProviders('agent-x')).rejects.toThrow();
+
+    mockOk([{ id: 'cp-1', name: 'A', base_url: '', has_api_key: false, models: [], created_at: '' }]);
+    const result = await getCustomProviders('agent-x');
+    expect(result).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -64,6 +64,9 @@ vi.mock('../../src/services/toast-store.js', () => ({
 const mockFetch = vi.fn();
 
 beforeEach(() => {
+  // mockFetch is module-scoped, so call counts and resolved values persist
+  // across tests if we don't reset them here.
+  mockFetch.mockReset();
   vi.stubGlobal('fetch', mockFetch);
   vi.stubGlobal('location', { origin: 'http://localhost:3000' });
   // Module-scoped caches survive across tests; reset them so a previous test's
@@ -410,12 +413,10 @@ describe('getAgentInfo', () => {
     expect(result).toBeNull();
   });
 
-  it('should return null on fetch error', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'));
+  it('propagates fetch errors instead of swallowing them', async () => {
+    mockError(500, 'Internal Server Error');
 
-    const result = await getAgentInfo('any-agent');
-
-    expect(result).toBeNull();
+    await expect(getAgentInfo('any-agent')).rejects.toThrow('API error: 500 Internal Server Error');
   });
 });
 

--- a/packages/frontend/tests/services/specificity.test.ts
+++ b/packages/frontend/tests/services/specificity.test.ts
@@ -59,7 +59,7 @@ describe('getSpecificityAssignments', () => {
     expect(result).toEqual([assignment]);
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:3000/api/v1/routing/my-agent/specificity',
-      { credentials: 'include', cache: 'no-store' },
+      { credentials: 'include', cache: 'default' },
     );
   });
 
@@ -70,7 +70,7 @@ describe('getSpecificityAssignments', () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:3000/api/v1/routing/agent%2Fwith%20spaces/specificity',
-      { credentials: 'include', cache: 'no-store' },
+      { credentials: 'include', cache: 'default' },
     );
   });
 });

--- a/packages/frontend/tests/services/sse.test.ts
+++ b/packages/frontend/tests/services/sse.test.ts
@@ -25,16 +25,22 @@ describe("sse", () => {
     expect(mockEventSource.close).toHaveBeenCalled();
   });
 
-  it("increments pingCount when legacy 'ping' event is received", async () => {
-    const { connectSse, pingCount } = await import("../../src/services/sse");
+  it("increments pingCount AND messagePing when legacy 'ping' event is received", async () => {
+    const { connectSse, pingCount, messagePing } = await import(
+      "../../src/services/sse"
+    );
     connectSse();
     const pingHandler = mockEventSource.addEventListener.mock.calls.find(
       (c: any[]) => c[0] === "ping",
     )?.[1];
     expect(pingHandler).toBeDefined();
-    const before = pingCount();
+    const beforePing = pingCount();
+    const beforeMessage = messagePing();
     pingHandler();
-    expect(pingCount()).toBe(before + 1);
+    expect(pingCount()).toBe(beforePing + 1);
+    // legacy ping is treated as a message-class change so MessageLog/Overview
+    // stay reactive when talking to an older backend.
+    expect(messagePing()).toBe(beforeMessage + 1);
   });
 
   it("increments messagePing AND pingCount on 'message' event", async () => {

--- a/packages/frontend/tests/services/sse.test.ts
+++ b/packages/frontend/tests/services/sse.test.ts
@@ -9,6 +9,7 @@ describe("sse", () => {
       close: vi.fn(),
     };
     vi.stubGlobal("EventSource", vi.fn(() => mockEventSource));
+    vi.resetModules();
   });
 
   it("creates EventSource with correct URL", async () => {
@@ -24,10 +25,9 @@ describe("sse", () => {
     expect(mockEventSource.close).toHaveBeenCalled();
   });
 
-  it("increments pingCount when ping event is received", async () => {
+  it("increments pingCount when legacy 'ping' event is received", async () => {
     const { connectSse, pingCount } = await import("../../src/services/sse");
     connectSse();
-    // Get the 'ping' event handler that was registered
     const pingHandler = mockEventSource.addEventListener.mock.calls.find(
       (c: any[]) => c[0] === "ping",
     )?.[1];
@@ -35,5 +35,56 @@ describe("sse", () => {
     const before = pingCount();
     pingHandler();
     expect(pingCount()).toBe(before + 1);
+  });
+
+  it("increments messagePing AND pingCount on 'message' event", async () => {
+    const { connectSse, pingCount, messagePing } = await import(
+      "../../src/services/sse"
+    );
+    connectSse();
+    const handler = mockEventSource.addEventListener.mock.calls.find(
+      (c: any[]) => c[0] === "message",
+    )?.[1];
+    expect(handler).toBeDefined();
+    const beforePing = pingCount();
+    const beforeMessage = messagePing();
+    handler();
+    expect(messagePing()).toBe(beforeMessage + 1);
+    expect(pingCount()).toBe(beforePing + 1);
+  });
+
+  it("increments agentPing AND pingCount on 'agent' event", async () => {
+    const { connectSse, pingCount, agentPing, messagePing } = await import(
+      "../../src/services/sse"
+    );
+    connectSse();
+    const handler = mockEventSource.addEventListener.mock.calls.find(
+      (c: any[]) => c[0] === "agent",
+    )?.[1];
+    expect(handler).toBeDefined();
+    const beforePing = pingCount();
+    const beforeAgent = agentPing();
+    const beforeMessage = messagePing();
+    handler();
+    expect(agentPing()).toBe(beforeAgent + 1);
+    expect(pingCount()).toBe(beforePing + 1);
+    // 'agent' event must NOT bump messagePing
+    expect(messagePing()).toBe(beforeMessage);
+  });
+
+  it("increments routingPing AND pingCount on 'routing' event", async () => {
+    const { connectSse, pingCount, routingPing } = await import(
+      "../../src/services/sse"
+    );
+    connectSse();
+    const handler = mockEventSource.addEventListener.mock.calls.find(
+      (c: any[]) => c[0] === "routing",
+    )?.[1];
+    expect(handler).toBeDefined();
+    const beforePing = pingCount();
+    const beforeRouting = routingPing();
+    handler();
+    expect(routingPing()).toBe(beforeRouting + 1);
+    expect(pingCount()).toBe(beforePing + 1);
   });
 });


### PR DESCRIPTION
### What changed

- SessionGuard caches Better Auth lookups for 60s per session cookie (LRU).
- AgentKeyAuthGuard selects only required columns; cache TTL 5m -> 30m with LRU touch.
- New migration retunes `IDX_agent_messages_miscategorized` to lead with `agent_id`.
- DB pool default 20 -> 50; adds `statement_timeout=30s` and `idle_in_transaction_session_timeout=60s`.
- Proxy `recordFailedFallbacks` batches N inserts into one `messageRepo.insert([rows])`.
- `getAgentList` collapses stats and sparkline into one query with `FILTER` clauses.
- `getDistinctModels` defaults to last 90 days when range is unset; cache TTL 60s -> 5m.
- New `GET /api/v1/agents/:agentName` so the frontend stops fetching the full list to find one row.
- Typed SSE events (`message` / `agent` / `routing`) on the bus and SSE controller; debounce 1000ms -> 250ms.
- Frontend exposes `messagePing` / `agentPing` / `routingPing`; pages only refetch on relevant kinds.
- Module-scoped `getCustomProviders` cache shared by Overview / MessageLog / Routing.
- Removed `cache: 'no-store'` from `fetchJson`.
- True LRU eviction in `ProxyRateLimiter`.

### Why

Audit of the dashboard and proxy hot path turned up redundant DB roundtrips on every request, sequential inserts under the proxy critical path, and SSE pings that triggered full refetches across every open dashboard page. This pass cuts those.

### For users

- Dashboard pages no longer refetch every time any LLM call lands. MessageLog only refreshes on message events, Workspace on agent CRUD, Routing on routing changes.
- Routing UI feels snappier on cache-miss because `AgentKeyAuthGuard` no longer hydrates full Agent + Tenant rows per request.

### For operators

- A new migration runs on boot (`1782000000000-RetuneSpecificityMiscategorizedIndex`). It drops and recreates a partial index on `agent_messages`. On large tables this is online but blocks writes briefly.
- DB pool default jumped from 20 to 50. If you run multiple Manifest instances against the same Postgres, set `DB_POOL_MAX` explicitly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts DB roundtrips and UI refetch storms by caching hot‑path auth, batching proxy writes, and narrowing SSE refetches with typed events + legacy back‑compat. Adds a single‑agent lookup API and retunes a specificity index; the index migration now runs in-transaction with a note on zero‑downtime pre‑creation.

- **Performance**
  - Caches Better Auth sessions per cookie for 60s (LRU) in `SessionGuard`.
  - Slims `AgentKeyAuthGuard` query (selects only needed columns), keeps 5m TTL with LRU touch-on-hit.
  - Batches proxy `recordFailedFallbacks` into one `insert([rows])` call.
  - Collapses agent stats+sparkline into one query with `FILTER`; bounds distinct‑models scan to last 90 days and raises models cache TTL to 5m.
  - Sends typed SSE events (`message`/`agent`/`routing`) with 250ms debounce; controller also emits a legacy `ping` for back‑compat. Frontend refetches only on relevant kinds and treats legacy `ping` as a message update.
  - Adds `GET /api/v1/agents/:agentName` returning `{ agent | null }`. True LRU eviction in `ProxyRateLimiter`. DB pool default 20→50 with `statement_timeout=30s` and `idle_in_transaction_session_timeout=60s`.
  - Adds module‑scoped cache for `getCustomProviders`; invalidated on mutations and `routing` events. Allows browser revalidation by removing `cache: 'no-store'`.

- **Migration**
  - New migration drops/recreates `IDX_agent_messages_miscategorized` to lead with `agent_id` (partial on `specificity_miscategorized=true`) and now runs in‑transaction. For zero‑downtime, operators can pre‑create the new index with `CREATE INDEX CONCURRENTLY` before deploying.
  - If running multiple app instances, set `DB_POOL_MAX` explicitly to avoid over‑provisioning.

<sup>Written for commit 9b3fddb0367ac70413debb68eef9a4ddb71e0fdb. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1745?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

