### PR TITLE
fix: inject include_usage for all OpenAI-format providers

### DIFF
--- a/.changeset/proxy-include-usage-all-providers.md
+++ b/.changeset/proxy-include-usage-all-providers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix proxy recording 0 tokens and "—" cost for streaming requests against Mistral, Kimi (Moonshot), MiniMax, DeepSeek, Qwen, xAI, Z.AI, Copilot, OpenCode-Go, and custom OpenAI-compatible providers. The proxy now injects `stream_options.include_usage: true` for all OpenAI-format endpoints so usage data flows back from the upstream.

--- a/.changeset/proxy-include-usage-all-providers.md
+++ b/.changeset/proxy-include-usage-all-providers.md
@@ -3,3 +3,5 @@
 ---
 
 Fix proxy recording 0 tokens and "—" cost for streaming requests against Mistral, Kimi (Moonshot), MiniMax, DeepSeek, Qwen, xAI, Z.AI, Copilot, OpenCode-Go, and custom OpenAI-compatible providers. The proxy now injects `stream_options.include_usage: true` for all OpenAI-format endpoints so usage data flows back from the upstream.
+
+Also fix the cache-tokens column staying empty for the same providers: usage extraction now reads `prompt_tokens_details.cached_tokens` (DeepSeek, Z.AI, Mistral, MiniMax, OpenAI shape) in addition to the top-level `cache_read_tokens` and Anthropic-native `input_tokens_details.cached_tokens` keys.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1830,18 +1830,46 @@ describe('ProviderClient', () => {
       expect(sentBody.stream_options).toBeUndefined();
     });
 
