### PR TITLE
fix: label Kimi Coding Plan as K2.7 Code

### DIFF
--- a/.changeset/kimi-k27-code-label.md
+++ b/.changeset/kimi-k27-code-label.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Display the Kimi Coding Plan `kimi-for-coding` alias as Kimi K2.7 Code while preserving Kimi Code's stable model ID.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ the same `/auto` endpoint.
 | [**DeepSeek**](https://www.deepseek.com/)                                                |    ✅    | —                            | deepseek-v3.2, deepseek-r1                              |
 | [**Mistral**](https://mistral.ai/)                                                       |    ✅    | —                            | mistral-large, codestral, magistral                     |
 | [**Qwen** (Alibaba Cloud)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) |    ✅    | —                            | qwen3-max, qwen3-coder, qwq-32b                         |
-| [**Moonshot** (Kimi)](https://kimi.ai/)                                                  |    ✅    | ✅ Kimi Coding Plan          | kimi-k2, kimi-for-coding, moonshot-v1-128k              |
+| [**Moonshot** (Kimi)](https://kimi.ai/)                                                  |    ✅    | ✅ Kimi Coding Plan          | Kimi K2.7 Code, kimi-k2, moonshot-v1-128k               |
 | [**MiniMax**](https://www.minimax.io/)                                                   |    ✅    | ✅ MiniMax Coding Plan       | minimax-m2, abab7-chat-preview                          |
 | [**Xiaomi MiMo**](https://platform.xiaomimimo.com/)                                      |    ✅    | ✅ MiMo Token Plan           | mimo-v2.5-pro, mimo-v2.5, mimo-v2-flash                 |
 | [**Z.ai** (Zhipu)](https://z.ai/)                                                        |    ✅    | ✅ GLM Coding Plan           | glm-4.6, glm-4.5-air                                    |

--- a/docs/providers/subscription-based-providers.md
+++ b/docs/providers/subscription-based-providers.md
@@ -15,7 +15,7 @@ If you already pay for one of the plans below, Manifest can route through that s
 | [Command Code](https://commandcode.ai/studio)               | Command Code subscription   | Subscription token   | Dynamic Provider API catalog                         |
 | [Qwen](https://home.qwencloud.com/api-keys)                 | Qwen Token Plan             | Subscription token   | Dynamic Token Plan catalog                           |
 | [Xiaomi MiMo](https://platform.xiaomimimo.com)              | MiMo Token Plan             | Subscription token   | Fixed MiMo Token Plan model list                     |
-| [Moonshot](https://www.kimi.com/code/console)               | Kimi Coding Plan            | Subscription token   | `kimi-for-coding`                                    |
+| [Moonshot](https://www.kimi.com/code/console)               | Kimi Coding Plan            | Subscription token   | `kimi-for-coding` stable alias for Kimi K2.7 Code    |
 | [Z.ai](https://z.ai)                                        | GLM Coding Plan             | Subscription token   | Fixed GLM Coding Plan model list                     |
 | [Google](https://ai.google.dev)                             | Sign in with Google         | OAuth (browser)      | Fixed Gemini CodeAssist model list                   |
 | [MiniMax](https://www.minimax.io)                           | MiniMax Coding Plan         | Device code or token | Fixed MiniMax Coding Plan model list                 |
@@ -65,7 +65,7 @@ Paste a MiMo Token Plan API key. Token Plan keys use the `tp-` prefix. Manifest 
 
 ### Moonshot
 
-Paste a Kimi Code API key from the Kimi Code console. Requests route through Kimi Code's Anthropic-compatible endpoint for the fixed `kimi-for-coding` model.
+Paste a Kimi Code API key from the Kimi Code console. Requests route through Kimi Code's Anthropic-compatible endpoint for the fixed `kimi-for-coding` alias, which Kimi Code maps to the latest coding model. Manifest displays that alias as Kimi K2.7 Code.
 
 ### Z.ai
 

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -317,6 +317,17 @@ describe('buildSubscriptionFallbackModels', () => {
     expect(result).toEqual([]);
   });
 
+  it('uses configured display names for opaque subscription aliases', () => {
+    const result = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'moonshot');
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'kimi-for-coding',
+        displayName: 'Kimi K2.7 Code',
+      }),
+    ]);
+  });
+
   describe('knownModelsMatch exact mode (gemini)', () => {
     it('includes only verbatim knownModel entries from the OpenRouter cache', () => {
       const cache = new Map([
@@ -561,6 +572,17 @@ describe('supplementWithKnownModels', () => {
 
     expect(ids).toContain('gemini-3.1-flash-lite');
     expect(ids).toContain('gemini-3.1-flash-lite-preview');
+  });
+
+  it('uses configured display names when supplementing opaque subscription aliases', () => {
+    const result = supplementWithKnownModels([], 'moonshot');
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'kimi-for-coding',
+        displayName: 'Kimi K2.7 Code',
+      }),
+    ]);
   });
 });
 

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -5,6 +5,7 @@ import {
 } from '../common/constants/providers';
 import {
   getSubscriptionKnownModels,
+  getSubscriptionKnownModelDisplayName,
   getSubscriptionKnownModelsMatch,
   getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
@@ -29,6 +30,10 @@ function normalizeProviderModelId(providerId: string, modelId: string): string {
   return providerId.toLowerCase() === 'anthropic'
     ? normalizeAnthropicShortModelId(modelId)
     : modelId;
+}
+
+function displayNameForKnownModel(providerId: string, modelId: string): string {
+  return getSubscriptionKnownModelDisplayName(providerId, modelId) ?? modelId;
 }
 
 /**
@@ -292,7 +297,7 @@ export function buildSubscriptionFallbackModels(
     if (covered) continue;
     models.push({
       id: modelId,
-      displayName: modelId,
+      displayName: displayNameForKnownModel(providerId, modelId),
       provider: providerId,
       contextWindow: defaultCtx,
       inputPricePerToken: 0,
@@ -334,7 +339,7 @@ export function supplementWithKnownModels(
     if (covered) continue;
     raw.push({
       id: modelId,
-      displayName: modelId,
+      displayName: displayNameForKnownModel(providerId, modelId),
       provider: providerId,
       contextWindow: defaultCtx,
       inputPricePerToken: 0,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -711,8 +711,8 @@ export class ProviderModelFetcherService {
     } else if (configKey === 'xiaomi' && authType === 'subscription') {
       configKey = 'xiaomi-subscription';
     } else if (configKey === 'moonshot' && authType === 'subscription') {
-      // Kimi Code documents a fixed subscription model id (`kimi-for-coding`)
-      // rather than a subscription-scoped /models endpoint.
+      // Kimi Code documents `kimi-for-coding` as the stable subscription model
+      // alias; it does not expose a subscription-scoped /models endpoint.
       return [];
     } else if (configKey === 'qwen' && authType === 'subscription') {
       configKey = 'qwen-subscription';

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -343,6 +343,8 @@ describe('getSubscriptionKnownModels', () => {
     expect(getSubscriptionKnownModelDisplayName('moonshot', 'kimi-for-coding')).toBe(
       'Kimi K2.7 Code',
     );
+    expect(getSubscriptionKnownModelDisplayName('moonshot', 'kimi-k2')).toBeNull();
+    expect(getSubscriptionKnownModelDisplayName('unsupported', 'kimi-for-coding')).toBeNull();
   });
 
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -4,6 +4,7 @@ import {
   getSubscriptionProviderConfig,
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
+  getSubscriptionKnownModelDisplayName,
   getSubscriptionKnownModelsMatch,
   getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
@@ -336,6 +337,12 @@ describe('getSubscriptionKnownModels', () => {
 
   it('returns the fixed model id for moonshot Kimi Coding Plan', () => {
     expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding']);
+  });
+
+  it('labels the Kimi Coding Plan alias as Kimi K2.7 Code', () => {
+    expect(getSubscriptionKnownModelDisplayName('moonshot', 'kimi-for-coding')).toBe(
+      'Kimi K2.7 Code',
+    );
   });
 
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -107,6 +107,7 @@ export {
   getSubscriptionProviderConfig,
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
+  getSubscriptionKnownModelDisplayName,
   getSubscriptionKnownModelsMatch,
   getSubscriptionExcludedModels,
   getSubscriptionCapabilities,

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -120,7 +120,12 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'Kimi Coding Plan',
     subscriptionAuthMode: 'token' as const,
     subscriptionKeyPlaceholder: 'Paste your Kimi Code API key',
+    // Kimi Code documents `kimi-for-coding` as a stable alias that is
+    // automatically moved to the latest coding model.
     knownModels: Object.freeze(['kimi-for-coding']),
+    knownModelDisplayNames: Object.freeze({
+      'kimi-for-coding': 'Kimi K2.7 Code',
+    }),
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 262144,

--- a/packages/shared/src/subscription/helpers.ts
+++ b/packages/shared/src/subscription/helpers.ts
@@ -31,6 +31,14 @@ export function getSubscriptionKnownModels(providerId: string): readonly string[
   return config?.knownModels ?? null;
 }
 
+export function getSubscriptionKnownModelDisplayName(
+  providerId: string,
+  modelId: string,
+): string | null {
+  const config = getSubscriptionProviderConfig(providerId);
+  return config?.knownModelDisplayNames?.[modelId] ?? null;
+}
+
 export function getSubscriptionKnownModelsMatch(providerId: string): 'prefix' | 'exact' {
   const config = getSubscriptionProviderConfig(providerId);
   return config?.knownModelsMatch ?? 'prefix';

--- a/packages/shared/src/subscription/index.ts
+++ b/packages/shared/src/subscription/index.ts
@@ -4,6 +4,7 @@ export {
   getSubscriptionProviderConfig,
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
+  getSubscriptionKnownModelDisplayName,
   getSubscriptionKnownModelsMatch,
   getSubscriptionExcludedModels,
   getSubscriptionCapabilities,

--- a/packages/shared/src/subscription/types.ts
+++ b/packages/shared/src/subscription/types.ts
@@ -12,6 +12,8 @@ export interface SubscriptionProviderConfig {
   subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
   subscriptionTokenPrefix?: string;
   knownModels?: readonly string[];
+  /** Optional display names for fixed knownModels that are opaque provider aliases. */
+  knownModelDisplayNames?: Readonly<Record<string, string>>;
   /**
    * How `knownModels` is matched against the OpenRouter pricing cache:
    *   `prefix` (default) — keep any cache entry whose id starts with one


### PR DESCRIPTION
## Summary
- keep Kimi Code requests on the documented stable `kimi-for-coding` model ID
- display that opaque subscription alias as Kimi K2.7 Code in subscription fallback catalogs
- add tests and docs for the Kimi Coding Plan alias behavior

## Model verification
- Kimi API docs list Kimi K2.7 Code: https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart
- Kimi Code docs require `kimi-for-coding` for third-party coding tools: https://www.kimi.com/code/docs/en/

## Validation
- `npm --workspace packages/shared test -- subscription.spec.ts`
- `npm --workspace packages/shared run build`
- `npm --workspace packages/backend test -- model-discovery/model-fallback.spec.ts`
- `npm --workspace packages/backend run build`
- `npm run lint -- --quiet packages/shared/src/index.ts packages/shared/src/subscription packages/shared/__tests__/subscription.spec.ts packages/backend/src/model-discovery/model-fallback.ts packages/backend/src/model-discovery/model-fallback.spec.ts packages/backend/src/model-discovery/provider-model-fetcher.service.ts`
- `npx prettier --check README.md docs/providers/subscription-based-providers.md .changeset/kimi-k27-code-label.md packages/shared/src/index.ts packages/shared/src/subscription/types.ts packages/shared/src/subscription/helpers.ts packages/shared/src/subscription/index.ts packages/shared/src/subscription/configs.ts packages/shared/__tests__/subscription.spec.ts packages/backend/src/model-discovery/model-fallback.ts packages/backend/src/model-discovery/model-fallback.spec.ts packages/backend/src/model-discovery/provider-model-fetcher.service.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Label the Kimi Coding Plan as Kimi K2.7 Code while continuing to call the stable `kimi-for-coding` alias. Updates backend fallbacks, known-model supplementation, and docs with the configured display name without changing model IDs.

- **Bug Fixes**
  - Map `moonshot` alias `kimi-for-coding` to display name "Kimi K2.7 Code".
  - Use configured display names in backend fallback catalogs and known-model supplementation.
  - Add `knownModelDisplayNames` to subscription config and export `getSubscriptionKnownModelDisplayName`.
  - Update README and provider docs to explain the stable alias mapping.
  - Add shared tests and backend tests covering fallback and supplementation display-name behavior.

<sup>Written for commit 6fa9d38b93e8f2d254ebab55687cbacf7b362e66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

