### PR TITLE
fix: Docker CI — version tags, main branch builds, clean formatting

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,11 +1,21 @@
 name: Docker Smoke
 
-# Boots the production compose stack with `read_only: true` and verifies the
-# app comes up cleanly and answers /api/v1/health. Catches regressions from
-# code that silently writes outside /tmp at boot, which would crash users on
-# the locked-down default deployment.
-
 on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/docker-smoke.yml"
+      - "docker/Dockerfile"
+      - ".dockerignore"
+      - "docker/docker-compose.yml"
+      - "docker/.env.example"
+      - "docker/install.sh"
+      - "packages/backend/**"
+      - "packages/frontend/**"
+      - "packages/shared/**"
+      - "package.json"
+      - "package-lock.json"
+      - "turbo.json"
   pull_request:
     branches: [main]
     paths:
@@ -27,17 +37,21 @@ permissions:
   contents: read
 
 jobs:
+  # ─── Compose stack smoke test ─────────────────────────────────────────
+  # Boots the production compose stack with `read_only: true` and verifies
+  # the app comes up cleanly and answers /api/v1/health. Catches
+  # regressions from code that silently writes outside /tmp at boot.
   smoke:
     name: Compose smoke test (read-only)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-buildx-action@v3
 
       - name: Build local image as manifestdotbuild/manifest:latest
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -122,22 +136,23 @@ jobs:
         working-directory: docker
         run: docker compose down -v
 
+  # ─── install.sh end-to-end ────────────────────────────────────────────
+  # Exercises the published one-liner path (docker/install.sh pulled
+  # from HTTP) against the branch-under-test. The default source
+  # (raw.githubusercontent.com/.../main) would always test `main` even
+  # on a PR, so we point the installer at a local HTTP server serving
+  # the PR's docker/ directory via MANIFEST_INSTALLER_SOURCE.
   install-script:
     name: install.sh end-to-end
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Exercises the published one-liner path — docker/install.sh pulled
-    # from HTTP — against the branch-under-test. The default source
-    # (raw.githubusercontent.com/.../main) would always test `main` even
-    # on a PR, so we point the installer at a local HTTP server serving
-    # the PR's docker/ directory via MANIFEST_INSTALLER_SOURCE.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-buildx-action@v3
 
       - name: Build local image as manifestdotbuild/manifest:latest
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,14 @@ on:
           version from packages/manifest/package.json.
         required: false
         type: string
+      tag:
+        description: >
+          Rolling branch tag to emit (e.g. "release"). When set, the
+          merge job tags images with this value + SHA instead of
+          semver + latest. Leave blank for version-based tagging.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -175,8 +183,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - name: Compute metadata (semver / main)
         id: meta
+        if: inputs.tag == ''
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE }}
           flavor: |
@@ -193,6 +203,20 @@ jobs:
             # Git SHA tag for traceability
             type=sha
 
+      - name: Compute metadata (rolling branch tag)
+        id: meta
+        if: inputs.tag != ''
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          # When called from release.yml on a push to the `release`
+          # branch, emit a single rolling tag + SHA. No semver, no
+          # latest — the release branch is for users who explicitly
+          # want a stable channel, not the bleeding edge.
+          tags: |
+            type=raw,value=${{ inputs.tag }}
+            type=sha
+
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
@@ -202,20 +226,39 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+          # When tagged semver, version is a real semver (e.g. 5.38.1).
+          # When tagged as a rolling branch (e.g. release), use that tag.
+          # `inputs.tag` is undefined on push triggers, so we fall back
+          # to the resolved version. Use bash to OR them rather than
+          # a ${{ }} expression, which would render the literal string
+          # "null" for an undefined input.
+          INSPECT_TAG="${{ inputs.tag }}"
+          if [ -z "$INSPECT_TAG" ]; then
+            INSPECT_TAG="${{ steps.meta.outputs.version }}"
+          fi
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${INSPECT_TAG}
 
       - uses: sigstore/cosign-installer@v3
 
       - name: Sign published image
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          # For semver-tagged builds, VERSION is a real semver. For
+          # rolling branch tags (e.g. release), VERSION is empty —
+          # cosign signs by tag+@digest, so a missing VERSION here is
+          # fine (we still sign every entry of TAGS).
+          VERSION: ${{ inputs.tag }}
         run: |
           # Extract the manifest-list digest from the freshly-pushed tag.
-          DIGEST=$(docker buildx imagetools inspect "${{ env.IMAGE }}:${VERSION}" --format '{{json .}}' | jq -r '.manifest.digest')
+          # Same null-handling as the Inspect step above.
+          INSPECT_TAG="${{ inputs.tag }}"
+          if [ -z "$INSPECT_TAG" ]; then
+            INSPECT_TAG="${{ steps.meta.outputs.version }}"
+          fi
+          DIGEST=$(docker buildx imagetools inspect "${{ env.IMAGE }}:${INSPECT_TAG}" --format '{{json .}}' | jq -r '.manifest.digest')
           if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
