### PR TITLE
fix: UI polish — modal z-index, sidebar hover, playground focus, model picker nav

### DIFF
--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -712,7 +712,6 @@ const ModelPickerModal: Component<Props> = (props) => {
               <Show when={!search().trim() && !showFreeOnly() && props.onConnectProviders}>
                 <button
                   class="btn btn--primary btn--sm"
-                  style="margin-top: 12px;"
                   onClick={() => props.onConnectProviders?.()}
                 >
                   Connect provider

--- a/packages/frontend/src/components/RoutingModals.tsx
+++ b/packages/frontend/src/components/RoutingModals.tsx
@@ -1,4 +1,5 @@
 import { Show, Suspense, createSignal, lazy, type Accessor, type Component } from 'solid-js';
+import { useNavigate } from '@solidjs/router';
 import RoutingInstructionModal from './RoutingInstructionModal.js';
 import KeyPickerModal from './KeyPickerModal.js';
 
@@ -89,6 +90,7 @@ function providerDisplayName(providerId: string, customProviders: CustomProvider
 }
 
 const RoutingModals: Component<RoutingModalsProps> = (props) => {
+  const navigate = useNavigate();
   const [pendingOverride, setPendingOverride] = createSignal<PendingOverride | null>(null);
   const requiredCapabilityForResponseMode = (
     responseMode: ResponseMode | undefined,
@@ -155,7 +157,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
               onClose={props.onDropdownClose}
               onConnectProviders={() => {
                 props.onDropdownClose();
-                props.onOpenProviderModal();
+                navigate(`/harnesses/${encodeURIComponent(props.agentName())}/providers`);
               }}
               onProviderRefreshed={props.onProviderUpdate}
             />
@@ -185,7 +187,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
                 onClose={() => props.onSpecificityDropdownClose?.()}
                 onConnectProviders={() => {
                   props.onSpecificityDropdownClose?.();
-                  props.onOpenProviderModal();
+                  navigate(`/harnesses/${encodeURIComponent(props.agentName())}/providers`);
                 }}
                 onProviderRefreshed={props.onProviderUpdate}
               />
@@ -293,7 +295,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
                 onClose={props.onFallbackPickerClose}
                 onConnectProviders={() => {
                   props.onFallbackPickerClose();
-                  props.onOpenProviderModal();
+                  navigate(`/harnesses/${encodeURIComponent(props.agentName())}/providers`);
                 }}
                 onProviderRefreshed={props.onProviderUpdate}
               />

--- a/packages/frontend/src/components/RoutingModals.tsx
+++ b/packages/frontend/src/components/RoutingModals.tsx
@@ -68,7 +68,6 @@ interface RoutingModalsProps {
   ) => void;
   onProviderUpdate: () => Promise<void>;
   onProviderPoll?: () => Promise<void>;
-  onOpenProviderModal: () => void;
 }
 
 interface PendingOverride {

--- a/packages/frontend/src/components/UpgradeSuccessModal.tsx
+++ b/packages/frontend/src/components/UpgradeSuccessModal.tsx
@@ -43,7 +43,7 @@ const UpgradeSuccessModal: Component<UpgradeSuccessModalProps> = (props) => {
                   <path d="M9 15.59 4.71 11.3 3.3 12.71l5 5c.2.2.45.29.71.29s.51-.1.71-.29l11-11-1.41-1.41L9.02 15.59Z" />
                 </svg>
               </div>
-              <h2 class="upgrade-success-modal__title">You're on the Pro plan</h2>
+              <h2 class="upgrade-success-modal__title">You're now on the Pro plan</h2>
               <p class="upgrade-success-modal__subtitle">
                 Your workspace has been upgraded. Here's what you now have access to:
               </p>

--- a/packages/frontend/src/components/playground/PlaygroundPrompt.tsx
+++ b/packages/frontend/src/components/playground/PlaygroundPrompt.tsx
@@ -18,6 +18,7 @@ interface Props {
   headersSlot?: JSX.Element;
   historyOpen?: boolean;
   onHeightChange?: (height: number) => void;
+  ref?: (el: HTMLTextAreaElement) => void;
 }
 
 const MAX_PROMPT_LINES = 15;
@@ -94,7 +95,10 @@ const PlaygroundPrompt: Component<Props> = (props) => {
         }}
       >
         <textarea
-          ref={setRef}
+          ref={(el) => {
+            setRef(el);
+            props.ref?.(el);
+          }}
           class="playground-prompt__textarea"
           placeholder="Send a prompt to compare models..."
           value={props.value}

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -177,6 +177,7 @@ const Playground: Component = () => {
   // Best pick for a run shown read-only as an overlay (store isn't loaded in
   // that path, so its best state is tracked separately).
   const [overlayBestId, setOverlayBestId] = createSignal<string | null>(null);
+  let promptRef: HTMLTextAreaElement | undefined;
 
   const effectiveBestId = () => (viewingHistory() ? overlayBestId() : store().bestColumnId());
 
@@ -207,6 +208,7 @@ const Playground: Component = () => {
     setSearchParams({ run: undefined });
     sessionStorage.removeItem('manifest.playground.lastRun');
     // pickDefaults will fire via the existing createEffect since columns are now empty
+    requestAnimationFrame(() => promptRef?.focus());
   };
 
   // Cmd+K (Mac) / Ctrl+K (Windows) opens the model picker
@@ -532,6 +534,7 @@ const Playground: Component = () => {
           }
         >
           <PlaygroundPrompt
+            ref={(el) => { promptRef = el; }}
             value={store().prompt()}
             onChange={store().setPrompt}
             onSubmit={handleSubmit}

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -929,7 +929,6 @@ const Routing: Component = () => {
         onAddFallback={handleAddFallback}
         onProviderUpdate={handleProviderUpdate}
         onProviderPoll={handleProviderPoll}
-        onOpenProviderModal={openProviderModal}
       />
 
       <SetupModal

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -423,6 +423,10 @@
   text-align: center;
   font-size: var(--font-size-sm);
   color: hsl(var(--muted-foreground));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
 }
 
 /* ── Inline model picker (used inside instruction modal) ── */

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -850,6 +850,12 @@ h6 {
   align-items: center;
   justify-content: space-between;
   margin: var(--gap-md) 0.5rem 1px;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+}
+
+.sidebar__section-header:hover {
+  background: hsl(var(--sidebar-accent));
 }
 
 /* Collapse toggle: carries the uppercased section label styling so it reads as
@@ -874,9 +880,12 @@ h6 {
   transition: background var(--transition-fast);
 }
 
-.sidebar__section-caret:hover,
 .sidebar__section-caret:focus-visible {
   background: hsl(var(--sidebar-accent));
+  color: hsl(var(--sidebar-foreground));
+}
+
+.sidebar__section-header:hover .sidebar__section-caret {
   color: hsl(var(--sidebar-foreground));
 }
 
@@ -886,10 +895,11 @@ h6 {
   justify-content: center;
   width: 22px;
   height: 22px;
-  background: hsl(var(--muted));
+  background: transparent;
   border: none;
   border-radius: var(--radius-sm);
   padding: 0;
+  margin-right: 2px;
   color: hsl(var(--muted-foreground));
   cursor: pointer;
   transition:

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -1155,7 +1155,7 @@ h6 {
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 100;
   background: rgb(0 0 0 / 0.5);
   display: flex;
   align-items: center;

--- a/packages/frontend/tests/components/RoutingModals.test.tsx
+++ b/packages/frontend/tests/components/RoutingModals.test.tsx
@@ -436,6 +436,45 @@ describe('RoutingModals', () => {
     expect(queryByTestId('instruction-modal-closed-enable')).not.toBeNull();
   });
 
+  it('navigates to the providers page when the dropdown picker fires onConnectProviders', async () => {
+    const onDropdownClose = vi.fn();
+    const { findByTestId } = render(() => (
+      <RoutingModals
+        {...makeProps({ dropdownTier: () => 'simple', onDropdownClose })}
+      />
+    ));
+    fireEvent.click(await findByTestId('picker-connect-simple'));
+    expect(onDropdownClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/harnesses/demo/providers');
+  });
+
+  it('navigates to the providers page when the fallback picker fires onConnectProviders', async () => {
+    const onFallbackPickerClose = vi.fn();
+    const { findByTestId } = render(() => (
+      <RoutingModals
+        {...makeProps({ fallbackPickerTier: () => 'simple', onFallbackPickerClose })}
+      />
+    ));
+    fireEvent.click(await findByTestId('picker-connect-simple'));
+    expect(onFallbackPickerClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/harnesses/demo/providers');
+  });
+
+  it('navigates to the providers page when the specificity picker fires onConnectProviders', async () => {
+    const onSpecificityDropdownClose = vi.fn();
+    const { findByTestId } = render(() => (
+      <RoutingModals
+        {...makeProps({
+          specificityDropdown: () => 'coding',
+          onSpecificityDropdownClose,
+        })}
+      />
+    ));
+    fireEvent.click(await findByTestId('picker-connect-coding'));
+    expect(onSpecificityDropdownClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/harnesses/demo/providers');
+  });
+
   it('calls onAddFallback when fallback picker selects a model', () => {
     const onAddFallback = vi.fn();
     const { getByTestId } = render(() => (

--- a/packages/frontend/tests/components/RoutingModals.test.tsx
+++ b/packages/frontend/tests/components/RoutingModals.test.tsx
@@ -128,6 +128,11 @@ vi.mock('../../src/components/RoutingInstructionModal.js', () => ({
   },
 }));
 
+const mockNavigate = vi.fn();
+vi.mock('@solidjs/router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
 import RoutingModals from '../../src/components/RoutingModals';
 import type {
   TierAssignment,
@@ -217,7 +222,6 @@ const baseProps = {
   onProviderModalClose: vi.fn(),
   onInstructionClose: vi.fn(),
   onProviderUpdate: vi.fn().mockResolvedValue(undefined),
-  onOpenProviderModal: vi.fn(),
   models: () => sampleModels,
   tiers: () => tiers,
   specificityAssignments: () => specificityAssignments,
@@ -247,6 +251,7 @@ describe('RoutingModals', () => {
     psmProps.length = 0;
     riProps.length = 0;
     kpmProps.length = 0;
+    mockNavigate.mockClear();
     vi.clearAllMocks();
   });
 
@@ -429,57 +434,6 @@ describe('RoutingModals', () => {
       <RoutingModals {...makeProps({ instructionModal: () => null })} />
     ));
     expect(queryByTestId('instruction-modal-closed-enable')).not.toBeNull();
-  });
-
-  it('forwards onConnectProviders from the dropdown picker through to onOpenProviderModal', () => {
-    const onOpenProviderModal = vi.fn();
-    const onDropdownClose = vi.fn();
-    const { getByTestId } = render(() => (
-      <RoutingModals
-        {...makeProps({
-          dropdownTier: () => 'simple',
-          onOpenProviderModal,
-          onDropdownClose,
-        })}
-      />
-    ));
-    fireEvent.click(getByTestId('picker-connect-simple'));
-    expect(onDropdownClose).toHaveBeenCalled();
-    expect(onOpenProviderModal).toHaveBeenCalled();
-  });
-
-  it('forwards onConnectProviders from the fallback picker through to onOpenProviderModal', () => {
-    const onOpenProviderModal = vi.fn();
-    const onFallbackPickerClose = vi.fn();
-    const { getByTestId } = render(() => (
-      <RoutingModals
-        {...makeProps({
-          fallbackPickerTier: () => 'simple',
-          onOpenProviderModal,
-          onFallbackPickerClose,
-        })}
-      />
-    ));
-    fireEvent.click(getByTestId('picker-connect-simple'));
-    expect(onFallbackPickerClose).toHaveBeenCalled();
-    expect(onOpenProviderModal).toHaveBeenCalled();
-  });
-
-  it('forwards onConnectProviders from the specificity picker through to onOpenProviderModal', () => {
-    const onOpenProviderModal = vi.fn();
-    const onSpecificityDropdownClose = vi.fn();
-    const { getByTestId } = render(() => (
-      <RoutingModals
-        {...makeProps({
-          specificityDropdown: () => 'coding',
-          onOpenProviderModal,
-          onSpecificityDropdownClose,
-        })}
-      />
-    ));
-    fireEvent.click(getByTestId('picker-connect-coding'));
-    expect(onSpecificityDropdownClose).toHaveBeenCalled();
-    expect(onOpenProviderModal).toHaveBeenCalled();
   });
 
   it('calls onAddFallback when fallback picker selects a model', () => {

--- a/packages/frontend/tests/components/UpgradeSuccessModal.test.tsx
+++ b/packages/frontend/tests/components/UpgradeSuccessModal.test.tsx
@@ -14,7 +14,7 @@ describe('UpgradeSuccessModal', () => {
     const onClose = vi.fn();
     render(() => <UpgradeSuccessModal open onClose={onClose} />);
 
-    expect(screen.getByText("You're on the Pro plan")).toBeDefined();
+    expect(screen.getByText("You're now on the Pro plan")).toBeDefined();
     expect(screen.getByText('Unlimited routed requests')).toBeDefined();
     expect(screen.getByText('365 days dashboard retention')).toBeDefined();
 

--- a/packages/frontend/tests/components/playground/PlaygroundPrompt.test.tsx
+++ b/packages/frontend/tests/components/playground/PlaygroundPrompt.test.tsx
@@ -33,6 +33,7 @@ interface PropsOverride {
   onRecallPrevious?: () => void;
   onHeightChange?: (h: number) => void;
   historyOpen?: boolean;
+  ref?: (el: HTMLTextAreaElement) => void;
 }
 
 function setup(o: PropsOverride = {}) {
@@ -49,6 +50,7 @@ function setup(o: PropsOverride = {}) {
       onRecallPrevious={onRecallPrevious}
       onHeightChange={o.onHeightChange}
       historyOpen={o.historyOpen}
+      ref={o.ref}
     />
   ));
   const textarea = utils.container.querySelector('textarea') as HTMLTextAreaElement;
@@ -250,5 +252,24 @@ describe('PlaygroundPrompt autoGrow', () => {
     Object.defineProperty(textarea, 'scrollHeight', { configurable: true, value: 88 });
     fireEvent.input(textarea, { target: { value: 'line1\nline2' } });
     expect(textarea.style.height).toBe('88px');
+  });
+});
+
+/* ── ref forwarding ────────────────────────────────────────────── */
+
+describe('PlaygroundPrompt ref forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the ref callback with the textarea element on mount', () => {
+    const refFn = vi.fn();
+    const { textarea } = setup({ ref: refFn });
+    expect(refFn).toHaveBeenCalledTimes(1);
+    expect(refFn).toHaveBeenCalledWith(textarea);
+  });
+
+  it('does not throw when ref prop is not provided', () => {
+    expect(() => setup()).not.toThrow();
   });
 });

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -360,7 +360,7 @@ describe('GlobalOverview filter onUnselectAll', () => {
       render(() => <GlobalOverview />);
 
       await waitFor(() => expect(localStorage.getItem('manifest_plan_chosen_u1')).toBe('1'));
-      await waitFor(() => expect(document.body.textContent).toContain("You're on the Pro plan"));
+      await waitFor(() => expect(document.body.textContent).toContain("You're now on the Pro plan"));
 
       await waitFor(() => expect(document.querySelector('.modal-backdrop')).not.toBeNull());
       fireEvent.click(document.querySelector('.modal-backdrop')!);

--- a/packages/frontend/tests/pages/Playground.test.tsx
+++ b/packages/frontend/tests/pages/Playground.test.tsx
@@ -89,31 +89,38 @@ vi.mock('../../src/components/playground/PlaygroundColumn.jsx', () => ({
   },
 }));
 
+let mockPromptTextarea: HTMLTextAreaElement | null = null;
 vi.mock('../../src/components/playground/PlaygroundPrompt.jsx', () => ({
-  default: (props: Record<string, unknown>) => (
-    <div data-testid="prompt">
-      <span data-testid="prompt-disabled">{String(props.disabled)}</span>
-      {/* Touch every prop so SolidJS evaluates each accessor (coverage). */}
-      <span data-testid="prompt-value">{String(props.value)}</span>
-      <span data-testid="prompt-running">{String(props.running)}</span>
-      {props.headersSlot as JSX.Element}
-      <button data-testid="prompt-submit" onClick={() => (props.onSubmit as () => void)()}>
-        submit
-      </button>
-      <button
-        data-testid="prompt-set"
-        onClick={() => (props.onChange as (v: string) => void)('hello world')}
-      >
-        set
-      </button>
-      <button
-        data-testid="prompt-recall"
-        onClick={() => (props.onRecallPrevious as () => void)()}
-      >
-        recall
-      </button>
-    </div>
-  ),
+  default: (props: Record<string, unknown>) => {
+    // Simulate the ref callback: create a fake textarea and pass it back.
+    const el = document.createElement('textarea');
+    mockPromptTextarea = el;
+    (props.ref as ((el: HTMLTextAreaElement) => void) | undefined)?.(el);
+    return (
+      <div data-testid="prompt">
+        <span data-testid="prompt-disabled">{String(props.disabled)}</span>
+        {/* Touch every prop so SolidJS evaluates each accessor (coverage). */}
+        <span data-testid="prompt-value">{String(props.value)}</span>
+        <span data-testid="prompt-running">{String(props.running)}</span>
+        {props.headersSlot as JSX.Element}
+        <button data-testid="prompt-submit" onClick={() => (props.onSubmit as () => void)()}>
+          submit
+        </button>
+        <button
+          data-testid="prompt-set"
+          onClick={() => (props.onChange as (v: string) => void)('hello world')}
+        >
+          set
+        </button>
+        <button
+          data-testid="prompt-recall"
+          onClick={() => (props.onRecallPrevious as () => void)()}
+        >
+          recall
+        </button>
+      </div>
+    );
+  },
 }));
 
 let lastSummaryProps: Record<string, unknown> | null = null;
@@ -361,6 +368,7 @@ describe('Playground page', () => {
     lastSummaryProps = null;
     providerModalProps = null;
     sidebarContent = null;
+    mockPromptTextarea = null;
     searchParamsState.run = undefined;
     for (const k of Object.keys(lsStore)) delete lsStore[k];
     for (const k of Object.keys(ssStore)) delete ssStore[k];
@@ -821,6 +829,26 @@ describe('Playground page', () => {
       fireEvent.click(await find('sidebar-new'));
       // Store reset clears columns; pickDefaults reseeds afterwards.
       expect(setSearchParamsFn).toHaveBeenCalledWith({ run: undefined });
+    });
+
+    it('schedules focus on the prompt textarea via requestAnimationFrame when starting a new playground', async () => {
+      const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0);
+        return 0;
+      });
+      const focusSpy = vi.fn();
+      render(() => <Playground />);
+      await waitFor(() =>
+        expect(document.querySelectorAll('[data-testid^="col-"]').length).toBeGreaterThan(0),
+      );
+      // Attach a focus spy to the textarea that the mock handed to promptRef.
+      if (mockPromptTextarea) mockPromptTextarea.focus = focusSpy;
+      renderSidebar();
+      rafSpy.mockClear();
+      fireEvent.click(await find('sidebar-new'));
+      expect(rafSpy).toHaveBeenCalled();
+      expect(focusSpy).toHaveBeenCalled();
+      rafSpy.mockRestore();
     });
 
     it('Ctrl+Shift+O starts a new playground', async () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -191,7 +191,6 @@ vi.mock('../../src/components/RoutingModals.js', () => ({
       props.specificityAssignments,
       props.customProviders,
       props.connectedProviders,
-      props.onOpenProviderModal,
       props.onProviderPoll,
     ];
     void _read;
@@ -274,12 +273,6 @@ vi.mock('../../src/components/RoutingModals.js', () => ({
           }
         >
           spec-override
-        </button>
-        <button
-          data-testid="modal-trigger-open-provider"
-          onClick={() => (props.onOpenProviderModal as () => void)?.()}
-        >
-          open-provider
         </button>
         <button
           data-testid="modal-trigger-provider-update"
@@ -1108,20 +1101,6 @@ describe('Routing page', () => {
     });
   });
 
-  it('opens the provider modal via the modals onOpenProviderModal handler', async () => {
-    // The standalone "Connect providers" button was removed; the modal is now
-    // opened through the onOpenProviderModal callback (fired by the pickers'
-    // "connect providers" affordance), which RoutingModals receives.
-    render(() => <Routing />);
-    await waitFor(() => {
-      expect(screen.getByTestId('modal-trigger-open-provider')).toBeDefined();
-    });
-    fireEvent.click(screen.getByTestId('modal-trigger-open-provider'));
-    await waitFor(() => {
-      expect((lastModalsProps?.showProviderModal as () => boolean)()).toBe(true);
-    });
-  });
-
   it('provides a lightweight onProviderPoll that only refetches providers', async () => {
     render(() => <Routing />);
     await waitFor(() => {
@@ -1429,23 +1408,6 @@ describe('Routing page', () => {
     });
   });
 
-  it('closes the provider modal via the modals onProviderModalClose handler', async () => {
-    render(() => <Routing />);
-    await waitFor(() => {
-      expect(screen.getByTestId('modal-trigger-open-provider')).toBeDefined();
-    });
-    fireEvent.click(screen.getByTestId('modal-trigger-open-provider'));
-    // After opening, showProviderModal accessor reports true.
-    await waitFor(() => {
-      expect((lastModalsProps?.showProviderModal as () => boolean)()).toBe(true);
-    });
-    fireEvent.click(screen.getByTestId('modal-trigger-provider-close'));
-    // After close, the signal flips back to false.
-    await waitFor(() => {
-      expect((lastModalsProps?.showProviderModal as () => boolean)()).toBe(false);
-    });
-  });
-
   it('closes the instruction modal via onInstructionClose', async () => {
     render(() => <Routing />);
     await waitFor(() => {
@@ -1664,41 +1626,6 @@ describe('Routing page', () => {
       baseUrl: undefined,
       apiKey: undefined,
       models: undefined,
-    });
-  });
-
-  it('opens the instruction modal when closing the provider modal after a fresh enable', async () => {
-    // Step 1: render with a connected-but-inactive provider.
-    mockGetProviders.mockResolvedValueOnce([
-      {
-        ...baseProvider,
-        is_active: false,
-      },
-    ]);
-    render(() => <Routing />);
-    // Wait until the providers resource has resolved with the inactive
-    // provider. The empty-state ("No providers connected") only renders once
-    // loading is done, which guarantees the openProviderModal snapshot below
-    // sees hadProviders=true (a connected-but-inactive provider exists).
-    await waitFor(() => {
-      expect(screen.getByText('No providers connected')).toBeDefined();
-    });
-    // Step 2: open the provider modal (snapshots wasEnabled=false, hadProviders=true).
-    fireEvent.click(screen.getByTestId('modal-trigger-open-provider'));
-    // Step 3: simulate the modal closing AFTER provider became active.
-    mockGetProviders.mockResolvedValue([baseProvider]); // active provider
-    // Trigger a refetch path so connectedProviders updates to is_active=true.
-    fireEvent.click(screen.getByTestId('modal-trigger-provider-update'));
-    await waitFor(() => {
-      expect(mockGetProviders).toHaveBeenCalledTimes(2);
-    });
-    fireEvent.click(screen.getByTestId('modal-trigger-provider-close'));
-    // closeProviderModal sets instructionModal to 'enable' because
-    // wasEnabledBeforeModal()=false, isEnabled()=true now, hadProvidersBeforeModal()=true.
-    await waitFor(() => {
-      expect((lastModalsProps?.instructionModal as () => string | null)()).toBe('enable');
-      // And the provider modal flipped back to closed.
-      expect((lastModalsProps?.showProviderModal as () => boolean)()).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- **Model picker empty state**: add spacing between text and "Connect provider" button, navigate to the agent's Providers tab instead of opening a modal
- **Playground**: auto-focus the prompt textarea on "New run" (click and keyboard shortcut)
- **Sidebar**: unify the HARNESSES header hover so the + button is visually inside the row
- **Upgrade modal**: fix text ("You're now on the Pro plan") and raise z-index above the header

## Test plan

- [ ] Open model picker with no providers connected — verify spacing and "Connect provider" navigates to Providers tab
- [ ] In Playground, click "New run" or press Cmd+Shift+O — verify prompt textarea gets focus
- [ ] Hover the HARNESSES sidebar section — verify unified hover background covers label + add button
- [ ] Subscribe to Pro plan — verify upgrade modal appears above the header
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished UI across the model picker, playground, sidebar, and upgrade modal for a clearer, smoother experience. The model picker now routes to Providers, the playground prompt auto-focuses on new runs, and the upgrade modal overlays the header with correct copy.

- **Bug Fixes**
  - Model picker empty state: added spacing; “Connect provider” navigates to the agent’s Providers tab.
  - Playground: on “New run” (click or Cmd+Shift+O), focus moves to the prompt textarea.
  - Sidebar: HARNESSES header hover covers the label and + button; add button sits visually inside the row.
  - Upgrade modal: title updated to “You’re now on the Pro plan”; backdrop z-index raised so it appears above the header.

- **Refactors**
  - Removed unused `onOpenProviderModal` prop from `RoutingModals`; navigation now uses the router.
  - Tests updated: added coverage for prompt ref forwarding and new-run focus; added navigation assertions for Providers routing; removed provider-modal tests and updated assertions for the new upgrade copy.

<sup>Written for commit 6f7d88458ef73f5ac9c2f4dfc0b73056cfd5a79f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
