### PR TITLE
feat: add Meta provider (Meta Model API) so muse-spark-1.1 is routable

### DIFF
--- a/packages/backend/src/common/constants/providers.spec.ts
+++ b/packages/backend/src/common/constants/providers.spec.ts
@@ -168,6 +168,17 @@ describe('PROVIDER_REGISTRY', () => {
     expect(pioneer!.keyPrefix).toBe('pio_sk_');
     expect(pioneer!.keyPlaceholder).toBe('pio_sk_...');
   });
+
+  it('meta is registered as a native API-key provider without OpenRouter prefixes', () => {
+    const meta = PROVIDER_REGISTRY.find((p) => p.id === 'meta');
+    expect(meta).toBeDefined();
+    expect(meta!.displayName).toBe('Meta');
+    expect(meta!.aliases).toEqual(['meta-model-api', 'meta model api']);
+    expect(meta!.openRouterPrefixes).toEqual([]);
+    expect(meta!.requiresApiKey).toBe(true);
+    expect(meta!.localOnly).toBe(false);
+    expect(meta!.keyPlaceholder).toBe('MODEL_API_KEY');
+  });
 });
 
 describe('PROVIDER_BY_ID', () => {
@@ -257,6 +268,15 @@ describe('PROVIDER_BY_ID_OR_ALIAS', () => {
       expect(entry).toBeDefined();
       expect(entry.id).toBe('pioneer');
       expect(entry.displayName).toBe('Pioneer');
+    }
+  });
+
+  it('resolves Meta Model API aliases to meta', () => {
+    for (const name of ['meta', 'meta-model-api', 'meta model api']) {
+      const entry = PROVIDER_BY_ID_OR_ALIAS.get(name) as ProviderRegistryEntry;
+      expect(entry).toBeDefined();
+      expect(entry.id).toBe('meta');
+      expect(entry.displayName).toBe('Meta');
     }
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -35,6 +35,7 @@ describe('ProviderModelFetcherService', () => {
       'nvidia',
       'xai',
       'minimax',
+      'meta',
       'minimax-subscription',
       'xiaomi',
       'xiaomi-subscription',
@@ -106,6 +107,38 @@ describe('ProviderModelFetcherService', () => {
       contextWindow: 128000,
       inputPricePerToken: null,
       outputPricePerToken: null,
+    });
+  });
+
+  it('should fetch Meta Model API models and keep only verified Muse Spark', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 'muse-spark-1.1' },
+          { id: 'unknown-meta-model' },
+          { id: 'text-embedding-test' },
+        ],
+      }),
+    });
+
+    const result = await service.fetch('meta', 'meta-api-key');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.meta.ai/v1/models',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer meta-api-key' },
+      }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'muse-spark-1.1',
+      displayName: 'muse-spark-1.1',
+      provider: 'meta',
+      contextWindow: 1048576,
+      inputPricePerToken: null,
+      outputPricePerToken: null,
+      inputModalities: ['text', 'image'],
     });
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -45,6 +45,8 @@ const NOUS_PORTAL_MODELS_URL = 'https://inference-api.nousresearch.com/v1/models
 const OPENCODE_GO_MODELS_URL = 'https://opencode.ai/zen/go/v1/models';
 const PIONEER_MODELS_URL = 'https://api.pioneer.ai/v1/models';
 const PIONEER_BASE_MODELS_URL = 'https://api.pioneer.ai/base-models';
+const META_MODELS_URL = 'https://api.meta.ai/v1/models';
+const MUSE_SPARK_CONTEXT_WINDOW = 1048576;
 
 /* ── Generic parser factory ── */
 
@@ -221,6 +223,22 @@ const parseXiaomiMimo = createModelParser<OpenAIModelEntry>({
   contextWindow: (entry) => XIAOMI_MIMO_CONTEXT_WINDOWS.get(entry.id) ?? DEFAULT_CONTEXT_WINDOW,
   capabilityCode: true,
 });
