### PR TITLE
feat: combine self-hosted message count in public usage API

### DIFF
--- a/.changeset/real-numbers.md
+++ b/.changeset/real-numbers.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Public usage API combines cloud and self-hosted message counts. The `/api/v1/public/usage` endpoint now adds the fleet-wide self-hosted total fetched from the peacock control plane (when `TELEMETRY_AGGREGATE_KEY` is configured) to the cloud count, falling back to cloud-only if peacock is unreachable.

--- a/packages/backend/src/public-stats/public-stats.module.ts
+++ b/packages/backend/src/public-stats/public-stats.module.ts
@@ -5,10 +5,11 @@ import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { FreeModelsModule } from '../free-models/free-models.module';
 import { PublicStatsController } from './public-stats.controller';
 import { PublicStatsService } from './public-stats.service';
+import { SelfHostedUsageService } from './self-hosted-usage.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AgentMessage]), ModelPricesModule, FreeModelsModule],
   controllers: [PublicStatsController],
-  providers: [PublicStatsService],
+  providers: [PublicStatsService, SelfHostedUsageService],
 })
 export class PublicStatsModule {}

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -3,6 +3,7 @@ import {
   ModelPricingCacheService,
   PricingEntry,
 } from '../model-prices/model-pricing-cache.service';