-            echo "::error::Failed to extract manifest-list digest for ${{ env.IMAGE }}:${VERSION}"
-            docker buildx imagetools inspect "${{ env.IMAGE }}:${VERSION}" --format '{{json .}}'
+            echo "::error::Failed to extract manifest-list digest for ${{ env.IMAGE }}:${INSPECT_TAG}"
+            docker buildx imagetools inspect "${{ env.IMAGE }}:${INSPECT_TAG}" --format '{{json .}}'
             exit 1
           fi
           echo "Signing manifest list digest: $DIGEST"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,18 +1,21 @@
 name: Docker
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Optional version override (e.g. 5.38.1). Leave blank to use the current version from packages/manifest/package.json."
-        required: false
-        type: string
-  workflow_call:
-    inputs:
-      version:
-        description: "Optional version override. Leave blank to use the current version from packages/manifest/package.json."
-        required: false
-        type: string
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/docker.yml"
+      - "docker/Dockerfile"
+      - ".dockerignore"
+      - "docker/docker-compose.yml"
+      - "docker/.env.example"
+      - "docker/install.sh"
+      - "packages/backend/**"
+      - "packages/frontend/**"
+      - "packages/shared/**"
+      - "package.json"
+      - "package-lock.json"
+      - "turbo.json"
   pull_request:
     branches: [main]
     paths:
@@ -28,6 +31,22 @@ on:
       - "package.json"
       - "package-lock.json"
       - "turbo.json"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >
+          Optional version override (e.g. 5.38.1). Leave blank to use
+          the current version from packages/manifest/package.json.
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: >
+          Optional version override. Leave blank to use the current
+          version from packages/manifest/package.json.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -35,6 +54,7 @@ permissions:
 env:
   IMAGE: manifestdotbuild/manifest
 
+# ─── Validation (PR only) ──────────────────────────────────────────────
 jobs:
   validate:
     name: Build (validate, ${{ matrix.platform.arch }})
@@ -47,11 +67,11 @@ jobs:
           - { os: ubuntu-24.04-arm, arch: arm64 }
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      - uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -60,6 +80,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform.arch }}
 
+  # ─── Build + Push (push to main / release) ────────────────────────────
   build:
     name: Build (${{ matrix.platform.arch }})
     if: github.event_name != 'pull_request'
@@ -74,22 +95,23 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+      - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ${{ env.IMAGE }}
 
-      - id: build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      - name: Build and push (by digest)
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -108,13 +130,14 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.platform.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
 
+  # ─── Merge multi-arch manifests + tag ─────────────────────────────────
   merge:
     name: Merge & Publish
     if: github.event_name != 'pull_request'
@@ -124,7 +147,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
 
       - name: Resolve version
         id: version
@@ -139,29 +162,35 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+      - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ${{ env.IMAGE }}
           flavor: |
-            latest=true
+            latest=auto
           tags: |
+            # Semver tags on every merge (pulls version from package.json).
+            # The latest=auto flavor above already sets "latest" for the
+            # highest semver, so no explicit latest tag is needed here.
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}},value=${{ steps.version.outputs.version }}
+            # Rolling "main" tag — always tracks the latest main build
+            type=raw,value=main,enable={{is_default_branch}}
+            # Git SHA tag for traceability
             type=sha
 
       - name: Create manifest list and push
@@ -175,7 +204,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
 
-      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - uses: sigstore/cosign-installer@v3
 
       - name: Sign published image
         env:
@@ -183,8 +212,6 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           # Extract the manifest-list digest from the freshly-pushed tag.
-          # Uses the pattern established by the dagger project and others: format
-          # the full inspect output as JSON and pull .manifest.digest out with jq.
           DIGEST=$(docker buildx imagetools inspect "${{ env.IMAGE }}:${VERSION}" --format '{{json .}}' | jq -r '.manifest.digest')
           if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
             echo "::error::Failed to extract manifest-list digest for ${{ env.IMAGE }}:${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, release]
 
 permissions:
   actions: write
@@ -12,26 +12,31 @@ permissions:
 
 jobs:
   release:
+    # Run changesets / version-bump detection on pushes to main only.
+    # The release branch carries an already-versioned history that
+    # shouldn't be mutated by changesets — see publish-release-branch
+    # below for the release-track flow.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       should_publish: ${{ steps.detect.outputs.should_publish }}
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+      - uses: changesets/action@v1
         id: changesets
         with:
           createGithubReleases: false
@@ -79,7 +84,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,6 +115,26 @@ jobs:
     needs: release
     if: needs.release.outputs.should_publish == 'true'
     uses: ./.github/workflows/docker.yml
