### PR TITLE
feat(dashboard): add two-tab Hermes setup matching OpenClaw pattern

### DIFF
--- a/packages/frontend/src/components/HermesSetup.tsx
+++ b/packages/frontend/src/components/HermesSetup.tsx
@@ -99,7 +99,7 @@ const HermesSetup: Component<Props> = (props) => {
           role="tab"
           aria-selected={subTab() === 'wizard'}
         >
-          hermes onboard
+          Hermes onboard
         </button>
       </div>
 

--- a/packages/frontend/src/components/HermesSetup.tsx
+++ b/packages/frontend/src/components/HermesSetup.tsx
@@ -3,6 +3,8 @@ import CopyButton from './CopyButton.jsx';
 import CodeBlock from './CodeBlock.jsx';
 import { highlight } from '../services/syntax-highlight.js';
 
+type SubTab = 'cli' | 'wizard';
+
 interface Props {
   apiKey: string | null;
   keyPrefix: string | null;
@@ -55,72 +57,133 @@ const OnboardField: Component<{
 );
 
 const HermesSetup: Component<Props> = (props) => {
-  const [keyRevealed, setKeyRevealed] = createSignal(false);
+  const [subTab, setSubTab] = createSignal<SubTab>('cli');
+  const [cliKeyRevealed, setCliKeyRevealed] = createSignal(false);
+  const [wizKeyRevealed, setWizKeyRevealed] = createSignal(false);
+
   const hasFullKey = () => !!props.apiKey;
   const masked = () => (props.keyPrefix ? `${props.keyPrefix}...` : 'mnfst_YOUR_KEY');
-  const displayKey = () => (keyRevealed() && props.apiKey ? props.apiKey : masked());
   const copyKey = () => props.apiKey ?? masked();
+  const cliKey = () => (cliKeyRevealed() && props.apiKey ? props.apiKey : masked());
+  const wizKey = () => (wizKeyRevealed() && props.apiKey ? props.apiKey : masked());
 
   const yamlConfig = () =>
-    `model:\n  provider: custom\n  base_url: ${props.baseUrl}\n  api_key: ${displayKey()}\n  default: auto`;
+    `model:\n  provider: custom\n  base_url: ${props.baseUrl}\n  api_key: ${cliKey()}\n  default: auto`;
   const yamlConfigCopy = () =>
     `model:\n  provider: custom\n  base_url: ${props.baseUrl}\n  api_key: ${copyKey()}\n  default: auto`;
 
   return (
     <div class="setup-agents-card">
       <p class="setup-step__desc">
-        Point Hermes at the Manifest endpoint to route requests through your configured providers.
+        Point Hermes at the Manifest endpoint to route requests across multiple models.
       </p>
 
-      <p class="setup-method__hint">Open the Hermes configuration file:</p>
-      <CodeBlock code="hermes config edit" language="bash" />
-
-      <p class="setup-method__hint" style="margin-top: 12px;">
-        Add the following <code class="setup-model-hint__code">model:</code> section to your{' '}
-        <code class="setup-model-hint__code">config.yaml</code>:
-      </p>
-      <div class="setup-cli-block">
-        <div class="setup-cli-block__actions">
-          <Show when={hasFullKey()}>
-            <button
-              class="setup-onboard-fields__eye"
-              onClick={() => setKeyRevealed(!keyRevealed())}
-              aria-label={keyRevealed() ? 'Hide API key' : 'Reveal API key'}
-              title={keyRevealed() ? 'Hide key' : 'Reveal key'}
-            >
-              <EyeIcon open={keyRevealed()} />
-            </button>
-          </Show>
-          <CopyButton text={yamlConfigCopy()} />
-        </div>
-        <div class="setup-method__code">
-          <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
-            <code class="hljs language-yaml" innerHTML={highlight(yamlConfig(), 'yaml')} />
-          </pre>
-        </div>
+      <div
+        class="setup-segment setup-segment--full"
+        role="tablist"
+        aria-label="Configuration method"
+      >
+        <button
+          class="setup-segment__btn"
+          classList={{ 'setup-segment__btn--active': subTab() === 'cli' }}
+          onClick={() => setSubTab('cli')}
+          role="tab"
+          aria-selected={subTab() === 'cli'}
+        >
+          Configuration file
+        </button>
+        <button
+          class="setup-segment__btn"
+          classList={{ 'setup-segment__btn--active': subTab() === 'wizard' }}
+          onClick={() => setSubTab('wizard')}
+          role="tab"
+          aria-selected={subTab() === 'wizard'}
+        >
+          hermes onboard
+        </button>
       </div>
 
-      <div class="setup-onboard-fields" role="list" aria-label="Configuration values">
-        <OnboardField label="Base URL" value={props.baseUrl} copyable />
-        <div class="setup-onboard-fields__row" role="listitem">
-          <span class="setup-onboard-fields__label">API Key</span>
-          <span class="setup-onboard-fields__value">
-            <code>{displayKey()}</code>
+      <Show when={subTab() === 'cli'}>
+        <p class="setup-method__hint">Open the Hermes configuration file:</p>
+        <CodeBlock code="hermes config edit" language="bash" />
+
+        <p class="setup-method__hint" style="margin-top: 12px;">
+          Add the following <code class="setup-model-hint__code">model:</code> section to your{' '}
+          <code class="setup-model-hint__code">config.yaml</code>:
+        </p>
+        <div class="setup-cli-block">
+          <div class="setup-cli-block__actions">
             <Show when={hasFullKey()}>
               <button
                 class="setup-onboard-fields__eye"
-                onClick={() => setKeyRevealed(!keyRevealed())}
-                aria-label={keyRevealed() ? 'Hide API key' : 'Reveal API key'}
-                title={keyRevealed() ? 'Hide key' : 'Reveal key'}
+                onClick={() => setCliKeyRevealed(!cliKeyRevealed())}
+                aria-label={cliKeyRevealed() ? 'Hide API key' : 'Reveal API key'}
+                title={cliKeyRevealed() ? 'Hide key' : 'Reveal key'}
               >
-                <EyeIcon open={keyRevealed()} />
+                <EyeIcon open={cliKeyRevealed()} />
               </button>
             </Show>
-            <CopyButton text={copyKey()} />
-          </span>
+            <CopyButton text={yamlConfigCopy()} />
+          </div>
+          <div class="setup-method__code">
+            <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
+              <code class="hljs language-yaml" innerHTML={highlight(yamlConfig(), 'yaml')} />
+            </pre>
+          </div>
         </div>
-        <OnboardField label="Model" value="auto" copyable />
-      </div>
+
+        <div class="setup-onboard-fields" role="list" aria-label="Configuration values">
+          <OnboardField label="provider" value="custom" copyable />
+          <OnboardField label="base_url" value={props.baseUrl} copyable />
+          <div class="setup-onboard-fields__row" role="listitem">
+            <span class="setup-onboard-fields__label">api_key</span>
+            <span class="setup-onboard-fields__value">
+              <code>{cliKey()}</code>
+              <Show when={hasFullKey()}>
+                <button
+                  class="setup-onboard-fields__eye"
+                  onClick={() => setCliKeyRevealed(!cliKeyRevealed())}
+                  aria-label={cliKeyRevealed() ? 'Hide API key' : 'Reveal API key'}
+                  title={cliKeyRevealed() ? 'Hide key' : 'Reveal key'}
+                >
+                  <EyeIcon open={cliKeyRevealed()} />
+                </button>
+              </Show>
+              <CopyButton text={copyKey()} />
+            </span>
+          </div>
+          <OnboardField label="default" value="auto" copyable />
+        </div>
+      </Show>
+
+      <Show when={subTab() === 'wizard'}>
+        <p class="setup-method__hint">
+          Run the onboarding wizard and select <strong>Custom endpoint</strong> when prompted. Then
+          enter the following values:
+        </p>
+        <CodeBlock code="hermes model" language="bash" />
+        <div class="setup-onboard-fields" role="list" aria-label="Configuration values">
+          <OnboardField label="API base URL" value={props.baseUrl} copyable />
+          <div class="setup-onboard-fields__row" role="listitem">
+            <span class="setup-onboard-fields__label">API Key</span>
+            <span class="setup-onboard-fields__value">
+              <code>{wizKey()}</code>
+              <Show when={hasFullKey()}>
+                <button
+                  class="setup-onboard-fields__eye"
+                  onClick={() => setWizKeyRevealed(!wizKeyRevealed())}
+                  aria-label={wizKeyRevealed() ? 'Hide API key' : 'Reveal API key'}
+                  title={wizKeyRevealed() ? 'Hide key' : 'Reveal key'}
+                >
+                  <EyeIcon open={wizKeyRevealed()} />
+                </button>
+              </Show>
+              <CopyButton text={copyKey()} />
+            </span>
+          </div>
+          <OnboardField label="Model name" value="auto" copyable />
+        </div>
+      </Show>
     </div>
   );
 };

--- a/packages/frontend/tests/components/HermesSetup.test.tsx
+++ b/packages/frontend/tests/components/HermesSetup.test.tsx
@@ -23,14 +23,14 @@ describe("HermesSetup", () => {
     expect(container.textContent).toContain("Point Hermes at the Manifest endpoint to route requests across multiple models");
   });
 
-  it("renders CLI and hermes onboard tabs", () => {
+  it("renders CLI and Hermes onboard tabs", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
     const segment = container.querySelector(".setup-segment--full");
     expect(segment).not.toBeNull();
     const btns = segment!.querySelectorAll(".setup-segment__btn");
     expect(btns).toHaveLength(2);
     expect(btns[0].textContent).toBe("Configuration file");
-    expect(btns[1].textContent).toBe("hermes onboard");
+    expect(btns[1].textContent).toBe("Hermes onboard");
   });
 
   it("defaults to Configuration file tab", () => {
@@ -180,9 +180,9 @@ describe("HermesSetup", () => {
     expect(container.textContent).toContain("mnfst_pre...");
   });
 
-  // --- hermes onboard (wizard) tab tests ---
+  // --- Hermes onboard (wizard) tab tests ---
 
-  it("switches to hermes onboard tab", () => {
+  it("switches to Hermes onboard tab", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
     const segment = container.querySelector(".setup-segment--full");
     const btns = segment!.querySelectorAll(".setup-segment__btn");
@@ -192,7 +192,7 @@ describe("HermesSetup", () => {
     expect(container.textContent).toContain("Custom endpoint");
   });
 
-  it("shows wizard hint text on hermes onboard tab", () => {
+  it("shows wizard hint text on Hermes onboard tab", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
     const segment = container.querySelector(".setup-segment--full");
     fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);

--- a/packages/frontend/tests/components/HermesSetup.test.tsx
+++ b/packages/frontend/tests/components/HermesSetup.test.tsx
@@ -20,12 +20,35 @@ describe("HermesSetup", () => {
 
   it("renders description text", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
-    expect(container.textContent).toContain("Point Hermes at the Manifest endpoint");
+    expect(container.textContent).toContain("Point Hermes at the Manifest endpoint to route requests across multiple models");
   });
 
-  it("shows hermes config edit command", () => {
+  it("renders CLI and hermes onboard tabs", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    expect(segment).not.toBeNull();
+    const btns = segment!.querySelectorAll(".setup-segment__btn");
+    expect(btns).toHaveLength(2);
+    expect(btns[0].textContent).toBe("Configuration file");
+    expect(btns[1].textContent).toBe("hermes onboard");
+  });
+
+  it("defaults to Configuration file tab", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    const btns = segment!.querySelectorAll(".setup-segment__btn");
+    expect(btns[0].classList.contains("setup-segment__btn--active")).toBe(true);
+    expect(btns[1].classList.contains("setup-segment__btn--active")).toBe(false);
+  });
+
+  it("shows hermes config edit command on CLI tab", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
     expect(container.textContent).toContain("hermes config edit");
+  });
+
+  it("shows CLI hint text on CLI tab", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    expect(container.textContent).toContain("Open the Hermes configuration file");
   });
 
   it("shows config.yaml code block with model section only", () => {
@@ -37,15 +60,17 @@ describe("HermesSetup", () => {
     expect(container.textContent).not.toContain("custom_providers:");
   });
 
-
-  it("shows onboard fields", () => {
+  it("shows onboard fields on CLI tab with YAML key names", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
-    const fields = container.querySelectorAll('[role="listitem"]');
-    expect(fields.length).toBeGreaterThanOrEqual(2);
-    expect(container.textContent).toContain("Model");
-    expect(container.textContent).toContain("auto");
-    expect(container.textContent).toContain("Base URL");
-    expect(container.textContent).toContain("API Key");
+    const fields = container.querySelectorAll(".setup-onboard-fields__row");
+    expect(fields.length).toBeGreaterThanOrEqual(4);
+    expect(fields[0].textContent).toContain("provider");
+    expect(fields[0].textContent).toContain("custom");
+    expect(fields[1].textContent).toContain("base_url");
+    expect(fields[1].textContent).toContain("http://localhost:3001/v1");
+    expect(fields[2].textContent).toContain("api_key");
+    expect(fields[3].textContent).toContain("default");
+    expect(fields[3].textContent).toContain("auto");
   });
 
   it("shows masked key placeholder when no apiKey or keyPrefix", () => {
@@ -67,14 +92,14 @@ describe("HermesSetup", () => {
     expect(container.querySelector('[aria-label="Reveal API key"]')).toBeNull();
   });
 
-  it("shows eye toggle when apiKey provided", () => {
+  it("shows eye toggle on CLI tab when apiKey provided", () => {
     const { container } = render(() => (
       <HermesSetup {...defaultProps} apiKey="mnfst_full_key" keyPrefix="mnfst_ful" />
     ));
     expect(container.querySelector('[aria-label="Reveal API key"]')).not.toBeNull();
   });
 
-  it("reveals key when eye toggle clicked", () => {
+  it("reveals key in CLI when eye toggle clicked", () => {
     const { container } = render(() => (
       <HermesSetup {...defaultProps} apiKey="mnfst_full_key" keyPrefix="mnfst_ful" />
     ));
@@ -83,7 +108,7 @@ describe("HermesSetup", () => {
     expect(container.textContent).toContain("mnfst_full_key");
   });
 
-  it("hides key again on second eye toggle click", () => {
+  it("hides key again on second CLI eye toggle click", () => {
     const { container } = render(() => (
       <HermesSetup {...defaultProps} apiKey="mnfst_full_key" keyPrefix="mnfst_ful" />
     ));
@@ -93,20 +118,13 @@ describe("HermesSetup", () => {
     expect(container.textContent).not.toContain("mnfst_full_key");
   });
 
-  it("shows copy button on API key row", () => {
+  it("shows CLI copy button", () => {
     const { container } = render(() => (
       <HermesSetup {...defaultProps} apiKey="mnfst_full_key" keyPrefix="mnfst_ful" />
     ));
-    const apiKeyRow = Array.from(container.querySelectorAll('[role="listitem"]'))
-      .find(r => r.textContent?.includes("API Key"));
-    const copyBtn = apiKeyRow?.querySelector('[aria-label="Copy to clipboard"]');
+    const cliBlock = container.querySelector(".setup-cli-block");
+    const copyBtn = cliBlock!.querySelector('[aria-label="Copy to clipboard"]');
     expect(copyBtn).not.toBeNull();
-  });
-
-  it("has copy buttons for copyable fields", () => {
-    const { container } = render(() => <HermesSetup {...defaultProps} />);
-    const copyBtns = container.querySelectorAll(".modal-terminal__copy");
-    expect(copyBtns.length).toBeGreaterThanOrEqual(1);
   });
 
   it("copies yaml config when copy button in code block is clicked", () => {
@@ -138,7 +156,6 @@ describe("HermesSetup", () => {
     const { container } = render(() => (
       <HermesSetup {...defaultProps} apiKey="mnfst_test" keyPrefix="mnfst_t" />
     ));
-    // The eye icon SVG should be present
     const eyeBtn = container.querySelector('[aria-label="Reveal API key"]');
     expect(eyeBtn).not.toBeNull();
     const svg = eyeBtn!.querySelector("svg");
@@ -163,13 +180,169 @@ describe("HermesSetup", () => {
     expect(container.textContent).toContain("mnfst_pre...");
   });
 
-  it("copy button copies full key when available", () => {
+  // --- hermes onboard (wizard) tab tests ---
+
+  it("switches to hermes onboard tab", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    const btns = segment!.querySelectorAll(".setup-segment__btn");
+    fireEvent.click(btns[1]);
+    expect(btns[1].classList.contains("setup-segment__btn--active")).toBe(true);
+    expect(container.textContent).toContain("hermes model");
+    expect(container.textContent).toContain("Custom endpoint");
+  });
+
+  it("shows wizard hint text on hermes onboard tab", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    expect(container.textContent).toContain("Custom endpoint");
+  });
+
+  it("shows onboard fields on wizard tab with Hermes field names", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    const fieldsList = container.querySelector('[aria-label="Configuration values"]');
+    const fields = fieldsList!.querySelectorAll(".setup-onboard-fields__row");
+    expect(fields).toHaveLength(3);
+    expect(fields[0].textContent).toContain("API base URL");
+    expect(fields[0].textContent).toContain("http://localhost:3001/v1");
+    expect(fields[1].textContent).toContain("API Key");
+    expect(fields[2].textContent).toContain("Model name");
+    expect(fields[2].textContent).toContain("auto");
+  });
+
+  it("does not show Provider row on wizard tab", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    const fieldsList = container.querySelector('[aria-label="Configuration values"]');
+    const fields = fieldsList!.querySelectorAll(".setup-onboard-fields__row");
+    const labels = Array.from(fields).map((f) => f.querySelector(".setup-onboard-fields__label")?.textContent);
+    expect(labels).not.toContain("Provider");
+  });
+
+  it("shows eye toggle on wizard API Key field when apiKey provided", () => {
     const { container } = render(() => (
-      <HermesSetup {...defaultProps} apiKey="mnfst_copy_test" keyPrefix="mnfst_co" />
+      <HermesSetup {...defaultProps} apiKey="mnfst_wiz" keyPrefix="mnfst_wi" />
     ));
-    // The copy button text should be based on copyKey() which is apiKey when available
-    const apiKeyRow = Array.from(container.querySelectorAll('[role="listitem"]'))
-      .find(r => r.textContent?.includes("API Key"));
-    expect(apiKeyRow).not.toBeNull();
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    const eyeBtns = container.querySelectorAll('[aria-label="Reveal API key"]');
+    expect(eyeBtns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reveals API key in wizard field when eye toggle clicked", () => {
+    const { container } = render(() => (
+      <HermesSetup {...defaultProps} apiKey="mnfst_wiz_full" keyPrefix="mnfst_wi" />
+    ));
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    expect(container.textContent).not.toContain("mnfst_wiz_full");
+    fireEvent.click(container.querySelector('[aria-label="Reveal API key"]')!);
+    expect(container.textContent).toContain("mnfst_wiz_full");
+  });
+
+  it("shows wizard copy button when key is hidden", () => {
+    const { container } = render(() => (
+      <HermesSetup {...defaultProps} apiKey="mnfst_wiz" keyPrefix="mnfst_wi" />
+    ));
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    const copyBtns = container.querySelectorAll('[aria-label="Copy to clipboard"]');
+    expect(copyBtns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("switches back from wizard to CLI tab", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    const btns = segment!.querySelectorAll(".setup-segment__btn");
+    fireEvent.click(btns[1]); // wizard
+    fireEvent.click(btns[0]); // back to CLI
+    expect(btns[0].classList.contains("setup-segment__btn--active")).toBe(true);
+    expect(container.textContent).toContain("Open the Hermes configuration file");
+  });
+
+  it("has correct aria attributes on tabs", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector('[role="tablist"]');
+    expect(segment).not.toBeNull();
+    const btns = segment!.querySelectorAll('[role="tab"]');
+    expect(btns).toHaveLength(2);
+    expect(btns[0].getAttribute("aria-selected")).toBe("true");
+    expect(btns[1].getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("hides CLI content when wizard tab is active", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    expect(container.textContent).not.toContain("hermes config edit");
+    expect(container.textContent).not.toContain("config.yaml");
+  });
+
+  it("hides wizard content when CLI tab is active", () => {
+    const { container } = render(() => <HermesSetup {...defaultProps} />);
+    expect(container.textContent).not.toContain("Run the onboarding wizard");
+  });
+
+  it("copies CLI snippet with full key to clipboard when revealed", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const { container } = render(() => (
+      <HermesSetup {...defaultProps} apiKey="mnfst_clip_key" keyPrefix="mnfst_cli" />
+    ));
+    fireEvent.click(container.querySelector('[aria-label="Reveal API key"]')!);
+    const cliBlock = container.querySelector(".setup-cli-block");
+    const copyBtn = cliBlock!.querySelector('[aria-label="Copy to clipboard"]');
+    fireEvent.click(copyBtn!);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalled();
+      const copiedText = writeText.mock.calls[0][0] as string;
+      expect(copiedText).toContain("mnfst_clip_key");
+      expect(copiedText).toContain("provider: custom");
+    });
+  });
+
+  it("wizard tab uses custom base URL", () => {
+    const { container } = render(() => (
+      <HermesSetup {...defaultProps} baseUrl="https://app.manifest.build/v1" />
+    ));
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    expect(container.textContent).toContain("https://app.manifest.build/v1");
+  });
+
+  it("wizard and CLI tabs have independent key reveal state", () => {
+    const { container } = render(() => (
+      <HermesSetup {...defaultProps} apiKey="mnfst_independent" keyPrefix="mnfst_in" />
+    ));
+    // Reveal key on CLI tab
+    fireEvent.click(container.querySelector('[aria-label="Reveal API key"]')!);
+    expect(container.textContent).toContain("mnfst_independent");
+    // Switch to wizard tab -- key should be masked there
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    const fieldsList = container.querySelector('[aria-label="Configuration values"]');
+    const fields = fieldsList!.querySelectorAll(".setup-onboard-fields__row");
+    const apiKeyField = Array.from(fields).find((f) =>
+      f.textContent?.includes("API Key")
+    );
+    expect(apiKeyField?.textContent).toContain("mnfst_in...");
+    expect(apiKeyField?.textContent).not.toContain("mnfst_independent");
+  });
+
+  it("CLI tab api_key field has eye toggle and copy button", () => {
+    const { container } = render(() => (
+      <HermesSetup {...defaultProps} apiKey="mnfst_cli_field" keyPrefix="mnfst_cl" />
+    ));
+    const fields = container.querySelectorAll(".setup-onboard-fields__row");
+    const apiKeyField = Array.from(fields).find((f) =>
+      f.querySelector(".setup-onboard-fields__label")?.textContent === "api_key"
+    );
+    expect(apiKeyField).not.toBeNull();
+    expect(apiKeyField!.querySelector('[aria-label="Reveal API key"]')).not.toBeNull();
+    expect(apiKeyField!.querySelector('[aria-label="Copy to clipboard"]')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## ✨ What changed
- Added two tabs to the Hermes setup modal: "Configuration file" and "hermes onboard"
- The "Configuration file" tab shows the YAML config block plus individual copyable fields (provider, base_url, api_key, default)
- The "hermes onboard" tab walks users through `hermes model` with Hermes-specific field names (API base URL, API Key, Model name)
- Independent key reveal state per tab so toggling visibility on one tab doesn't affect the other

## 💭 Why
Hermes users only had a raw YAML block to copy, while OpenClaw users had a full two-tab experience with a step-by-step wizard. This gap made onboarding harder for the growing Hermes user segment.

## 👤 For users
When setting up a Hermes agent, the setup modal now shows two tabs. The "Configuration file" tab works like before but adds copyable individual fields below the YAML block. The new "hermes onboard" tab guides users through the `hermes model` interactive wizard with pre-filled values to enter at each prompt.

## 🔧 For operators
No operator impact.

## 🧪 How to test
1. Open the dashboard and create a new agent with "Hermes Agent" as the platform
2. The setup modal should show two tabs: "Configuration file" and "hermes onboard"
3. On "Configuration file": verify the YAML block and individual copyable fields (provider, base_url, api_key, default) appear
4. On "hermes onboard": verify the `hermes model` command block and fields (API base URL, API Key, Model name) appear
5. Toggle key visibility on one tab, switch tabs, confirm the other tab's key stays masked

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-tab Hermes setup modal that matches the OpenClaw pattern, making onboarding clearer and faster. Users can choose a YAML-based setup or a guided `hermes model` flow.

- **New Features**
  - Configuration file tab: shows YAML plus copyable fields (`provider`, `base_url`, `api_key`, `default`) and a copy-all button.
  - Hermes onboard tab: walks through `hermes model` with Hermes terms (API base URL, API Key, Model name).
  - Independent API key visibility per tab; improved hint text to “route requests across multiple models.”

- **Bug Fixes**
  - Capitalized the tab label to “Hermes onboard.”

<sup>Written for commit c5f0bfe2b868aaee12c6317e19b4673429a3703f. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1754?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

