### PR TITLE
fix(dashboard): point OpenClaw setup snippet at Chat Completions

### DIFF
--- a/.changeset/openclaw-snippet-api-shape.md
+++ b/.changeset/openclaw-snippet-api-shape.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix(dashboard): the OpenClaw setup snippet was generating a config with `api: 'openai-responses'`, but Manifest's cloud proxy speaks Chat Completions. OpenClaw rendered empty assistant bubbles even though tokens were billed correctly. Snippet now writes `api: 'openai-completions'` and the dashboard label reads "OpenAI Chat Completions-compatible". Existing OpenClaw users who pasted the broken snippet need to re-run the updated config block (or flip `models.providers.manifest.api` manually).

--- a/packages/frontend/src/components/OpenClawSetup.tsx
+++ b/packages/frontend/src/components/OpenClawSetup.tsx
@@ -146,7 +146,7 @@ const OpenClawSetup: Component<Props> = (props) => {
               <CopyButton text={copyKey()} />
             </span>
           </div>
-          <OnboardField label="Endpoint compatibility" value="OpenAI Responses-compatible" />
+          <OnboardField label="Endpoint compatibility" value="OpenAI Chat Completions-compatible" />
           <OnboardField label="Model ID" value="auto" copyable />
           <OnboardField label="Endpoint ID" value="manifest" copyable />
         </div>

--- a/packages/frontend/src/services/framework-snippets.ts
+++ b/packages/frontend/src/services/framework-snippets.ts
@@ -259,9 +259,15 @@ const response = await client.responses.create({
 }
 
 export function getOpenClawSnippet(baseUrl: string, apiKey: string): string {
+  // Manifest's cloud proxy speaks OpenAI Chat Completions
+  // (`/v1/chat/completions`). OpenClaw's `openai-responses` parser reads
+  // assistant text from the Responses API shape (`output[].content[].text`),
+  // which doesn't match — chat bubbles render empty even though tokens are
+  // billed correctly. Stay on `openai-completions` until the proxy exposes a
+  // first-class `/v1/responses` endpoint.
   const providerJson = JSON.stringify({
     baseUrl,
-    api: 'openai-responses',
+    api: 'openai-completions',
     apiKey,
     models: [{ id: 'auto', name: 'Manifest Auto' }],
   });

--- a/packages/frontend/tests/components/OpenClawSetup.test.tsx
+++ b/packages/frontend/tests/components/OpenClawSetup.test.tsx
@@ -126,7 +126,7 @@ describe("OpenClawSetup", () => {
     expect(fields[0].textContent).toContain("http://localhost:3001/v1");
     expect(fields[1].textContent).toContain("API Key");
     expect(fields[2].textContent).toContain("Endpoint compatibility");
-    expect(fields[2].textContent).toContain("OpenAI Responses-compatible");
+    expect(fields[2].textContent).toContain("OpenAI Chat Completions-compatible");
     expect(fields[3].textContent).toContain("Model ID");
     expect(fields[3].textContent).toContain("auto");
     expect(fields[4].textContent).toContain("Endpoint ID");
@@ -189,15 +189,15 @@ describe("OpenClawSetup", () => {
       <OpenClawSetup {...defaultProps} baseUrl="https://example.com/v1" />
     ));
     expect(container.textContent).toContain("https://example.com/v1");
-    expect(container.textContent).toContain("openai-responses");
-    expect(container.textContent).not.toContain("openai-completions");
+    expect(container.textContent).toContain("openai-completions");
+    expect(container.textContent).not.toContain("openai-responses");
   });
 
-  it("labels the onboarding compatibility as Responses-compatible", () => {
+  it("labels the onboarding compatibility as Chat Completions-compatible", () => {
     const { container } = render(() => <OpenClawSetup {...defaultProps} />);
     const segment = container.querySelector(".setup-segment--full");
     fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
-    expect(container.textContent).toContain("OpenAI Responses-compatible");
+    expect(container.textContent).toContain("OpenAI Chat Completions-compatible");
   });
 
   it("renders CLI copy button with snippet text containing masked key", () => {

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -136,7 +136,7 @@ describe("SetupStepAddProvider", () => {
     expect(fields[0].textContent).toContain("http://localhost:3001/v1");
     expect(fields[1].textContent).toContain("API Key");
     expect(fields[2].textContent).toContain("Endpoint compatibility");
-    expect(fields[2].textContent).toContain("OpenAI Responses-compatible");
+    expect(fields[2].textContent).toContain("OpenAI Chat Completions-compatible");
     expect(fields[3].textContent).toContain("Model ID");
     expect(fields[3].textContent).toContain("auto");
     expect(fields[4].textContent).toContain("Endpoint ID");

--- a/packages/frontend/tests/services/framework-snippets.test.ts
+++ b/packages/frontend/tests/services/framework-snippets.test.ts
@@ -278,8 +278,8 @@ describe("getOpenClawSnippet", () => {
     const snippet = getOpenClawSnippet("https://app.manifest.build/v1", "mnfst_test");
     expect(snippet).toContain("app.manifest.build/v1");
     expect(snippet).toContain("mnfst_test");
-    expect(snippet).toContain("openai-responses");
-    expect(snippet).not.toContain("openai-completions");
+    expect(snippet).toContain("openai-completions");
+    expect(snippet).not.toContain("openai-responses");
   });
 });
 


### PR DESCRIPTION
## Summary

Since `cc09e4f3` (2026-04-24, shipped in `manifest@5.55.1` and every release after) the dashboard's **OpenClaw setup snippet** has been generating:

```json
"api": "openai-responses"
```

Manifest's cloud proxy speaks **OpenAI Chat Completions** (`/v1/chat/completions`, content at `choices[0].message.content`). OpenClaw's Responses parser reads assistant text from `output[].content[].text`, so the path lookup misses and **chat bubbles render empty** — even though `usage` is billed correctly because that field happens to live in a similar place.

I just hit this myself routing through cloud and confirmed end-to-end:
- Direct cURL to `app.manifest.build/v1/chat/completions` → returns `"content": "pong"` correctly.
- OpenClaw with `api: openai-responses` → empty bubble, `usage.output: 5`.
- Flipping `models.providers.manifest.api = openai-completions` and restarting the gateway → text renders fine.

## Who's affected

- **Affected**: every cloud user who pasted the OpenClaw config from the dashboard between 2026-04-24 and now. Their messages routed, tokens were billed, but assistant replies looked blank in OpenClaw's chat UI.
- **Not affected**:
  - Direct cURL / OpenAI SDK / Vercel AI SDK / LangChain users (they parse responses themselves).
  - CLI installs via the `openclaw-model-router` skill — `install_manifest.sh` already writes `openai-completions`.

## Changes

- `packages/frontend/src/services/framework-snippets.ts` — `getOpenClawSnippet()` now writes `api: 'openai-completions'`.
- `packages/frontend/src/components/OpenClawSetup.tsx` — "Endpoint compatibility" label now reads "OpenAI Chat Completions-compatible".
- Updated the two tests that pinned the old strings.
- Changeset: patch bump.

Existing users who already pasted the broken config need to re-run the updated snippet from the dashboard, or set `models.providers.manifest.api` = `openai-completions` manually and `openclaw gateway restart`. Worth a short status post / discord note after the deploy.

## Test plan

- [x] `npx vitest run tests/services/framework-snippets.test.ts tests/components/OpenClawSetup.test.tsx` — 110 tests pass
- [x] `npx tsc --noEmit` clean in `packages/frontend`
- [ ] After deploy: copy the OpenClaw snippet from the cloud dashboard onto a clean machine, paste it, send a message, confirm assistant text appears in the OpenClaw chat UI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty assistant bubbles in OpenClaw by switching the dashboard setup snippet to Chat Completions so replies render correctly. Also updates the onboarding label and test assertions to match.

- **Bug Fixes**
  - Updated `getOpenClawSnippet()` to write `api: 'openai-completions'`.
  - Changed the onboarding label to "OpenAI Chat Completions-compatible".
  - Updated tests in `OpenClawSetup`, `framework-snippets`, and `SetupStepAddProvider`.

- **Migration**
  - If you used the previous snippet, re-copy it from the dashboard or set `models.providers.manifest.api` to `openai-completions` and restart the OpenClaw gateway.

<sup>Written for commit 18a9ddda887c25ec6b07c5440ef07a7f7484afba. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1751?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

