### PR TITLE
fix: peel agent envelopes and demote generic coding signals

### DIFF
--- a/.changeset/scoring-peel-and-coding-fix.md
+++ b/.changeset/scoring-peel-and-coding-fix.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix two routing regressions caused by agent-wrapped user messages. Strip leading metadata envelopes (e.g. `Sender (untrusted metadata):` blocks emitted by OpenClaw, NanoBot, Hermes) before scoring so simple greetings like "say hello" no longer route to standard/complex (#1766). Tighten coding specificity signals so generic agent tools (`read`, `write`, `edit`, `bash`, etc.) and tiny envelope code fences no longer hijack every prompt to the coding tier (#1767).

--- a/packages/backend/src/scoring/__tests__/agent-envelope-regression.spec.ts
+++ b/packages/backend/src/scoring/__tests__/agent-envelope-regression.spec.ts
@@ -1,0 +1,97 @@
+import { scoreRequest, scanMessages } from '../index';
+
+/**
+ * Regression tests for #1766 (simple → standard/complex) and #1767 (coding
+ * specificity hijack) — both triggered by agents wrapping the user prompt
+ * in a metadata envelope plus shipping a generic tool kit. See the issues
+ * for full root-cause analysis.
+ */
+
+const OPENCLAW_WRAPPER =
+  'Sender (untrusted metadata):\n' +
+  '```json\n' +
+  '{ "label": "openclaw-tui", "id": "openclaw-tui" }\n' +
+  '```\n\n';
+
+const GENERIC_AGENT_TOOLS = [
+  { type: 'function', function: { name: 'read' } },
+  { type: 'function', function: { name: 'write' } },
+  { type: 'function', function: { name: 'edit' } },
+  { type: 'function', function: { name: 'bash' } },
+  { type: 'function', function: { name: 'grep' } },
+];
+
+describe('agent envelope regressions', () => {
+  describe('#1766 — wrapped greetings route to simple', () => {
+    it('routes a wrapped "say hello" to simple via short_message', () => {
+      const result = scoreRequest({
+        messages: [{ role: 'user', content: OPENCLAW_WRAPPER + 'say hello' }],
+      });
+      expect(result.tier).toBe('simple');
+      expect(result.reason).toBe('short_message');
+    });
+
+    it('routes a wrapped "hey" with tools to simple', () => {
+      const result = scoreRequest({
+        messages: [{ role: 'user', content: OPENCLAW_WRAPPER + 'hey' }],
+        tools: GENERIC_AGENT_TOOLS,
+      });
+      // Tools force standard at minimum via tool_detected floor; without
+      // tools it would be simple. The point is it must NOT drift to
+      // complex on a wrapped greeting.
+      expect(['simple', 'standard']).toContain(result.tier);
+    });
+
+    it('keeps a 6-turn wrapped greeting conversation in simple', () => {
+      const turns = ['hi', 'hello', 'how are you', 'thanks', 'ok', 'say hello'];
+      const messages: { role: string; content: string }[] = [];
+      turns.forEach((t, i) => {
+        messages.push({ role: 'user', content: OPENCLAW_WRAPPER + t });
+        if (i < turns.length - 1) messages.push({ role: 'assistant', content: 'ok' });
+      });
+      const result = scoreRequest({ messages });
+      expect(result.tier).toBe('simple');
+    });
+  });
+
+  describe('#1767 — generic agent tools no longer hijack coding', () => {
+    it('does not classify "hey" + read tool as coding', () => {
+      expect(
+        scanMessages(
+          [{ role: 'user', content: 'hey' }],
+          [{ type: 'function', function: { name: 'read' } }],
+        ),
+      ).toBeNull();
+    });
+
+    it('does not classify "hey" + the full generic agent kit as coding', () => {
+      expect(scanMessages([{ role: 'user', content: 'hey' }], GENERIC_AGENT_TOOLS)).toBeNull();
+    });
+
+    it('does not classify a wrapped greeting (with code-fenced metadata) as coding', () => {
+      expect(scanMessages([{ role: 'user', content: OPENCLAW_WRAPPER + 'hello' }])).toBeNull();
+    });
+
+    it('still classifies a real coding request as coding', () => {
+      const result = scanMessages(
+        [
+          {
+            role: 'user',
+            content:
+              'help me debug this TypeError in src/scoring/index.ts — the function returns undefined',
+          },
+        ],
+        [{ type: 'function', function: { name: 'apply_patch' } }],
+      );
+      expect(result?.category).toBe('coding');
+    });
+
+    it('still classifies a uniquely-coding tool + coding keyword as coding', () => {
+      const result = scanMessages(
+        [{ role: 'user', content: 'apply this patch to fix the bug' }],
+        [{ type: 'function', function: { name: 'apply_patch' } }],
+      );
+      expect(result?.category).toBe('coding');
+    });
+  });
+});

--- a/packages/backend/src/scoring/__tests__/envelope-peeler.spec.ts
+++ b/packages/backend/src/scoring/__tests__/envelope-peeler.spec.ts
@@ -1,0 +1,106 @@
+import { peelEnvelope } from '../envelope-peeler';
+
+const OPENCLAW = [
+  'Sender (untrusted metadata):',
+  '```json',
+  '{ "label": "openclaw-tui", "id": "openclaw-tui" }',
+  '```',
+  '',
+  'say hello',
+].join('\n');
+
+describe('peelEnvelope', () => {
+  it('returns empty input unchanged', () => {
+    expect(peelEnvelope('')).toBe('');
+  });
+
+  it('strips a labeled JSON envelope and returns the human prompt (#1766)', () => {
+    expect(peelEnvelope(OPENCLAW)).toBe('say hello');
+  });
+
+  it('strips an unlabeled leading json fence with structured body', () => {
+    const wrapped = '```json\n{"k":"v"}\n```\n\nhi';
+    expect(peelEnvelope(wrapped)).toBe('hi');
+  });
+
+  it('strips a yaml envelope', () => {
+    const wrapped = '```yaml\nlabel: openclaw\nid: tui\n```\n\nhello world';
+    expect(peelEnvelope(wrapped)).toBe('hello world');
+  });
+
+  it('strips a fence whose body parses as JSON even without a language hint', () => {
+    const wrapped = '```\n{"label":"x"}\n```\n\nhey';
+    expect(peelEnvelope(wrapped)).toBe('hey');
+  });
+
+  it('strips a fence whose body looks like YAML even without a language hint', () => {
+    const wrapped = '```\nlabel: openclaw-tui\nid: openclaw-tui\n```\n\nthanks';
+    expect(peelEnvelope(wrapped)).toBe('thanks');
+  });
+
+  it('preserves a code fence wrapping real code (no false peel)', () => {
+    const text = '```ts\nfunction add(a: number, b: number) { return a + b; }\n```';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('preserves text with no leading fence', () => {
+    expect(peelEnvelope('say hello')).toBe('say hello');
+  });
+
+  it('preserves a fence that is not at the start of the message', () => {
+    const text = 'here is some json:\n```json\n{}\n```';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('returns the original when an envelope header has no following fence', () => {
+    const text = 'Sender (untrusted metadata):\nhello';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('returns the original when nothing follows the envelope', () => {
+    const text = '```json\n{"k":"v"}\n```';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('peels an empty body when the language hint is structured', () => {
+    // A labeled `json` fence is unambiguously envelope-shaped even when
+    // empty — peeling is safe and produces the human prompt.
+    expect(peelEnvelope('```json\n\n```\n\nhi')).toBe('hi');
+  });
+
+  it('does not peel an empty unlabeled fence (no structural signal)', () => {
+    // Without a language hint and with no structured body, the fence could
+    // be anything — keep the original so the scorer sees what arrived.
+    const text = '```\n\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('returns the original for a fenced array with trailing content', () => {
+    const wrapped = '```json\n[1,2,3]\n```\n\nthat is the data';
+    expect(peelEnvelope(wrapped)).toBe('that is the data');
+  });
+
+  it('does not peel a single-line yaml-shaped fence (insufficient structure)', () => {
+    // One `key: value` line could just as easily be prose. We require ≥2
+    // structured lines before peeling an unlabeled fence.
+    const text = '```\nlabel: x\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('does not peel when fence body is non-structured prose', () => {
+    const text = '```\nthis is just a paragraph not data\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('handles other envelope headers like "context:" and "system message:"', () => {
+    const a = 'context:\n```json\n{"a":1}\n```\n\nask me anything';
+    const b = 'system message:\n```yaml\nrole: dev\nteam: infra\n```\n\nhelp';
+    expect(peelEnvelope(a)).toBe('ask me anything');
+    expect(peelEnvelope(b)).toBe('help');
+  });
+
+  it('preserves multi-line trailing content after the envelope', () => {
+    const wrapped = 'Sender (untrusted metadata):\n```json\n{"k":"v"}\n```\n\nline one\nline two';
+    expect(peelEnvelope(wrapped)).toBe('line one\nline two');
+  });
+});

--- a/packages/backend/src/scoring/__tests__/specificity-signals.spec.ts
+++ b/packages/backend/src/scoring/__tests__/specificity-signals.spec.ts
@@ -33,9 +33,19 @@ describe('computeSignalBoosts', () => {
   });
 
   describe('coding structural signals', () => {
-    it('boosts coding when the text contains a fenced code block', () => {
-      const { boosts } = computeSignalBoosts('here is the snippet ```const x = 1;```');
+    it('boosts coding when the text contains a fenced code block with substantive body', () => {
+      const body = 'const longer = "snippet that exceeds forty characters in body";';
+      const { boosts } = computeSignalBoosts('here is the snippet\n```ts\n' + body + '\n```');
       expect(boosts.get('coding')).toBe(3);
+    });
+
+    it('does not boost coding for tiny envelope-style fences (#1767)', () => {
+      // Empty/minimal fenced blocks (e.g. agent metadata wrappers like
+      // ```json\n{}\n```) used to fire CODE_FENCE_BOOST and push every
+      // wrapped prompt into coding. A fence body of <40 chars no longer
+      // counts.
+      const { boosts } = computeSignalBoosts('hi ```json\n{}\n```');
+      expect(boosts.has('coding')).toBe(false);
     });
 
     it('boosts coding when the text contains a file path', () => {
@@ -68,22 +78,43 @@ describe('computeSignalBoosts', () => {
 
   describe('coding tool-name signals', () => {
     it('boosts coding when a tool name matches a known coding tool (flat name)', () => {
-      const tools: ScorerTool[] = [{ name: 'Read' }];
+      const tools: ScorerTool[] = [{ name: 'apply_patch' }];
       const { boosts } = computeSignalBoosts('x', tools);
-      expect(boosts.get('coding')).toBe(3);
+      expect(boosts.get('coding')).toBe(1);
     });
 
     it('boosts coding when a tool name matches via function.name', () => {
-      const tools: ScorerTool[] = [{ function: { name: 'bash' } }];
+      const tools: ScorerTool[] = [{ function: { name: 'multiedit' } }];
       const { boosts } = computeSignalBoosts('x', tools);
-      expect(boosts.get('coding')).toBe(3);
+      expect(boosts.get('coding')).toBe(1);
     });
 
     it('only applies the coding-tool boost once even with multiple matching tools', () => {
-      const tools: ScorerTool[] = [{ name: 'edit' }, { name: 'bash' }, { name: 'grep' }];
+      const tools: ScorerTool[] = [
+        { name: 'apply_patch' },
+        { name: 'str_replace' },
+        { name: 'multiedit' },
+      ];
       const { boosts } = computeSignalBoosts('x', tools);
-      // Loop short-circuits after the first coding tool — stays at CODING_TOOL_BOOST (3).
-      expect(boosts.get('coding')).toBe(3);
+      // Loop short-circuits after the first coding tool — stays at CODING_TOOL_BOOST (1).
+      expect(boosts.get('coding')).toBe(1);
+    });
+
+    it('does not boost coding for generic agent tools like read/write/edit (#1767)', () => {
+      // These tool names ship with every modern agent CLI and were
+      // misclassifying every prompt as coding. They were removed from
+      // CODING_TOOL_NAMES; the only legitimate coding signal from tools
+      // alone is now a uniquely-coding tool (apply_patch, str_replace, etc).
+      const tools: ScorerTool[] = [
+        { name: 'read' },
+        { name: 'write' },
+        { name: 'edit' },
+        { name: 'bash' },
+        { name: 'grep' },
+        { name: 'glob' },
+      ];
+      const { boosts } = computeSignalBoosts('x', tools);
+      expect(boosts.has('coding')).toBe(false);
     });
 
     it('ignores tools whose name is not in the coding tool set', () => {

--- a/packages/backend/src/scoring/__tests__/text-extractor.spec.ts
+++ b/packages/backend/src/scoring/__tests__/text-extractor.spec.ts
@@ -152,6 +152,14 @@ describe('extractUserTexts', () => {
     const result = extractUserTexts([{ role: 'assistant', content: 'I can help' }]);
     expect(result).toHaveLength(0);
   });
+
+  it('peels agent metadata envelopes before scoring (#1766)', () => {
+    const wrapped =
+      'Sender (untrusted metadata):\n```json\n{ "label": "openclaw-tui" }\n```\n\nsay hello';
+    const result = extractUserTexts([{ role: 'user', content: wrapped }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('say hello');
+  });
 });
 
 describe('countConversationMessages', () => {

--- a/packages/backend/src/scoring/envelope-peeler.ts
+++ b/packages/backend/src/scoring/envelope-peeler.ts
@@ -1,0 +1,95 @@
+/**
+ * Strip a leading agent metadata wrapper from a user message before scoring.
+ *
+ * Modern agents (OpenClaw, NanoBot, Hermes, etc.) wrap the human's prompt
+ * in a structured envelope. A typical OpenClaw user message looks like:
+ *
+ *     Sender (untrusted metadata):
+ *     ```json
+ *     { "label": "openclaw-tui", "id": "openclaw-tui" }
+ *     ```
+ *
+ *     say hello
+ *
+ * The scorer must score the human's intent, not the envelope. Without
+ * peeling, "say hello" sails past the short-message shortcut (it's now
+ * 100+ chars), the trie matches `json`/`metadata` as technical vocabulary,
+ * the leading code fence triggers the coding-specificity boost, and the
+ * request misroutes to standard/complex (#1766) and to coding (#1767).
+ *
+ * The peeler errs on the side of NOT peeling: if the structure doesn't
+ * unambiguously look like an envelope, the original text is returned.
+ */
+
+const ENVELOPE_HEADER_REGEX =
+  /^\s*[^\n]{0,120}?(?:metadata|sender|envelope|context|system message)[^\n]{0,80}:\s*\n/i;
+const FENCE_LANGUAGE_REGEX = /^```([a-z+_-]*)\n([\s\S]*?)\n```/;
+const STRUCTURED_LANGUAGES = new Set(['json', 'jsonl', 'yaml', 'yml', 'toml', 'xml']);
+
+/**
+ * Returns the human portion of a wrapped user message, or the original
+ * text unchanged when no envelope is detected.
+ */
+export function peelEnvelope(text: string): string {
+  if (text.length === 0) return text;
+
+  let working = text;
+  const headerMatch = working.match(ENVELOPE_HEADER_REGEX);
+  if (headerMatch) {
+    working = working.slice(headerMatch[0].length);
+  }
+
+  const trimmed = working.replace(/^\s+/, '');
+  const fenceMatch = trimmed.match(FENCE_LANGUAGE_REGEX);
+  if (!fenceMatch) {
+    // Header without a fenced block isn't a recognizable envelope shape.
+    return text;
+  }
+
+  const language = fenceMatch[1].toLowerCase();
+  const inner = fenceMatch[2];
+  const isStructured = STRUCTURED_LANGUAGES.has(language) || looksLikeStructuredData(inner);
+  if (!isStructured) {
+    // A code fence wrapping actual code is the legitimate "user pasted code"
+    // case. Leave it for the scorer to see.
+    return text;
+  }
+
+  const afterFence = trimmed.slice(fenceMatch[0].length);
+  const trailing = afterFence.replace(/^\s+/, '');
+  if (trailing.length === 0) {
+    // No human prompt after the envelope — keep the original so the scorer
+    // can still see what arrived.
+    return text;
+  }
+
+  return trailing;
+}
+
+/**
+ * Cheap structural check for JSON/YAML-shaped fence bodies that arrived
+ * without a language hint. Avoids parsing — we only need to know whether
+ * peeling is safe.
+ */
+function looksLikeStructuredData(inner: string): boolean {
+  const stripped = inner.trim();
+  if (stripped.length === 0) return false;
+
+  const first = stripped[0];
+  const last = stripped[stripped.length - 1];
+  if ((first === '{' && last === '}') || (first === '[' && last === ']')) return true;
+
+  // YAML front-matter style: every non-empty line is `key: value` or a list item.
+  const lines = stripped.split('\n');
+  let yamlLines = 0;
+  for (const line of lines) {
+    const t = line.trim();
+    if (t.length === 0) continue;
+    if (/^[A-Za-z_][\w.-]*\s*:\s*\S/.test(t) || /^- /.test(t)) {
+      yamlLines++;
+    } else {
+      return false;
+    }
+  }
+  return yamlLines >= 2;
+}

--- a/packages/backend/src/scoring/specificity-signals.ts
+++ b/packages/backend/src/scoring/specificity-signals.ts
@@ -27,8 +27,11 @@ const URL_BOOST = 2;
 const BARE_HOST_BOOST = 1;
 
 // ── Code-context negative signals ──
-// Fenced code block — anywhere.
-const CODE_FENCE_REGEX = /```/;
+// Fenced code block with a non-trivial body. The previous ungated `/```/`
+// fired on agent metadata wrappers (e.g. ```json\n{}\n```) and pushed coding
+// onto every prompt — see #1767. Requiring a body of ≥40 chars keeps
+// real pasted code in scope while ignoring tiny envelope fences.
+const CODE_FENCE_REGEX = /```[a-z+_-]*\n[\s\S]{40,}?\n?```/i;
 // Looks like a file path. Covers `./foo`, `/foo` and the named `src/` /
 // `packages/` / etc. prefixes. Bare ` / ` (slash between whitespace, like
 // "a / b") is intentionally NOT matched — the `\/\w` trailer requires a
@@ -39,28 +42,28 @@ const FILE_PATH_REGEX =
   /(?:^|\s)(?:\.?\/\w|src\/|packages\/|app\/|lib\/|components\/|pages\/|[\w-]+\.(?:ts|tsx|js|jsx|py|go|rs|rb|java|kt|swift|php|cs|cpp|c|h|hpp|sh|sql|yaml|yml|json|toml|md|html|css|scss)\b)/i;
 // Stack trace fragments.
 const STACK_TRACE_REGEX = /\b(?:TypeError|ReferenceError|SyntaxError|Traceback|at \w+\.\w+\s*\()/;
-// Common coding tool names that imply a coding session.
+// Tool names that uniquely indicate a coding session. Generic agent verbs
+// (`read`, `write`, `edit`, `view`, `bash`, `grep`, `glob`, `create_file`)
+// were removed in #1767 — every modern agent CLI ships them, so they were
+// activating coding on every prompt regardless of intent.
 const CODING_TOOL_NAMES = new Set([
-  'read',
-  'write',
-  'edit',
-  'bash',
-  'grep',
-  'glob',
   'str_replace',
   'str_replace_editor',
   'apply_patch',
   'multiedit',
   'notebookedit',
-  'create_file',
-  'view',
 ]);
 
 /** Per-signal boost for coding. */
 const CODE_FENCE_BOOST = 3;
 const FILE_PATH_BOOST = 2;
 const STACK_TRACE_BOOST = 3;
-const CODING_TOOL_BOOST = 3;
+// A single tool-name match is a corroborating hint, not a strong anchor.
+// Lowered from 3 → 1 in #1767: the previous boost was enough to cross the
+// activation threshold all on its own, so any agent shipping `read`/`write`
+// tooling routed every prompt to coding. Requires combination with another
+// signal (keyword, file path, stack trace) for coding to activate now.
+const CODING_TOOL_BOOST = 1;
 
 /**
  * Inspect the user text + tool list and emit structural signal boosts.

--- a/packages/backend/src/scoring/specificity-weights.ts
+++ b/packages/backend/src/scoring/specificity-weights.ts
@@ -70,7 +70,11 @@ export const KEYWORD_WEIGHTS: Record<string, number> = {
  * with additional signal before it flips routing. Other categories stay at 1.0
  * so prior positive-detection coverage (80%+ on 100 prompts per category)
  * remains intact — they never had the false-positive blast radius that
- * web_browsing did.
+ * web_browsing did. The `coding` false positive in #1767 was fixed at the
+ * signal source (trimming generic tool names, requiring a substantive code
+ * fence body, peeling agent metadata envelopes) rather than by raising this
+ * threshold — which would have hurt detection accuracy on real coding
+ * prompts that only carry a single technical keyword.
  */
 export const ACTIVATION_THRESHOLDS: Record<SpecificityCategory, number> = {
   coding: 1.0,

--- a/packages/backend/src/scoring/text-extractor.ts
+++ b/packages/backend/src/scoring/text-extractor.ts
@@ -1,4 +1,5 @@
 import { ScorerMessage } from './types';
+import { peelEnvelope } from './envelope-peeler';
 
 export interface ExtractedText {
   text: string;
@@ -39,7 +40,11 @@ export function extractUserTexts(messages: ScorerMessage[]): ExtractedText[] {
     if (EXCLUDED_ROLES.has(msg.role)) continue;
     if (msg.role !== 'user') continue;
 
-    const text = extractTextFromContent(msg.content);
+    const raw = extractTextFromContent(msg.content);
+    if (raw.length === 0) continue;
+
+    // Score the human's words, not the agent's metadata envelope.
+    const text = peelEnvelope(raw);
     if (text.length === 0) continue;
 
     userMessages.push({ text, index: i });


### PR DESCRIPTION
### ✨ What changed
- New `peelEnvelope()` strips leading metadata wrappers from user messages before scoring.
- `extractUserTexts()` runs every user message through the peeler.
- `CODE_FENCE_REGEX` now requires a fence body of at least 40 chars.
- `CODING_TOOL_NAMES` trimmed to uniquely-coding tools (`apply_patch`, `str_replace`, `multiedit`, ...). Generic agent verbs removed.
- `CODING_TOOL_BOOST` lowered from 3 to 1.

### 💭 Why
Agents wrap the user's prompt in a metadata block before sending. The scorer was reading the envelope as the user's intent, so "say hello" wrapped by OpenClaw was 100+ chars of JSON metadata and routed to standard/complex (#1766). Separately, generic agent tools like `read`/`write`/`edit` plus an ungated triple-backtick regex pushed every prompt above the coding activation threshold (#1767).

### 👤 For users
Wrapped greetings now route to simple correctly. Coding tier no longer activates on every prompt just because the agent ships standard file tools.

### 📝 Notes
- Closes #1766
- Closes #1767
- Coverage: 18-case `envelope-peeler` spec, new `agent-envelope-regression` spec, updated `specificity-signals` and `text-extractor` specs. 4336 backend unit tests + 137 e2e + 2604 frontend + 97 shared all pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misrouting from agent-wrapped prompts and over-eager coding signals. Wrapped greetings now route to simple, and coding only activates on real code signals or uniquely coding tools. Addresses #1766 and #1767.

- **Bug Fixes**
  - Added `peelEnvelope()` and applied it in `extractUserTexts()` to strip leading agent metadata blocks (e.g., OpenClaw) before scoring.
  - Tightened `CODE_FENCE_REGEX` to require a fence body ≥40 chars so tiny envelope fences no longer trigger coding.
  - Trimmed `CODING_TOOL_NAMES` to uniquely coding tools (`apply_patch`, `str_replace`, `multiedit`, `notebookedit`) and lowered `CODING_TOOL_BOOST` from 3 to 1.

<sup>Written for commit 4bd40399ec29467c0dd12e659e552e13d8e5b0a8. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1770?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

