### PR TITLE
Fix provider metadata when duplicating agents

### DIFF
--- a/.changeset/fix-duplicate-provider-label.md
+++ b/.changeset/fix-duplicate-provider-label.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve provider `label` and `priority` when duplicating agents so copied providers no longer fail database inserts on self-hosted PostgreSQL schemas that require non-null labels.

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -214,6 +214,8 @@ describe('AgentDuplicationService', () => {
             api_key_encrypted: 'enc',
             key_prefix: 'sk-',
             auth_type: 'api_key',
+            label: 'Anthropic prod',
+            priority: 7,
             region: null,
             is_active: true,
             cached_models: [{ id: 'm' }],
@@ -290,6 +292,8 @@ describe('AgentDuplicationService', () => {
       const userProviderRow = (insertedRows['UserProvider'] as Array<Record<string, unknown>>)[0];
       expect(userProviderRow['agent_id']).toBe(agentRow['id']);
       expect(userProviderRow['api_key_encrypted']).toBe('enc');
+      expect(userProviderRow['label']).toBe('Anthropic prod');
+      expect(userProviderRow['priority']).toBe(7);
       expect(userProviderRow['id']).not.toBe('up1');
 
       expect(mockInvalidateAgent).toHaveBeenCalledWith(agentRow['id']);

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -176,6 +176,8 @@ export class AgentDuplicationService {
             api_key_encrypted: p.api_key_encrypted,
             key_prefix: p.key_prefix,
             auth_type: p.auth_type,
+            label: p.label,
+            priority: p.priority,
             region: p.region,
             is_active: p.is_active,
             connected_at: now,


### PR DESCRIPTION
## Summary

  Fix agent duplication failing when copied provider rows hit self-hosted PostgreSQL schemas that require non-null `user_providers.label`.

  This change preserves `label` and `priority` when duplicating `UserProvider` rows.

  ## Why

  `AgentDuplicationService` copied provider rows without `label`, which caused inserts to fail with a database error on schemas where `user_providers.label` is `NOT NULL`.

  ## Testing

  - Added regression coverage for duplicated provider metadata
  - Ran backend duplication unit tests
  - Ran full repo build
  - Verified in the running Docker Compose environment that duplicating an agent now succeeds

  ## Notes

  Backend e2e tests were not completed in this environment because the local test database was unavailable from the test runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix agent duplication by preserving provider `label` and `priority` when copying `UserProvider` rows. This prevents insert failures on self-hosted PostgreSQL schemas that require a non-null `user_providers.label`, with regression tests added to ensure the metadata is kept.

<sup>Written for commit 59bb32e1a73f94155a9af030f91bf3f7902394dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

