### PR TITLE
Handle default tier display in ModelPickerModal

### DIFF
--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -6,7 +6,7 @@ import type {
   RoutingProvider,
   TierAssignment,
 } from '../services/api.js';
-import { PROVIDERS, STAGES, SPECIFICITY_STAGES } from '../services/providers.js';
+import { PROVIDERS, STAGES, SPECIFICITY_STAGES, DEFAULT_STAGE } from '../services/providers.js';
 import { customProviderColor } from '../services/formatters.js';
 import { inferProviderFromModel, pricePerM, resolveProviderId } from '../services/routing-utils.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
@@ -205,12 +205,12 @@ const ModelPickerModal: Component<Props> = (props) => {
               Select a model
             </div>
             <div class="routing-modal__subtitle">
-              {
-                (
-                  STAGES.find((s) => s.id === props.tierId) ??
-                  SPECIFICITY_STAGES.find((s) => s.id === props.tierId)
-                )?.label
-              }{' '}
+              {props.tierId === DEFAULT_STAGE.id
+                ? 'Default'
+                : (
+                    STAGES.find((s) => s.id === props.tierId) ??
+                    SPECIFICITY_STAGES.find((s) => s.id === props.tierId)
+                  )?.label}{' '}
               tier
             </div>
           </div>

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -63,6 +63,13 @@ describe("ModelPickerModal", () => {
     expect(screen.getByText("Simple tier")).toBeDefined();
   });
 
+  it("shows Default tier subtitle for the default stage", () => {
+    render(() => (
+      <ModelPickerModal tierId="default" models={baseModels} tiers={baseTiers} onSelect={onSelect} onClose={onClose} />
+    ));
+    expect(screen.getByText("Default tier")).toBeDefined();
+  });
+
   it("renders model groups", () => {
     render(() => (
       <ModelPickerModal tierId="simple" models={baseModels} tiers={baseTiers} onSelect={onSelect} onClose={onClose} />


### PR DESCRIPTION
## Summary
Updated the ModelPickerModal component to properly display "Default" as the tier label when the default stage is selected, rather than attempting to look it up in the STAGES or SPECIFICITY_STAGES arrays.

## Key Changes
- Imported `DEFAULT_STAGE` constant from the providers service
- Added explicit check for `DEFAULT_STAGE.id` to display "Default" tier label
- Refactored subtitle rendering logic to handle the default tier case separately from other tier lookups
- Added test case to verify "Default tier" subtitle displays correctly when `tierId="default"`

## Implementation Details
The change adds a conditional check that displays "Default" as the tier label when `props.tierId === DEFAULT_STAGE.id`, falling back to the existing lookup logic for other tier IDs. This prevents the need to maintain the default stage in both the STAGES/SPECIFICITY_STAGES arrays and the DEFAULT_STAGE constant.

https://claude.ai/code/session_01RpDq9Lb1fyBZJJ7zsFEu6K