### PR TITLE
Add Requesty provider

### DIFF
--- a/.changeset/add-requesty-provider.md
+++ b/.changeset/add-requesty-provider.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add Requesty as a first-class OpenAI-compatible router provider, mirroring the existing OpenRouter entry. Requesty uses `provider/model` naming and routes through `https://router.requesty.ai/v1`; models are discovered from its `/v1/models` catalog and chat traffic is proxied to `/v1/chat/completions`. Includes the provider registry entry, proxy endpoint, model fetcher config, frontend tile/icon/key-URL wiring, and docs.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Open [http://localhost:2099](http://localhost:2099) and sign up — the first ac
 
 ## Providers
 
-Manifest connects to **300+ models across 18 providers** plus any custom provider (OpenAI/Anthropic compatible). Bring your own API key, reuse a paid subscription you already have, or run models locally — all routed through
+Manifest connects to **300+ models across 19 providers** plus any custom provider (OpenAI/Anthropic compatible). Bring your own API key, reuse a paid subscription you already have, or run models locally — all routed through
 the same `/auto` endpoint.
 
 | Provider                                                                                 | API key  | Subscription                 | Featured models                                         |
@@ -84,6 +84,7 @@ the same `/auto` endpoint.
 | [**LM Studio**](https://lmstudio.ai/)                                                    | 🖥️ Local | —                            | Any GGUF model, port `1234`                             |
 | [**llama.cpp**](https://github.com/ggml-org/llama.cpp)                                   | 🖥️ Local | —                            | Any GGUF model, port `8080`                             |
 | [**OpenRouter**](https://openrouter.ai/)                                                 |    ✅    | —                            | Routes to 300+ models across labs                       |
+| [**Requesty**](https://requesty.ai/)                                                     |    ✅    | —                            | Routes to 500+ models across providers                  |
 | [**GitHub Copilot**](https://github.com/features/copilot)                                |    —     | ✅ Copilot subscription      | OAuth, no API key needed                                |
 | **Custom** (OpenAI/Anthropic-compatible)                                                 |    ✅    | —                            | Any `/v1/chat/completions` or `/v1/messages` endpoint   |
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Full deployment guides: [Railway](https://manifest.build/docs/deploy/railway), [
 
 ## Providers
 
-Manifest connects to **300+ models through 35 built-in provider connections** plus any custom OpenAI/Anthropic-compatible endpoint. Bring your own API key, reuse one of **18 subscription flows**, or run models locally. Everything is routed through the same OpenAI-compatible endpoint — send `"model": "auto"` and Manifest picks the model.
+Manifest connects to **300+ models through 36 built-in provider connections** plus any custom OpenAI/Anthropic-compatible endpoint. Bring your own API key, reuse one of **18 subscription flows**, or run models locally. Everything is routed through the same OpenAI-compatible endpoint — send `"model": "auto"` and Manifest picks the model.
 
 Provider catalogs are discovered dynamically when credentials are connected. The examples below are representative, not exhaustive.
 
@@ -123,6 +123,7 @@ Provider catalogs are discovered dynamically when credentials are connected. The
 | [**LM Studio**](https://lmstudio.ai/)                                                    |    🖥️ Local     | —                            | Local GGUF models, port `1234`                                  |
 | [**llama.cpp**](https://github.com/ggml-org/llama.cpp)                                   |    🖥️ Local     | —                            | Local GGUF models, port `8080`                                  |
 | [**OpenRouter**](https://openrouter.ai/)                                                 |       ✅        | —                            | 300+ models across labs                                         |
+| [**Requesty**](https://requesty.ai/)                                                     |       ✅        | —                            | Routes to 500+ models across providers                          |
 | [**OpenCode Zen**](https://opencode.ai/)                                                 |       ✅        | —                            | Curated Claude, GPT, DeepSeek, MiMo, Nemotron                   |
 | [**Kilo**](https://kilo.ai/)                                                             |       ✅        | —                            | Kilo Gateway catalog                                            |
 | [**Cerebras**](https://www.cerebras.ai/)                                                 |       ✅        | —                            | GPT-OSS, GLM, Gemma on Cerebras inference                       |

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -45,7 +45,7 @@ Manifest is a smart model router for **AI agents** like OpenClaw, Hermes, or any
 
 ## Supported providers
 
-Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, Mistral, Qwen, MiniMax, Kimi, Amazon Nova, Z.ai, OpenRouter, Ollama, and any provider with an OpenAI-compatible API. Connect with an API key, or reuse an existing paid subscription (ChatGPT Plus/Pro, Claude Max/Pro, Kimi Coding Plan, GLM Coding Plan, etc.) where supported.
+Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, Mistral, Qwen, MiniMax, Kimi, Amazon Nova, Z.ai, OpenRouter, Requesty, Ollama, and any provider with an OpenAI-compatible API. Connect with an API key, or reuse an existing paid subscription (ChatGPT Plus/Pro, Claude Max/Pro, Kimi Coding Plan, GLM Coding Plan, etc.) where supported.
 
 ## Manifest vs OpenRouter
 

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -55,7 +55,7 @@ Manifest is a smart model router for **AI agents** like OpenClaw, Hermes, or any
 
 ## Supported providers
 
-Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, Mistral, Qwen, MiniMax, Kimi, Amazon Nova, Z.ai, OpenRouter, Ollama, and any provider with an OpenAI-compatible API. Connect with an API key, or reuse an existing paid subscription (ChatGPT Plus/Pro, Claude Max/Pro, Kimi Coding Plan, GLM Coding Plan, etc.) where supported.
+Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, Mistral, Qwen, MiniMax, Kimi, Amazon Nova, Z.ai, OpenRouter, Requesty, Ollama, and any provider with an OpenAI-compatible API. Connect with an API key, or reuse an existing paid subscription (ChatGPT Plus/Pro, Claude Max/Pro, Kimi Coding Plan, GLM Coding Plan, etc.) where supported.
 
 ## Manifest vs OpenRouter
 

--- a/packages/backend/src/common/constants/providers.spec.ts
+++ b/packages/backend/src/common/constants/providers.spec.ts
@@ -60,6 +60,16 @@ describe('PROVIDER_REGISTRY', () => {
     expect(openrouter!.requiresApiKey).toBe(true);
   });
 
+  it('requesty is registered as an API-key router mirroring OpenRouter', () => {
+    const requesty = PROVIDER_REGISTRY.find((p) => p.id === 'requesty');
+    expect(requesty).toBeDefined();
+    expect(requesty!.displayName).toBe('Requesty');
+    expect(requesty!.aliases).toEqual([]);
+    expect(requesty!.openRouterPrefixes).toEqual(['requesty']);
+    expect(requesty!.requiresApiKey).toBe(true);
+    expect(requesty!.localOnly).toBe(false);
+  });
+
   it('anthropic has no aliases', () => {
     const anthropic = PROVIDER_REGISTRY.find((p) => p.id === 'anthropic');
     expect(anthropic).toBeDefined();

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -663,6 +663,14 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: () => ({}),
     parse: parseOpenRouter,
   },
+  // Requesty exposes an OpenAI-compatible model catalog at /v1/models.
+  // The endpoint requires a Bearer API key (unlike OpenRouter's public
+  // catalog), and returns a standard `{ data: [{ id, ... }] }` shape.
+  requesty: {
+    endpoint: 'https://router.requesty.ai/v1/models',
+    buildHeaders: bearerHeaders,
+    parse: parseOpenAI,
+  },
   ollama: {
     endpoint: `${OLLAMA_HOST}/api/tags`,
     buildHeaders: () => ({}),

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -1054,6 +1054,14 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: () => ({}),
     parse: parseOpenRouter,
   },
+  // Requesty exposes an OpenAI-compatible model catalog at /v1/models.
+  // The endpoint requires a Bearer API key (unlike OpenRouter's public
+  // catalog), and returns a standard `{ data: [{ id, ... }] }` shape.
+  requesty: {
+    endpoint: 'https://router.requesty.ai/v1/models',
+    buildHeaders: bearerHeaders,
+    parse: parseOpenAI,
+  },
   ...MANAGED_FREE_FETCHER_CONFIGS,
   ollama: {
     endpoint: `${OLLAMA_HOST}/api/tags`,

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -149,6 +149,7 @@ describe('resolveEndpointKey', () => {
     expect(known).toContain('commandcode-anthropic');
     expect(known).toContain('fireworks');
     expect(known).toContain('openrouter');
+    expect(known).toContain('requesty');
     expect(known).toContain('nvidia');
     expect(known).toContain('ollama');
     expect(known).toContain('ollama-cloud');
@@ -411,6 +412,20 @@ describe('PROVIDER_ENDPOINTS', () => {
   it('openrouter buildPath returns /api/v1/chat/completions', () => {
     const path = PROVIDER_ENDPOINTS['openrouter'].buildPath('openai/gpt-4o');
     expect(path).toBe('/api/v1/chat/completions');
+  });
+
+  it('requesty uses the OpenAI-compatible router endpoint with branded headers', () => {
+    const ep = PROVIDER_ENDPOINTS['requesty'];
+    expect(ep.baseUrl).toBe('https://router.requesty.ai');
+    expect(ep.format).toBe('openai');
+    expect(ep.buildPath('openai/gpt-4o-mini')).toBe('/v1/chat/completions');
+    expect(ep.streamUsageReporting).toBe('openai_stream_options');
+    expect(ep.buildHeaders('sk-requesty-test')).toEqual({
+      Authorization: 'Bearer sk-requesty-test',
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://manifest.build',
+      'X-Title': 'Manifest',
+    });
   });
 
   it('openai-subscription uses chatgpt.com backend base URL', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -173,6 +173,7 @@ describe('resolveEndpointKey', () => {
     expect(known).toContain('gemini-free');
     expect(known).toContain('nous');
     expect(known).toContain('openrouter');
+    expect(known).toContain('requesty');
     expect(known).toContain('nvidia');
     expect(known).toContain('ollama');
     expect(known).toContain('ollama-cloud');
@@ -587,6 +588,20 @@ describe('PROVIDER_ENDPOINTS', () => {
   it('openrouter buildPath returns /api/v1/chat/completions', () => {
     const path = PROVIDER_ENDPOINTS['openrouter'].buildPath('openai/gpt-4o');
     expect(path).toBe('/api/v1/chat/completions');
+  });
+
+  it('requesty uses the OpenAI-compatible router endpoint with branded headers', () => {
+    const ep = PROVIDER_ENDPOINTS['requesty'];
+    expect(ep.baseUrl).toBe('https://router.requesty.ai');
+    expect(ep.format).toBe('openai');
+    expect(ep.buildPath('openai/gpt-4o-mini')).toBe('/v1/chat/completions');
+    expect(ep.streamUsageReporting).toBe('openai_stream_options');
+    expect(ep.buildHeaders('sk-requesty-test')).toEqual({
+      Authorization: 'Bearer sk-requesty-test',
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://manifest.build',
+      'X-Title': 'Manifest',
+    });
   });
 
   it('openai-subscription uses chatgpt.com backend base URL', () => {

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -66,6 +66,15 @@ const openaiHeaders = (apiKey: string) => ({
 
 const openaiPath = () => '/v1/chat/completions';
 
+// Shared headers for OpenAI-compatible routers (OpenRouter, Requesty) that
+// accept the optional HTTP-Referer / X-Title attribution headers.
+const routerHeaders = (apiKey: string) => ({
+  Authorization: `Bearer ${apiKey}`,
+  'Content-Type': 'application/json',
+  'HTTP-Referer': 'https://manifest.build',
+  'X-Title': 'Manifest',
+});
+
 const anthropicHeaders = (apiKey: string, authType?: string): Record<string, string> => {
   if (authType === 'subscription') {
     return buildClaudeCodeSubscriptionHeaders(apiKey);
@@ -370,12 +379,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   },
   openrouter: {
     baseUrl: 'https://openrouter.ai',
-    buildHeaders: (apiKey: string) => ({
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      'HTTP-Referer': 'https://manifest.build',
-      'X-Title': 'Manifest',
-    }),
+    buildHeaders: routerHeaders,
     buildPath: () => '/api/v1/chat/completions',
     format: 'openai',
     ...openaiStreamUsage,
@@ -385,12 +389,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   // router host, and models are listed at /v1/models.
   requesty: {
     baseUrl: 'https://router.requesty.ai',
-    buildHeaders: (apiKey: string) => ({
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      'HTTP-Referer': 'https://manifest.build',
-      'X-Title': 'Manifest',
-    }),
+    buildHeaders: routerHeaders,
     buildPath: () => '/v1/chat/completions',
     format: 'openai',
     ...openaiStreamUsage,

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -380,6 +380,21 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     format: 'openai',
     ...openaiStreamUsage,
   },
+  // Requesty is an OpenAI-compatible router (provider/model naming, like
+  // OpenRouter). The chat endpoint lives at /v1/chat/completions under the
+  // router host, and models are listed at /v1/models.
+  requesty: {
+    baseUrl: 'https://router.requesty.ai',
+    buildHeaders: (apiKey: string) => ({
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://manifest.build',
+      'X-Title': 'Manifest',
+    }),
+    buildPath: () => '/v1/chat/completions',
+    format: 'openai',
+    ...openaiStreamUsage,
+  },
   ollama: {
     baseUrl: OLLAMA_HOST,
     buildHeaders: () => ({ 'Content-Type': 'application/json' }),

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -95,6 +95,15 @@ export function resolveBedrockEndpointKey(
   return 'bedrock';
 }
 
+// Shared headers for OpenAI-compatible routers (OpenRouter, Requesty) that
+// accept the optional HTTP-Referer / X-Title attribution headers.
+const routerHeaders = (apiKey: string) => ({
+  Authorization: `Bearer ${apiKey}`,
+  'Content-Type': 'application/json',
+  'HTTP-Referer': 'https://manifest.build',
+  'X-Title': 'Manifest',
+});
+
 const anthropicHeaders = (apiKey: string, authType?: string): Record<string, string> => {
   if (authType === 'subscription') {
     return buildClaudeCodeSubscriptionHeaders(apiKey);
@@ -502,12 +511,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   },
   openrouter: {
     baseUrl: 'https://openrouter.ai',
-    buildHeaders: (apiKey: string) => ({
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      'HTTP-Referer': 'https://manifest.build',
-      'X-Title': 'Manifest',
-    }),
+    buildHeaders: routerHeaders,
     buildPath: () => '/api/v1/chat/completions',
     format: 'openai',
     ...openaiStreamUsage,
@@ -517,12 +521,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   // router host, and models are listed at /v1/models.
   requesty: {
     baseUrl: 'https://router.requesty.ai',
-    buildHeaders: (apiKey: string) => ({
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      'HTTP-Referer': 'https://manifest.build',
-      'X-Title': 'Manifest',
-    }),
+    buildHeaders: routerHeaders,
     buildPath: () => '/v1/chat/completions',
     format: 'openai',
     ...openaiStreamUsage,

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -512,6 +512,21 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     format: 'openai',
     ...openaiStreamUsage,
   },
+  // Requesty is an OpenAI-compatible router (provider/model naming, like
+  // OpenRouter). The chat endpoint lives at /v1/chat/completions under the
+  // router host, and models are listed at /v1/models.
+  requesty: {
+    baseUrl: 'https://router.requesty.ai',
+    buildHeaders: (apiKey: string) => ({
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://manifest.build',
+      'X-Title': 'Manifest',
+    }),
+    buildPath: () => '/v1/chat/completions',
+    format: 'openai',
+    ...openaiStreamUsage,
+  },
   ...MANAGED_FREE_ENDPOINTS,
   ollama: {
     baseUrl: OLLAMA_HOST,

--- a/packages/frontend/src/components/ProviderIcon.tsx
+++ b/packages/frontend/src/components/ProviderIcon.tsx
@@ -405,6 +405,24 @@ export function providerIcon(id: string, size: number = 20): JSX.Element | null 
         </svg>
       );
 
+    /* ── Requesty ─────────────────────────────────── */
+    case 'requesty':
+      return (
+        <svg
+          style={s}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <rect width="24" height="24" rx="5" fill="#6e56cf" />
+          <path
+            d="M6.5 18V6h5.6c2.4 0 3.9 1.4 3.9 3.6 0 1.6-.8 2.8-2.2 3.3l2.7 5.1h-2.7l-2.4-4.7H8.8V18H6.5Zm2.3-6.5h3c1.1 0 1.8-.6 1.8-1.7s-.7-1.7-1.8-1.7h-3v3.4Z"
+            fill="#ffffff"
+          />
+        </svg>
+      );
+
     /* ── Ollama ───────────────────────────────────── */
     case 'ollama':
     case 'ollama-cloud':

--- a/packages/frontend/src/components/ProviderIcon.tsx
+++ b/packages/frontend/src/components/ProviderIcon.tsx
@@ -553,6 +553,24 @@ export function providerIcon(id: string, size: number = 20): JSX.Element | null 
         </svg>
       );
 
+    /* ── Requesty ─────────────────────────────────── */
+    case 'requesty':
+      return (
+        <svg
+          style={s}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <rect width="24" height="24" rx="5" fill="#6e56cf" />
+          <path
+            d="M6.5 18V6h5.6c2.4 0 3.9 1.4 3.9 3.6 0 1.6-.8 2.8-2.2 3.3l2.7 5.1h-2.7l-2.4-4.7H8.8V18H6.5Zm2.3-6.5h3c1.1 0 1.8-.6 1.8-1.7s-.7-1.7-1.8-1.7h-3v3.4Z"
+            fill="#ffffff"
+          />
+        </svg>
+      );
+
     /* ── Ollama ───────────────────────────────────── */
     case 'ollama':
     case 'ollama-cloud':

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -16,6 +16,7 @@ export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   openai: 'https://platform.openai.com/api-keys',
   'opencode-zen': 'https://opencode.ai/auth',
   openrouter: 'https://openrouter.ai/keys',
+  requesty: 'https://app.requesty.ai/api-keys',
   qwen: 'https://www.alibabacloud.com/help/en/model-studio/developer-reference/get-api-key',
   xiaomi: 'https://platform.xiaomimimo.com/console/api-keys',
   xai: 'https://docs.x.ai/docs/api-reference',

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -26,6 +26,7 @@ export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   pioneer: 'https://pioneer.ai',
   'opencode-zen': 'https://opencode.ai/auth',
   openrouter: 'https://openrouter.ai/keys',
+  requesty: 'https://app.requesty.ai/api-keys',
   qwen: 'https://www.alibabacloud.com/help/en/model-studio/developer-reference/get-api-key',
   xiaomi: 'https://platform.xiaomimimo.com/console/api-keys',
   xai: 'https://docs.x.ai/docs/api-reference',

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -360,6 +360,11 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     subtitle: 'Auto-route to 300+ models',
     models: [],
   },
+  requesty: {
+    initial: 'Rq',
+    subtitle: 'Unified router for 500+ models across providers',
+    models: [],
+  },
   xai: {
     initial: 'X',
     subtitle: 'Grok 3, Grok 2',
@@ -429,6 +434,7 @@ const PROVIDER_ORDER = [
   'opencode-go',
   'opencode-zen',
   'openrouter',
+  'requesty',
   'xai',
   'xiaomi',
   'zai',

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -458,6 +458,11 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     subtitle: 'Auto-route to 300+ models',
     models: [],
   },
+  requesty: {
+    initial: 'Rq',
+    subtitle: 'Unified router for 500+ models across providers',
+    models: [],
+  },
   xai: {
     initial: 'X',
     subtitle: 'Grok 4.5, Grok 4.3, Grok Build',
@@ -535,6 +540,7 @@ const PROVIDER_ORDER = [
   'opencode-zen',
   'openrouter',
   'pioneer',
+  'requesty',
   'xai',
   'xiaomi',
   'zai',

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -776,6 +776,21 @@ describe('PROVIDERS', () => {
     });
   });
 
+  it('Requesty is an API-key router with a key URL and generic key validation', () => {
+    const requesty = PROVIDERS.find((p) => p.id === 'requesty')!;
+    expect(requesty).toBeDefined();
+    expect(requesty.name).toBe('Requesty');
+    expect(requesty.supportsSubscription).toBeUndefined();
+    expect(requesty.subscriptionOnly).toBeUndefined();
+    expect(requesty.models).toEqual([]);
+    expect(getRoutingProviderApiKeyUrl('requesty')).toBe('https://app.requesty.ai/api-keys');
+    expect(validateApiKey(requesty, '')).toEqual({
+      valid: false,
+      error: 'API key is required',
+    });
+    expect(validateApiKey(requesty, 'sk-' + 'a'.repeat(30))).toEqual({ valid: true });
+  });
+
   it('requires an API key URL for every provider that needs one', () => {
     const missingProviderIds = PROVIDERS.filter(
       (provider) =>

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -1036,6 +1036,21 @@ describe('PROVIDERS', () => {
     });
   });
 
+  it('Requesty is an API-key router with a key URL and generic key validation', () => {
+    const requesty = PROVIDERS.find((p) => p.id === 'requesty')!;
+    expect(requesty).toBeDefined();
+    expect(requesty.name).toBe('Requesty');
+    expect(requesty.supportsSubscription).toBeUndefined();
+    expect(requesty.subscriptionOnly).toBeUndefined();
+    expect(requesty.models).toEqual([]);
+    expect(getRoutingProviderApiKeyUrl('requesty')).toBe('https://app.requesty.ai/api-keys');
+    expect(validateApiKey(requesty, '')).toEqual({
+      valid: false,
+      error: 'API key is required',
+    });
+    expect(validateApiKey(requesty, 'sk-' + 'a'.repeat(30))).toEqual({ valid: true });
+  });
+
   it('requires an API key URL for every provider that needs one', () => {
     const missingProviderIds = PROVIDERS.filter(
       (provider) =>

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -354,6 +354,18 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     keyPlaceholder: 'sk-or-...',
   },
   {
+    id: 'requesty',
+    displayName: 'Requesty',
+    aliases: [],
+    openRouterPrefixes: ['requesty'],
+    requiresApiKey: true,
+    localOnly: false,
+    color: '#6e56cf',
+    keyPrefix: 'sk-',
+    minKeyLength: 30,
+    keyPlaceholder: 'sk-...',
+  },
+  {
     id: 'xai',
     displayName: 'xAI',
     aliases: [],

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -473,6 +473,18 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     keyPlaceholder: 'sk-or-...',
   },
   {
+    id: 'requesty',
+    displayName: 'Requesty',
+    aliases: [],
+    openRouterPrefixes: ['requesty'],
+    requiresApiKey: true,
+    localOnly: false,
+    color: '#6e56cf',
+    keyPrefix: 'sk-',
+    minKeyLength: 30,
+    keyPlaceholder: 'sk-...',
+  },
+  {
     id: 'xai',
     displayName: 'xAI',
     aliases: [],


### PR DESCRIPTION
## Add Requesty as a first-class provider

This adds **Requesty** (`https://router.requesty.ai`) as a dedicated, named provider, mirroring the existing OpenRouter entry as closely as possible. Requesty is an OpenAI-compatible router that uses the same `provider/model` naming scheme as OpenRouter (e.g. `openai/gpt-4o-mini`), so it slots into the existing registry/proxy/model-discovery machinery without new abstractions.

### What changed

**Shared**
- `packages/shared/src/providers.ts`: new `requesty` entry in `SHARED_PROVIDERS` (id `requesty`, display name `Requesty`, `requiresApiKey: true`, `openRouterPrefixes: ['requesty']`, mirroring OpenRouter's shape). All derived maps (`PROVIDER_BY_ID`, `OPENROUTER_PREFIX_TO_PROVIDER`, `ALL_PROVIDER_IDS`) pick it up automatically.

**Backend**
- `packages/backend/src/routing/proxy/provider-endpoints.ts`: `requesty` `ProviderEndpoint`: base URL `https://router.requesty.ai`, path `/v1/chat/completions`, OpenAI format, `openai_stream_options` usage reporting, with the same `HTTP-Referer` / `X-Title` attribution headers OpenRouter uses.
- `packages/backend/src/model-discovery/provider-model-fetcher.service.ts`: `requesty` fetcher config: discovers models from `https://router.requesty.ai/v1/models` (Bearer auth, OpenAI `{ data: [...] }` shape via `parseOpenAI`).
- `packages/backend/src/common/constants/providers.spec.ts`: mirror test asserting the `requesty` registry entry.
- `packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts`: assertions for the `requesty` endpoint and that `resolveEndpointKey` resolves it.

**Frontend**
- `packages/frontend/src/services/providers.ts`: `requesty` UI overlay + position in `PROVIDER_ORDER`.
- `packages/frontend/src/services/provider-api-key-urls.ts`: key URL `https://app.requesty.ai/api-keys`.
- `packages/frontend/src/components/ProviderIcon.tsx`: branded `requesty` icon.
- `packages/frontend/tests/services/providers.test.ts`: mirror test for the Requesty tile + key URL + validation.

**Docs**
- `README.md`: Requesty row in the providers table; bumped provider count.
- `docker/DOCKER_README.md`: Requesty added to the supported-providers list.
- `.changeset/add-requesty-provider.md`: changeset (`manifest`, minor).

### Verification

- **Typecheck**: `npm run build` (shared + backend + frontend via Turborepo): passes (3/3 tasks successful).
- **Tests**: backend `providers.spec.ts` + `provider-endpoints.spec.ts` (`npm test --workspace=packages/backend` → 172 passed) and frontend `providers.test.ts` (`npm test --workspace=packages/frontend` → 261 passed). New mirror tests for the `requesty` entry pass.
- **Live test** against `https://router.requesty.ai` using a real `REQUESTY_API_KEY`:
  - `GET /v1/models` → `200` (554 models)
  - `POST /v1/chat/completions` with `openai/gpt-4o-mini` → `200`, returned a real completion (`requesty-ok`, resolved model `gpt-4o-mini-2024-07-18`).

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it is not a fit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Requesty as a first-class OpenAI-compatible router provider using OpenRouter's `provider/model` naming (e.g., `openai/gpt-4o-mini`). Routes through `https://router.requesty.ai` with model discovery, UI, tests, and docs; the README provider connections count goes from 35 to 36.

- New Features
  - Shared: register `requesty` (API-key router; `openRouterPrefixes: ['requesty']`).
  - Backend: proxy to `https://router.requesty.ai/v1/chat/completions` (OpenAI format, branded headers, stream usage reporting).
  - Backend: model discovery from `https://router.requesty.ai/v1/models` (Bearer auth; OpenAI `{ data: [...] }` shape).
  - Frontend/Docs/Tests: tile/order, icon, key URL `https://app.requesty.ai/api-keys`; provider lists updated; mirror tests; changeset.
- Refactors
  - Extracted shared `routerHeaders` for `openrouter` and `requesty` to keep attribution headers consistent.

<sup>Written for commit a8bdad19d0850511e6cd80dae956175d99ffb55e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


