### PR TITLE
fix: detect Podman/Kubernetes as self-hosted, narrow IMDS SSRF block

### DIFF
--- a/.changeset/podman-self-hosted-detection.md
+++ b/.changeset/podman-self-hosted-detection.md
@@ -1,0 +1,7 @@
+---
+"manifest": patch
+---
+
+Fix: detect Podman and Kubernetes as self-hosted runtimes. Manifest now reads `/run/.containerenv` (Podman) and `KUBERNETES_SERVICE_HOST` in addition to `/.dockerenv`, so rootless Podman and Kubernetes installs no longer fall back to cloud-mode SSRF rules and reject `http://` URLs to local LLM servers.
+
+Also narrows the cloud-metadata SSRF block to the actual IMDS addresses (`169.254.169.254`, `169.254.169.253`, `100.100.100.200`, `fd00:ec2::254`) instead of the entire `169.254.0.0/16` link-local range, so self-hosted users can reach `host.containers.internal` (which Podman maps to `169.254.x.y` under pasta/slirp4netns). Cloud mode is unchanged: link-local space is still rejected via the private-IP guard.

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -331,6 +331,19 @@ For vLLM, text-generation-webui, TogetherAI proxies, Azure OpenAI gateways, or a
 
 If Ollama runs on a different host on your LAN, set `OLLAMA_HOST` in `.env` to the full URL (e.g. `http://192.168.1.20:11434`) and restart the stack. Private IPs are allowed in the self-hosted version.
 
+### Podman / rootless containers
+
+Podman doesn't ship `/.dockerenv` or `host.docker.internal`. Manifest still
+auto-detects Podman via `/run/.containerenv` and treats the install as
+self-hosted, but the canonical hostname for reaching the host from inside
+a Podman container is `host.containers.internal` (Podman 4+ exposes this
+by default; older versions need `--add-host=host.containers.internal:host-gateway`).
+If you run Manifest as one Podman service and your LLM server (llama.cpp,
+Ollama, etc.) as another, point Manifest at the service name on the shared
+network — e.g. `http://llamacpp:8080/v1` — and **Add custom provider** will
+accept it as long as `MANIFEST_MODE=selfhosted` (the bundled compose file
+sets this automatically).
+
 ## Environment variables
 
 | Variable             | Required | Default                 | Description                                   |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,6 +64,13 @@ services:
       - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
       - SEED_DATA=false
       - NODE_ENV=production
+      # Force self-hosted semantics regardless of the container runtime.
+      # The auto-detection inside the app reads /.dockerenv (Docker),
+      # /run/.containerenv (Podman), and KUBERNETES_SERVICE_HOST, but
+      # explicit beats inferred — and a number of rootless / nspawn /
+      # exotic runtimes produce neither marker. Setting this avoids
+      # silently flipping users back to cloud-mode SSRF rules (issue #1780).
+      - MANIFEST_MODE=${MANIFEST_MODE:-selfhosted}
       # Email provider (optional). Covers both login/verification emails
       # and threshold alert notifications. Set one provider block — see
       # DOCKER_README.md "Email setup". Supports resend, mailgun, sendgrid.

--- a/packages/backend/src/common/utils/detect-self-hosted.spec.ts
+++ b/packages/backend/src/common/utils/detect-self-hosted.spec.ts
@@ -1,4 +1,4 @@
-import { isSelfHosted } from './detect-self-hosted';
+import { getContainerHostAlias, isSelfHosted } from './detect-self-hosted';
 import * as fs from 'fs';
 
 jest.mock('fs');