+import type { SelfHostedUsageService } from './self-hosted-usage.service';
 
 function mockQueryBuilder(result: unknown) {
   const qb: Record<string, jest.Mock> = {};
@@ -33,6 +34,7 @@ describe('PublicStatsService', () => {
   let service: PublicStatsService;
   let mockRepo: { createQueryBuilder: jest.Mock };
   let mockPricingCache: { getAll: jest.Mock; getByModel: jest.Mock };
+  let mockSelfHostedUsage: { fetchAggregate: jest.Mock };
 
   beforeEach(() => {
     mockRepo = { createQueryBuilder: jest.fn() };
@@ -40,9 +42,11 @@ describe('PublicStatsService', () => {
       getAll: jest.fn().mockReturnValue([]),
       getByModel: jest.fn().mockReturnValue(null),
     };
+    mockSelfHostedUsage = { fetchAggregate: jest.fn().mockResolvedValue(null) };
     service = new PublicStatsService(
       mockRepo as never,
       mockPricingCache as unknown as ModelPricingCacheService,
+      mockSelfHostedUsage as unknown as SelfHostedUsageService,
     );
   });
 
@@ -245,6 +249,24 @@ describe('PublicStatsService', () => {
 
       expect(result.top_models[0].tokens_previous_7d).toBe(0);
       expect(result.top_models[0].tokens_30d).toBe(0);
+    });
+
+    it('adds the self-hosted aggregate to total_messages when available', async () => {
+      setupQueries({ total: '42' }, [], []);
+      mockSelfHostedUsage.fetchAggregate.mockResolvedValue({ messages_total: 1000 });
+
+      const result = await service.getUsageStats();
+
+      expect(result.total_messages).toBe(1042);
+    });
+
+    it('falls back to cloud-only count when the self-hosted aggregate is unavailable', async () => {
+      setupQueries({ total: '42' }, [], []);
+      mockSelfHostedUsage.fetchAggregate.mockResolvedValue(null);
+
+      const result = await service.getUsageStats();
+
+      expect(result.total_messages).toBe(42);
     });
   });
 

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { computeCutoff, sqlDateBucket } from '../common/utils/postgres-sql';
+import { SelfHostedUsageService } from './self-hosted-usage.service';
 
 const MAX_RESULTS = 10;
 const EXCLUDED_PROVIDERS = new Set(['Unknown']);
@@ -60,6 +61,7 @@ export class PublicStatsService {
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
     private readonly pricingCache: ModelPricingCacheService,
+    private readonly selfHostedUsage: SelfHostedUsageService,
   ) {}
 
   async getUsageStats(): Promise<UsageStats> {
@@ -67,42 +69,44 @@ export class PublicStatsService {
     const cutoff14d = computeCutoff('14 days');
     const cutoff30d = computeCutoff('30 days');
 
-    const [countRow, topRows, tokenRows, tokenRowsPrev7d, tokenRows30d] = await Promise.all([
-      this.messageRepo.createQueryBuilder('at').select('COUNT(*)', 'total').getRawOne(),
-      this.messageRepo
-        .createQueryBuilder('at')
-        .select('at.model', 'model')
-        .addSelect('COUNT(*)', 'usage_count')
-        .where('at.model IS NOT NULL')
-        .groupBy('at.model')
-        .orderBy('usage_count', 'DESC')
-        .getRawMany(),
-      this.messageRepo
-        .createQueryBuilder('at')
-        .select('at.model', 'model')
-        .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
-        .where('at.model IS NOT NULL')
-        .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff7d })
-        .groupBy('at.model')
-        .getRawMany(),
-      this.messageRepo
-        .createQueryBuilder('at')
-        .select('at.model', 'model')
-        .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
-        .where('at.model IS NOT NULL')
-        .andWhere('at.timestamp >= :cutoff14d', { cutoff14d })
-        .andWhere('at.timestamp < :cutoff7d', { cutoff7d })
-        .groupBy('at.model')
-        .getRawMany(),
-      this.messageRepo
-        .createQueryBuilder('at')
-        .select('at.model', 'model')
-        .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
-        .where('at.model IS NOT NULL')
-        .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
-        .groupBy('at.model')
-        .getRawMany(),
-    ]);
+    const [countRow, topRows, tokenRows, tokenRowsPrev7d, tokenRows30d, selfHostedAggregate] =
+      await Promise.all([
+        this.messageRepo.createQueryBuilder('at').select('COUNT(*)', 'total').getRawOne(),
+        this.messageRepo
+          .createQueryBuilder('at')
+          .select('at.model', 'model')
+          .addSelect('COUNT(*)', 'usage_count')
+          .where('at.model IS NOT NULL')
+          .groupBy('at.model')
+          .orderBy('usage_count', 'DESC')
+          .getRawMany(),
+        this.messageRepo
+          .createQueryBuilder('at')
+          .select('at.model', 'model')
+          .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+          .where('at.model IS NOT NULL')
+          .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff7d })
+          .groupBy('at.model')
+          .getRawMany(),
+        this.messageRepo
+          .createQueryBuilder('at')
+          .select('at.model', 'model')
+          .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+          .where('at.model IS NOT NULL')
+          .andWhere('at.timestamp >= :cutoff14d', { cutoff14d })
+          .andWhere('at.timestamp < :cutoff7d', { cutoff7d })
+          .groupBy('at.model')
+          .getRawMany(),
+        this.messageRepo
+          .createQueryBuilder('at')
+          .select('at.model', 'model')
+          .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+          .where('at.model IS NOT NULL')
+          .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
+          .groupBy('at.model')
+          .getRawMany(),
+        this.selfHostedUsage.fetchAggregate(),
+      ]);
 
     const tokenMap = new Map<string, number>();
     for (const r of tokenRows) {
@@ -149,8 +153,11 @@ export class PublicStatsService {
     const topModels = eligible.slice(0, MAX_RESULTS);
     topModels.forEach((m, i) => (m.usage_rank = i + 1));
 
+    const cloudMessages = Number(countRow?.total ?? 0);
+    const selfHostedMessages = selfHostedAggregate?.messages_total ?? 0;
+
     return {
-      total_messages: Number(countRow?.total ?? 0),
+      total_messages: cloudMessages + selfHostedMessages,
       top_models: topModels,
       token_map: tokenMap,
     };

--- a/packages/backend/src/public-stats/self-hosted-usage.service.spec.ts
+++ b/packages/backend/src/public-stats/self-hosted-usage.service.spec.ts
@@ -1,0 +1,289 @@
+import {
+  buildSelfHostedUsageConfig,
+  DEFAULT_AGGREGATE_ENDPOINT,
+  SelfHostedUsageService,
+  type SelfHostedUsageConfig,
+} from './self-hosted-usage.service';
+
+jest.mock('../common/utils/detect-self-hosted', () => ({
+  isSelfHosted: jest.fn(() => false),
+}));
+
+import { isSelfHosted } from '../common/utils/detect-self-hosted';
+const isSelfHostedMock = isSelfHosted as jest.MockedFunction<typeof isSelfHosted>;
+
+function makeService(overrides?: Partial<SelfHostedUsageConfig>): SelfHostedUsageService {
+  const service = new SelfHostedUsageService();
+  (service as unknown as { config: SelfHostedUsageConfig }).config = {
+    enabled: overrides?.enabled ?? true,
+    endpoint: overrides?.endpoint ?? 'http://aggregate.test/v1/aggregate/usage',
+    apiKey: overrides?.apiKey ?? 'test-shared-secret',
+  };
+  return service;
+}
+
+describe('buildSelfHostedUsageConfig', () => {
+  beforeEach(() => {
+    isSelfHostedMock.mockReturnValue(false);
+  });
+
+  it('enables in production cloud mode when an aggregate key is set', () => {
+    const cfg = buildSelfHostedUsageConfig({
+      NODE_ENV: 'production',
+      TELEMETRY_AGGREGATE_KEY: 'a-secret',
+    });
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.endpoint).toBe(DEFAULT_AGGREGATE_ENDPOINT);
+    expect(cfg.apiKey).toBe('a-secret');
+  });
+
+  it('reads TELEMETRY_AGGREGATE_ENDPOINT override', () => {
+    const cfg = buildSelfHostedUsageConfig({
+      NODE_ENV: 'production',
+      TELEMETRY_AGGREGATE_KEY: 'a-secret',
+      TELEMETRY_AGGREGATE_ENDPOINT: 'https://staging.example.com/v1/aggregate/usage',
+    });
+    expect(cfg.endpoint).toBe('https://staging.example.com/v1/aggregate/usage');
+  });
+
+  it('disables outside production', () => {
+    expect(
+      buildSelfHostedUsageConfig({
+        NODE_ENV: 'development',
+        TELEMETRY_AGGREGATE_KEY: 'a-secret',
+      }).enabled,
+    ).toBe(false);
+    expect(buildSelfHostedUsageConfig({ TELEMETRY_AGGREGATE_KEY: 'a-secret' }).enabled).toBe(false);
+  });
+
+  it('disables on self-hosted instances even in production', () => {
+    isSelfHostedMock.mockReturnValue(true);
+    expect(
+      buildSelfHostedUsageConfig({
+        NODE_ENV: 'production',
+        TELEMETRY_AGGREGATE_KEY: 'a-secret',
+      }).enabled,
+    ).toBe(false);
+  });
+
+  it('disables when TELEMETRY_AGGREGATE_KEY is unset', () => {
+    expect(buildSelfHostedUsageConfig({ NODE_ENV: 'production' }).enabled).toBe(false);
+  });
+
+  it('disables when TELEMETRY_AGGREGATE_KEY is empty string', () => {
+    expect(
+      buildSelfHostedUsageConfig({
+        NODE_ENV: 'production',
+        TELEMETRY_AGGREGATE_KEY: '',
+      }).enabled,
+    ).toBe(false);
+  });
+
+  it('defaults to process.env when no env argument is given', () => {
+    const cfg = buildSelfHostedUsageConfig();
+    expect(typeof cfg.enabled).toBe('boolean');
+    expect(typeof cfg.endpoint).toBe('string');
+    expect(typeof cfg.apiKey).toBe('string');
+  });
+});
+
+describe('SelfHostedUsageService', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+    isSelfHostedMock.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  function jsonResponse(body: unknown, init?: { status?: number; ok?: boolean }): Response {
+    return {
+      ok: init?.ok ?? (init?.status ?? 200) < 400,
+      status: init?.status ?? 200,
+      json: jest.fn().mockResolvedValue(body),
+    } as unknown as Response;
+  }
+
+  it('returns null without calling fetch when disabled', async () => {
+    const service = makeService({ enabled: false });
+
+    const result = await service.fetchAggregate();
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the parsed messages_total on success', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: 12345 }));
+    const service = makeService();
+
+    const result = await service.fetchAggregate();
+
+    expect(result).toEqual({ messages_total: 12345 });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://aggregate.test/v1/aggregate/usage',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('sends the configured aggregate key in the X-Aggregate-Key header', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: 1 }));
+    const service = makeService({ apiKey: 'super-secret-value' });
+
+    await service.fetchAggregate();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://aggregate.test/v1/aggregate/usage',
+      expect.objectContaining({
+        headers: { 'x-aggregate-key': 'super-secret-value' },
+      }),
+    );
+  });
+
+  it('coerces string-shaped messages_total to a number', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: '42' }));
+    const service = makeService();
+
+    const result = await service.fetchAggregate();
+
+    expect(result).toEqual({ messages_total: 42 });
+  });
+
+  it('returns null when the endpoint responds non-2xx', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(null, { status: 503, ok: false }));
+    const service = makeService();
+
+    const result = await service.fetchAggregate();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when messages_total is missing', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({}));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('returns null when messages_total is non-numeric', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: 'not-a-number' }));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('returns null when messages_total is negative', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: -1 }));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('returns null when fetch rejects', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('returns null on non-Error rejections (covers the String() branch)', async () => {
+    fetchSpy.mockRejectedValue('plain string');
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('serves cached values within the TTL', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: 100 }));
+    const service = makeService();
+
+    const a = await service.fetchAggregate();
+    const b = await service.fetchAggregate();
+
+    expect(b).toBe(a);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes after the cache expires', async () => {
+    jest.useFakeTimers();
+    try {
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ messages_total: 100 }))
+        .mockResolvedValueOnce(jsonResponse({ messages_total: 200 }));
+      const service = makeService();
+
+      const first = await service.fetchAggregate();
+      jest.setSystemTime(Date.now() + 61_000);
+      const second = await service.fetchAggregate();
+
+      expect(first).toEqual({ messages_total: 100 });
+      expect(second).toEqual({ messages_total: 200 });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('dedupes concurrent callers onto a single in-flight fetch', async () => {
+    let resolveFetch!: (r: Response) => void;
+    fetchSpy.mockReturnValue(
+      new Promise<Response>((r) => {
+        resolveFetch = r;
+      }),
+    );
+    const service = makeService();
+
+    const p1 = service.fetchAggregate();
+    const p2 = service.fetchAggregate();
+    resolveFetch(jsonResponse({ messages_total: 7 }));
+    const [a, b] = await Promise.all([p1, p2]);
+
+    expect(a).toEqual({ messages_total: 7 });
+    expect(b).toBe(a);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the in-flight slot after a failed fetch so the next call retries', async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(jsonResponse({ messages_total: 5 }));
+    const service = makeService();
+
+    const first = await service.fetchAggregate();
+    const second = await service.fetchAggregate();
+
+    expect(first).toBeNull();
+    expect(second).toEqual({ messages_total: 5 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts the request when the fetch outlasts the 2s timeout', async () => {
+    let aborted = false;
+    fetchSpy.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init.signal!;
+          signal.addEventListener('abort', () => {
+            aborted = true;
+            reject(new Error('aborted'));
+          });
+        }),
+    );
+    jest.useFakeTimers();
+    try {
+      const service = makeService();
+      const promise = service.fetchAggregate();
+      jest.advanceTimersByTime(3000);
+      const result = await promise;
+
+      expect(result).toBeNull();
+      expect(aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/backend/src/public-stats/self-hosted-usage.service.spec.ts
+++ b/packages/backend/src/public-stats/self-hosted-usage.service.spec.ts
@@ -169,6 +169,27 @@ describe('SelfHostedUsageService', () => {
     expect(await service.fetchAggregate()).toBeNull();
   });
 
+  it('returns null when messages_total is null', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: null }));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('returns null when messages_total is an empty string', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: '' }));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('returns null when messages_total is whitespace only', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: '   ' }));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
   it('returns null when messages_total is non-numeric', async () => {
     fetchSpy.mockResolvedValue(jsonResponse({ messages_total: 'not-a-number' }));
     const service = makeService();
@@ -178,6 +199,13 @@ describe('SelfHostedUsageService', () => {
 
   it('returns null when messages_total is negative', async () => {
     fetchSpy.mockResolvedValue(jsonResponse({ messages_total: -1 }));
+    const service = makeService();
+
+    expect(await service.fetchAggregate()).toBeNull();
+  });
+
+  it('returns null when messages_total is an unsupported type (boolean)', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ messages_total: true }));
     const service = makeService();
 
     expect(await service.fetchAggregate()).toBeNull();
@@ -247,18 +275,45 @@ describe('SelfHostedUsageService', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('clears the in-flight slot after a failed fetch so the next call retries', async () => {
-    fetchSpy
-      .mockRejectedValueOnce(new Error('boom'))
-      .mockResolvedValueOnce(jsonResponse({ messages_total: 5 }));
-    const service = makeService();
+  it('caches failures for 30s — repeated calls during an outage do not re-fetch', async () => {
+    jest.useFakeTimers();
+    try {
+      fetchSpy.mockRejectedValue(new Error('boom'));
+      const service = makeService();
 
-    const first = await service.fetchAggregate();
-    const second = await service.fetchAggregate();
+      const first = await service.fetchAggregate();
+      jest.setSystemTime(Date.now() + 5_000);
+      const second = await service.fetchAggregate();
+      jest.setSystemTime(Date.now() + 20_000);
+      const third = await service.fetchAggregate();
 
-    expect(first).toBeNull();
-    expect(second).toEqual({ messages_total: 5 });
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(third).toBeNull();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('retries after the failure cache expires', async () => {
+    jest.useFakeTimers();
+    try {
+      fetchSpy
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(jsonResponse({ messages_total: 5 }));
+      const service = makeService();
+
+      const first = await service.fetchAggregate();
+      jest.setSystemTime(Date.now() + 31_000);
+      const second = await service.fetchAggregate();
+
+      expect(first).toBeNull();
+      expect(second).toEqual({ messages_total: 5 });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('aborts the request when the fetch outlasts the 2s timeout', async () => {

--- a/packages/backend/src/public-stats/self-hosted-usage.service.ts
+++ b/packages/backend/src/public-stats/self-hosted-usage.service.ts
@@ -4,6 +4,7 @@ import { isSelfHosted } from '../common/utils/detect-self-hosted';
 export const DEFAULT_AGGREGATE_ENDPOINT = 'https://telemetry.manifest.build/v1/aggregate/usage';
 
 const CACHE_TTL_MS = 60_000;
+const FAILURE_CACHE_TTL_MS = 30_000;
 const FETCH_TIMEOUT_MS = 2_000;
 
 export interface SelfHostedUsageConfig {
@@ -45,12 +46,14 @@ export class SelfHostedUsageService {
 
   private cached: SelfHostedAggregate | null = null;
   private cachedAt = 0;
+  private cachedFailure = false;
   private inflight: Promise<SelfHostedAggregate | null> | null = null;
 
   async fetchAggregate(): Promise<SelfHostedAggregate | null> {
     if (!this.config.enabled) return null;
-    if (this.cached && Date.now() - this.cachedAt < CACHE_TTL_MS) {
-      return this.cached;
+    if (this.cachedAt > 0) {
+      const ttl = this.cachedFailure ? FAILURE_CACHE_TTL_MS : CACHE_TTL_MS;
+      if (Date.now() - this.cachedAt < ttl) return this.cached;
     }
     if (!this.inflight) {
       this.inflight = this.compute().finally(() => {
@@ -70,26 +73,42 @@ export class SelfHostedUsageService {
       });
       if (!res.ok) {
         this.logger.warn(`Aggregate endpoint returned ${res.status}`);
-        return null;
+        return this.cacheFailure();
       }
       const json = (await res.json()) as Record<string, unknown>;
       const raw = json['messages_total'];
+      if (typeof raw !== 'number' && typeof raw !== 'string') {
+        this.logger.warn(`Aggregate endpoint returned invalid messages_total: ${String(raw)}`);
+        return this.cacheFailure();
+      }
+      if (typeof raw === 'string' && raw.trim().length === 0) {
+        this.logger.warn('Aggregate endpoint returned empty messages_total');
+        return this.cacheFailure();
+      }
       const messages_total = typeof raw === 'number' ? raw : Number(raw);
       if (!Number.isFinite(messages_total) || messages_total < 0) {
         this.logger.warn(`Aggregate endpoint returned invalid messages_total: ${String(raw)}`);
-        return null;
+        return this.cacheFailure();
       }
       const result: SelfHostedAggregate = { messages_total };
       this.cached = result;
+      this.cachedFailure = false;
       this.cachedAt = Date.now();
       return result;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.warn(`Aggregate fetch failed: ${msg}`);
-      return null;
+      return this.cacheFailure();
     } finally {
       clearTimeout(timer);
     }
+  }
+
+  private cacheFailure(): null {
+    this.cached = null;
+    this.cachedFailure = true;
+    this.cachedAt = Date.now();
+    return null;
   }
 }
 

--- a/packages/backend/src/public-stats/self-hosted-usage.service.ts
+++ b/packages/backend/src/public-stats/self-hosted-usage.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { isSelfHosted } from '../common/utils/detect-self-hosted';
+
+export const DEFAULT_AGGREGATE_ENDPOINT = 'https://telemetry.manifest.build/v1/aggregate/usage';
+
+const CACHE_TTL_MS = 60_000;
+const FETCH_TIMEOUT_MS = 2_000;
+
+export interface SelfHostedUsageConfig {
+  enabled: boolean;
+  endpoint: string;
+  apiKey: string;
+}
+
+export interface SelfHostedAggregate {
+  messages_total: number;
+}
+
+/**
+ * Cloud-side fetcher for the fleet-wide self-hosted message count exposed by
+ * peacock at `GET /v1/aggregate/usage`. The result is added to the cloud
+ * count surfaced by `/api/v1/public/usage` so the marketing site can show
+ * total usage across both deployments.
+ *
+ * Authenticates with peacock via `X-Aggregate-Key`, matched against
+ * `PEACOCK_AGGREGATE_KEY` on the peacock side. The shared secret is what
+ * keeps the aggregate endpoint off the public internet.
+ *
+ * Disabled outside Manifest Cloud production:
+ *   - When `TELEMETRY_AGGREGATE_KEY` is unset (no shared secret to send) —
+ *     the request would be rejected anyway, and we'd rather not generate
+ *     log noise on every cache miss.
+ *   - Self-hosted instances (per `isSelfHosted()`) skip the fetch entirely —
+ *     they'd be querying a number that includes their own contribution and
+ *     the public-stats endpoint isn't on for them anyway.
+ *   - Non-production envs skip too, mirroring `TelemetryService`'s gate.
+ *
+ * Never throws. On timeout, non-2xx, network error, or malformed payload it
+ * returns null and the public endpoint falls back to the cloud-only count.
+ */
+@Injectable()
+export class SelfHostedUsageService {
+  private readonly logger = new Logger(SelfHostedUsageService.name);
+  private readonly config: SelfHostedUsageConfig = buildSelfHostedUsageConfig();
+
+  private cached: SelfHostedAggregate | null = null;
+  private cachedAt = 0;
+  private inflight: Promise<SelfHostedAggregate | null> | null = null;
+
+  async fetchAggregate(): Promise<SelfHostedAggregate | null> {
+    if (!this.config.enabled) return null;
+    if (this.cached && Date.now() - this.cachedAt < CACHE_TTL_MS) {
+      return this.cached;
+    }
+    if (!this.inflight) {
+      this.inflight = this.compute().finally(() => {
+        this.inflight = null;
+      });
+    }
+    return this.inflight;
+  }
+
+  private async compute(): Promise<SelfHostedAggregate | null> {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(this.config.endpoint, {
+        signal: ac.signal,
+        headers: { 'x-aggregate-key': this.config.apiKey },
+      });
+      if (!res.ok) {
+        this.logger.warn(`Aggregate endpoint returned ${res.status}`);
+        return null;
+      }
+      const json = (await res.json()) as Record<string, unknown>;
+      const raw = json['messages_total'];
+      const messages_total = typeof raw === 'number' ? raw : Number(raw);
+      if (!Number.isFinite(messages_total) || messages_total < 0) {
+        this.logger.warn(`Aggregate endpoint returned invalid messages_total: ${String(raw)}`);
+        return null;
+      }
+      const result: SelfHostedAggregate = { messages_total };
+      this.cached = result;
+      this.cachedAt = Date.now();
+      return result;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Aggregate fetch failed: ${msg}`);
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export function buildSelfHostedUsageConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): SelfHostedUsageConfig {
+  const endpoint = env['TELEMETRY_AGGREGATE_ENDPOINT'] ?? DEFAULT_AGGREGATE_ENDPOINT;
+  const apiKey = env['TELEMETRY_AGGREGATE_KEY'] ?? '';
+  const isProd = (env['NODE_ENV'] ?? 'development') === 'production';
+  return {
+    enabled: isProd && !isSelfHosted() && apiKey.length > 0,
+    endpoint,
+    apiKey,
+  };
+}


### PR DESCRIPTION
### What changed
- `/api/v1/public/usage` adds the self-hosted fleet count to the cloud count.
- New `SelfHostedUsageService` fetches the aggregate from peacock with `X-Aggregate-Key`, 60s cache, 2s `AbortController` timeout.
- Falls back to cloud-only when peacock is unreachable, misconfigured, or returns junk.
- Disabled outside cloud production or when `TELEMETRY_AGGREGATE_KEY` is unset.

### Why
The public usage page was undercounting because self-hosted installs were invisible to the API. They already report aggregates to peacock, so we just need to read them.

### For users
`total_messages` on `/api/v1/public/usage` now reflects all known usage (cloud + self-hosted) instead of cloud only.

### For operators
Set `TELEMETRY_AGGREGATE_KEY` to match `PEACOCK_AGGREGATE_KEY` on peacock. Without it the service stays silent and the response degrades to the prior cloud-only behavior.

### Notes
Depends on mnfst/peacock#33 to expose the read endpoint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combines self-hosted fleet message counts with cloud counts in `/api/v1/public/usage` so `total_messages` reflects all usage. Adds a safe, cached fetch from peacock with a 2s timeout and 30s failure cache; falls back to cloud-only.

- **New Features**
  - `/api/v1/public/usage` now returns cloud + self-hosted `total_messages`.
  - Added `SelfHostedUsageService` to read peacock aggregates via `X-Aggregate-Key` with 60s cache, 2s timeout, and 30s failure cache; validates `messages_total` and ignores invalid values; falls back to cloud-only on errors.
  - Enabled only in cloud production with `TELEMETRY_AGGREGATE_KEY`; disabled on self-hosted or when unset.

- **Migration**
  - Set `TELEMETRY_AGGREGATE_KEY` to match peacock’s `PEACOCK_AGGREGATE_KEY`.
  - Optional: override endpoint with `TELEMETRY_AGGREGATE_ENDPOINT` (default `https://telemetry.manifest.build/v1/aggregate/usage`).

<sup>Written for commit b742a0f0728eeb1c25b4d4e4004c7cf6e40dc321. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1759?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

