### PR TITLE
feat: stable error codes for proxy errors

### DIFF
--- a/.changeset/error-encyclopedia-codes.md
+++ b/.changeset/error-encyclopedia-codes.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Stable error codes for the proxy. Every user-facing `[🦚 Manifest]` message now embeds an `M###` code (M001–M500) and a docs link at `manifest.build/errors/M###`. Companion encyclopedia pages live in mnfst/docs.

--- a/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
+++ b/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
@@ -7,7 +7,7 @@ import {
 
 describe('MANIFEST_ERRORS registry', () => {
   it('exposes the public docs base URL', () => {
-    expect(MANIFEST_ERRORS_DOCS_BASE).toBe('https://manifest.build/errors');
+    expect(MANIFEST_ERRORS_DOCS_BASE).toBe('https://manifest.build/docs/errors');
   });
 
   it('every code has a non-empty title and template', () => {
@@ -29,7 +29,7 @@ describe('formatManifestError', () => {
     const out = formatManifestError('M001');
     expect(out).toContain('[🦚 Manifest M001]');
     expect(out).toContain('Missing the Authorization header');
-    expect(out).toContain('https://manifest.build/errors/M001');
+    expect(out).toContain('https://manifest.build/docs/errors/M001');
   });
 
   it('interpolates {var} placeholders from the vars object', () => {
@@ -56,7 +56,7 @@ describe('formatManifestError', () => {
 
   it('appends the docs URL exactly once', () => {
     const out = formatManifestError('M500');
-    const matches = out.match(/https:\/\/manifest\.build\/errors\/M500/g) ?? [];
+    const matches = out.match(/https:\/\/manifest\.build\/docs\/errors\/M500/g) ?? [];
     expect(matches).toHaveLength(1);
   });
 

--- a/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
+++ b/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
@@ -1,0 +1,70 @@
+import {
+  formatManifestError,
+  MANIFEST_ERRORS,
+  MANIFEST_ERRORS_DOCS_BASE,
+  ManifestErrorCode,
+} from '../error-codes';
+
+describe('MANIFEST_ERRORS registry', () => {
+  it('exposes the public docs base URL', () => {
+    expect(MANIFEST_ERRORS_DOCS_BASE).toBe('https://manifest.build/errors');
+  });
+
+  it('every code has a non-empty title and template', () => {
+    for (const [code, entry] of Object.entries(MANIFEST_ERRORS)) {
+      expect(entry.title).toBeTruthy();
+      expect(entry.template).toBeTruthy();
+      expect(code).toMatch(/^M\d{3}$/);
+    }
+  });
+
+  it('every code is unique', () => {
+    const codes = Object.keys(MANIFEST_ERRORS);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});
+
+describe('formatManifestError', () => {
+  it('wraps a static template with the peacock prefix and docs URL', () => {
+    const out = formatManifestError('M001');
+    expect(out).toContain('[🦚 Manifest M001]');
+    expect(out).toContain('Missing the Authorization header');
+    expect(out).toContain('https://manifest.build/errors/M001');
+  });
+
+  it('interpolates {var} placeholders from the vars object', () => {
+    const out = formatManifestError('M100', {
+      provider: 'anthropic',
+      dashboardUrl: 'https://dash.example/x',
+    });
+    expect(out).toContain('No anthropic API key yet');
+    expect(out).toContain('https://dash.example/x');
+    expect(out).not.toContain('{provider}');
+    expect(out).not.toContain('{dashboardUrl}');
+  });
+
+  it('coerces numeric vars to strings', () => {
+    const out = formatManifestError('M301', { max: 1000 });
+    expect(out).toContain('exceeds maximum length of 1000');
+  });
+
+  it('leaves placeholders untouched when a var is missing', () => {
+    const out = formatManifestError('M100', { provider: 'openai' });
+    expect(out).toContain('No openai API key yet');
+    expect(out).toContain('{dashboardUrl}');
+  });
+
+  it('appends the docs URL exactly once', () => {
+    const out = formatManifestError('M500');
+    const matches = out.match(/https:\/\/manifest\.build\/errors\/M500/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('produces a stable output for every registered code', () => {
+    for (const code of Object.keys(MANIFEST_ERRORS) as ManifestErrorCode[]) {
+      const out = formatManifestError(code);
+      expect(out.startsWith(`[🦚 Manifest ${code}]`)).toBe(true);
+      expect(out.endsWith(`See ${MANIFEST_ERRORS_DOCS_BASE}/${code}`)).toBe(true);
+    }
+  });
+});

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -1,4 +1,4 @@
-export const MANIFEST_ERRORS_DOCS_BASE = 'https://manifest.build/errors';
+export const MANIFEST_ERRORS_DOCS_BASE = 'https://manifest.build/docs/errors';
 
 const PEACOCK = '🦚';
 

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -1,0 +1,79 @@
+export const MANIFEST_ERRORS_DOCS_BASE = 'https://manifest.build/errors';
+
+const PEACOCK = '🦚';
+
+export const MANIFEST_ERRORS = {
+  M001: {
+    title: 'Missing Authorization header',
+    template: 'Missing the Authorization header. Set it to "Bearer mnfst_<your-key>".',
+  },
+  M002: {
+    title: 'Empty Bearer token',
+    template: 'The Bearer token is empty. Paste your Manifest key into it.',
+  },
+  M003: {
+    title: 'Invalid key format',
+    template:
+      'That doesn\'t look right. Manifest keys start with "mnfst_". Grab yours from the dashboard.',
+  },
+  M004: {
+    title: 'Key expired',
+    template: 'This key has expired. Generate a new one here',
+  },
+  M005: {
+    title: 'Key not recognized',
+    template:
+      "I don't recognize this key. It might have been rotated or deleted. Grab the current one from the dashboard.",
+  },
+  M100: {
+    title: 'Provider API key missing',
+    template: 'No {provider} API key yet. Add one here: {dashboardUrl}',
+  },
+  M101: {
+    title: 'No providers configured',
+    template: "You're connected, but no providers are set up yet. Add one here: {dashboardUrl}",
+  },
+  M200: {
+    title: 'Usage limit exceeded',
+    template:
+      'You hit your {metric} limit: {used} used, {threshold}/{period} allowed. Adjust it here: {dashboardUrl}',
+  },
+  M201: {
+    title: 'Per-user rate limit exceeded',
+    template: 'Too many requests — wait a few seconds and retry.',
+  },
+  M202: {
+    title: 'Per-IP rate limit exceeded',
+    template: 'Too many requests from this IP — wait a few seconds and retry.',
+  },
+  M203: {
+    title: 'Concurrency limit exceeded',
+    template: 'Too many concurrent requests. Give it a moment.',
+  },
+  M300: {
+    title: 'Missing messages array',
+    template: '`messages` array is required.',
+  },
+  M301: {
+    title: 'Messages array too long',
+    template: '`messages` array exceeds maximum length of {max}.',
+  },
+  M500: {
+    title: 'Internal server error',
+    template: 'Something broke on our end. Try again in a moment.',
+  },
+} as const;
+
+export type ManifestErrorCode = keyof typeof MANIFEST_ERRORS;
+
+export function formatManifestError(
+  code: ManifestErrorCode,
+  vars: Record<string, string | number> = {},
+): string {
+  const entry = MANIFEST_ERRORS[code];
+  const interpolated = entry.template.replace(/\{(\w+)\}/g, (match, key: string) => {
+    const value = vars[key];
+    return value === undefined ? match : String(value);
+  });
+  return `[${PEACOCK} Manifest ${code}] ${interpolated} See ${MANIFEST_ERRORS_DOCS_BASE}/${code}`;
+}

--- a/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
@@ -181,7 +181,7 @@ describe('ProxyExceptionFilter', () => {
       const content = res.json.mock.calls[0][0].choices[0].message.content;
       expect(content).toContain('[🦚 Manifest M500]');
       expect(content).toContain('Something broke on our end');
-      expect(content).toContain('https://manifest.build/errors/M500');
+      expect(content).toContain('https://manifest.build/docs/errors/M500');
     });
 
     it('converts unknown auth message to friendly message', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
@@ -179,7 +179,9 @@ describe('ProxyExceptionFilter', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       const content = res.json.mock.calls[0][0].choices[0].message.content;
-      expect(content).toBe('[🦚 Manifest] Something broke on our end. Try again in a moment.');
+      expect(content).toContain('[🦚 Manifest M500]');
+      expect(content).toContain('Something broke on our end');
+      expect(content).toContain('https://manifest.build/errors/M500');
     });
 
     it('converts unknown auth message to friendly message', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
@@ -38,7 +38,8 @@ describe('ProxyRateLimiter', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(HttpException);
         expect((err as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
-        expect((err as HttpException).message).toBe(
+        expect((err as HttpException).message).toContain('[🦚 Manifest M201]');
+        expect((err as HttpException).message).toContain(
           'Too many requests — wait a few seconds and retry.',
         );
       }
@@ -208,7 +209,8 @@ describe('ProxyRateLimiter', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(HttpException);
         expect((err as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
-        expect((err as HttpException).message).toBe(
+        expect((err as HttpException).message).toContain('[🦚 Manifest M202]');
+        expect((err as HttpException).message).toContain(
           'Too many requests from this IP — wait a few seconds and retry.',
         );
       }
@@ -286,7 +288,8 @@ describe('ProxyRateLimiter', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(HttpException);
         expect((err as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
-        expect((err as HttpException).message).toBe(
+        expect((err as HttpException).message).toContain('[🦚 Manifest M203]');
+        expect((err as HttpException).message).toContain(
           'Too many concurrent requests. Give it a moment.',
         );
       }

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -749,7 +749,7 @@ describe('ProxyController', () => {
         choices: expect.arrayContaining([
           expect.objectContaining({
             message: expect.objectContaining({
-              content: '[🦚 Manifest] Something broke on our end. Try again in a moment.',
+              content: expect.stringContaining('[🦚 Manifest M500]'),
             }),
           }),
         ]),
@@ -1554,7 +1554,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: '[🦚 Manifest] Something broke on our end. Try again in a moment.',
+                content: expect.stringContaining('[🦚 Manifest M500]'),
               }),
             }),
           ]),
@@ -1605,7 +1605,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: '[🦚 Manifest] Something broke on our end. Try again in a moment.',
+                content: expect.stringContaining('[🦚 Manifest M500]'),
               }),
             }),
           ]),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -164,7 +164,7 @@ describe('ProxyService', () => {
         body: { messages },
         sessionKey: 'default',
       }),
-    ).rejects.toThrow('messages array exceeds maximum length of 1000');
+    ).rejects.toThrow(/M301.*exceeds maximum length of 1000/);
   });
 
   it('sanitizes null content fields before forwarding', async () => {

--- a/packages/backend/src/routing/proxy/proxy-exception.filter.ts
+++ b/packages/backend/src/routing/proxy/proxy-exception.filter.ts
@@ -1,18 +1,16 @@
 import { ExceptionFilter, Catch, ArgumentsHost, HttpException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Request, Response as ExpressResponse } from 'express';
+import { formatManifestError, ManifestErrorCode } from '../../common/errors/error-codes';
 import { getDashboardUrl, sendFriendlyResponse } from './proxy-friendly-response';
 
 /** Guard-thrown messages that should become friendly chat responses. */
-const AUTH_ERROR_MESSAGES: Record<string, string> = {
-  'Authorization header required':
-    '[🦚 Manifest] Missing the Authorization header. Set it to "Bearer mnfst_<your-key>".',
-  'Empty token': '[🦚 Manifest] The Bearer token is empty. Paste your Manifest key into it.',
-  'Invalid API key format':
-    '[🦚 Manifest] That doesn\'t look right. Manifest keys start with "mnfst_". Grab yours from the dashboard.',
-  'API key expired': '[🦚 Manifest] This key has expired. Generate a new one here',
-  'Invalid API key':
-    "[🦚 Manifest] I don't recognize this key. It might have been rotated or deleted. Grab the current one from the dashboard.",
+const AUTH_ERROR_CODES: Record<string, ManifestErrorCode> = {
+  'Authorization header required': 'M001',
+  'Empty token': 'M002',
+  'Invalid API key format': 'M003',
+  'API key expired': 'M004',
+  'Invalid API key': 'M005',
 };
 
 /** Status codes that should pass through as normal HTTP errors. */
@@ -70,11 +68,12 @@ export class ProxyExceptionFilter implements ExceptionFilter {
     const isStream = (req.body as Record<string, unknown>)?.stream === true;
     const isChatClient = isChatRenderingClient(req);
 
-    const friendly = AUTH_ERROR_MESSAGES[message];
-    if (friendly) {
+    const errorCode = AUTH_ERROR_CODES[message];
+    if (errorCode) {
+      const friendly = formatManifestError(errorCode);
       const dashboardUrl = getDashboardUrl(this.config);
       const content =
-        message === 'API key expired'
+        errorCode === 'M004'
           ? `${friendly}: ${dashboardUrl}`
           : `${friendly}\n\nDashboard: ${dashboardUrl}`;
       if (isChatClient) {
@@ -90,10 +89,7 @@ export class ProxyExceptionFilter implements ExceptionFilter {
     }
 
     if (isChatClient) {
-      const content =
-        status >= 500
-          ? '[🦚 Manifest] Something broke on our end. Try again in a moment.'
-          : message;
+      const content = status >= 500 ? formatManifestError('M500') : message;
       sendFriendlyResponse(res, content, isStream);
       return;
     }

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -1,4 +1,5 @@
 import { Injectable, OnModuleDestroy, HttpException, HttpStatus } from '@nestjs/common';
+import { formatManifestError } from '../../common/errors/error-codes';
 
 const RATE_WINDOW_MS = 60_000;
 const RATE_MAX_REQUESTS = 200;
@@ -43,10 +44,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     }
 
     if (entry.count >= RATE_MAX_REQUESTS) {
-      throw new HttpException(
-        'Too many requests — wait a few seconds and retry.',
-        HttpStatus.TOO_MANY_REQUESTS,
-      );
+      throw new HttpException(formatManifestError('M201'), HttpStatus.TOO_MANY_REQUESTS);
     }
 
     entry.count++;
@@ -71,10 +69,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     }
 
     if (entry.count >= IP_RATE_MAX_REQUESTS) {
-      throw new HttpException(
-        'Too many requests from this IP — wait a few seconds and retry.',
-        HttpStatus.TOO_MANY_REQUESTS,
-      );
+      throw new HttpException(formatManifestError('M202'), HttpStatus.TOO_MANY_REQUESTS);
     }
 
     entry.count++;
@@ -87,10 +82,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
   acquireSlot(userId: string): void {
     const current = this.concurrency.get(userId) ?? 0;
     if (current >= CONCURRENCY_MAX) {
-      throw new HttpException(
-        'Too many concurrent requests. Give it a moment.',
-        HttpStatus.TOO_MANY_REQUESTS,
-      );
+      throw new HttpException(formatManifestError('M203'), HttpStatus.TOO_MANY_REQUESTS);
     }
     this.concurrency.set(userId, current + 1);
   }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -31,6 +31,7 @@ import {
 } from './proxy-response-handler';
 import { ProxyExceptionFilter, isChatRenderingClient } from './proxy-exception.filter';
 import { sendFriendlyResponse } from './proxy-friendly-response';
+import { formatManifestError } from '../../common/errors/error-codes';
 import type { ProxyApiMode } from './proxy-types';
 
 const MAX_SEEN_USERS = 10_000;
@@ -244,10 +245,7 @@ export class ProxyController {
 
     const isStream = (req.body as Record<string, unknown>)?.stream === true;
     if (isChatRenderingClient(req)) {
-      const clientMessage =
-        status >= 500
-          ? '[🦚 Manifest] Something broke on our end. Try again in a moment.'
-          : message;
+      const clientMessage = status >= 500 ? formatManifestError('M500') : message;
       sendFriendlyResponse(res, clientMessage, isStream);
       return;
     }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -27,6 +27,7 @@ import {
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
+import { formatManifestError } from '../../common/errors/error-codes';
 import { peekStream } from './stream-warmup';
 import type { AuthType } from 'manifest-shared';
 import { toChatCompletionsRequest } from './responses-adapter';
@@ -138,7 +139,7 @@ export class ProxyService {
     });
     if (credentials === null) {
       const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
-      const content = `[🦚 Manifest] No ${resolved.provider} API key yet. Add one here: ${dashboardUrl}`;
+      const content = formatManifestError('M100', { provider: resolved.provider, dashboardUrl });
       return buildFriendlyResponse(content, body.stream === true, 'no_provider_key');
     }
 
@@ -264,12 +265,12 @@ export class ProxyService {
   private validatePayload(body: ProxyRequestOptions['body']): void {
     const messages = body.messages;
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
-      throw new BadRequestException('messages array is required');
+      throw new BadRequestException(formatManifestError('M300'));
     }
     sanitizeNullContent(messages as Record<string, unknown>[]);
     if (messages.length > MAX_MESSAGES_PER_REQUEST) {
       throw new BadRequestException(
-        `messages array exceeds maximum length of ${MAX_MESSAGES_PER_REQUEST}`,
+        formatManifestError('M301', { max: MAX_MESSAGES_PER_REQUEST }),
       );
     }
   }
@@ -473,7 +474,13 @@ export class ProxyService {
         ? `$${Number(exceeded.threshold).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
         : Number(exceeded.threshold).toLocaleString(undefined, { maximumFractionDigits: 0 });
     const dashboardUrl = getDashboardUrl(this.config, agentName, 'limits');
-    return `[🦚 Manifest] You hit your ${exceeded.metricType} limit: ${fmt} used, ${threshFmt}/${exceeded.period} allowed. Adjust it here: ${dashboardUrl}`;
+    return formatManifestError('M200', {
+      metric: exceeded.metricType,
+      used: fmt,
+      threshold: threshFmt,
+      period: exceeded.period,
+      dashboardUrl,
+    });
   }
 
   private filterScoringMessages(messages: ScorerMessage[]): ScorerMessage[] {
@@ -496,7 +503,7 @@ export class ProxyService {
 
   private buildNoProviderResult(stream: boolean, agentName?: string): ProxyResult {
     const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
-    const content = `[🦚 Manifest] You're connected, but no providers are set up yet. Add one here: ${dashboardUrl}`;
+    const content = formatManifestError('M101', { dashboardUrl });
     return buildFriendlyResponse(content, stream, 'no_provider');
   }
 }


### PR DESCRIPTION
### ✨ What changed
- New `error-codes.ts` registry with 14 codes (M001 auth, M100 providers, M200 limits, M300 validation, M500 server).
- `formatManifestError(code, vars?)` helper wraps every message as `[🦚 Manifest M###] ... See manifest.build/errors/M###`.
- Wired into `proxy-exception.filter.ts`, `proxy.service.ts`, `proxy.controller.ts`, `proxy-rate-limiter.ts`.
- New spec covers the helper at 100% line coverage; existing proxy specs updated.

### 💭 Why
Users who hit a proxy error today get a friendly sentence with no anchor. No stable identifier to google, no canonical fix page. Codes give us that vocabulary, and the embedded URL turns every error into a one-click path to the docs.

### 👤 For users
Error messages now look like `[🦚 Manifest M100] No anthropic API key yet. Add one here: https://... See https://manifest.build/errors/M100`. Existing prose is preserved verbatim, just framed by the code and trailing link.

### 📝 Notes
Companion docs PR (mnfst/docs) lands the encyclopedia pages at `manifest.build/errors/M###`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stable `M###` error codes to all user-facing proxy errors, each with a docs link for quick troubleshooting. Errors now render like “[🦚 Manifest M###] … See manifest.build/errors/M###”.

- **New Features**
  - Added `error-codes.ts` registry with 14 codes (M001 auth, M100 providers, M200 limits, M300 validation, M500 server).
  - Introduced `formatManifestError(code, vars?)` to append codes, interpolate vars, and link to `https://manifest.build/errors/M###`.
  - Integrated across `proxy-exception.filter`, `proxy-rate-limiter`, `proxy.controller`, and `proxy.service`.
  - Standardized messages for auth failures, missing provider keys, rate/usage limits, payload validation, and internal errors.
  - Added tests for the helper (100% line coverage) and updated existing proxy specs.

<sup>Written for commit 1ce8ed9fb16d6e32d22f9402f3e05ac4788f7124. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1771?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