@@ -6,11 +6,14 @@ jest.mock('fs');
 const mockedExistsSync = jest.mocked(fs.existsSync);
 
 describe('isSelfHosted', () => {
-  const originalEnv = process.env['MANIFEST_MODE'];
+  const originalMode = process.env['MANIFEST_MODE'];
+  const originalK8s = process.env['KUBERNETES_SERVICE_HOST'];
 
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env['MANIFEST_MODE'];
-    else process.env['MANIFEST_MODE'] = originalEnv;
+    if (originalMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = originalMode;
+    if (originalK8s === undefined) delete process.env['KUBERNETES_SERVICE_HOST'];
+    else process.env['KUBERNETES_SERVICE_HOST'] = originalK8s;
     mockedExistsSync.mockReset();
   });
 
@@ -26,33 +29,85 @@ describe('isSelfHosted', () => {
 
   it('returns false when MANIFEST_MODE is "cloud"', () => {
     process.env['MANIFEST_MODE'] = 'cloud';
+    delete process.env['KUBERNETES_SERVICE_HOST'];
     expect(isSelfHosted()).toBe(false);
   });
 
   it('returns false when MANIFEST_MODE is "cloud" even inside Docker', () => {
     process.env['MANIFEST_MODE'] = 'cloud';
+    delete process.env['KUBERNETES_SERVICE_HOST'];
     mockedExistsSync.mockReturnValue(true);
     expect(isSelfHosted()).toBe(false);
   });
 
   it('auto-detects Docker via /.dockerenv when MANIFEST_MODE is not set', () => {
     delete process.env['MANIFEST_MODE'];
-    mockedExistsSync.mockReturnValue(true);
+    delete process.env['KUBERNETES_SERVICE_HOST'];
+    mockedExistsSync.mockImplementation((p) => p === '/.dockerenv');
     expect(isSelfHosted()).toBe(true);
     expect(mockedExistsSync).toHaveBeenCalledWith('/.dockerenv');
   });
 
-  it('returns false when not in Docker and MANIFEST_MODE is not set', () => {
+  it('auto-detects Podman via /run/.containerenv when MANIFEST_MODE is not set', () => {
     delete process.env['MANIFEST_MODE'];
+    delete process.env['KUBERNETES_SERVICE_HOST'];
+    mockedExistsSync.mockImplementation((p) => p === '/run/.containerenv');
+    expect(isSelfHosted()).toBe(true);
+  });
+
+  it('auto-detects Kubernetes via KUBERNETES_SERVICE_HOST', () => {
+    delete process.env['MANIFEST_MODE'];
+    process.env['KUBERNETES_SERVICE_HOST'] = '10.0.0.1';
+    mockedExistsSync.mockReturnValue(false);
+    expect(isSelfHosted()).toBe(true);
+  });
+
+  it('returns false when no container marker is present and MANIFEST_MODE is not set', () => {
+    delete process.env['MANIFEST_MODE'];
+    delete process.env['KUBERNETES_SERVICE_HOST'];
     mockedExistsSync.mockReturnValue(false);
     expect(isSelfHosted()).toBe(false);
   });
 
   it('returns false when existsSync throws', () => {
     delete process.env['MANIFEST_MODE'];
+    delete process.env['KUBERNETES_SERVICE_HOST'];
     mockedExistsSync.mockImplementation(() => {
       throw new Error('permission denied');
     });
     expect(isSelfHosted()).toBe(false);
+  });
+});
+
+describe('getContainerHostAlias', () => {
+  afterEach(() => {
+    mockedExistsSync.mockReset();
+  });
+
+  it("returns 'host.docker.internal' when /.dockerenv exists", () => {
+    mockedExistsSync.mockImplementation((p) => p === '/.dockerenv');
+    expect(getContainerHostAlias()).toBe('host.docker.internal');
+  });
+
+  it("returns 'host.containers.internal' when only /run/.containerenv exists (Podman)", () => {
+    mockedExistsSync.mockImplementation((p) => p === '/run/.containerenv');
+    expect(getContainerHostAlias()).toBe('host.containers.internal');
+  });
+
+  it("prefers 'host.docker.internal' when both markers exist (Docker writes both in some setups)", () => {
+    mockedExistsSync.mockReturnValue(true);
+    expect(getContainerHostAlias()).toBe('host.docker.internal');
+  });
+
+  it("returns 'localhost' when no marker exists", () => {
+    mockedExistsSync.mockReturnValue(false);
+    expect(getContainerHostAlias()).toBe('localhost');
+  });
+
+  it("returns 'localhost' when existsSync throws", () => {
+    mockedExistsSync.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+    expect(getContainerHostAlias()).toBe('localhost');
   });
 });

--- a/packages/backend/src/common/utils/detect-self-hosted.ts
+++ b/packages/backend/src/common/utils/detect-self-hosted.ts
@@ -7,16 +7,38 @@ import { existsSync } from 'fs';
  * 1. Explicit `MANIFEST_MODE` env var — always wins
  *    - `selfhosted` (canonical) or legacy `local` → self-hosted
  *    - `cloud` → cloud
- * 2. Auto-detect Docker container via `/.dockerenv` → self-hosted
+ * 2. Auto-detect a containerised runtime → self-hosted
+ *    - Docker writes `/.dockerenv`
+ *    - Podman writes `/run/.containerenv` (rootless and rootful)
+ *    - Kubernetes injects `KUBERNETES_SERVICE_HOST`
  * 3. Default → cloud
  */
 export function isSelfHosted(): boolean {
   const explicit = process.env['MANIFEST_MODE'];
   if (explicit === 'cloud') return false;
   if (explicit === 'selfhosted' || explicit === 'local') return true;
+  if (process.env['KUBERNETES_SERVICE_HOST']) return true;
   try {
-    return existsSync('/.dockerenv');
+    return existsSync('/.dockerenv') || existsSync('/run/.containerenv');
   } catch {
     return false;
   }
+}
+
+/**
+ * Returns the canonical hostname the container should use to reach the
+ * host. Docker uses `host.docker.internal` (mapped via `host-gateway` in
+ * compose). Podman exposes the same gateway as `host.containers.internal`.
+ * Outside any container, `localhost` resolves correctly.
+ */
+export function getContainerHostAlias(): string {
+  try {
+    if (existsSync('/run/.containerenv') && !existsSync('/.dockerenv')) {
+      return 'host.containers.internal';
+    }
+    if (existsSync('/.dockerenv')) return 'host.docker.internal';
+  } catch {
+    // fall through
+  }
+  return 'localhost';
 }

--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -91,20 +91,33 @@ describe('isPrivateIp', () => {
 });
 
 describe('isCloudMetadataIp', () => {
-  it('detects 169.254.169.254 as cloud metadata', () => {
+  it('detects 169.254.169.254 as cloud metadata (AWS/GCP/Azure IMDS)', () => {
     expect(isCloudMetadataIp('169.254.169.254')).toBe(true);
   });
 
-  it('detects 169.254.0.1 as link-local (cloud metadata range)', () => {
-    expect(isCloudMetadataIp('169.254.0.1')).toBe(true);
+  it('detects 169.254.169.253 as cloud metadata (Alibaba/OCI IMDS)', () => {
+    expect(isCloudMetadataIp('169.254.169.253')).toBe(true);
   });
 
-  it('detects fd00::1 as cloud metadata IPv6', () => {
-    expect(isCloudMetadataIp('fd00::1')).toBe(true);
+  it('detects 100.100.100.200 as cloud metadata (Alibaba)', () => {
+    expect(isCloudMetadataIp('100.100.100.200')).toBe(true);
   });
 
-  it('detects fe80::1 as cloud metadata IPv6 link-local', () => {
-    expect(isCloudMetadataIp('fe80::1')).toBe(true);
+  it('does NOT flag generic link-local IPs (e.g. Podman host-gateway 169.254.1.2)', () => {
+    expect(isCloudMetadataIp('169.254.1.2')).toBe(false);
+    expect(isCloudMetadataIp('169.254.0.1')).toBe(false);
+  });
+
+  it('does NOT flag IPv6 ULA (fd00::/8) as metadata', () => {
+    expect(isCloudMetadataIp('fd00::1')).toBe(false);
+  });
+
+  it('does NOT flag IPv6 link-local (fe80::/10) as metadata', () => {
+    expect(isCloudMetadataIp('fe80::1')).toBe(false);
+  });
+
+  it('detects fd00:ec2::254 as IPv6 IMDS', () => {
+    expect(isCloudMetadataIp('fd00:ec2::254')).toBe(true);
   });
 
   it('detects IPv4-mapped metadata IP', () => {
@@ -210,7 +223,13 @@ describe('validatePublicUrl', () => {
 
   it('rejects plaintext http scheme (AC-2 passive exfiltration)', async () => {
     await expect(validatePublicUrl('http://example.com/api')).rejects.toThrow(
-      'Only https URLs are allowed',
+      /Only https URLs are allowed in cloud mode/,
+    );
+  });
+
+  it('hints at MANIFEST_MODE=selfhosted when http is rejected (issue #1780)', async () => {
+    await expect(validatePublicUrl('http://llamacpp:8080/v1')).rejects.toThrow(
+      /MANIFEST_MODE=selfhosted/,
     );
   });
 

--- a/packages/backend/src/common/utils/url-validation.ts
+++ b/packages/backend/src/common/utils/url-validation.ts
@@ -51,12 +51,24 @@ export function isPrivateIp(ip: string): boolean {
   return PRIVATE_RANGES.some((range) => (addr & range.mask) === range.addr);
 }
 
+// Only the specific IMDS addresses, not the whole link-local /16. Rootless
+// Podman maps `host.containers.internal` to a 169.254.x.y address (commonly
+// 169.254.1.2 with pasta/slirp4netns), and blocking the entire range would
+// stop self-hosted users from reaching their host gateway. The remaining
+// link-local space is still rejected in cloud mode by the private-IP guard
+// (PRIVATE_RANGES below), so the only path that goes through here is
+// allowPrivate: true — and there we still want to block the IMDS endpoints
+// even on a self-hosted box, in case the operator deployed inside EC2/GCE.
 const CLOUD_METADATA_RANGES: { addr: bigint; mask: bigint }[] = [
-  cidr('169.254.169.254', 32), // AWS/GCP/Azure metadata
-  cidr('169.254.0.0', 16), // Link-local
+  cidr('169.254.169.254', 32), // AWS / GCP / Azure / OpenStack IMDS
+  cidr('169.254.169.253', 32), // Alibaba Cloud / OCI IMDS
+  cidr('100.100.100.200', 32), // Alibaba Cloud (alternative)
 ];
 
-const CLOUD_METADATA_V6 = ['fd00::', 'fe80::'];
+// IPv6 IMDS endpoints. ULA (`fd00::/8`) and link-local (`fe80::/10`) are
+// regular private space — not metadata — so they are NOT in this list.
+// `fd00:ec2::254` is the AWS IPv6 IMDS endpoint.
+const CLOUD_METADATA_V6 = ['fd00:ec2::254'];
 
 export function isCloudMetadataIp(ip: string): boolean {
   const mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
@@ -101,7 +113,12 @@ export async function validatePublicUrl(
   // (AC-2 in the Mine paper, arXiv:2604.08407). In self-hosted mode we allow
   // http:// for local destinations only — see the final check below.
   if (parsed.protocol === 'http:' && !allowPrivate) {
-    throw new Error('Only https URLs are allowed');
+    throw new Error(
+      'Only https URLs are allowed in cloud mode. ' +
+        'Self-hosted installs allow http:// for private destinations — ' +
+        'set MANIFEST_MODE=selfhosted if you are running Manifest yourself ' +
+        '(e.g. inside Docker, Podman, or Kubernetes).',
+    );
   }
 
   const hostname = parsed.hostname.replace(/^\[|\]$/g, '');

--- a/packages/backend/src/routing/custom-provider/probe-error.spec.ts
+++ b/packages/backend/src/routing/custom-provider/probe-error.spec.ts
@@ -47,7 +47,7 @@ describe('classifyProbeError', () => {
     expect(out.message).toMatch(/loading a model/);
   });
 
-  it('classifies ENOTFOUND as dns_failure with the host.docker.internal hint', () => {
+  it('classifies ENOTFOUND as dns_failure with Docker, Podman, and native hints', () => {
     const out = classifyProbeError({
       url,
       error: Object.assign(new Error('getaddrinfo ENOTFOUND bad.host'), {
@@ -56,6 +56,8 @@ describe('classifyProbeError', () => {
     });
     expect(out.kind).toBe('dns_failure');
     expect(out.message).toMatch(/host\.docker\.internal/);
+    expect(out.message).toMatch(/host\.containers\.internal/);
+    expect(out.message).toMatch(/localhost/);
   });
 
   it('classifies TLS errors as tls_mismatch with a try-http-instead hint', () => {

--- a/packages/backend/src/routing/custom-provider/probe-error.ts
+++ b/packages/backend/src/routing/custom-provider/probe-error.ts
@@ -114,7 +114,8 @@ export function classifyProbeError(input: ClassifyInput): ProbeError {
       kind: 'dns_failure',
       message:
         `Could not resolve the hostname in ${url}. Inside Docker use ` +
-        `host.docker.internal; natively use localhost.`,
+        `host.docker.internal; inside Podman use host.containers.internal; ` +
+        `natively use localhost.`,
     };
   }
   if (/EPROTO|SSL|TLS|wrong version number/i.test(msg)) {

--- a/packages/backend/src/setup/setup.service.spec.ts
+++ b/packages/backend/src/setup/setup.service.spec.ts
@@ -61,6 +61,12 @@ describe('SetupService', () => {
       expect(service.getLocalLlmHost()).toBe('host.docker.internal');
     });
 
+    it("returns 'host.containers.internal' under Podman (/run/.containerenv only)", () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('fs').existsSync = (p: string) => p === '/run/.containerenv';
+      expect(service.getLocalLlmHost()).toBe('host.containers.internal');
+    });
+
     it("returns 'localhost' when /.dockerenv is absent", () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       require('fs').existsSync = () => false;

--- a/packages/backend/src/setup/setup.service.ts
+++ b/packages/backend/src/setup/setup.service.ts
@@ -1,9 +1,8 @@
 import { ConflictException, Injectable, Logger } from '@nestjs/common';
-import { existsSync } from 'fs';
 import { DataSource } from 'typeorm';
 import { CreateAdminDto } from './dto/create-admin.dto';
 import { OLLAMA_HOST } from '../common/constants/ollama';
-import { isSelfHosted } from '../common/utils/detect-self-hosted';
+import { getContainerHostAlias, isSelfHosted } from '../common/utils/detect-self-hosted';
 
 /**
  * Postgres advisory lock key reserved for the first-run setup wizard.
@@ -29,15 +28,11 @@ export class SetupService {
   /**
    * Returns the hostname the backend should use to reach host-installed
    * LLM servers. Inside Docker the container reaches the host via
-   * `host.docker.internal` (mapped to the host-gateway in compose);
-   * on a native install, `localhost` resolves correctly.
+   * `host.docker.internal`; under Podman it's `host.containers.internal`.
+   * On a native install `localhost` resolves correctly.
    */
   getLocalLlmHost(): string {
-    try {
-      return existsSync('/.dockerenv') ? 'host.docker.internal' : 'localhost';
-    } catch {
-      return 'localhost';
-    }
+    return getContainerHostAlias();
   }
 
   /**

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -322,9 +322,9 @@ const CustomProviderForm: Component<Props> = (props) => {
               class="provider-detail__hint"
               style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); margin-top: 4px;"
             >
-              For local servers use <code>http://host.docker.internal:&lt;port&gt;</code> (Docker)
-              or <code>http://localhost:&lt;port&gt;</code> (native). HTTPS required for public
-              URLs.
+              For local servers use <code>http://host.docker.internal:&lt;port&gt;</code> (Docker),{' '}
+              <code>http://host.containers.internal:&lt;port&gt;</code> (Podman), or{' '}
+              <code>http://localhost:&lt;port&gt;</code> (native). HTTPS required for public URLs.
             </div>
           </Show>
           <Show when={probeError()}>


### PR DESCRIPTION
### ✨ What changed
- `isSelfHosted()` now also reads `/run/.containerenv` (Podman) and `KUBERNETES_SERVICE_HOST`.
- New `getContainerHostAlias()` returns `host.containers.internal` under Podman, `host.docker.internal` under Docker.
- `CLOUD_METADATA_RANGES` narrowed from `169.254.0.0/16` to the actual IMDS endpoints (`169.254.169.254`, `169.254.169.253`, `100.100.100.200`, `fd00:ec2::254`).
- SSRF error now names `MANIFEST_MODE=selfhosted` as the fix; DNS-failure probe hint covers Podman.
- Bundled `docker-compose.yml` pins `MANIFEST_MODE=${MANIFEST_MODE:-selfhosted}`.
- `DOCKER_README.md` adds a Podman / rootless section.

### 💭 Why
Closes #1780. Rootless Podman has no `/.dockerenv`, so Manifest classified those installs as cloud and rejected `http://llamacpp:8080` with "Only https URLs are allowed". The over-broad link-local block also stopped Podman's `host.containers.internal` (which maps to `169.254.1.2` under pasta) from reaching the host even after detection was fixed.

### 👤 For users
Self-hosted users on Podman can now add local LLM servers via "Add custom provider" with `http://` URLs, same as Docker. Cloud users see no change beyond a clearer error string when they try to send a private/http URL.

### 🔧 For operators
No required steps. The bundled compose now pins `MANIFEST_MODE=selfhosted` belt-and-suspenders, so exotic runtimes that produce neither container marker still pick up the right semantics.

### 📝 Notes
- Verified end-to-end on Docker 29.1 and rootless Podman 5.4 with a real `llama.cpp` container; the user's exact `http://llamacpp:8080` scenario now succeeds and discovers the model.
- Cloud-mode regression matrix re-checked: every previously-rejected URL (http private, http public, https IMDS, https private) is still rejected with the same status code.
- Closes #1780.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect Podman and Kubernetes as self-hosted and narrow IMDS SSRF checks to real metadata endpoints, fixing false http URL rejections in rootless Podman. Improves host-gateway detection and guidance; the bundled compose now defaults to self-hosted. Closes #1780.

- **Bug Fixes**
  - `isSelfHosted()` now detects `/run/.containerenv` (Podman) and `KUBERNETES_SERVICE_HOST` (Kubernetes).
  - Added `getContainerHostAlias()` → `host.containers.internal` (Podman) or `host.docker.internal` (Docker); used by setup.
  - SSRF guard narrowed to IMDS IPs only: `169.254.169.254`, `169.254.169.253`, `100.100.100.200`, `fd00:ec2::254`; other `169.254.x.y` are allowed.
  - Clearer cloud-mode error suggests `MANIFEST_MODE=selfhosted`; DNS hint adds Podman; UI/docs include `host.containers.internal`.
  - `docker-compose.yml` pins `MANIFEST_MODE=${MANIFEST_MODE:-selfhosted}` to prevent misclassification on non-Docker runtimes.

<sup>Written for commit f0082d5c5f9ecdc29b5e66292f23789d752d10dc. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1785?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

