### PR TITLE
fix: avoid Safari modal backdrop blur

### DIFF
--- a/.changeset/safari-modal-backdrop.md
+++ b/.changeset/safari-modal-backdrop.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix the harness sidebar rendering after creation in Safari.

--- a/packages/frontend/src/styles/modals.css
+++ b/packages/frontend/src/styles/modals.css
@@ -152,6 +152,13 @@
   animation: fadeIn 150ms ease-out;
 }
 
+/* Safari can miscompose a dynamically mounted backdrop filter. */
+@supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
+  .modal-overlay {
+    backdrop-filter: none;
+  }
+}
+
 .dark .modal-overlay {
   background: rgb(0 0 0 / 0.7);
 }


### PR DESCRIPTION
### ✨ What changed
- Remove the blur filter from the shared modal overlay.

### 💭 Why
Safari can miscompose a dynamically mounted backdrop filter, leaving the sidebar washed out after harness creation.

### 👤 For users
Creating a harness in Safari keeps the sidebar readable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the modal overlay `backdrop-filter` on Safari to fix a compositing bug that washed out the sidebar after harness creation. Other browsers keep the blur.

<sup>Written for commit 94e3f9fa0658d096372d5d9a3f6b4f87fe4d4415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

