### PR TITLE
fix(db): pass session timeouts via PostgreSQL options, not startup params

### DIFF
--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -192,8 +192,13 @@ const migrations = [
         extra: {
           max: config.get<number>('app.dbPoolMax') ?? 50,
           idleTimeoutMillis: 30000,
-          statement_timeout: 30000,
-          idle_in_transaction_session_timeout: 60000,
+          // Pass session GUCs via PostgreSQL's `options` connection parameter
+          // (`-c name=value`) instead of as top-level pg client options. The pg
+          // driver forwards keys like `statement_timeout` as protocol-level
+          // startup parameters, which poolers such as Railway's PgBouncer
+          // reject with "FATAL: unsupported startup parameter: statement_timeout"
+          // — crashing the app before it can listen on PORT.
+          options: '-c statement_timeout=30000 -c idle_in_transaction_session_timeout=60000',
         },
       }),
     }),


### PR DESCRIPTION
## Summary

- Production deploys to Railway have been failing since #1745 with `FATAL: unsupported startup parameter: statement_timeout`. The pg driver was forwarding `statement_timeout` and `idle_in_transaction_session_timeout` as protocol-level startup parameters, which Railway's PgBouncer rejects — the app crashed before it could listen on `PORT`, so the healthcheck timed out after 5 minutes and every deploy failed.
- Move both into the connection's `options` string (`-c name=value`). PostgreSQL applies them as session GUCs after handshake, which poolers accept.
- Same effective behavior (30s statement timeout, 60s idle-in-transaction timeout); just delivered through the supported channel.

## Test plan

- [x] `npx tsc --noEmit` clean in `packages/backend`
- [x] `npx jest --testPathPattern=database` — 34 suites, 316 tests pass locally
- [ ] Verify Railway deploy succeeds and `/api/v1/health` responds
- [ ] Confirm `SHOW statement_timeout;` returns `30s` on a live session and `SHOW idle_in_transaction_session_timeout;` returns `1min`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Railway deploy failures caused by PgBouncer rejecting PostgreSQL startup params. Session timeouts are now set via the connection `options` string so the app boots and keeps the same limits.

- **Bug Fixes**
  - Send `statement_timeout` and `idle_in_transaction_session_timeout` via `options: '-c name=value'` so PostgreSQL applies them after handshake; poolers accept this.
  - Preserve the same values: 30s statement timeout, 60s idle-in-transaction session timeout.
  - Restores successful Railway deploys and health checks.

<sup>Written for commit 99a2a3fb7dcc6f9dc1592091539fb9faec19a5d7. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1749?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

