### PR TITLE
fix: strip reasoning_details before forwarding to non-OpenRouter providers

### DIFF
--- a/.changeset/strip-reasoning-details.md
+++ b/.changeset/strip-reasoning-details.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Strip `reasoning_details` from message history before forwarding to non-OpenRouter providers. Mistral, Groq, and other strict OpenAI-compatible providers were rejecting requests with `extra_forbidden` (422) when conversations contained extended-thinking blocks from a prior turn.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -189,6 +189,54 @@ describe('provider-client-converters', () => {
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
+    /* ── Message sanitization: reasoning_details ── */
+
+    it('should strip reasoning_details for non-openrouter providers', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '4',
+            reasoning_details: [{ type: 'thinking', thinking: '2+2', signature: 'sig' }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'mistral', 'ministral-3b-2512');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).not.toHaveProperty('reasoning_details');
+    });
+
+    it('should strip reasoning_details for native openai targets', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '4',
+            reasoning_details: [{ type: 'thinking', thinking: 't', signature: 's' }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-4o');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).not.toHaveProperty('reasoning_details');
+    });
+
+    it('should preserve reasoning_details for openrouter targets', () => {
+      const details = [{ type: 'thinking', thinking: 't', signature: 's' }];
+      const body = {
+        messages: [{ role: 'assistant', content: '4', reasoning_details: details }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'openrouter', 'minimax/minimax-m2.7');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_details', details);
+    });
+
     it('should handle non-array messages gracefully', () => {
       const body = { messages: 'not-an-array' };
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1352,6 +1352,17 @@ describe('ProviderClient', () => {
       ],
       temperature: 0.7,
     });
+    const makeBodyWithReasoningDetails = () => ({
+      messages: [
+        { role: 'user', content: 'What is 2+2?' },
+        {
+          role: 'assistant',
+          content: '4',
+          reasoning_details: [{ type: 'thinking', thinking: 'add them', signature: 'sig-abc' }],
+        },
+      ],
+      temperature: 0.7,
+    });
 
     it('strips OpenAI-only fields for Mistral', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
@@ -1544,6 +1555,75 @@ describe('ProviderClient', () => {
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
+    });
+
+    it('strips reasoning_details for Mistral assistant messages without mutating the input', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
+
+      await client.forward({
+        provider: 'mistral',
+        apiKey: 'sk-mi',
+        model: 'ministral-3b-2512',
+        body: bodyWithReasoningDetails,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
+      expect(bodyWithReasoningDetails.messages[1].reasoning_details).toEqual([
+        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
+      ]);
+    });
+
+    it('strips reasoning_details for native OpenAI targets', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: bodyWithReasoningDetails,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
+    });
+
+    it('strips reasoning_details for DeepSeek (does not support reasoning_details)', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
+
+      await client.forward({
+        provider: 'deepseek',
+        apiKey: 'sk-ds',
+        model: 'deepseek-reasoner',
+        body: bodyWithReasoningDetails,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
+    });
+
+    it('preserves reasoning_details for OpenRouter targets', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
+
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: 'minimax/minimax-m2.7',
+        body: bodyWithReasoningDetails,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_details).toEqual([
+        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
+      ]);
     });
 
     it('leaves non-array messages unchanged during sanitization', async () => {

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -108,10 +108,23 @@ function supportsReasoningContent(endpointKey: string, model: string): boolean {
   return false;
 }
 
+/**
+ * `reasoning_details` is OpenRouter's structured echo of extended-thinking
+ * blocks in assistant messages (array of `{type, thinking, signature}`).
+ * Only OpenRouter accepts it as an input field — every other OpenAI-compatible
+ * provider (Mistral, native OpenAI, Groq, etc.) rejects unknown message fields
+ * with `extra_forbidden` / 422. Strip it before forwarding to those targets so
+ * that turn N+1 doesn't fail when routing flips off a reasoning model.
+ */
+function supportsReasoningDetails(endpointKey: string): boolean {
+  return endpointKey === 'openrouter';
+}
+
 function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: string): unknown {
   if (!Array.isArray(messages)) return messages;
 
   const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
+  const preserveReasoningDetails = supportsReasoningDetails(endpointKey);
   const isMistral = endpointKey === 'mistral';
   const mistralIdMap = new Map<string, string>();
   const reservedMistralIds = new Set<string>();
@@ -177,6 +190,9 @@ function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: s
     const cleaned = { ...(message as Record<string, unknown>) };
     if (!preserveReasoningContent) {
       delete cleaned.reasoning_content;
+    }
+    if (!preserveReasoningDetails) {
+      delete cleaned.reasoning_details;
     }
 
     if (isMistral && Array.isArray(cleaned.tool_calls)) {


### PR DESCRIPTION
### ✨ What changed
- `sanitizeOpenAiMessages` deletes `reasoning_details` from each message unless the target is OpenRouter.
- Added 7 tests covering Mistral, native OpenAI, DeepSeek, and OpenRouter (preserved) at both converter and integration level.

### 💭 Why
Hermes (and any agent talking to a reasoning model) sends `reasoning_details` blocks in subsequent turns. When `auto` routing flips to a non-reasoning model like `ministral-3b-2512`, Mistral rejects the unknown field with `extra_forbidden` (422). Closes #1728.

### 👤 For users
Multi-turn conversations on `auto` no longer fail when routing changes between a reasoning and a non-reasoning model. OpenRouter requests are unchanged.

### 📝 Notes
Reproduced live against Mistral with `magistral` -> `ministral` flip, then verified the fix end-to-end. Backend (4321), e2e (137), frontend (2620), shared (97), tsc all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 422 errors when routing from reasoning models to strict providers by stripping `reasoning_details` from assistant messages for non-OpenRouter targets. OpenRouter requests are unchanged; multi-turn on `auto` is now stable (fixes #1728).

- **Bug Fixes**
  - Remove `reasoning_details` during sanitization for Mistral, native OpenAI, DeepSeek, and others; preserve for OpenRouter.
  - Added 7 tests across converters and integration to cover provider behavior and ensure no input mutation.

<sup>Written for commit bdb43dfdde22b63a4f77c672bcd813dd683505ae. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1761?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

