### PR TITLE
chore: harden OWASP-flagged surfaces across CI, runtime, and crypto

### DIFF
--- a/.changeset/owasp-hardening.md
+++ b/.changeset/owasp-hardening.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Security hardening across the build pipeline and runtime: every GitHub Action is now pinned by commit SHA, the awesome-free-llm-apis data feed is pinned to an immutable commit and validated for HTTPS shape before render, the encryption-key cache no longer keeps the raw secret as a Map key, the Google Gemini API key moves from `?key=` query param to the `x-goog-api-key` header (so it stays out of upstream proxy/LB access logs), OpenAI OAuth error logs run through `scrubSecrets`, the OAuth `backendUrl` now prefers `BETTER_AUTH_URL` over the request `Host` header, the dev-loopback agent fallback prefers the seeded tenant over picking the first active key, rejected agent keys log only the fixed `mnfst_` prefix, and migrations log via the TypeORM logger instead of `console.log`. `npm audit fix` resolved vite + postcss CVEs. A boot-time check counts active legacy static-salt API-key hashes and warns if any remain (no forced rotation). `MANIFEST_ENCRYPTION_KEY` is now documented and threaded through `docker-compose.yml`; if unset the runtime still falls back to `BETTER_AUTH_SECRET`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: npm
@@ -46,8 +46,8 @@ jobs:
       NODE_ENV: test
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: npm
@@ -62,7 +62,7 @@ jobs:
       - run: npm run test:e2e --workspace=packages/backend -- --coverage --coverageReporters=lcov
       - name: Upload backend coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend
@@ -72,8 +72,8 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: npm
@@ -88,7 +88,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload frontend coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: frontend
@@ -98,8 +98,8 @@ jobs:
   shared:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: npm
@@ -108,7 +108,7 @@ jobs:
       - run: npm test --workspace=packages/shared -- --coverage --coverageReporters=lcov
       - name: Upload shared coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: shared
@@ -120,10 +120,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           languages: javascript-typescript
           build-mode: none
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build local image as manifestdotbuild/manifest:latest
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: docker/Dockerfile
@@ -132,12 +132,12 @@ jobs:
     # on a PR, so we point the installer at a local HTTP server serving
     # the PR's docker/ directory via MANIFEST_INSTALLER_SOURCE.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build local image as manifestdotbuild/manifest:latest
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,11 +47,11 @@ jobs:
           - { os: ubuntu-24.04-arm, arch: arm64 }
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: docker/Dockerfile
@@ -74,22 +74,22 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         id: meta
         with:
           images: ${{ env.IMAGE }}
 
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: docker/Dockerfile
@@ -108,7 +108,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ matrix.platform.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -124,7 +124,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Resolve version
         id: version
@@ -139,20 +139,20 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         id: meta
         with:
           images: ${{ env.IMAGE }}
@@ -175,7 +175,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
 
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
       - name: Sign published image
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,20 +18,20 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: changesets/action@v1
+      - uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         id: changesets
         with:
           createGithubReleases: false
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -3,6 +3,13 @@
 # Session signing secret. Generate with: openssl rand -hex 32
 BETTER_AUTH_SECRET=
 
