### PR TITLE
fix(db): drop pg timeouts that Railway's PgBouncer rejects

### DIFF
--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -192,13 +192,12 @@ const migrations = [
         extra: {
           max: config.get<number>('app.dbPoolMax') ?? 50,
           idleTimeoutMillis: 30000,
-          // Pass session GUCs via PostgreSQL's `options` connection parameter
-          // (`-c name=value`) instead of as top-level pg client options. The pg
-          // driver forwards keys like `statement_timeout` as protocol-level
-          // startup parameters, which poolers such as Railway's PgBouncer
-          // reject with "FATAL: unsupported startup parameter: statement_timeout"
-          // — crashing the app before it can listen on PORT.
-          options: '-c statement_timeout=30000 -c idle_in_transaction_session_timeout=60000',
+          // statement_timeout / idle_in_transaction_session_timeout were tried
+          // here (#1745) and via the `options` connection string (#1749), but
+          // Railway's PgBouncer rejects both forms — its
+          // `ignore_startup_parameters` allowlist only includes
+          // `extra_float_digits`. If we need per-query timeouts later, set
+          // them with `SET LOCAL` inside the relevant transaction instead.
         },
       }),
     }),


### PR DESCRIPTION
## Summary

Production is still down. #1749 didn't fully fix it — Railway's PgBouncer rejects both forms we've tried:

- `extra.statement_timeout` (#1745) → `FATAL: unsupported startup parameter: statement_timeout`
- `extra.options = '-c statement_timeout=...'` (#1749) → `FATAL: unsupported startup parameter in options: statement_timeout`

PgBouncer's `ignore_startup_parameters` allowlist on Railway only includes `extra_float_digits`, so any other GUC at handshake — top-level or nested in `options` — kills the connection. The app dies in the TypeORM connection retry loop before binding `PORT`.

Drop both timeouts. They were a perf nice-to-have, not load-bearing — the app ran fine without them until #1745. If we want per-query timeouts later, the right shape is `SET LOCAL statement_timeout = …` inside the transaction that needs it (works through transaction-mode poolers).

## Test plan

- [x] `npx tsc --noEmit` clean in `packages/backend`
- [x] `npx jest --testPathPattern=database` — 34 suites, 316 tests pass
- [ ] Verify Railway deploy succeeds and `/api/v1/health` returns 200
- [ ] Confirm app stays up under normal traffic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove Postgres connection timeouts that Railway’s PgBouncer rejects, restoring successful connections and allowing the backend to start normally. Drops `statement_timeout` and `idle_in_transaction_session_timeout` from startup config.

- **Bug Fixes**
  - Remove `options: '-c statement_timeout=30000 -c idle_in_transaction_session_timeout=60000'` from the pool config in `packages/backend/src/database/database.module.ts`.
  - Note: if needed later, use `SET LOCAL` inside transactions for per-query timeouts.

<sup>Written for commit 4fecaae646f442f7d234ee748f0b76d672c442bc. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1750?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

