### PR TITLE
fix: mark canned Manifest responses as failed

### DIFF
--- a/.changeset/canned-response-failed-status.md
+++ b/.changeset/canned-response-failed-status.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Mark Manifest's canned setup-prompt and limit responses as Failed in the Messages list. Requests that hit `no_provider`, `no_provider_key`, `limit_exceeded`, or `friendly_error` (the `[🦚 Manifest] …` stubs) now show a red Failed badge with a tooltip explaining why, instead of an ambiguous green Success.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -912,6 +912,78 @@ describe('ProxyMessageRecorder', () => {
         duration_ms: 1500,
       });
     });
+
+    describe('canned Manifest responses (no_provider / no_provider_key / limit_exceeded / friendly_error)', () => {
+      const cases: Array<{ reason: string; errorMessage: string }> = [
+        { reason: 'no_provider', errorMessage: 'No providers configured for this agent' },
+        { reason: 'no_provider_key', errorMessage: 'Provider API key missing' },
+        { reason: 'limit_exceeded', errorMessage: 'Usage limit exceeded' },
+        { reason: 'friendly_error', errorMessage: 'Manifest internal error' },
+      ];
+
+      it.each(cases)(
+        'inserts status=error and error_message="$errorMessage" when reason=$reason',
+        async ({ reason, errorMessage }) => {
+          await recorder.recordSuccessMessage(ctx, 'manifest', 'simple', reason, {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+          });
+          expect(insertMock).toHaveBeenCalledTimes(1);
+          expect(insertMock.mock.calls[0][0]).toMatchObject({
+            status: 'error',
+            error_message: errorMessage,
+            routing_reason: reason,
+            model: 'manifest',
+          });
+        },
+      );
+
+      it('keeps status=ok and error_message=null for non-canned reasons (e.g. "scored")', async () => {
+        await recorder.recordSuccessMessage(ctx, 'gpt-4o', 'standard', 'scored', {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+        });
+        expect(insertMock).toHaveBeenCalledTimes(1);
+        expect(insertMock.mock.calls[0][0]).toMatchObject({
+          status: 'ok',
+          error_message: null,
+          routing_reason: 'scored',
+        });
+      });
+
+      it('flips status to error and populates error_message on the dedup-update path', async () => {
+        const updateMock = jest.fn();
+        (dedupWithLock.withAgentMessageTransaction as jest.Mock).mockImplementation(
+          (_repo: unknown, _ctx: unknown, fn: (r: unknown) => Promise<void>) =>
+            fn({ insert: insertMock, update: updateMock }),
+        );
+        // Pre-existing zero-token row from an earlier write — recordSuccessMessage
+        // takes the update branch and must overwrite both status and error_message.
+        (dedupWithLock.findExistingSuccessMessage as jest.Mock).mockResolvedValue({
+          id: 'existing-canned',
+          timestamp: new Date().toISOString(),
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          duration_ms: null,
+        });
+
+        await recorder.recordSuccessMessage(ctx, 'manifest', 'simple', 'no_provider', {
+          prompt_tokens: 0,
+          completion_tokens: 0,
+        });
+
+        expect(updateMock).toHaveBeenCalledTimes(1);
+        expect(updateMock.mock.calls[0][0]).toEqual({ id: 'existing-canned' });
+        expect(updateMock.mock.calls[0][1]).toMatchObject({
+          status: 'error',
+          error_message: 'No providers configured for this agent',
+          routing_reason: 'no_provider',
+        });
+        expect(insertMock).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('request_headers persistence', () => {

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -73,6 +73,19 @@ export interface SuccessMessageOpts extends HeaderTierRef {
   requestHeaders?: Record<string, string> | null;
 }
 
+/**
+ * Reasons that mark a `recordSuccessMessage` call as a Manifest-generated
+ * stub instead of a real upstream completion. The HTTP envelope is 200 OK
+ * (so the chat client renders the canned `[🦚 Manifest] …` text), but the
+ * dashboard should classify the row as failed and surface why.
+ */
+const CANNED_RESPONSE_REASONS: Record<string, string> = {
+  no_provider: 'No providers configured for this agent',
+  no_provider_key: 'Provider API key missing',
+  limit_exceeded: 'Usage limit exceeded',
+  friendly_error: 'Manifest internal error',
+};
+
 function buildMessageRow(
   ctx: IngestionContext,
   overrides: Partial<AgentMessage>,
@@ -442,6 +455,10 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
 
     const normalizedSessionKey = this.dedup.normalizeSessionKey(sessionKey);
 
+    const cannedMessage = CANNED_RESPONSE_REASONS[reason];
+    const status = cannedMessage ? 'error' : 'ok';
+    const errorMessage = cannedMessage ?? null;
+
     let wrote = false;
     await this.dedup.withSuccessWriteLock(
       this.dedup.getSuccessWriteLockKey(ctx, canonicalModel, traceId, normalizedSessionKey),
@@ -462,6 +479,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
             if (hasRecordedTokens) return;
 
             const updatePayload: Partial<AgentMessage> = {
+              status,
+              error_message: errorMessage,
               model: canonicalModel,
               provider: canonicalProvider,
               routing_tier: tier,
@@ -495,7 +514,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
               trace_id: traceId ?? null,
               session_key: normalizedSessionKey,
               timestamp: new Date().toISOString(),
-              status: 'ok',
+              status,
+              error_message: errorMessage,
               model: canonicalModel,
               provider: canonicalProvider,
               routing_tier: tier,


### PR DESCRIPTION
### ✨ What changed
- Map `no_provider`, `no_provider_key`, `limit_exceeded`, `friendly_error` to `status='error'` in `recordSuccessMessage`.
- Populate `error_message` with a short label so the Messages tooltip explains why.
- Apply on both insert and dedup-update paths.

### 💭 Why
The proxy returns HTTP 200 for `[🦚 Manifest] …` setup-prompt stubs, so they were persisted as Success. The dashboard then showed a green Success badge for requests that never reached an LLM, which is misleading when a user has not yet configured providers or hits a usage limit.

### 👤 For users
Recent Messages and the Messages log now show a red **Failed** badge with a tooltip ("No providers configured for this agent", "Provider API key missing", "Usage limit exceeded", or "Manifest internal error") instead of an ambiguous green Success when Manifest itself produced the response.

### 📝 Notes
Auth-error stubs from `ProxyExceptionFilter` are still not persisted to `agent_messages` at all today. Separate gap, not fixed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark Manifest’s canned setup/limit responses as Failed so Messages shows accurate status and a clear reason. Maps `no_provider`, `no_provider_key`, `limit_exceeded`, and `friendly_error` to `status='error'` with a short tooltip message.

- **Bug Fixes**
  - In `recordSuccessMessage`, set `status='error'` and `error_message` for canned Manifest reasons; keep `status='ok'` otherwise.
  - Apply on both insert and dedup-update paths to prevent green Success for stubbed responses.
  - Added tests to cover all reasons and the dedup-update overwrite behavior.

<sup>Written for commit 7394235071b3b2a89e1219b07f95cd34b618da14. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1769?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