-    it('does not inject stream_options for non-passthrough providers', async () => {
+    it.each([
+      ['mistral', 'mistral-small'],
+      ['deepseek', 'deepseek-chat'],
+      ['moonshot', 'kimi-k2-0905-preview'],
+      ['minimax', 'MiniMax-M2'],
+      ['qwen', 'qwen-max'],
+      ['xai', 'grok-3'],
+      ['zai', 'glm-4.6'],
+      ['copilot', 'gpt-4o-copilot'],
+      ['opencode-go', 'claude-sonnet-4'],
+    ])(
+      'injects stream_options.include_usage for %s streaming requests',
+      async (provider, model) => {
+        mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+        await client.forward({
+          provider,
+          apiKey: 'sk-test',
+          model,
+          body: { messages: [{ role: 'user', content: 'Hello' }] },
+          stream: true,
+        });
+
+        const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(sentBody.stream_options).toEqual({ include_usage: true });
+      },
+    );
+
+    it('injects stream_options.include_usage for Z.AI subscription streaming requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({
-        provider: 'mistral',
-        apiKey: 'sk-mi',
-        model: 'mistral-small',
+        provider: 'zai',
+        apiKey: 'sk-zai-sub',
+        model: 'glm-4.6',
         body: { messages: [{ role: 'user', content: 'Hello' }] },
         stream: true,
+        authType: 'subscription',
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.stream_options).toBeUndefined();
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
     it('preserves existing stream_options fields when injecting include_usage', async () => {
@@ -1922,6 +1950,7 @@ describe('ProviderClient', () => {
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.stream).toBe(true);
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
     it('merges extraHeaders with custom endpoint headers', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -903,6 +903,36 @@ describe('proxy-response-handler', () => {
       expect(res.json).toHaveBeenCalledWith(body);
     });
 
+    it('should extract cached prompt tokens from prompt_tokens_details', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const body = {
+        id: 'chatcmpl-cached',
+        usage: {
+          prompt_tokens: 50,
+          completion_tokens: 25,
+          prompt_tokens_details: { cached_tokens: 12 },
+        },
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta();
+
+      const usage = await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+      );
+
+      expect(usage).toEqual({
+        prompt_tokens: 50,
+        completion_tokens: 25,
+        cache_read_tokens: 12,
+        cache_creation_tokens: undefined,
+      });
+    });
+
     it('should pass through native Responses JSON and extract Responses usage', async () => {
       const { res } = mockResponse();
       const client = mockProviderClient();

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -1,4 +1,10 @@
-import { initSseHeaders, parseSseEvents, pipeStream, extractUsageFromSse } from '../stream-writer';
+import {
+  initSseHeaders,
+  parseSseEvents,
+  pipeStream,
+  extractUsageFromSse,
+  parseUsageObject,
+} from '../stream-writer';
 
 function mockResponse(): {
   res: Record<string, jest.Mock | boolean>;
@@ -506,6 +512,32 @@ describe('pipeStream', () => {
     });
   });
 
+  it('should capture response.usage from leftover passthrough buffer', async () => {
+    const { res } = mockResponse();
+    const usagePayload = JSON.stringify({
+      response: {
+        usage: {
+          input_tokens: 7,
+          output_tokens: 9,
+          input_tokens_details: { cached_tokens: 2 },
+        },
+      },
+    });
+    const stream = createReadableStream([
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'hi' } }] })}\n\n`,
+      `data: ${usagePayload}`,
+    ]);
+
+    const usage = await pipeStream(stream, res as never);
+
+    expect(usage).toEqual({
+      prompt_tokens: 7,
+      completion_tokens: 9,
+      cache_read_tokens: 2,
+      cache_creation_tokens: 0,
+    });
+  });
+
   it('should handle non-JSON leftover in passthrough buffer', async () => {
     const { res } = mockResponse();
     const stream = createReadableStream([
@@ -556,6 +588,113 @@ describe('pipeStream', () => {
     const usage = await pipeStream(stream, res as never, transform);
 
     expect(usage).toEqual(expect.objectContaining({ prompt_tokens: 50, completion_tokens: 25 }));
+  });
+});
+
+describe('parseUsageObject', () => {
+  it('returns null for null/undefined/non-object', () => {
+    expect(parseUsageObject(null)).toBeNull();
+    expect(parseUsageObject(undefined)).toBeNull();
+    expect(parseUsageObject('not an object')).toBeNull();
+    expect(parseUsageObject(42)).toBeNull();
+  });
+
+  it('returns null when neither prompt_tokens nor input_tokens is present', () => {
+    expect(parseUsageObject({ total_tokens: 5 })).toBeNull();
+  });
+
+  it('falls back to prompt_tokens_details.cached_tokens when cache_read_tokens is absent', () => {
+    expect(
+      parseUsageObject({
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        prompt_tokens_details: { cached_tokens: 4 },
+      }),
+    ).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      cache_read_tokens: 4,
+      cache_creation_tokens: undefined,
+    });
+  });
+
+  it('ignores non-object prompt_tokens_details', () => {
+    expect(
+      parseUsageObject({ prompt_tokens: 7, completion_tokens: 1, prompt_tokens_details: null }),
+    ).toEqual({
+      prompt_tokens: 7,
+      completion_tokens: 1,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: undefined,
+    });
+  });
+
+  it('ignores non-numeric cached_tokens in prompt_tokens_details', () => {
+    expect(
+      parseUsageObject({
+        prompt_tokens: 7,
+        completion_tokens: 1,
+        prompt_tokens_details: { cached_tokens: 'oops' },
+      }),
+    ).toEqual({
+      prompt_tokens: 7,
+      completion_tokens: 1,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: undefined,
+    });
+  });
+
+  it('ignores non-object input_tokens_details and missing cached_tokens', () => {
+    expect(parseUsageObject({ input_tokens: 3, output_tokens: 2 })).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 2,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: 0,
+    });
+    expect(
+      parseUsageObject({ input_tokens: 3, output_tokens: 2, input_tokens_details: null }),
+    ).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 2,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: 0,
+    });
+    expect(
+      parseUsageObject({
+        input_tokens: 3,
+        output_tokens: 2,
+        input_tokens_details: { cached_tokens: 'oops' },
+      }),
+    ).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 2,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  it('passes through cache_creation_tokens for the OpenAI-compat shape', () => {
+    expect(
+      parseUsageObject({
+        prompt_tokens: 5,
+        completion_tokens: 5,
+        cache_creation_tokens: 11,
+      }),
+    ).toEqual({
+      prompt_tokens: 5,
+      completion_tokens: 5,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: 11,
+    });
+  });
+
+  it('defaults output_tokens to 0 in the Anthropic shape when missing', () => {
+    expect(parseUsageObject({ input_tokens: 4 })).toEqual({
+      prompt_tokens: 4,
+      completion_tokens: 0,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: 0,
+    });
   });
 });
 
@@ -619,6 +758,43 @@ describe('extractUsageFromSse', () => {
       completion_tokens: 60,
       cache_read_tokens: 25,
       cache_creation_tokens: 0,
+    });
+  });
+
+  it('should extract cached prompt tokens from prompt_tokens_details (DeepSeek/Z.AI/Mistral shape)', () => {
+    const sseText = `data: ${JSON.stringify({
+      choices: [],
+      usage: {
+        prompt_tokens: 22,
+        completion_tokens: 4,
+        prompt_tokens_details: { cached_tokens: 8 },
+      },
+    })}\n\n`;
+
+    expect(extractUsageFromSse(sseText)).toEqual({
+      prompt_tokens: 22,
+      completion_tokens: 4,
+      cache_read_tokens: 8,
+      cache_creation_tokens: undefined,
+    });
+  });
+
+  it('should prefer top-level cache_read_tokens over prompt_tokens_details when both are present', () => {
+    const sseText = `data: ${JSON.stringify({
+      choices: [],
+      usage: {
+        prompt_tokens: 50,
+        completion_tokens: 10,
+        cache_read_tokens: 12,
+        prompt_tokens_details: { cached_tokens: 99 },
+      },
+    })}\n\n`;
+
+    expect(extractUsageFromSse(sseText)).toEqual({
+      prompt_tokens: 50,
+      completion_tokens: 10,
+      cache_read_tokens: 12,
+      cache_creation_tokens: undefined,
     });
   });
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -41,7 +41,23 @@ const PROVIDER_TIMEOUT_MS = 180_000;
  * `stream_options.include_usage`. Token usage is needed for DB logging and for
  * downstream clients (e.g. OpenClaw context management).
  */
-const SUPPORTS_USAGE_STREAM_OPTIONS = new Set(['openai', 'openrouter', 'ollama', 'ollama-cloud']);
+const SUPPORTS_USAGE_STREAM_OPTIONS = new Set([
+  'openai',
+  'openrouter',
+  'ollama',
+  'ollama-cloud',
+  'mistral',
+  'deepseek',
+  'moonshot',
+  'minimax',
+  'qwen',
+  'xai',
+  'zai',
+  'zai-subscription',
+  'copilot',
+  'opencode-go',
+  'custom',
+]);
 
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -6,7 +6,7 @@ import { FailedFallback } from './proxy-fallback.service';
 import { ForwardResult } from './provider-client';
 import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ProviderClient } from './provider-client';
-import { initSseHeaders, pipeStream, StreamUsage } from './stream-writer';
+import { initSseHeaders, parseUsageObject, pipeStream, StreamUsage } from './stream-writer';
 import { sanitizeProviderError } from './proxy-error-sanitizer';
 import {
   chatCompletionStreamChunkToResponses,
@@ -360,29 +360,7 @@ export async function handleNonStreamResponse(
   }
 
   const body = responseBody as Record<string, unknown> | undefined;
-  const usage = body?.usage as Record<string, number | Record<string, number>> | undefined;
-  let streamUsage: StreamUsage | null = null;
-  if (usage && typeof usage.prompt_tokens === 'number') {
-    streamUsage = {
-      prompt_tokens: usage.prompt_tokens,
-      completion_tokens: typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0,
-      cache_read_tokens:
-        typeof usage.cache_read_tokens === 'number' ? usage.cache_read_tokens : undefined,
-      cache_creation_tokens:
-        typeof usage.cache_creation_tokens === 'number' ? usage.cache_creation_tokens : undefined,
-    };
-  } else if (usage && typeof usage.input_tokens === 'number') {
-    const inputDetails =
-      typeof usage.input_tokens_details === 'object' && usage.input_tokens_details !== null
-        ? (usage.input_tokens_details as Record<string, number>)
-        : undefined;
-    streamUsage = {
-      prompt_tokens: usage.input_tokens,
-      completion_tokens: typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
-      cache_read_tokens: inputDetails?.cached_tokens,
-      cache_creation_tokens: 0,
-    };
-  }
+  const streamUsage = parseUsageObject(body?.usage);
 
   res.status(200);
   setHeaders(res, metaHeaders);

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -7,6 +7,58 @@ export interface StreamUsage {
   cache_creation_tokens?: number;
 }
 
+/**
+ * Read a usage block in either OpenAI-compat (`prompt_tokens`/`completion_tokens`)
+ * or Anthropic-native (`input_tokens`/`output_tokens`) shape and normalise it
+ * to a `StreamUsage`. Returns null when neither shape is present.
+ *
+ * OpenAI-compatible providers expose cached prompt tokens under the nested
+ * `prompt_tokens_details.cached_tokens` field, not the top-level
+ * `cache_read_tokens` key — DeepSeek, Z.AI, MiniMax, Mistral, etc. all use the
+ * nested form. Falling back to the nested key keeps the cache column populated
+ * for those providers.
+ */
+export function parseUsageObject(usage: unknown): StreamUsage | null {
+  if (!usage || typeof usage !== 'object') return null;
+  const u = usage as Record<string, unknown>;
+
+  if (typeof u.prompt_tokens === 'number') {
+    const promptDetails =
+      typeof u.prompt_tokens_details === 'object' && u.prompt_tokens_details !== null
+        ? (u.prompt_tokens_details as Record<string, unknown>)
+        : undefined;
+    const cacheRead =
+      typeof u.cache_read_tokens === 'number'
+        ? u.cache_read_tokens
+        : typeof promptDetails?.cached_tokens === 'number'
+          ? promptDetails.cached_tokens
+          : undefined;
+    return {
+      prompt_tokens: u.prompt_tokens,
+      completion_tokens: typeof u.completion_tokens === 'number' ? u.completion_tokens : 0,
+      cache_read_tokens: cacheRead,
+      cache_creation_tokens:
+        typeof u.cache_creation_tokens === 'number' ? u.cache_creation_tokens : undefined,
+    };
+  }
+
+  if (typeof u.input_tokens === 'number') {
+    const inputDetails =
+      typeof u.input_tokens_details === 'object' && u.input_tokens_details !== null
+        ? (u.input_tokens_details as Record<string, unknown>)
+        : undefined;
+    return {
+      prompt_tokens: u.input_tokens,
+      completion_tokens: typeof u.output_tokens === 'number' ? u.output_tokens : 0,
+      cache_read_tokens:
+        typeof inputDetails?.cached_tokens === 'number' ? inputDetails.cached_tokens : undefined,
+      cache_creation_tokens: 0,
+    };
+  }
+
+  return null;
+}
+
 /** Extract usage data from an SSE-formatted text chunk (e.g. `data: {...}\n\n`). */
 export function extractUsageFromSse(sseText: string): StreamUsage | null {
   for (const line of sseText.split('\n')) {
@@ -16,30 +68,10 @@ export function extractUsageFromSse(sseText: string): StreamUsage | null {
     if (json === '[DONE]') continue;
     try {
       const obj = JSON.parse(json);
-      if (obj.usage && typeof obj.usage.prompt_tokens === 'number') {
-        return {
-          prompt_tokens: obj.usage.prompt_tokens,
-          completion_tokens: obj.usage.completion_tokens ?? 0,
-          cache_read_tokens: obj.usage.cache_read_tokens,
-          cache_creation_tokens: obj.usage.cache_creation_tokens,
-        };
-      }
-      if (obj.usage && typeof obj.usage.input_tokens === 'number') {
-        return {
-          prompt_tokens: obj.usage.input_tokens,
-          completion_tokens: obj.usage.output_tokens ?? 0,
-          cache_read_tokens: obj.usage.input_tokens_details?.cached_tokens,
-          cache_creation_tokens: 0,
-        };
-      }
-      if (obj.response?.usage && typeof obj.response.usage.input_tokens === 'number') {
-        return {
-          prompt_tokens: obj.response.usage.input_tokens,
-          completion_tokens: obj.response.usage.output_tokens ?? 0,
-          cache_read_tokens: obj.response.usage.input_tokens_details?.cached_tokens,
-          cache_creation_tokens: 0,
-        };
-      }
+      const fromUsage = parseUsageObject(obj.usage);
+      if (fromUsage) return fromUsage;
+      const fromResponse = parseUsageObject(obj.response?.usage);
+      if (fromResponse) return fromResponse;
     } catch {
       /* ignore parse errors */
     }
@@ -144,30 +176,12 @@ export async function pipeStream(
           for (const ev of ptEvents) {
             try {
               const obj = JSON.parse(ev);
-              if (obj.usage && typeof obj.usage.prompt_tokens === 'number') {
-                capturedUsage = {
-                  prompt_tokens: obj.usage.prompt_tokens,
-                  completion_tokens: obj.usage.completion_tokens ?? 0,
-                  cache_read_tokens: obj.usage.cache_read_tokens,
-                  cache_creation_tokens: obj.usage.cache_creation_tokens,
-                };
-              } else if (obj.usage && typeof obj.usage.input_tokens === 'number') {
-                capturedUsage = {
-                  prompt_tokens: obj.usage.input_tokens,
-                  completion_tokens: obj.usage.output_tokens ?? 0,
-                  cache_read_tokens: obj.usage.input_tokens_details?.cached_tokens,
-                  cache_creation_tokens: 0,
-                };
-              } else if (
-                obj.response?.usage &&
-                typeof obj.response.usage.input_tokens === 'number'
-              ) {
-                capturedUsage = {
-                  prompt_tokens: obj.response.usage.input_tokens,
-                  completion_tokens: obj.response.usage.output_tokens ?? 0,
-                  cache_read_tokens: obj.response.usage.input_tokens_details?.cached_tokens,
-                  cache_creation_tokens: 0,
-                };
+              const fromUsage = parseUsageObject(obj.usage);
+              if (fromUsage) {
+                capturedUsage = fromUsage;
+              } else {
+                const fromResponse = parseUsageObject(obj.response?.usage);
+                if (fromResponse) capturedUsage = fromResponse;
               }
             } catch {
               /* ignore non-JSON events */
@@ -189,27 +203,12 @@ export async function pipeStream(
       if (payload && payload !== '[DONE]') {
         try {
           const obj = JSON.parse(payload);
-          if (obj.usage && typeof obj.usage.prompt_tokens === 'number') {
-            capturedUsage = {
-              prompt_tokens: obj.usage.prompt_tokens,
-              completion_tokens: obj.usage.completion_tokens ?? 0,
-              cache_read_tokens: obj.usage.cache_read_tokens,
-              cache_creation_tokens: obj.usage.cache_creation_tokens,
-            };
-          } else if (obj.usage && typeof obj.usage.input_tokens === 'number') {
-            capturedUsage = {
-              prompt_tokens: obj.usage.input_tokens,
-              completion_tokens: obj.usage.output_tokens ?? 0,
-              cache_read_tokens: obj.usage.input_tokens_details?.cached_tokens,
-              cache_creation_tokens: 0,
-            };
-          } else if (obj.response?.usage && typeof obj.response.usage.input_tokens === 'number') {
-            capturedUsage = {
-              prompt_tokens: obj.response.usage.input_tokens,
-              completion_tokens: obj.response.usage.output_tokens ?? 0,
-              cache_read_tokens: obj.response.usage.input_tokens_details?.cached_tokens,
-              cache_creation_tokens: 0,
-            };
+          const fromUsage = parseUsageObject(obj.usage);
+          if (fromUsage) {
+            capturedUsage = fromUsage;
+          } else {
+            const fromResponse = parseUsageObject(obj.response?.usage);
+            if (fromResponse) capturedUsage = fromResponse;
           }
         } catch {
           /* ignore non-JSON remaining content */


### PR DESCRIPTION
### What changed
- Expand `SUPPORTS_USAGE_STREAM_OPTIONS` to every OpenAI-format endpoint we ship plus `custom`.
- Replace the test that codified the old behavior with a parametric `it.each` covering the 9 newly-injected providers.
- Add a Z.AI subscription test and assert injection on the custom-endpoint streaming test.
- Add a changeset for the changelog.

### Why
The proxy recorded 0 tokens and "—" cost for streaming requests against Mistral, Kimi, MiniMax, DeepSeek, Qwen, xAI, Z.AI, Copilot, OpenCode-Go, and custom providers. Without `stream_options.include_usage`, those upstreams emit no usage block, `pipeStream` returns null, the recorder defaults to `{0, 0}`, and the cost calculator returns null on zero tokens.

### For users
Token counts and cost now populate on the Messages page for every API-key provider we support, not just OpenAI / OpenRouter / Ollama. Existing zero-token rows are not backfilled.

### Notes
Closes #1755.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 0-token and "—" cost on streaming chat by injecting `stream_options.include_usage` for all OpenAI-format providers. Also fixes empty cache-tokens by reading `prompt_tokens_details.cached_tokens`, so usage and cost render on the Messages page.

- **Bug Fixes**
  - Expanded `SUPPORTS_USAGE_STREAM_OPTIONS` to include mistral, deepseek, moonshot (Kimi), minimax, qwen, xai, zai (+ subscription), copilot, opencode-go, and custom.
  - Centralized usage parsing in `parseUsageObject` and reused in `extractUsageFromSse`, `pipeStream`, and `handleNonStreamResponse`; prefers `cache_read_tokens`, falls back to `prompt_tokens_details.cached_tokens`, and captures `response.usage` from leftover passthrough buffers.
  - Added parametric tests for injection across these providers (incl. Z.AI subscription and custom streaming), tests for nested cached tokens and passthrough flush, and a changeset for the changelog.

<sup>Written for commit 0b8039be8ce33ea884d4fb6554fb6848a1cc71b4. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1758?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