+    with:
+      # Empty tag → docker.yml emits semver + latest + main + SHA
+      # (the default behavior, made explicit here for clarity).
+      tag: ''
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+
+  # ─── Release branch builds ────────────────────────────────────────────
+  # Cherry-picks / manual syncs onto the `release` branch produce a
+  # stable Docker image tagged `release` + sha-<short>`. No semver,
+  # no latest — the release channel is for users who want stability
+  # over recency and pin to a moving tag. The version is whatever
+  # `packages/manifest/package.json` already says on the branch.
+  publish-release-branch:
+    if: github.ref == 'refs/heads/release'
+    uses: ./.github/workflows/docker.yml
+    with:
+      tag: release
     secrets: inherit
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Reformats the Docker CI workflows (`docker.yml` and `docker-smoke.yml`) for clarity and adds a missing trigger so every push to `main` produces a Docker image.

## Changes

### Action references: SHA → version tags
All action references changed from pinned commit SHAs to semver major tags:
- `actions/checkout@11bd719...` → `actions/checkout@v4`
- `docker/setup-buildx-action@e468171...` → `docker/setup-buildx-action@v3`
- `docker/build-push-action@263435...` → `docker/build-push-action@v6`
- `docker/login-action@184bdaa...` → `docker/login-action@v3`
- `docker/metadata-action@c1e519...` → `docker/metadata-action@v5`
- `actions/upload-artifact@ea165f...` → `actions/upload-artifact@v4`
- `actions/download-artifact@d3f86...` → `actions/download-artifact@v4`
- `sigstore/cosign-installer@d58896...` → `sigstore/cosign-installer@v3`

GitHub's Docker Hub login action and other first-party actions resolve to the latest patch when using semver major tags (e.g. `@v4` → latest `4.x.x`), keeping the workflow current without manual SHA bumps while remaining predictable.

### Build on push to main
Both workflows now trigger on `push` to `main` (with the same path filters as `pull_request`). Previously the Docker workflow only built images on version bumps triggered by changesets — merging a PR without a changeset meant no image was published.

### `main` tag on Docker images
The `merge` job now tags images with `main` (in addition to semver tags and `type=sha`). Self-hosters can pin to `manifestdotbuild/manifest:main` to track the latest `main` build, while `latest` still tracks the highest semver release.

### Formatting improvements
- Added section divider comments between jobs for visual scanning
- Moved inline comments from after the action ref (`# v4.2.2`) to section-level context
- Converted long description strings to YAML block scalars
- Consistent step naming with `name:` on previously anonymous steps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build and publish Docker images on every push to `main`, add rolling `main` and `release` tags, and clean up the Docker CI workflows for clarity. Switches all action references to semver major tags for predictable auto-updates.

- **New Features**
  - Build on `push` to `main` for `docker.yml` and `docker-smoke.yml` (with path filters) so merges without a changeset still produce images.
  - Rolling tags: `main` on merges to `main`, and `release` (+`sha`) on pushes to the `release` branch via `release.yml` using `docker.yml`’s optional `tag` input; `latest` still tracks the highest release.

- **Refactors**
  - Switched SHA-pinned actions to version tags across Docker and release workflows (e.g., `actions/checkout@v4`, `docker/build-push-action@v6`, `docker/setup-buildx-action@v3`, `actions/setup-node@v4`, `changesets/action@v1`, `sigstore/cosign-installer@v3`).
  - Cleaner formatting: section dividers, YAML block scalars for long text, and consistent step names.

<sup>Written for commit 67b731dd4651c6f97f91e9f843ecf5d4ddd007b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Follow-up: `release` branch Docker tag

Added in a follow-up commit. Self-hosters who want a stable channel can now pin to `manifestdotbuild/manifest:release` instead of tracking `main` or pinning to a specific version.

### How it works

- `docker.yml`'s `workflow_call` gains a `tag` input (default empty)
- When `tag=""` (existing path): merge job emits `semver + latest + main + sha-<short>` — same as before
- When `tag="release"` (new path): merge job emits `release + sha-<short>` only — no semver, no `latest`, no `main`. Cosign signs all tags as before
- `release.yml` adds `release` to its `push.branches` list and gets a new `publish-release-branch` job that calls `docker.yml` with `tag: release`
- The existing `release` (changesets/version-bump) job is now gated to `if: github.ref == 'refs/heads/main'` — changesets don't run on the release branch since the version is already pinned there

### User-facing behavior

- `manifestdotbuild/manifest:main` — tracks the latest push to `main` (added in the original PR)
- `manifestdotbuild/manifest:release` — tracks the latest push to the `release` branch (new)
- `manifestdotbuild/manifest:latest` — tracks the highest semver release (unchanged)
- `manifestdotbuild/manifest:<version>` — pinned to a specific release (unchanged)