+# ─── At-rest encryption (recommended) ──────────────────────────────────────
+# Encrypts stored LLM provider API keys / OAuth tokens. If unset, falls back
+# to BETTER_AUTH_SECRET — convenient, but a session-cookie leak then also
+# decrypts every stored provider credential. Set to a SEPARATE 32+ char value
+# so the two leak surfaces stay independent. Generate with: openssl rand -hex 32
+# MANIFEST_ENCRYPTION_KEY=
+
 
 # ─── Deployment URL + port ─────────────────────────────────────────────────
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,6 +58,9 @@ services:
       - PORT=${PORT:-2099}
       - DATABASE_URL=${DATABASE_URL:-postgresql://manifest:manifest@postgres:5432/manifest}
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set in .env}
+      # Optional dedicated at-rest encryption key for stored provider/OAuth
+      # credentials. When unset, the backend falls back to BETTER_AUTH_SECRET.
+      - MANIFEST_ENCRYPTION_KEY=${MANIFEST_ENCRYPTION_KEY:-}
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:${PORT:-2099}}
       # Defaults to the host-installed Ollama. Override in .env if your
       # Ollama runs elsewhere (e.g. on another host on your LAN).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,6 +1422,278 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
       "cpu": [
@@ -1432,6 +1704,159 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -6491,6 +6916,431 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
@@ -10352,7 +11202,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "devOptional": true,
       "funding": [
         {
@@ -12518,7 +13370,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -12560,89 +13414,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/vite-node/node_modules/esbuild": {
-      "version": "0.27.4",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
-      }
-    },
-    "node_modules/vite-node/node_modules/vite": {
-      "version": "7.3.1",
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -12712,6 +13487,91 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -13757,7 +14617,9 @@
       "license": "MIT"
     },
     "packages/frontend/node_modules/vite": {
-      "version": "6.4.1",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13967,7 +14829,7 @@
       }
     },
     "packages/manifest": {
-      "version": "5.57.0"
+      "version": "6.0.0"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -2,6 +2,14 @@
 BETTER_AUTH_SECRET=          # Min 32 chars. Generate with: openssl rand -hex 32
 DATABASE_URL=                # PostgreSQL connection string: postgresql://user:password@host:port/database
 
+# ── At-rest encryption (recommended) ─────────────────
+# Encrypts stored LLM provider API keys / OAuth tokens (the AES-256-GCM key
+# is derived from this secret via scrypt). If unset, MANIFEST falls back to
+# BETTER_AUTH_SECRET — convenient, but a session-cookie leak then also
+# decrypts every stored provider credential. Set this to a SEPARATE 32+ char
+# value so the two leak surfaces stay independent.
+# MANIFEST_ENCRYPTION_KEY=    # Min 32 chars. Generate with: openssl rand -hex 32
+
 
 # ── Server ───────────────────────────────────────────
 PORT=3001

--- a/packages/backend/src/common/utils/crypto.util.ts
+++ b/packages/backend/src/common/utils/crypto.util.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
+import { createCipheriv, createDecipheriv, createHmac, randomBytes, scryptSync } from 'crypto';
 import { Logger as NestLogger } from '@nestjs/common';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -20,7 +20,10 @@ const keyCache = new Map<string, Buffer>();
 const KEY_CACHE_MAX = 1024;
 
 function deriveKey(secret: string, salt: Buffer): Buffer {
-  const cacheKey = `${secret.length}:${secret}:${salt.toString('base64')}`;
+  // Index the cache by HMAC(secret, salt) so the raw secret never lives as a
+  // Map key string. A heap dump of the Node.js process previously exposed
+  // the encryption secret directly via the cache key; HMAC removes that path.
+  const cacheKey = createHmac('sha256', secret).update(salt).digest('hex');
   const cached = keyCache.get(cacheKey);
   if (cached) return cached;
   const derived = scryptSync(secret, salt, KEY_LENGTH);

--- a/packages/backend/src/database/migrations/1771900000000-EncryptApiKeys.ts
+++ b/packages/backend/src/database/migrations/1771900000000-EncryptApiKeys.ts
@@ -1,19 +1,16 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
-import {
-  encrypt,
-  isEncrypted,
-} from '../../common/utils/crypto.util';
+import { encrypt, isEncrypted } from '../../common/utils/crypto.util';
 
 export class EncryptApiKeys1771900000000 implements MigrationInterface {
   name = 'EncryptApiKeys1771900000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const secret =
-      process.env['MANIFEST_ENCRYPTION_KEY'] ||
-      process.env['BETTER_AUTH_SECRET'];
+    const log = queryRunner.connection.logger;
+    const secret = process.env['MANIFEST_ENCRYPTION_KEY'] || process.env['BETTER_AUTH_SECRET'];
 
     if (!secret || secret.length < 32) {
-      console.warn(
+      log.log(
+        'warn',
         'EncryptApiKeys: No encryption secret found. Skipping — set MANIFEST_ENCRYPTION_KEY or BETTER_AUTH_SECRET.',
       );
       return;
@@ -24,27 +21,24 @@ export class EncryptApiKeys1771900000000 implements MigrationInterface {
     );
     if (tableExists.length === 0) return;
 
-    const rows: { id: string; api_key_encrypted: string }[] =
-      await queryRunner.query(
-        `SELECT id, api_key_encrypted FROM "user_providers" WHERE api_key_encrypted IS NOT NULL AND api_key_encrypted != ''`,
-      );
+    const rows: { id: string; api_key_encrypted: string }[] = await queryRunner.query(
+      `SELECT id, api_key_encrypted FROM "user_providers" WHERE api_key_encrypted IS NOT NULL AND api_key_encrypted != ''`,
+    );
 
     let encrypted = 0;
     for (const row of rows) {
       if (isEncrypted(row.api_key_encrypted)) continue;
 
       const ciphertext = encrypt(row.api_key_encrypted, secret);
-      await queryRunner.query(
-        `UPDATE "user_providers" SET api_key_encrypted = $1 WHERE id = $2`,
-        [ciphertext, row.id],
-      );
+      await queryRunner.query(`UPDATE "user_providers" SET api_key_encrypted = $1 WHERE id = $2`, [
+        ciphertext,
+        row.id,
+      ]);
       encrypted++;
     }
 
     if (encrypted > 0) {
-      console.log(
-        `EncryptApiKeys: Encrypted ${encrypted} plaintext API key(s).`,
-      );
+      log.log('info', `EncryptApiKeys: Encrypted ${encrypted} plaintext API key(s).`);
     }
   }
 

--- a/packages/backend/src/database/migrations/1772843035514-AddPerformanceIndexes.ts
+++ b/packages/backend/src/database/migrations/1772843035514-AddPerformanceIndexes.ts
@@ -45,11 +45,13 @@ export class AddPerformanceIndexes1772843035514 implements MigrationInterface {
   }
 
   private async backfillKeyPrefix(queryRunner: QueryRunner): Promise<void> {
+    const log = queryRunner.connection.logger;
     let secret: string;
     try {
       secret = getEncryptionSecret();
     } catch {
-      console.warn(
+      log.log(
+        'warn',
         'AddPerformanceIndexes: No encryption secret found. Skipping key_prefix backfill.',
       );
       return;
@@ -76,7 +78,10 @@ export class AddPerformanceIndexes1772843035514 implements MigrationInterface {
     }
 
     if (backfilled > 0) {
-      console.log(`AddPerformanceIndexes: Backfilled key_prefix for ${backfilled} provider(s).`);
+      log.log(
+        'info',
+        `AddPerformanceIndexes: Backfilled key_prefix for ${backfilled} provider(s).`,
+      );
     }
   }
 }

--- a/packages/backend/src/free-models/free-models-sync.service.spec.ts
+++ b/packages/backend/src/free-models/free-models-sync.service.spec.ts
@@ -1,7 +1,7 @@
 import { FreeModelsSyncService } from './free-models-sync.service';
 
 const GITHUB_RAW_URL =
-  'https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/main/data.json';
+  'https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/8b0feb0e3adda96455bcc380b815454944ff3832/data.json';
 
 const sampleData = {
   lastUpdated: '2026-04-17',
@@ -135,6 +135,89 @@ describe('FreeModelsSyncService', () => {
       expect(count).toBe(0);
       // Stale cache preserved
       expect(service.getAll()).toHaveLength(2);
+    });
+
+    it('drops entries whose url is not https', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lastUpdated: '2026-04-17',
+          providers: [
+            { ...sampleData.providers[0], url: 'http://insecure.example/keys' },
+            sampleData.providers[1],
+          ],
+        }),
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+      expect(service.getAll()[0].name).toBe('Google Gemini');
+    });
+
+    it('drops entries whose baseUrl is not https or null', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lastUpdated: '2026-04-17',
+          providers: [
+            { ...sampleData.providers[0], baseUrl: 'http://insecure.example/v1' },
+            sampleData.providers[1],
+          ],
+        }),
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+    });
+
+    it('keeps entries whose baseUrl is null', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lastUpdated: '2026-04-17',
+          providers: [{ ...sampleData.providers[0], baseUrl: null }],
+        }),
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+    });
+
+    it('drops entries with non-string name', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lastUpdated: '2026-04-17',
+          providers: [{ ...sampleData.providers[0], name: 123 }, sampleData.providers[1]],
+        }),
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+      expect(service.getAll()[0].name).toBe('Google Gemini');
+    });
+
+    it('drops entries whose models array contains non-objects', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lastUpdated: '2026-04-17',
+          providers: [
+            { ...sampleData.providers[0], models: ['not-an-object'] },
+            sampleData.providers[1],
+          ],
+        }),
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+    });
+
+    it('drops null providers without throwing', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lastUpdated: '2026-04-17',
+          providers: [null, sampleData.providers[1]],
+        }),
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
     });
 
     it('replaces entire cache on successful refresh', async () => {

--- a/packages/backend/src/free-models/free-models-sync.service.ts
+++ b/packages/backend/src/free-models/free-models-sync.service.ts
@@ -27,8 +27,40 @@ interface GitHubDataJson {
   providers: GitHubProvider[];
 }
 
-const GITHUB_RAW_URL =
-  'https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/main/data.json';
+// Pinned to an immutable commit SHA so a compromise of the awesome-free-llm-apis
+// repo (or its `main` branch) cannot deliver a poisoned data.json that the
+// frontend would render. Bump this SHA when refreshing the upstream data.
+const GITHUB_RAW_REF = '8b0feb0e3adda96455bcc380b815454944ff3832';
+const GITHUB_RAW_URL = `https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/${GITHUB_RAW_REF}/data.json`;
+
+function isHttpsUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isOptionalHttpsUrl(value: unknown): value is string | null {
+  return value === null || value === undefined || isHttpsUrl(value);
+}
+
+function isValidProvider(p: unknown): p is GitHubProvider {
+  if (!p || typeof p !== 'object') return false;
+  const v = p as Record<string, unknown>;
+  if (typeof v.name !== 'string' || v.name.length === 0) return false;
+  if (typeof v.category !== 'string') return false;
+  if (typeof v.country !== 'string') return false;
+  if (typeof v.flag !== 'string') return false;
+  if (!isHttpsUrl(v.url)) return false;
+  if (!isOptionalHttpsUrl(v.baseUrl)) return false;
+  if (typeof v.description !== 'string') return false;
+  if (!Array.isArray(v.models)) return false;
+  return v.models.every(
+    (m) => m && typeof m === 'object' && typeof (m as { name?: unknown }).name === 'string',
+  );
+}
 
 @Injectable()
 export class FreeModelsSyncService implements OnModuleInit {
@@ -50,10 +82,22 @@ export class FreeModelsSyncService implements OnModuleInit {
     const data = await this.fetchData();
     if (!data) return 0;
 
-    this.cache = data.providers;
+    const validated = data.providers.filter((p) => {
+      if (!isValidProvider(p)) {
+        this.logger.warn(
+          `Dropping free-models provider with invalid shape: ${
+            (p as { name?: unknown })?.name ?? '<unnamed>'
+          }`,
+        );
+        return false;
+      }
+      return true;
+    });
+
+    this.cache = validated;
     this.lastFetchedAt = new Date();
-    this.logger.log(`Free models cache loaded: ${data.providers.length} providers`);
-    return data.providers.length;
+    this.logger.log(`Free models cache loaded: ${validated.length} providers`);
+    return validated.length;
   }
 
   getAll(): readonly GitHubProvider[] {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -49,7 +49,11 @@ describe('AgentKeyAuthGuard', () => {
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(0),
       getMany: mockGetMany,
+      // resolveDevContext seeds-tenant lookup; default to no row so it falls
+      // back to repo.findOne — preserves existing test scenarios.
+      getOne: jest.fn().mockResolvedValue(null),
     };
     mockExecute = jest.fn().mockResolvedValue({});
     const mockUpdateQb = {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   Logger,
   OnModuleDestroy,
+  OnModuleInit,
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -31,7 +32,7 @@ interface CachedKey {
 }
 
 @Injectable()
-export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
+export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(AgentKeyAuthGuard.name);
   private cache = new Map<string, CachedKey>();
   private devContext: { context: IngestionContext; expiresAt: number } | null = null;
@@ -50,6 +51,31 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
     this.cleanupTimer = setInterval(() => this.evictExpired(), 60_000);
     if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
       this.cleanupTimer.unref();
+    }
+  }
+
+  async onModuleInit(): Promise<void> {
+    // Pre-migration API keys were hashed with a static salt
+    // ("manifest-api-key-salt"). The verifyKey path still accepts them for
+    // backward compatibility, but a leaked DB backup gives an attacker a
+    // rainbow-table head start. Surface a one-shot warning so operators
+    // know to rotate them via the dashboard.
+    try {
+      const legacyCount = await this.keyRepo
+        .createQueryBuilder('k')
+        .where("k.key_hash NOT LIKE '%:%'")
+        .andWhere('k.is_active = true')
+        .getCount();
+      if (legacyCount > 0) {
+        this.logger.warn(
+          `${legacyCount} active agent API key(s) still use the legacy static-salt hash. ` +
+            'Rotate them in the dashboard (Agent → Rotate Key) when convenient.',
+        );
+      }
+    } catch (err) {
+      // Don't block boot on this informational check (e.g. fresh DB before
+      // migrations run on the very first boot of an old install).
+      this.logger.debug(`Legacy hash audit skipped: ${(err as Error).message}`);
     }
   }
 
@@ -148,7 +174,10 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
     const keyRecord = candidates.find((c) => verifyKey(token, c.key_hash));
 
     if (!keyRecord) {
-      this.logger.warn(`Rejected unknown agent key: ${token.substring(0, 8)}...`);
+      // Log only the fixed prefix — even leaking the next character or two
+      // narrows the search space if these warnings end up in a SIEM that
+      // retains them indefinitely.
+      this.logger.warn(`Rejected unknown agent key (prefix: ${API_KEY_PREFIX}...)`);
       throw new UnauthorizedException('Invalid API key');
     }
 
@@ -194,10 +223,23 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
       return this.devContext.context;
     }
 
-    const keyRecord = await this.keyRepo.findOne({
-      where: { is_active: true },
-      relations: ['agent', 'tenant'],
-    });
+    // Prefer the seed tenant when present so a shared dev DB doesn't
+    // accidentally route loopback traffic into another developer's data
+    // simply because their key was inserted first.
+    const seedKey = await this.keyRepo
+      .createQueryBuilder('k')
+      .leftJoinAndSelect('k.agent', 'a')
+      .leftJoinAndSelect('k.tenant', 't')
+      .where('k.is_active = true')
+      .andWhere('k.tenant_id = :tid', { tid: 'seed-tenant-001' })
+      .getOne();
+
+    const keyRecord =
+      seedKey ??
+      (await this.keyRepo.findOne({
+        where: { is_active: true },
+        relations: ['agent', 'tenant'],
+      }));
 
     if (!keyRecord) return null;
 

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { randomBytes } from 'crypto';
 import { Request, Response } from 'express';
 import { Public } from '../../common/decorators/public.decorator';
@@ -29,6 +30,7 @@ export class OpenaiOauthController {
     private readonly resolveAgent: ResolveAgentService,
     private readonly providerKeyService: ProviderKeyService,
     private readonly providerService: ProviderService,
+    private readonly configService: ConfigService,
   ) {}
 
   /**
@@ -46,7 +48,11 @@ export class OpenaiOauthController {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    const backendUrl = `${req.protocol}://${req.get('host')}`;
+    // Prefer the operator-configured BETTER_AUTH_URL so a forged Host header
+    // can't redirect the OAuth flow. Fall back to the request's host:port for
+    // the dev case where BETTER_AUTH_URL isn't set.
+    const trustedBackendUrl = this.configService.get<string>('BETTER_AUTH_URL');
+    const backendUrl = trustedBackendUrl || `${req.protocol}://${req.get('host')}`;
     try {
       const url = await this.oauthService.generateAuthorizationUrl(agent.id, user.id, backendUrl);
       return { url };

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -4,6 +4,7 @@ import { randomBytes, createHash } from 'crypto';
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
 import { PendingOAuth, OAuthTokenBlob, oauthDoneHtml } from './openai-oauth.types';
 
 export { PendingOAuth, OAuthTokenBlob, oauthDoneHtml };
@@ -96,7 +97,7 @@ export class OpenaiOauthService {
     });
     if (!response.ok) {
       const text = await response.text();
-      this.logger.error(`OpenAI token exchange failed: ${text}`);
+      this.logger.error(`OpenAI token exchange failed: ${scrubSecrets(text)}`);
       throw new Error('Token exchange failed');
     }
     const data = (await response.json()) as {
@@ -138,7 +139,7 @@ export class OpenaiOauthService {
     });
     if (!response.ok) {
       const text = await response.text();
-      this.logger.error(`OpenAI token refresh failed: ${text}`);
+      this.logger.error(`OpenAI token refresh failed: ${scrubSecrets(text)}`);
       throw new Error('Token refresh failed');
     }
     const data = (await response.json()) as {
@@ -190,7 +191,7 @@ export class OpenaiOauthService {
       });
       if (!response.ok) {
         const text = await response.text();
-        this.logger.warn(`OpenAI token revocation failed: ${text}`);
+        this.logger.warn(`OpenAI token revocation failed: ${scrubSecrets(text)}`);
       } else {
         this.logger.log('OpenAI OAuth token revoked');
       }

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -1,4 +1,5 @@
 import { HttpException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { OpenaiOauthController } from './oauth/openai-oauth.controller';
 import { OpenaiOauthService } from './oauth/openai-oauth.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
@@ -12,6 +13,7 @@ describe('OpenaiOauthController', () => {
   let resolveAgent: jest.Mocked<ResolveAgentService>;
   let providerKeyService: jest.Mocked<ProviderKeyService>;
   let providerService: jest.Mocked<ProviderService>;
+  let configService: jest.Mocked<ConfigService>;
 
   beforeEach(() => {
     oauthService = {
@@ -31,11 +33,16 @@ describe('OpenaiOauthController', () => {
       removeProvider: jest.fn().mockResolvedValue({ notifications: [] }),
     } as unknown as jest.Mocked<ProviderService>;
 
+    configService = {
+      get: jest.fn().mockReturnValue(undefined),
+    } as unknown as jest.Mocked<ConfigService>;
+
     controller = new OpenaiOauthController(
       oauthService,
       resolveAgent,
       providerKeyService,
       providerService,
+      configService,
     );
   });
 
@@ -110,6 +117,25 @@ describe('OpenaiOauthController', () => {
       await expect(
         controller.authorize('my-agent', { id: 'user-1' } as never, req),
       ).rejects.toThrow('Failed to start OAuth callback server');
+    });
+
+    it('uses BETTER_AUTH_URL from config when set, ignoring Host header', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+      oauthService.generateAuthorizationUrl.mockResolvedValue('https://auth.openai.com/oauth/...');
+      configService.get.mockReturnValue('https://manifest.example.com');
+
+      const req = {
+        protocol: 'http',
+        get: jest.fn().mockReturnValue('evil.example'),
+      } as unknown as Request;
+
+      await controller.authorize('my-agent', { id: 'user-1' } as never, req);
+
+      expect(oauthService.generateAuthorizationUrl).toHaveBeenCalledWith(
+        'agent-id-1',
+        'user-1',
+        'https://manifest.example.com',
+      );
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -424,7 +424,7 @@ describe('ProviderClient', () => {
   });
 
   describe('Google provider', () => {
-    it('uses query param auth and Gemini path', async () => {
+    it('uses x-goog-api-key header and keeps key out of URL', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const result = await client.forward({
@@ -436,10 +436,12 @@ describe('ProviderClient', () => {
       });
 
       const url = mockFetch.mock.calls[0][0] as string;
+      const init = mockFetch.mock.calls[0][1] as { headers: Record<string, string> };
       expect(url).toContain('generativelanguage.googleapis.com');
       expect(url).toContain('gemini-2.0-flash:generateContent');
-      expect(url).toContain('key=AIza-test');
+      expect(url).not.toContain('key=AIza-test');
       expect(url).not.toContain('alt=sse');
+      expect(init.headers['x-goog-api-key']).toBe('AIza-test');
       expect(result.isGoogle).toBe(true);
       expect(result.isAnthropic).toBe(false);
     });
@@ -1240,10 +1242,10 @@ describe('ProviderClient', () => {
   });
 
   describe('URL masking', () => {
-    it('masks API key in Google URL for debug logging', async () => {
+    it('keeps the Google API key out of the debug log entirely', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
-      // Spy on the logger to verify the masked URL
+      // Spy on the logger to verify the URL has no key in it
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const debugSpy = jest.spyOn((client as any).logger, 'debug');
 
@@ -1255,8 +1257,9 @@ describe('ProviderClient', () => {
         stream: false,
       });
 
-      expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('key=***'));
+      // Key is now sent in the x-goog-api-key header, never in the URL.
       expect(debugSpy).toHaveBeenCalledWith(expect.not.stringContaining('AIzaSyABCDEF12345'));
+      expect(debugSpy).toHaveBeenCalledWith(expect.not.stringContaining('key='));
 
       debugSpy.mockRestore();
     });

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -196,9 +196,12 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(path).toBe('/v1/messages');
   });
 
-  it('google buildHeaders returns Content-Type only', () => {
-    const headers = PROVIDER_ENDPOINTS['google'].buildHeaders('');
-    expect(headers).toEqual({ 'Content-Type': 'application/json' });
+  it('google buildHeaders sends the API key in x-goog-api-key (not query string)', () => {
+    const headers = PROVIDER_ENDPOINTS['google'].buildHeaders('AIza-test');
+    expect(headers).toEqual({
+      'Content-Type': 'application/json',
+      'x-goog-api-key': 'AIza-test',
+    });
   });
 
   it('google buildPath includes model name with generateContent suffix', () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -201,10 +201,11 @@ export class ProviderClient {
     const requestSource = ctx.apiMode === 'responses' ? (chatBody ?? body) : body;
 
     if (endpoint.format === 'google') {
-      // Google Gemini API requires the key as a URL parameter (not a header).
-      // It may be visible to intermediate proxies between Manifest and Google's API.
-      let url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}?key=${apiKey}`;
-      if (stream) url += '&alt=sse';
+      // Google accepts the API key via header (set by buildHeaders below) so
+      // we no longer need to embed it in the URL. Keeping the key out of the
+      // URL avoids leaking it into upstream proxy / LB access logs.
+      let url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`;
+      if (stream) url += '?alt=sse';
       return {
         url,
         headers: endpoint.buildHeaders(apiKey, authType),

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -155,7 +155,13 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   },
   google: {
     baseUrl: 'https://generativelanguage.googleapis.com',
-    buildHeaders: () => ({ 'Content-Type': 'application/json' }),
+    // Google accepts the API key via the `x-goog-api-key` header as well as
+    // the `?key=` query parameter. Header is preferable: query strings show
+    // up in upstream proxy / load-balancer access logs, header values do not.
+    buildHeaders: (apiKey: string) => ({
+      'Content-Type': 'application/json',
+      'x-goog-api-key': apiKey,
+    }),
     buildPath: (model: string) => `/v1beta/models/${model}:generateContent`,
     format: 'google',
   },


### PR DESCRIPTION
### ✨ What changed
- Pin every GitHub Action `uses:` line to a commit SHA across all 5 workflows.
- Pin awesome-free-llm-apis data feed to commit `8b0feb0` and validate https URL shape on each entry.
- HMAC the encryption-key cache key so the raw secret never lives as a Map key.
- Move Google Gemini API key from `?key=` query into `x-goog-api-key` header.
- Run OpenAI OAuth error responses through `scrubSecrets` before logging.
- Prefer `BETTER_AUTH_URL` over the request `Host` header for the OAuth `backendUrl`.
- Dev-loopback agent fallback prefers `seed-tenant-001` over the first active key.
- Log only the fixed `mnfst_` prefix on rejected keys (was first 8 chars).
- Migrations log via `queryRunner.connection.logger` instead of `console.log`.
- Document `MANIFEST_ENCRYPTION_KEY` in both `.env.example` files and pass it through `docker-compose.yml`.
- `npm audit fix` resolves vite + postcss CVEs.
- Boot-time warning when active `agent_api_keys` still use the legacy static-salt hash.

### 💭 Why
Findings from the 2026-05-01 OWASP audit. These are the changes that don't alter user or operator workflows. Higher-impact items (forcing `MANIFEST_ENCRYPTION_KEY`, restricting the setup wizard, bumping password min, gating email verification) are deferred pending a separate decision.

### 🔧 For operators
None required. `MANIFEST_ENCRYPTION_KEY` stays optional. If you want to set it, it's now picked up by docker-compose automatically. The legacy-hash warning is informational. The data feed is pinned to a specific commit, so future awesome-free-llm-apis updates require a code bump (deliberate).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens OWASP-flagged areas across CI and runtime to reduce secret exposure and tighten provider/OAuth handling. No operator action required.

- **Refactors**
  - Runtime/crypto/logging: HMAC the encryption-key cache key, run OpenAI OAuth errors through secret scrubber, prefer `BETTER_AUTH_URL` over `Host`, log only the fixed `mnfst_` prefix for rejected keys, warn at boot if legacy static-salt agent keys exist, and route migration logs through the TypeORM logger.
  - Provider routing: Move Google Gemini auth to the `x-goog-api-key` header; key no longer appears in URLs or debug logs.
  - Free models feed: Pin to commit `8b0feb0` and drop entries unless URLs are HTTPS; tests cover shape validation.
  - Dev loopback/env: Dev fallback prefers `seed-tenant-001`; document `MANIFEST_ENCRYPTION_KEY` and pass it through `docker-compose.yml` (still optional).

- **Dependencies**
  - Pin all GitHub Actions by commit SHA across workflows (`actions/checkout`, `actions/setup-node`, `codecov/codecov-action`, `docker/*`, `github/codeql-action`, `changesets/action`, `actions/*`, `sigstore/cosign-installer`).
  - `npm audit fix` resolves `vite` and `postcss` CVEs.

<sup>Written for commit e8162c39a01f28b7ab29747aa91a545db684da2a. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1784?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