+
+const parseMeta = createModelParser<OpenAIModelEntry>({
+  arrayKey: 'data',
+  filter: (entry) => entry.id === 'muse-spark-1.1',
+  getId: (entry) => entry.id,
+  getDisplayName: (_entry, id) => id,
+  contextWindow: MUSE_SPARK_CONTEXT_WINDOW,
+});
+
+function enrichMetaModels(models: DiscoveredModel[]): DiscoveredModel[] {
+  return models.map((model) =>
+    model.id === 'muse-spark-1.1'
+      ? { ...model, inputModalities: ['text', 'image'] as const }
+      : model,
+  );
+}
 
 /* ── OpenAI-specific structural filters (not non-chat) ── */
 
@@ -692,6 +710,11 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     endpoint: 'https://api.minimaxi.chat/v1/models',
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
+  },
+  meta: {
+    endpoint: META_MODELS_URL,
+    buildHeaders: bearerHeaders,
+    parse: (body, provider) => enrichMetaModels(parseMeta(body, provider)),
   },
   'minimax-subscription': {
     endpoint: MINIMAX_SUBSCRIPTION_MODELS_URL,

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -78,6 +78,7 @@ describe('resolveEndpointKey', () => {
     expect(resolveEndpointKey('nvidia')).toBe('nvidia');
     expect(resolveEndpointKey('ollama')).toBe('ollama');
     expect(resolveEndpointKey('kilo')).toBe('kilo');
+    expect(resolveEndpointKey('meta')).toBe('meta');
     expect(resolveEndpointKey('zai')).toBe('zai');
     expect(resolveEndpointKey('xiaomi')).toBe('xiaomi');
   });
@@ -115,6 +116,11 @@ describe('resolveEndpointKey', () => {
   it('resolves Pioneer aliases to pioneer', () => {
     expect(resolveEndpointKey('pioneer-ai')).toBe('pioneer');
     expect(resolveEndpointKey('Pioneer AI')).toBe('pioneer');
+  });
+
+  it('resolves Meta Model API aliases to meta', () => {
+    expect(resolveEndpointKey('meta-model-api')).toBe('meta');
+    expect(resolveEndpointKey('Meta Model API')).toBe('meta');
   });
 
   it('resolves Xiaomi MiMo aliases to xiaomi', () => {
@@ -162,6 +168,7 @@ describe('resolveEndpointKey', () => {
     expect(known).toContain('nous');
     expect(known).toContain('openrouter');
     expect(known).toContain('nvidia');
+    expect(known).toContain('meta');
     expect(known).toContain('ollama');
     expect(known).toContain('ollama-cloud');
     expect(known).toContain('qwen-subscription');
@@ -343,6 +350,17 @@ describe('PROVIDER_ENDPOINTS', () => {
     const headers = PROVIDER_ENDPOINTS['nvidia'].buildHeaders('nvapi-test-key');
     expect(headers).toEqual({
       Authorization: 'Bearer nvapi-test-key',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('meta uses the Meta Model API OpenAI-compatible endpoint', () => {
+    const ep = PROVIDER_ENDPOINTS['meta'];
+    expect(ep.baseUrl).toBe('https://api.meta.ai');
+    expect(ep.format).toBe('openai');
+    expect(ep.buildPath('muse-spark-1.1')).toBe('/v1/chat/completions');
+    expect(ep.buildHeaders('meta-api-key')).toEqual({
+      Authorization: 'Bearer meta-api-key',
       'Content-Type': 'application/json',
     });
   });
@@ -691,6 +709,7 @@ describe('PROVIDER_ENDPOINTS', () => {
       'mistral',
       'xai',
       'minimax',
+      'meta',
       'xiaomi',
       'moonshot',
       'nous',

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -120,6 +120,7 @@ const NOUS_PORTAL_BASE = 'https://inference-api.nousresearch.com';
 const NVIDIA_NIM_BASE = 'https://integrate.api.nvidia.com';
 const FIREWORKS_INFERENCE_BASE = 'https://api.fireworks.ai/inference';
 const PIONEER_BASE = 'https://api.pioneer.ai';
+const META_MODEL_API_BASE = 'https://api.meta.ai';
 const chatgptSubscriptionHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -267,6 +268,13 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   },
   minimax: {
     baseUrl: 'https://api.minimax.io',
+    buildHeaders: openaiHeaders,
+    buildPath: openaiPath,
+    format: 'openai',
+    ...openaiStreamUsage,
+  },
+  meta: {
+    baseUrl: META_MODEL_API_BASE,
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -9,6 +9,7 @@ export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   kiro: 'https://app.kiro.dev',
   groq: 'https://console.groq.com/keys',
   kilo: 'https://app.kilo.ai',
+  meta: 'https://ai.meta.com/blog/introducing-muse-spark-meta-model-api/',
   minimax: 'https://platform.minimax.io/user-center/basic-information/interface-key',
   mistral: 'https://console.mistral.ai/api-keys/',
   moonshot: 'https://platform.moonshot.ai/',

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -312,6 +312,11 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     },
     models: [],
   },
+  meta: {
+    initial: 'Me',
+    subtitle: 'Muse Spark via Meta Model API',
+    models: [{ label: 'Muse Spark 1.1', value: 'muse-spark-1.1' }],
+  },
   xiaomi: {
     initial: 'Mi',
     subtitle: 'MiMo V2.5 Pro, V2.5, Flash',
@@ -492,6 +497,7 @@ const PROVIDER_ORDER = [
   'kiro',
   'llamacpp',
   'lmstudio',
+  'meta',
   'minimax',
   'mistral',
   'moonshot',

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -206,6 +206,20 @@ describe('validateApiKey', () => {
     });
     expect(validateApiKey(nvidia, 'x'.repeat(20))).toEqual({ valid: true });
   });
+
+  it('validates Meta Model API keys by length without enforcing an undocumented prefix', () => {
+    const meta = getProvider('meta')!;
+    expect(meta.keyPlaceholder).toBe('MODEL_API_KEY');
+    expect(validateApiKey(meta, '')).toEqual({
+      valid: false,
+      error: 'API key is required',
+    });
+    expect(validateApiKey(meta, 'short')).toEqual({
+      valid: false,
+      error: 'Key is too short (minimum 20 characters)',
+    });
+    expect(validateApiKey(meta, 'x'.repeat(20))).toEqual({ valid: true });
+  });
 });
 
 /* ── validateSubscriptionKey ────────────────────── */
@@ -696,6 +710,18 @@ describe('PROVIDERS', () => {
     expect(kilo.models).toEqual([]);
   });
 
+  it('Meta is an API-key provider for Muse Spark', () => {
+    const meta = PROVIDERS.find((p) => p.id === 'meta')!;
+    expect(meta).toBeDefined();
+    expect(meta.name).toBe('Meta');
+    expect(meta.supportsSubscription).toBeUndefined();
+    expect(meta.subscriptionOnly).toBeUndefined();
+    expect(meta.keyPrefix).toBe('');
+    expect(meta.keyPlaceholder).toBe('MODEL_API_KEY');
+    expect(meta.minKeyLength).toBe(20);
+    expect(meta.models).toEqual([{ label: 'Muse Spark 1.1', value: 'muse-spark-1.1' }]);
+  });
+
   it('provides an API key URL for ollama-cloud in both the API-key and subscription maps', () => {
     expect(getRoutingProviderApiKeyUrl('ollama-cloud')).toBe('https://ollama.com/settings/keys');
     expect(getSubscriptionProviderKeyUrl('ollama-cloud')).toBe('https://ollama.com/settings/keys');
@@ -745,6 +771,13 @@ describe('PROVIDERS', () => {
   it('provides an API-key URL for Kilo', () => {
     expect(getRoutingProviderApiKeyUrl('kilo')).toBe('https://app.kilo.ai');
     expect(getSubscriptionProviderKeyUrl('kilo')).toBeUndefined();
+  });
+
+  it('provides an official Meta Model API URL', () => {
+    expect(getRoutingProviderApiKeyUrl('meta')).toBe(
+      'https://ai.meta.com/blog/introducing-muse-spark-meta-model-api/',
+    );
+    expect(getSubscriptionProviderKeyUrl('meta')).toBeUndefined();
   });
 
   it('exposes a subscription-key URL for every token-mode subscription-only provider', () => {

--- a/packages/shared/__tests__/providers.spec.ts
+++ b/packages/shared/__tests__/providers.spec.ts
@@ -221,6 +221,18 @@ describe('SHARED_PROVIDER_BY_ID', () => {
     expect(xiaomi!.minKeyLength).toBe(50);
     expect(xiaomi!.keyPlaceholder).toBe('sk-xxxxx');
   });
+
+  it('meta exposes the Meta Model API as a native API-key provider', () => {
+    const meta = SHARED_PROVIDER_BY_ID.get('meta');
+    expect(meta).toBeDefined();
+    expect(meta!.displayName).toBe('Meta');
+    expect(meta!.aliases).toEqual(['meta-model-api', 'meta model api']);
+    expect(meta!.openRouterPrefixes).toEqual([]);
+    expect(meta!.requiresApiKey).toBe(true);
+    expect(meta!.localOnly).toBe(false);
+    expect(meta!.keyPrefix).toBe('');
+    expect(meta!.keyPlaceholder).toBe('MODEL_API_KEY');
+  });
 });
 
 describe('LOCAL_SERVER_HINTS', () => {

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -232,6 +232,18 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     keyPlaceholder: 'sk-...',
   },
   {
+    id: 'meta',
+    displayName: 'Meta',
+    aliases: ['meta-model-api', 'meta model api'],
+    openRouterPrefixes: [],
+    requiresApiKey: true,
+    localOnly: false,
+    color: '#0668E1',
+    keyPrefix: '',
+    minKeyLength: 20,
+    keyPlaceholder: 'MODEL_API_KEY',
+  },
+  {
     id: 'xiaomi',
     displayName: 'Xiaomi MiMo',
     aliases: ['mimo', 'xiaomi-mimo', 'xiaomi mimo'],


### PR DESCRIPTION
### ✨ What changed
- Adds Meta (Meta Model API, `https://api.meta.ai/v1`, OpenAI-compatible) as a first-class provider — shared registry entry, native `/models` fetcher (restricted to `muse-spark-1.1`), routing endpoint, frontend entry, and api-key help link — so `muse-spark-1.1` can be connected and routed.

### 💭 Why
Meta launched its first public model API on July 9 2026 (Muse Spark 1.1: 1M context, multimodal). Meta is absent from the provider registry, so users cannot connect it — and the model is not on OpenRouter, so the fallback catalog cannot cover it either.

### 📝 Notes
- Verification: existence per the official Meta announcement; NOT on OpenRouter (checked 2026-07-11), so no cross-gateway probe was possible; interestingly `muse-spark-1.1` already appears in Manifest discovery via commandcode:subscription. No Meta API key available on the test stack (US-only preview) — untested end-to-end, hence draft.
- Typecheck + jest green across shared/backend/frontend per the authoring run; tests added in all three packages.
- https://ai.meta.com/blog/introducing-muse-spark-meta-model-api/
- https://simonwillison.net/2026/Jul/9/gpt-5-6/
- Draft PR, auto-generated by manifest-model-watch. Pricing (models.dev) and params (modelparams.dev) out of scope.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Meta Model API as a first-class provider so `muse-spark-1.1` can be connected and routed via our OpenAI-compatible flow.

- New Features
  - Added `meta` to the shared provider registry with aliases, API-key rules (min 20 chars, no prefix), and no OpenRouter prefixes.
  - Implemented native `/models` fetcher against https://api.meta.ai/v1/models, filtering to `muse-spark-1.1` with 1,048,576 context and text/image modalities.
  - Added routing endpoint for `meta` using OpenAI format (`/v1/chat/completions`) with Bearer auth.
  - Exposed Meta in the frontend provider list with “Muse Spark 1.1” and an API key help link.
  - Added tests across shared, backend, and frontend to cover registry, discovery, routing, and validation.

<sup>Written for commit 4f46aaad29d76e74a4bb3f680ed4528ae0e3b16c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

