### PR TITLE
fix(docker): drop bundled esbuild Go binary to clear 11 CVEs

### DIFF
--- a/.changeset/docker-cves-esbuild.md
+++ b/.changeset/docker-cves-esbuild.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Drop bundled `@esbuild/linux-x64` from the Docker image so CVE scanners no longer flag the embedded Go 1.23.12 stdlib (CVE-2025-68121 plus 10 high-severity CVEs). The binary was hoisted into the production `node_modules` despite `npm ci --omit=dev`; adding `--omit=optional` removes it along with other unused platform-specific binaries.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,11 @@ RUN npx turbo build --filter=manifest-backend --filter=manifest-frontend --filte
 
 # Stage 3: Production dependencies only. npm ci runs with --ignore-scripts
 # so nothing is compiled — all runtime deps are pure JS, making the glibc
-# of this stage irrelevant to the final image.
+# of this stage irrelevant to the final image. --omit=optional drops the
+# platform-specific binaries that vite/rollup/esbuild ship as
+# optionalDependencies; without it, npm hoists @esbuild/linux-x64 (a Go
+# binary) into node_modules even though `--omit=dev` strips its parent,
+# and CVE scanners then flag the embedded Go stdlib.
 FROM node:24-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS prod-deps
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -33,14 +37,12 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/frontend/package.json packages/frontend/
 COPY packages/backend/package.json packages/backend/
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev --ignore-scripts \
+    npm ci --omit=dev --omit=optional --ignore-scripts \
            --prefer-offline --no-audit --no-fund --loglevel=error && \
     rm -rf node_modules/typescript node_modules/@types \
            node_modules/ts-node node_modules/acorn \
            node_modules/create-require node_modules/v8-compile-cache-lib && \
-    find . -path "*/node_modules/vitest" -type d -exec rm -rf {} + 2>/dev/null; \
-    find . -path "*/node_modules/vite-node" -type d -exec rm -rf {} + 2>/dev/null; \
-    find . -path "*/node_modules/rollup" -type d -exec rm -rf {} + 2>/dev/null; \
+    find . -path "*/node_modules/@esbuild" -type d -exec rm -rf {} + 2>/dev/null; \
     find . -path "*/node_modules/@vitest" -type d -exec rm -rf {} + 2>/dev/null; \
     find . -path "*/node_modules/*" \( -name "*.map" -o -name "README*" \
       -o -name "LICENSE*" -o -name "CHANGELOG*" -o -name "*.txt" \


### PR DESCRIPTION
### What changed
- Add `--omit=optional` to the prod-deps `npm ci` in `docker/Dockerfile`.
- Replace `vitest`/`vite-node`/`rollup` cleanup `find` lines with `@esbuild` (the empty parent scope that survives the new install).
- Add a changeset bumping `manifest` (patch) so the next Docker tag ships the fix.

### Why
Docker Hub's scanner flagged the latest `manifestdotbuild/manifest` images (`5.55`, `5.55.2`) with 1 critical (CVSS 10.0) and 10 high CVEs, all in `pkg:golang/stdlib@1.23.12`. Tracing it inside the published image, every CVE came from a single Go binary: `node_modules/@esbuild/linux-x64/bin/esbuild`. esbuild is a transitive dev dep of vite/vitest, but npm hoists the platform-specific binary into `node_modules` and `--omit=dev` alone doesn't remove it. `--omit=optional` does.

### For users
- Next Docker release reports 0 critical/high vulnerabilities from this scanner.
- Image gets a bit smaller (`node_modules` layer 23 MB to 14.8 MB) since rollup / esbuild platform binaries no longer ship.

### For operators
- No config changes. Existing deployments keep working as is.

### Notes
Verified locally:
- Built image, no Go/ELF binaries remain in `/app/node_modules`.
- Container boots end to end (Nest starts, migrations run, telemetry initializes, all routes register).
- Backend tests: 4288 passed. Frontend tests: 2597 passed. tsc clean on both packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the hoisted `@esbuild/linux-x64` Go binary from the production Docker image to clear 11 CVEs (1 critical, 10 high) flagged by Docker Hub. Prod installs now use `npm ci --omit=dev --omit=optional`, and we delete any leftover `@esbuild`, which also reduces image size.

- **Bug Fixes**
  - Add `--omit=optional` to prod `npm ci` so optional platform binaries from `vite`/`rollup`/`@esbuild` aren’t installed; replace cleanup to remove `node_modules/@esbuild`.

- **Dependencies**
  - Add a patch changeset for `manifest` to ship the fixed Docker tag.

<sup>Written for commit b2f01c450258b28c986062fcf84a8550ff432392. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1747?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

