### PR TITLE
chore: drop message compatibility view

### DIFF
--- a/.changeset/calm-requests-attempts.md
+++ b/.changeset/calm-requests-attempts.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Separate caller requests from provider attempts in storage, analytics, and the dashboard.

--- a/.changeset/drop-agent-messages-compat-view.md
+++ b/.changeset/drop-agent-messages-compat-view.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove the temporary database compatibility view after the request model rollout.

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { ManifestRequest } from '../entities/request.entity';
 import { Agent } from '../entities/agent.entity';
 import { Tenant } from '../entities/tenant.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
@@ -39,6 +40,7 @@ import { BillingModule } from '../billing/billing.module';
   imports: [
     TypeOrmModule.forFeature([
       AgentMessage,
+      ManifestRequest,
       Agent,
       Tenant,
       CustomProvider,

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -13,6 +13,15 @@ function mockAggregation(): Record<string, jest.Mock> {
     // Previous-window totals power the trend arrows; the current-window summary
     // is derived from the timeseries buckets below.
     getPreviousWindowMetrics: jest.fn().mockResolvedValue({ tokens: 900, cost: 4.0, messages: 45 }),
+    getRequestReliability: jest.fn().mockResolvedValue({
+      total: 50,
+      successful: 48,
+      success_rate: 96,
+      attempt_success_rate: 90,
+      manifest_lift_pct: 6,
+      recovered: 3,
+      previous_total: 45,
+    }),
     hasAnyData: jest.fn().mockResolvedValue(true),
   };
 }

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -109,10 +109,11 @@ describe('OverviewController', () => {
     );
   });
 
-  it('derives the current-window summary by summing the timeseries buckets', async () => {
+  it('derives token and cost totals from buckets and messages from requests', async () => {
     const result = await controller.getOverview({ range: '24h' }, ctx as never);
 
-    // 600 + 400 input/output tokens, $5 cost, 50 messages from the buckets.
+    // Tokens and cost come from attempt buckets; the message total comes from
+    // request reliability (the fixtures intentionally both contain 50).
     expect(result.summary.tokens_today.value).toBe(1000);
     expect(result.summary.tokens_today.sub_values).toEqual({ input: 600, output: 400 });
     expect(result.summary.cost_today.value).toBe(5.0);
@@ -121,6 +122,15 @@ describe('OverviewController', () => {
     expect(result.summary.tokens_today.trend_pct).toBe(11); // (1000-900)/900
     expect(result.summary.cost_today.trend_pct).toBe(25); // (5-4)/4
     expect(result.summary.messages.trend_pct).toBe(11); // (50-45)/45
+    expect(result.request_reliability).toEqual({
+      total: 50,
+      successful: 48,
+      success_rate: 96,
+      attempt_success_rate: 90,
+      manifest_lift_pct: 6,
+      recovered: 3,
+      previous_total: 45,
+    });
   });
 
   it('returns overview with daily timeseries for 7d range', async () => {
@@ -158,6 +168,7 @@ describe('OverviewController', () => {
     await controller.getOverview({ range: '24h', agent_name: 'bot-1' }, ctx as never);
 
     expect(agg.getPreviousWindowMetrics).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true);
+    expect(agg.getRequestReliability).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true);
     expect(ts.getTimeseries).toHaveBeenCalledWith(
       '24h',
       'tenant-123',

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -148,6 +148,36 @@ describe('OverviewController', () => {
     );
   });
 
+  it('uses request rows for recent activity when the request query service is available', async () => {
+    const requestItems = [{ id: 'request-1', status: 'ok' }];
+    const messagesQuery = { getMessages: jest.fn().mockResolvedValue({ items: requestItems }) };
+    const requestAwareController = new OverviewController(
+      agg as never,
+      ts as never,
+      { getProviders: mockGetProviders } as never,
+      { resolve: mockResolveAgent } as never,
+      { find: mockAccessFind } as never,
+      messagesQuery as never,
+    );
+
+    const result = await requestAwareController.getOverview(
+      { range: '24h', agent_name: 'bot-1' },
+      ctx as never,
+    );
+
+    expect(result.recent_activity).toEqual(requestItems);
+    expect(messagesQuery.getMessages).toHaveBeenCalledWith({
+      range: '24h',
+      tenantId: 'tenant-123',
+      agent_name: 'bot-1',
+      limit: 5,
+      include_total: false,
+      include_filter_options: false,
+      exclude_playground: true,
+    });
+    expect(ts.getRecentActivity).not.toHaveBeenCalled();
+  });
+
   it('returns combined agent usage timeseries', async () => {
     await controller.getOverviewAgentsUsage({ range: '24h' }, ctx as never);
     expect(ts.getAgentUsageTimeseries).toHaveBeenCalledWith('24h', 'tenant-123', true);

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseInterceptors } from '@nestjs/common';
+import { Controller, Get, Optional, Query, UseInterceptors } from '@nestjs/common';
 import { CacheTTL } from '@nestjs/cache-manager';
 import { RangeQueryDto } from '../../common/dto/range-query.dto';
 import { isHourlyRange } from '../../common/utils/range.util';
@@ -12,6 +12,8 @@ import { ResolveAgentService } from '../../routing/routing-core/resolve-agent.se
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
+import { computeTrend } from '../services/query-helpers';
+import { MessagesQueryService } from '../services/messages-query.service';
 
 /** Sum the timeseries buckets into current-window totals for the summary cards. */
 function sumTimeseries(tsData: {
@@ -41,6 +43,8 @@ export class OverviewController {
     private readonly resolveAgent: ResolveAgentService,
     @InjectRepository(AgentEnabledProvider)
     private readonly enabledProviderRepo: Repository<AgentEnabledProvider>,
+    @Optional()
+    private readonly messagesQuery?: MessagesQueryService,
   ) {}
 
   @Get('overview')
@@ -50,38 +54,55 @@ export class OverviewController {
     const hourly = isHourlyRange(range);
     const tenantId = ctx.tenantId;
 
-    const [prevMetrics, tsData, costByModel, recentActivity, activeSkills, hasData, hasProviders] =
-      await Promise.all([
-        // The overview excludes the reserved Playground (is_playground) agent's
-        // traffic EVERYWHERE: the per-agent/per-provider charts on the same page
-        // always drop it, so the summary cards, the aggregate timeseries and the
-        // breakdown widgets must agree or the page contradicts itself. Every call
-        // below passes excludePlayground=true so has_data and the visible widgets
-        // never disagree (a Playground-only tenant reads as empty, not a populated
-        // state painted over blank charts).
-        //
-        // The current-window summary is derived from the timeseries buckets
-        // below (which scan the same Playground-excluded rows), so we only query
-        // the previous window here for the trend arrows instead of repeating the
-        // full current+previous double-scan.
-        this.aggregation.getPreviousWindowMetrics(range, tenantId, agentName, true),
-        this.timeseries.getTimeseries(
-          range,
-          tenantId,
-          hourly,
-          agentName,
-          undefined,
-          undefined,
-          true,
-        ),
-        this.timeseries.getCostByModel(range, tenantId, agentName, true),
-        this.timeseries.getRecentActivity(range, tenantId, 5, agentName, true),
-        this.timeseries.getActiveSkills(range, tenantId, agentName, true),
-        this.aggregation.hasAnyData(tenantId, agentName, true),
-        this.hasActiveProviders(tenantId, agentName),
-      ]);
+    const [
+      prevMetrics,
+      requestReliability,
+      tsData,
+      costByModel,
+      recentActivity,
+      activeSkills,
+      hasData,
+      hasProviders,
+    ] = await Promise.all([
+      // The overview excludes the reserved Playground (is_playground) agent's
+      // traffic EVERYWHERE: the per-agent/per-provider charts on the same page
+      // always drop it, so the summary cards, the aggregate timeseries and the
+      // breakdown widgets must agree or the page contradicts itself. Every call
+      // below passes excludePlayground=true so has_data and the visible widgets
+      // never disagree (a Playground-only tenant reads as empty, not a populated
+      // state painted over blank charts).
+      //
+      // The current-window summary is derived from the timeseries buckets
+      // below (which scan the same Playground-excluded rows), so we only query
+      // the previous window here for the trend arrows instead of repeating the
+      // full current+previous double-scan.
+      this.aggregation.getPreviousWindowMetrics(range, tenantId, agentName, true),
+      this.aggregation.getRequestReliability(range, tenantId, agentName, true),
+      this.timeseries.getTimeseries(range, tenantId, hourly, agentName, undefined, undefined, true),
+      this.timeseries.getCostByModel(range, tenantId, agentName, true),
+      this.messagesQuery
+        ? this.messagesQuery
+            .getMessages({
+              range,
+              tenantId,
+              agent_name: agentName,
+              limit: 5,
+              include_total: false,
+              include_filter_options: false,
+              exclude_playground: true,
+            })
+            .then((result) => result.items)
+        : this.timeseries.getRecentActivity(range, tenantId, 5, agentName, true),
+      this.timeseries.getActiveSkills(range, tenantId, agentName, true),
+      this.aggregation.hasAnyData(tenantId, agentName, true),
+      this.hasActiveProviders(tenantId, agentName),
+    ]);
 
     const summary = AggregationService.buildSummary(sumTimeseries(tsData), prevMetrics);
+    summary.messages = {
+      value: requestReliability.total,
+      trend_pct: computeTrend(requestReliability.total, requestReliability.previous_total),
+    };
 
     return {
       summary: {
@@ -96,6 +117,7 @@ export class OverviewController {
       cost_by_model: costByModel,
       recent_activity: recentActivity,
       active_skills: activeSkills,
+      request_reliability: requestReliability,
       has_data: hasData,
       has_providers: hasProviders,
     };

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
@@ -142,6 +142,20 @@ describe('ProviderAnalyticsController', () => {
       );
     });
 
+    it.each(['90d', '365d'])('honors the Connection Detail %s range', async (range) => {
+      await controller.getAnalytics(ctx, undefined, range);
+      expect(aggregation.getSummaryMetrics).toHaveBeenCalledWith(
+        range,
+        'tenant-1',
+        undefined,
+        undefined,
+        undefined,
+        true,
+        undefined,
+        undefined,
+      );
+    });
+
     it('passes a null tenantId straight through when the account has no tenant', async () => {
       const noTenant: TenantContext = { tenantId: null, userId: 'u1' };
       await controller.getAnalytics(noTenant, 'subscription');
@@ -247,6 +261,19 @@ describe('ProviderAnalyticsController', () => {
         false,
         'api_key',
         'anthropic',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('uses 365d for matching provider timeseries endpoints', async () => {
+      await controller.getPerAgentMessageTimeseries(ctx, 'api_key', 'openai', '365d');
+      expect(timeseries.getPerAgentMessageTimeseries).toHaveBeenCalledWith(
+        '365d',
+        'tenant-1',
+        false,
+        'api_key',
+        'openai',
         undefined,
         undefined,
       );

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
@@ -69,7 +69,11 @@ describe('ProviderAnalyticsController', () => {
       getAgentNamesByAuthType: jest.fn().mockResolvedValue(['agent-1']),
     };
     providerRepo = { findOne: jest.fn() };
-    messageRepo = { createQueryBuilder: jest.fn() };
+    messageRepo = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValue(makeQb({ rawOne: { total: 0, successful: 0 } })),
+    };
 
     controller = new ProviderAnalyticsController(
       aggregation as unknown as AggregationService,

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
@@ -113,6 +113,14 @@ describe('ProviderAnalyticsController', () => {
       expect(out.token_usage).toEqual([{ hour: '01' }]);
     });
 
+    it('defaults missing provider-attempt reliability aggregates to zero', async () => {
+      messageRepo.createQueryBuilder.mockReturnValueOnce(makeQb({ rawOne: undefined }));
+
+      const out = await controller.getAnalytics(ctx, 'subscription');
+
+      expect(out.attempts).toEqual({ total: 0, successful: 0, success_rate: 0 });
+    });
+
     it('honors 7d range (non-hourly) and agent + provider filters', async () => {
       await controller.getAnalytics(ctx, 'api_key', '7d', 'agent-x', 'openai');
       expect(timeseries.getTimeseries).toHaveBeenCalledWith(

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -132,7 +132,7 @@ export class ProviderAnalyticsController {
     @Query('label') label?: string,
     @Query('connection_id') connectionId?: string,
   ) {
-    const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    const validRange = this.validateRange(range);
     const hourly = validRange === '24h';
 
     return this.timeseries.getPerAgentTimeseries(
@@ -155,7 +155,7 @@ export class ProviderAnalyticsController {
     @Query('label') label?: string,
     @Query('connection_id') connectionId?: string,
   ) {
-    const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    const validRange = this.validateRange(range);
     const hourly = validRange === '24h';
 
     return this.timeseries.getPerAgentMessageTimeseries(
@@ -178,7 +178,7 @@ export class ProviderAnalyticsController {
     @Query('label') label?: string,
     @Query('connection_id') connectionId?: string,
   ) {
-    const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    const validRange = this.validateRange(range);
     const hourly = validRange === '24h';
 
     return this.timeseries.getPerAgentCostTimeseries(
@@ -348,6 +348,6 @@ export class ProviderAnalyticsController {
   }
 
   private validateRange(range?: string): string {
-    return range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    return range === '7d' || range === '30d' || range === '90d' || range === '365d' ? range : '24h';
   }
 }

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -11,9 +11,12 @@ import {
   filterByTenantProviderId,
   excludePlaygroundAgents,
   sqlCountMessages,
+  addTenantFilter,
+  scopeToConnection,
 } from '../services/query-helpers';
 import { computeCutoff } from '../../common/utils/postgres-sql';
 import { sqlCastFloat, sqlSanitizeCost } from '../../common/utils/postgres-sql';
+import { rangeToInterval } from '../../common/utils/range.util';
 
 @Controller('api/v1/provider-analytics')
 export class ProviderAnalyticsController {
@@ -43,7 +46,7 @@ export class ProviderAnalyticsController {
     const hourly = validRange === '24h';
     const agent = agentName || undefined;
 
-    const [summary, ts] = await Promise.all([
+    const [summary, ts, attempts] = await Promise.all([
       // excludePlayground=true: Playground (is_playground) usage must not pollute
       // provider analytics aggregates.
       this.aggregation.getSummaryMetrics(
@@ -67,6 +70,15 @@ export class ProviderAnalyticsController {
         label,
         connectionId,
       ),
+      this.getAttemptReliability(
+        validRange,
+        ctx.tenantId,
+        agent,
+        authType,
+        provider,
+        label,
+        connectionId,
+      ),
     ]);
 
     return {
@@ -76,6 +88,38 @@ export class ProviderAnalyticsController {
       },
       token_usage: ts.tokenUsage,
       message_usage: ts.messageUsage,
+      attempts,
+    };
+  }
+
+  private async getAttemptReliability(
+    range: string,
+    tenantId: string | null,
+    agentName?: string,
+    authType?: string,
+    provider?: string,
+    label?: string,
+    connectionId?: string,
+  ): Promise<{ total: number; successful: number; success_rate: number }> {
+    const qb = this.messageRepo
+      .createQueryBuilder('at')
+      .select('COUNT(*)', 'total')
+      .addSelect("COUNT(*) FILTER (WHERE at.status = 'ok')", 'successful')
+      .where('at.timestamp >= :attemptCutoff', {
+        attemptCutoff: computeCutoff(rangeToInterval(range)),
+      });
+    addTenantFilter(qb, tenantId, agentName);
+    if (authType) qb.andWhere('at.auth_type = :attemptAuthType', { attemptAuthType: authType });
+    if (provider) qb.andWhere('at.provider = :attemptProvider', { attemptProvider: provider });
+    excludePlaygroundAgents(qb);
+    scopeToConnection(qb, connectionId, label);
+    const row = await qb.getRawOne();
+    const total = Number(row?.total ?? 0);
+    const successful = Number(row?.successful ?? 0);
+    return {
+      total,
+      successful,
+      success_rate: total === 0 ? 0 : (successful / total) * 100,
     };
   }
 
@@ -178,7 +222,7 @@ export class ProviderAnalyticsController {
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
 
     // A connection is identified by its tenant_providers row id, stamped on
-    // agent_messages.tenant_provider_id at proxy time. Filtering on it pins every
+    // provider_attempts.tenant_provider_id at proxy time. Filtering on it pins every
     // widget below to the exact key that served each message — unlike the old
     // (provider, auth_type, label) tuple, two keys that share a label no longer
     // merge. Pre-upgrade rows the backfill could not disambiguate carry a NULL

--- a/packages/backend/src/analytics/controllers/provider-usage.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-usage.controller.ts
@@ -6,7 +6,7 @@ import { ProviderUsageService, ProviderUsageSummary } from '../services/provider
  * Usage half of the provider dashboard split. Config (cheap, from
  * `tenant_providers`) is served by `TenantProvidersController` at
  * `GET /api/v1/providers`; this endpoint serves the expensive per-(provider,
- * auth_type) usage stats so a config read never touches `agent_messages`.
+ * auth_type) usage stats so a config read never touches `provider_attempts`.
  *
  * The frontend fetches the two independently and merges by (provider,
  * auth_type), so the page paints from config immediately and fills in usage

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -294,7 +294,7 @@ describe('AgentLifecycleService', () => {
       await service.renameAgent('test-user', 'old-agent', 'new-agent', 'New Agent');
 
       expect(mockTransaction).toHaveBeenCalledTimes(1);
-      expect(mockExecute).toHaveBeenCalledTimes(3);
+      expect(mockExecute).toHaveBeenCalledTimes(4);
       expect(mockManagerQb.update).toHaveBeenCalledWith('agents');
       expect(mockManagerQb.set).toHaveBeenCalledWith({
         name: 'new-agent',
@@ -304,13 +304,14 @@ describe('AgentLifecycleService', () => {
       const updateCalls = mockManagerQb.update.mock.calls.map((c: unknown[]) => c[0]);
       expect(updateCalls).toContain('agents');
       expect(updateCalls).toContain('provider_attempts');
+      expect(updateCalls).toContain('requests');
       expect(updateCalls).toContain('notification_rules');
       expect(updateCalls).not.toContain('notification_logs');
 
       const tenantScopedWhereCalls = mockManagerQb.where.mock.calls.filter(
         (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('tenant_id'),
       );
-      expect(tenantScopedWhereCalls.length).toBe(2);
+      expect(tenantScopedWhereCalls.length).toBe(3);
       for (const call of tenantScopedWhereCalls) {
         expect(call[1]).toEqual({ tenantId: 'tenant-1', currentName: 'old-agent' });
       }

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -303,7 +303,7 @@ describe('AgentLifecycleService', () => {
 
       const updateCalls = mockManagerQb.update.mock.calls.map((c: unknown[]) => c[0]);
       expect(updateCalls).toContain('agents');
-      expect(updateCalls).toContain('agent_messages');
+      expect(updateCalls).toContain('provider_attempts');
       expect(updateCalls).toContain('notification_rules');
       expect(updateCalls).not.toContain('notification_logs');
 

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -150,7 +150,7 @@ export class AgentLifecycleService {
 
       // Scope all denormalised agent_name columns by tenant_id so we don't
       // rewrite rows belonging to other tenants that happen to share the slug.
-      const tenantScoped = ['agent_messages', 'notification_rules'] as const;
+      const tenantScoped = ['provider_attempts', 'notification_rules'] as const;
       await Promise.all(
         tenantScoped.map((table) =>
           manager

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -150,7 +150,7 @@ export class AgentLifecycleService {
 
       // Scope all denormalised agent_name columns by tenant_id so we don't
       // rewrite rows belonging to other tenants that happen to share the slug.
-      const tenantScoped = ['provider_attempts', 'notification_rules'] as const;
+      const tenantScoped = ['provider_attempts', 'requests', 'notification_rules'] as const;
       await Promise.all(
         tenantScoped.map((table) =>
           manager

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -98,6 +98,31 @@ describe('AggregationService', () => {
       expect(clauses).toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
     });
 
+    it('treats a zero-attempt request as data', async () => {
+      const attemptQb = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue(null),
+      };
+      const requestQb = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ '?column?': 1 }),
+      };
+      const requestAware = new AggregationService(
+        { createQueryBuilder: jest.fn(() => attemptQb) } as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      await expect(requestAware.hasAnyData('tenant-1', undefined, true)).resolves.toBe(true);
+      expect(requestQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('playag.name = r.agent_name'),
+      );
+    });
+
     it('does not exclude Playground traffic by default', async () => {
       mockGetRawOne.mockResolvedValueOnce({ '?column?': 1 });
       await service.hasAnyData('tenant-1');

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -123,6 +123,34 @@ describe('AggregationService', () => {
       );
     });
 
+    it('scopes request-only data by live agent and handles a missing tenant', async () => {
+      const attemptQb = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue(null),
+      };
+      const requestQb = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue(null),
+      };
+      const requestAware = new AggregationService(
+        { createQueryBuilder: jest.fn(() => attemptQb) } as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      await expect(requestAware.hasAnyData('tenant-1', 'agent-1')).resolves.toBe(false);
+      expect(requestQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('deleted_at IS NULL'),
+        { requestAgentName: 'agent-1' },
+      );
+      await expect(requestAware.hasAnyData(null)).resolves.toBe(false);
+      expect(requestQb.where).toHaveBeenCalledWith('1 = 0');
+    });
+
     it('does not exclude Playground traffic by default', async () => {
       mockGetRawOne.mockResolvedValueOnce({ '?column?': 1 });
       await service.hasAnyData('tenant-1');
@@ -320,6 +348,69 @@ describe('AggregationService', () => {
       expect(
         clauses.some((c: unknown) => typeof c === 'string' && c.includes('is_playground')),
       ).toBe(true);
+    });
+  });
+
+  describe('getRequestReliability', () => {
+    it('returns zero metrics without a tenant', async () => {
+      await expect(service.getRequestReliability('24h', null)).resolves.toEqual({
+        total: 0,
+        successful: 0,
+        success_rate: 0,
+        attempt_success_rate: 0,
+        manifest_lift_pct: 0,
+        recovered: 0,
+        previous_total: 0,
+      });
+    });
+
+    it('combines request and attempt reliability with agent and Playground scopes', async () => {
+      const query = jest.fn().mockResolvedValue([
+        {
+          total: '4',
+          successful: '3',
+          attempts: '6',
+          successful_attempts: '4',
+          recovered: '2',
+          previous_total: '5',
+        },
+      ]);
+      const requestAware = new AggregationService({ query } as never, {} as never);
+
+      const result = await requestAware.getRequestReliability('24h', 'tenant-1', 'agent-1', true);
+
+      expect(result).toEqual({
+        total: 4,
+        successful: 3,
+        success_rate: 75,
+        attempt_success_rate: (4 / 6) * 100,
+        manifest_lift_pct: 75 - (4 / 6) * 100,
+        recovered: 2,
+        previous_total: 5,
+      });
+      expect(query).toHaveBeenCalledWith(expect.stringContaining('scoped_requests'), [
+        'tenant-1',
+        expect.any(String),
+        expect.any(String),
+        'agent-1',
+      ]);
+      expect(query.mock.calls[0][0]).toContain('playag.is_playground = true');
+    });
+
+    it('avoids division by zero when no scoped rows exist', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+      const requestAware = new AggregationService({ query } as never, {} as never);
+
+      await expect(requestAware.getRequestReliability('7d', 'tenant-1')).resolves.toEqual({
+        total: 0,
+        successful: 0,
+        success_rate: 0,
+        attempt_success_rate: 0,
+        manifest_lift_pct: 0,
+        recovered: 0,
+        previous_total: 0,
+      });
+      expect(query.mock.calls[0][1]).toHaveLength(3);
     });
   });
 

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
@@ -10,8 +10,10 @@ import {
   excludePlaygroundAgents,
   scopeToConnection,
   sqlCountMessages,
+  sqlExcludePlayground,
 } from './query-helpers';
 import { computeCutoff, sqlSanitizeCost } from '../../common/utils/postgres-sql';
+import { ManifestRequest } from '../../entities/request.entity';
 
 export { MetricWithTrend };
 
@@ -25,6 +27,9 @@ export class AggregationService {
   constructor(
     @InjectRepository(AgentMessage)
     private readonly turnRepo: Repository<AgentMessage>,
+    @Optional()
+    @InjectRepository(ManifestRequest)
+    private readonly requestRepo?: Repository<ManifestRequest>,
   ) {}
 
   async hasAnyData(
@@ -32,14 +37,35 @@ export class AggregationService {
     agentName?: string,
     excludePlayground = false,
   ): Promise<boolean> {
-    const qb = this.turnRepo.createQueryBuilder('at').select('1').limit(1);
-    addTenantFilter(qb, tenantId, agentName);
+    const attemptQb = this.turnRepo.createQueryBuilder('at').select('1').limit(1);
+    addTenantFilter(attemptQb, tenantId, agentName);
     // Mirror the overview's exclusion: a tenant whose only traffic is Playground
     // must read as empty, or has_data=true paints a non-empty state over cards
     // and charts that all dropped Playground and so render blank.
-    if (excludePlayground) excludePlaygroundAgents(qb);
-    const row = await qb.getRawOne();
-    return row != null;
+    if (excludePlayground) excludePlaygroundAgents(attemptQb);
+
+    let requestRow: Promise<unknown> = Promise.resolve(null);
+    if (this.requestRepo) {
+      const requestQb = this.requestRepo.createQueryBuilder('r').select('1').limit(1);
+      if (tenantId)
+        requestQb.where('r.tenant_id = :requestTenantId', { requestTenantId: tenantId });
+      else requestQb.where('1 = 0');
+      if (agentName && tenantId) {
+        requestQb.andWhere(
+          `r.agent_id = (
+            SELECT id FROM agents
+            WHERE tenant_id = :requestTenantId AND name = :requestAgentName AND deleted_at IS NULL
+            LIMIT 1
+          )`,
+          { requestAgentName: agentName },
+        );
+      }
+      if (excludePlayground) requestQb.andWhere(sqlExcludePlayground('r'));
+      requestRow = requestQb.getRawOne();
+    }
+
+    const [attempt, request] = await Promise.all([attemptQb.getRawOne(), requestRow]);
+    return attempt != null || request != null;
   }
 
   async getPreviousTokenTotal(
@@ -204,9 +230,7 @@ export class AggregationService {
           LIMIT 1
         )`
       : '';
-    const playgroundPredicate = excludePlayground
-      ? `AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.id = r.agent_id AND a.is_playground = true)`
-      : '';
+    const playgroundPredicate = excludePlayground ? `AND ${sqlExcludePlayground('r')}` : '';
     const unlinkedAgentPredicate = agentName
       ? `AND pa.agent_id = (
           SELECT id FROM agents
@@ -215,7 +239,7 @@ export class AggregationService {
         )`
       : '';
     const unlinkedPlaygroundPredicate = excludePlayground
-      ? `AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.id = pa.agent_id AND a.is_playground = true)`
+      ? `AND ${sqlExcludePlayground('pa')}`
       : '';
     const queryParams = agentName
       ? [tenantId, prevCutoff, cutoff, agentName]

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -170,6 +170,122 @@ export class AggregationService {
     };
   }
 
+  /** Request-level reliability for the headline KPI and Manifest value gap. */
+  async getRequestReliability(
+    range: string,
+    tenantId: string | null,
+    agentName?: string,
+    excludePlayground = false,
+  ): Promise<{
+    total: number;
+    successful: number;
+    success_rate: number;
+    attempt_success_rate: number;
+    manifest_lift_pct: number;
+    recovered: number;
+    previous_total: number;
+  }> {
+    if (!tenantId) {
+      return {
+        total: 0,
+        successful: 0,
+        success_rate: 0,
+        attempt_success_rate: 0,
+        manifest_lift_pct: 0,
+        recovered: 0,
+        previous_total: 0,
+      };
+    }
+    const { cutoff, prevCutoff } = this.computeWindow(range);
+    const agentPredicate = agentName
+      ? `AND r.agent_id = (
+          SELECT id FROM agents
+          WHERE tenant_id = $1 AND name = $4 AND deleted_at IS NULL
+          LIMIT 1
+        )`
+      : '';
+    const playgroundPredicate = excludePlayground
+      ? `AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.id = r.agent_id AND a.is_playground = true)`
+      : '';
+    const unlinkedAgentPredicate = agentName
+      ? `AND pa.agent_id = (
+          SELECT id FROM agents
+          WHERE tenant_id = $1 AND name = $4 AND deleted_at IS NULL
+          LIMIT 1
+        )`
+      : '';
+    const unlinkedPlaygroundPredicate = excludePlayground
+      ? `AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.id = pa.agent_id AND a.is_playground = true)`
+      : '';
+    const rows = (await this.turnRepo.query(
+      `WITH scoped_requests AS (
+         SELECT r.id, r.timestamp, r.status
+         FROM requests r
+         WHERE r.tenant_id = $1
+           AND r.timestamp >= $2
+           ${agentPredicate}
+           ${playgroundPredicate}
+         UNION ALL
+         SELECT 'unlinked:' || pa.id, pa.timestamp, pa.status
+         FROM provider_attempts pa
+         WHERE pa.request_id IS NULL
+           AND pa.tenant_id = $1
+           AND pa.timestamp >= $2
+           ${unlinkedAgentPredicate}
+           ${unlinkedPlaygroundPredicate}
+       ), attempt_stats AS (
+         SELECT pa.request_id,
+                COUNT(*) AS attempts,
+                COUNT(*) FILTER (WHERE pa.status = 'ok') AS successful_attempts,
+                BOOL_OR(pa.status <> 'ok') AS had_failure
+         FROM provider_attempts pa
+         JOIN scoped_requests r ON r.id = pa.request_id
+         GROUP BY pa.request_id
+         UNION ALL
+         SELECT r.id,
+                1 AS attempts,
+                CASE WHEN pa.status = 'ok' THEN 1 ELSE 0 END AS successful_attempts,
+                pa.status <> 'ok' AS had_failure
+         FROM provider_attempts pa
+         JOIN scoped_requests r ON r.id = 'unlinked:' || pa.id
+         WHERE pa.request_id IS NULL
+       )
+       SELECT
+         COUNT(*) FILTER (WHERE r.timestamp >= $3)::int AS total,
+         COUNT(*) FILTER (WHERE r.timestamp >= $3 AND r.status = 'ok')::int AS successful,
+         COUNT(*) FILTER (WHERE r.timestamp < $3)::int AS previous_total,
+         COALESCE(SUM(a.attempts) FILTER (WHERE r.timestamp >= $3), 0)::int AS attempts,
+         COALESCE(SUM(a.successful_attempts) FILTER (WHERE r.timestamp >= $3), 0)::int AS successful_attempts,
+         COUNT(*) FILTER (WHERE r.timestamp >= $3 AND r.status = 'ok' AND a.had_failure)::int AS recovered
+       FROM scoped_requests r
+       LEFT JOIN attempt_stats a ON a.request_id = r.id`,
+      [tenantId, prevCutoff, cutoff, agentName ?? null],
+    )) as Array<{
+      total: number;
+      successful: number;
+      previous_total: number;
+      attempts: number;
+      successful_attempts: number;
+      recovered: number;
+    }>;
+    const row = rows[0];
+    const total = Number(row?.total ?? 0);
+    const successful = Number(row?.successful ?? 0);
+    const attempts = Number(row?.attempts ?? 0);
+    const successfulAttempts = Number(row?.successful_attempts ?? 0);
+    const successRate = total === 0 ? 0 : (successful / total) * 100;
+    const attemptSuccessRate = attempts === 0 ? 0 : (successfulAttempts / attempts) * 100;
+    return {
+      total,
+      successful,
+      success_rate: successRate,
+      attempt_success_rate: attemptSuccessRate,
+      manifest_lift_pct: successRate - attemptSuccessRate,
+      recovered: Number(row?.recovered ?? 0),
+      previous_total: Number(row?.previous_total ?? 0),
+    };
+  }
+
   /**
    * Assemble the Overview summary cards (value + trend vs the previous window)
    * from already-computed current totals and previous-window totals. Pure (no

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -217,6 +217,9 @@ export class AggregationService {
     const unlinkedPlaygroundPredicate = excludePlayground
       ? `AND NOT EXISTS (SELECT 1 FROM agents a WHERE a.id = pa.agent_id AND a.is_playground = true)`
       : '';
+    const queryParams = agentName
+      ? [tenantId, prevCutoff, cutoff, agentName]
+      : [tenantId, prevCutoff, cutoff];
     const rows = (await this.turnRepo.query(
       `WITH scoped_requests AS (
          SELECT r.id, r.timestamp, r.status
@@ -259,7 +262,7 @@ export class AggregationService {
          COUNT(*) FILTER (WHERE r.timestamp >= $3 AND r.status = 'ok' AND a.had_failure)::int AS recovered
        FROM scoped_requests r
        LEFT JOIN attempt_stats a ON a.request_id = r.id`,
-      [tenantId, prevCutoff, cutoff, agentName ?? null],
+      queryParams,
     )) as Array<{
       total: number;
       successful: number;

--- a/packages/backend/src/analytics/services/error-breakdown.service.ts
+++ b/packages/backend/src/analytics/services/error-breakdown.service.ts
@@ -5,7 +5,7 @@ import { ERROR_ORIGINS, MANIFEST_ERROR_ORIGINS } from 'manifest-shared';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { rangeToInterval } from '../../common/utils/range.util';
 import { computeCutoff } from '../../common/utils/postgres-sql';
-import { addTenantFilter, excludePlaygroundAgents, sqlCountMessages } from './query-helpers';
+import { addTenantFilter, excludePlaygroundAgents } from './query-helpers';
 
 export interface ErrorBreakdownResponse {
   range: string;
@@ -89,7 +89,7 @@ export class ErrorBreakdownService {
   ): Promise<number> {
     const qb = this.messageRepo
       .createQueryBuilder('at')
-      .select(sqlCountMessages(), 'count')
+      .select("COUNT(*) FILTER (WHERE at.status = 'ok')", 'count')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(qb, tenantId, agentName);
     excludePlaygroundAgents(qb);

--- a/packages/backend/src/analytics/services/message-details.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-details.service.spec.ts
@@ -292,4 +292,130 @@ describe('MessageDetailsService', () => {
     expect(result.message.error_class).toBe('no_provider_key');
     expect(result.message.superseded).toBe(false);
   });
+
+  it('rolls up all provider attempts into a request detail', async () => {
+    const requestRow = {
+      id: 'request-1',
+      tenant_id: 't1',
+      timestamp: '2026-07-14T10:00:00Z',
+      agent_name: 'my-agent',
+      requested_model: 'requested-model',
+      status: 'ok',
+      error_message: null,
+      error_code: null,
+      error_http_status: null,
+      error_origin: null,
+      error_class: null,
+      duration_ms: 900,
+      trace_id: 'trace-request',
+      session_key: 'session-request',
+      feedback_rating: 'like',
+      feedback_tags: 'Accurate,Fast',
+      feedback_details: 'good',
+      request_headers: { 'x-test': 'yes' },
+      request_params: { temperature: 0.2 },
+      caller_attribution: { sdk: 'openai-js' },
+    };
+    const attempts = [
+      {
+        ...baseMessage,
+        id: 'attempt-1',
+        status: 'error',
+        provider: 'openai',
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_tokens: 1,
+        cache_creation_tokens: 2,
+        cost_usd: null,
+        duration_ms: null,
+      },
+      {
+        ...baseMessage,
+        id: 'attempt-2',
+        status: 'ok',
+        provider: 'anthropic',
+        model: 'claude',
+        input_tokens: 20,
+        output_tokens: 8,
+        cache_read_tokens: 3,
+        cache_creation_tokens: 4,
+        cost_usd: 0.12,
+        duration_ms: 400,
+        autofix_applied: true,
+      },
+    ];
+    const requestAware = new MessageDetailsService(
+      { find: jest.fn().mockResolvedValue(attempts) } as never,
+      { findOne: jest.fn().mockResolvedValue(requestRow) } as never,
+    );
+
+    const result = await requestAware.getDetails('request-1', 't1');
+
+    expect(result.message).toEqual(
+      expect.objectContaining({
+        id: 'request-1',
+        model: 'claude',
+        input_tokens: 30,
+        output_tokens: 13,
+        cache_read_tokens: 4,
+        cache_creation_tokens: 6,
+        cost_usd: 0.12,
+        duration_ms: 400,
+        trace_id: 'trace-request',
+        session_key: 'session-request',
+        feedback_tags: ['Accurate', 'Fast'],
+        autofix_applied: true,
+      }),
+    );
+    expect(result.message.attempts).toEqual([
+      expect.objectContaining({ id: 'attempt-1', provider: 'openai' }),
+      expect.objectContaining({ id: 'attempt-2', provider: 'anthropic' }),
+    ]);
+  });
+
+  it('returns a zero-attempt request with request-level fallbacks', async () => {
+    const requestAware = new MessageDetailsService(
+      { find: jest.fn().mockResolvedValue([]) } as never,
+      {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'request-zero',
+          tenant_id: 't1',
+          timestamp: '2026-07-14T10:00:00Z',
+          agent_name: null,
+          requested_model: 'gpt-4o',
+          status: 'error',
+          error_message: 'No provider',
+          error_code: 'MNFST001',
+          error_http_status: 400,
+          error_origin: 'config',
+          error_class: 'no_provider',
+          duration_ms: 15,
+          trace_id: null,
+          session_key: null,
+          feedback_rating: null,
+          feedback_tags: null,
+          feedback_details: null,
+          request_headers: null,
+          request_params: null,
+          caller_attribution: null,
+        }),
+      } as never,
+    );
+
+    const result = await requestAware.getDetails('request-zero', 't1');
+
+    expect(result.message).toEqual(
+      expect.objectContaining({
+        id: 'request-zero',
+        model: 'gpt-4o',
+        status: 'error',
+        error_code: 'MNFST001',
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_usd: 0,
+        duration_ms: 15,
+        attempts: [],
+      }),
+    );
+  });
 });

--- a/packages/backend/src/analytics/services/message-details.service.ts
+++ b/packages/backend/src/analytics/services/message-details.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import type { CallerAttribution } from '../../routing/proxy/caller-classifier';
 import type { PhoenixOperation } from '../../routing/autofix/phoenix.types';
 import type { RequestParamDefaults } from 'manifest-shared';
+import { ManifestRequest } from '../../entities/request.entity';
 
 export interface MessageDetailResponse {
   message: {
@@ -58,6 +59,15 @@ export interface MessageDetailResponse {
     } | null;
     /** The paired row (failed original ↔ successful retry), for the visual link. */
     autofix_sibling: { id: string; role: string | null; status: string } | null;
+    attempts?: Array<{
+      id: string;
+      model: string | null;
+      provider: string | null;
+      status: string;
+      error_http_status: number | null;
+      duration_ms: number | null;
+      cost_usd: number | null;
+    }>;
   };
 }
 
@@ -66,76 +76,130 @@ export class MessageDetailsService {
   constructor(
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
+    @Optional()
+    @InjectRepository(ManifestRequest)
+    private readonly requestRepo?: Repository<ManifestRequest>,
   ) {}
 
   async getDetails(messageId: string, tenantId: string | null): Promise<MessageDetailResponse> {
     // No tenant → no messages, so any id is unknown.
     if (!tenantId) throw new NotFoundException('Message not found');
 
-    const message = await this.messageRepo
-      .createQueryBuilder('m')
-      .where('m.id = :id', { id: messageId })
-      .andWhere('m.tenant_id = :tenantId', { tenantId })
-      .getOne();
-    if (!message) throw new NotFoundException('Message not found');
+    const request = this.requestRepo
+      ? await this.requestRepo.findOne({ where: { id: messageId, tenant_id: tenantId } })
+      : null;
+    const attempts = request
+      ? await this.messageRepo.find({
+          where: { request_id: request.id, tenant_id: tenantId },
+          order: { timestamp: 'ASC' },
+        })
+      : [];
+    const message = request
+      ? ([...attempts].reverse().find((attempt) => attempt.status === 'ok') ??
+        attempts[attempts.length - 1] ??
+        null)
+      : await this.messageRepo
+          .createQueryBuilder('m')
+          .where('m.id = :id', { id: messageId })
+          .andWhere('m.tenant_id = :tenantId', { tenantId })
+          .getOne();
+    if (!message && !request) throw new NotFoundException('Message not found');
 
-    const autofix_sibling = message.autofix_group_id
+    const autofix_sibling = message?.autofix_group_id
       ? await this.findAutofixSibling(message.id, message.autofix_group_id, tenantId)
       : null;
 
-    return {
+    const inputTokens = request
+      ? attempts.reduce((sum, attempt) => sum + attempt.input_tokens, 0)
+      : message!.input_tokens;
+    const outputTokens = request
+      ? attempts.reduce((sum, attempt) => sum + attempt.output_tokens, 0)
+      : message!.output_tokens;
+    const cacheReadTokens = request
+      ? attempts.reduce((sum, attempt) => sum + attempt.cache_read_tokens, 0)
+      : message!.cache_read_tokens;
+    const cacheCreationTokens = request
+      ? attempts.reduce((sum, attempt) => sum + attempt.cache_creation_tokens, 0)
+      : message!.cache_creation_tokens;
+    const cost = request
+      ? attempts.reduce((sum, attempt) => sum + Number(attempt.cost_usd ?? 0), 0)
+      : message!.cost_usd;
+    const duration = request
+      ? attempts.length > 0
+        ? attempts.reduce((sum, attempt) => sum + (attempt.duration_ms ?? 0), 0)
+        : request.duration_ms
+      : message!.duration_ms;
+
+    const response: MessageDetailResponse = {
       message: {
-        id: message.id,
-        timestamp: message.timestamp,
-        agent_name: message.agent_name,
-        model: message.model,
-        status: message.status,
-        error_message: message.error_message,
-        error_code: message.error_code,
-        error_http_status: message.error_http_status,
-        error_origin: message.error_origin,
-        error_class: message.error_class,
-        superseded: message.superseded,
-        description: message.description,
-        service_type: message.service_type,
-        input_tokens: message.input_tokens,
-        output_tokens: message.output_tokens,
-        cache_read_tokens: message.cache_read_tokens,
-        cache_creation_tokens: message.cache_creation_tokens,
-        cost_usd: message.cost_usd,
-        duration_ms: message.duration_ms,
-        trace_id: message.trace_id,
-        routing_tier: message.routing_tier,
-        routing_reason: message.routing_reason,
-        specificity_category: message.specificity_category,
-        specificity_miscategorized: message.specificity_miscategorized,
-        auth_type: message.auth_type,
-        provider_key_label: message.provider_key_label,
-        skill_name: message.skill_name,
-        fallback_from_model: message.fallback_from_model,
-        fallback_index: message.fallback_index,
-        session_key: message.session_key,
-        feedback_rating: message.feedback_rating,
-        feedback_tags: message.feedback_tags ? message.feedback_tags.split(',') : null,
-        feedback_details: message.feedback_details,
-        request_headers: message.request_headers,
-        request_params: message.request_params as RequestParamDefaults | null,
-        caller_attribution: message.caller_attribution,
-        header_tier_id: message.header_tier_id,
-        header_tier_name: message.header_tier_name,
-        header_tier_color: message.header_tier_color,
-        autofix_applied: message.autofix_applied,
-        autofix_role: message.autofix_role,
-        autofix_operations: (message.autofix_operations as PhoenixOperation[] | null) ?? null,
+        id: request?.id ?? message!.id,
+        timestamp: request?.timestamp ?? message!.timestamp,
+        agent_name: request?.agent_name ?? message?.agent_name ?? null,
+        model: message?.model ?? request?.requested_model ?? null,
+        status: request?.status ?? message!.status,
+        error_message: request?.error_message ?? message?.error_message ?? null,
+        error_code: request ? (request.error_code ?? null) : message!.error_code,
+        error_http_status: request?.error_http_status ?? message?.error_http_status ?? null,
+        error_origin: request?.error_origin ?? message?.error_origin ?? null,
+        error_class: request?.error_class ?? message?.error_class ?? null,
+        superseded: false,
+        description: message?.description ?? null,
+        service_type: message?.service_type ?? null,
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_read_tokens: cacheReadTokens,
+        cache_creation_tokens: cacheCreationTokens,
+        cost_usd: cost,
+        duration_ms: duration,
+        trace_id: request?.trace_id ?? message?.trace_id ?? null,
+        routing_tier: message?.routing_tier ?? null,
+        routing_reason: message?.routing_reason ?? null,
+        specificity_category: message?.specificity_category ?? null,
+        specificity_miscategorized: message?.specificity_miscategorized ?? false,
+        auth_type: message?.auth_type ?? null,
+        provider_key_label: message?.provider_key_label ?? null,
+        skill_name: message?.skill_name ?? null,
+        fallback_from_model: message?.fallback_from_model ?? null,
+        fallback_index: message?.fallback_index ?? null,
+        session_key: request?.session_key ?? message?.session_key ?? null,
+        feedback_rating: request?.feedback_rating ?? message?.feedback_rating ?? null,
+        feedback_tags: (request?.feedback_tags ?? message?.feedback_tags)?.split(',') ?? null,
+        feedback_details: request?.feedback_details ?? message?.feedback_details ?? null,
+        request_headers: request?.request_headers ?? message?.request_headers ?? null,
+        request_params: (request?.request_params ??
+          message?.request_params) as RequestParamDefaults | null,
+        caller_attribution: request?.caller_attribution ?? message?.caller_attribution ?? null,
+        header_tier_id: message?.header_tier_id ?? null,
+        header_tier_name: message?.header_tier_name ?? null,
+        header_tier_color: message?.header_tier_color ?? null,
+        autofix_applied:
+          attempts.some((attempt) => attempt.autofix_applied) ||
+          (message?.autofix_applied ?? false),
+        autofix_role: message?.autofix_role ?? null,
+        autofix_operations: (message?.autofix_operations as PhoenixOperation[] | null) ?? null,
         autofix_phoenix:
-          (message.autofix_phoenix as {
+          (message?.autofix_phoenix as {
             issueId: string | null;
             patchId: string | null;
             healAttemptId: string | null;
           } | null) ?? null,
         autofix_sibling,
+        ...(request
+          ? {
+              attempts: attempts.map((attempt) => ({
+                id: attempt.id,
+                model: attempt.model,
+                provider: attempt.provider,
+                status: attempt.status,
+                error_http_status: attempt.error_http_status,
+                duration_ms: attempt.duration_ms,
+                cost_usd: attempt.cost_usd,
+              })),
+            }
+          : {}),
       },
     };
+    return response;
   }
 
   /** Resolve the paired Auto-fix row (failed original ↔ successful retry). */

--- a/packages/backend/src/analytics/services/message-feedback.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.spec.ts
@@ -128,4 +128,51 @@ describe('MessageFeedbackService', () => {
       expect(msgQb.andWhere).toHaveBeenCalled();
     });
   });
+
+  describe('request-first storage', () => {
+    it('stores feedback on an explicit request', async () => {
+      const requestUpdate = jest.fn().mockResolvedValue({ affected: 1 });
+      const requestRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'req-1', tenant_id: 'tenant-123' }),
+        update: requestUpdate,
+      };
+      const messageRepo = {
+        createQueryBuilder: jest.fn(),
+        update: jest.fn(),
+      };
+      const requestService = new MessageFeedbackService(messageRepo as never, requestRepo as never);
+
+      await requestService.setFeedback('req-1', 'tenant-123', 'like');
+
+      expect(requestUpdate).toHaveBeenCalledWith('req-1', {
+        feedback_rating: 'like',
+        feedback_tags: null,
+        feedback_details: null,
+      });
+      expect(messageRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('stores feedback on an unlinked attempt exposed as a synthetic request', async () => {
+      const attemptQb = mockQb({ id: 'attempt-1', tenant_id: 'tenant-123', request_id: null });
+      const attemptUpdate = jest.fn().mockResolvedValue({ affected: 1 });
+      const requestRepo = {
+        findOne: jest.fn().mockResolvedValue(null),
+        update: jest.fn(),
+      };
+      const messageRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue(attemptQb),
+        update: attemptUpdate,
+      };
+      const requestService = new MessageFeedbackService(messageRepo as never, requestRepo as never);
+
+      await requestService.setFeedback('attempt-1', 'tenant-123', 'dislike', ['Too slow']);
+
+      expect(attemptQb.andWhere).toHaveBeenCalledWith('m.request_id IS NULL');
+      expect(attemptUpdate).toHaveBeenCalledWith('attempt-1', {
+        feedback_rating: 'dislike',
+        feedback_tags: 'Too slow',
+        feedback_details: null,
+      });
+    });
+  });
 });

--- a/packages/backend/src/analytics/services/message-feedback.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.spec.ts
@@ -206,5 +206,48 @@ describe('MessageFeedbackService', () => {
       });
       expect(messageRepo.update).not.toHaveBeenCalled();
     });
+
+    it('clears feedback on an explicit request', async () => {
+      const requestUpdate = jest.fn().mockResolvedValue({ affected: 1 });
+      const requestService = new MessageFeedbackService(
+        { createQueryBuilder: jest.fn(), update: jest.fn() } as never,
+        {
+          findOne: jest.fn().mockResolvedValue({ id: 'req-1', tenant_id: 'tenant-123' }),
+          update: requestUpdate,
+        } as never,
+      );
+
+      await requestService.clearFeedback('req-1', 'tenant-123');
+
+      expect(requestUpdate).toHaveBeenCalledWith('req-1', {
+        feedback_rating: null,
+        feedback_tags: null,
+        feedback_details: null,
+      });
+    });
+
+    it('rejects a linked attempt whose parent is outside the tenant', async () => {
+      const attemptQb = mockQb({
+        id: 'attempt-1',
+        tenant_id: 'tenant-123',
+        request_id: 'req-missing',
+      });
+      const requestService = new MessageFeedbackService(
+        { createQueryBuilder: jest.fn(() => attemptQb), update: jest.fn() } as never,
+        { findOne: jest.fn().mockResolvedValue(null), update: jest.fn() } as never,
+      );
+
+      await expect(requestService.setFeedback('attempt-1', 'tenant-123', 'like')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('does not query request ownership without a tenant', async () => {
+      const requestRepo = { findOne: jest.fn(), update: jest.fn() };
+      const requestService = new MessageFeedbackService({} as never, requestRepo as never);
+
+      await expect((requestService as any).findOwnedRequest('req-1', null)).resolves.toBeNull();
+      expect(requestRepo.findOne).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/backend/src/analytics/services/message-feedback.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.spec.ts
@@ -167,12 +167,44 @@ describe('MessageFeedbackService', () => {
 
       await requestService.setFeedback('attempt-1', 'tenant-123', 'dislike', ['Too slow']);
 
-      expect(attemptQb.andWhere).toHaveBeenCalledWith('m.request_id IS NULL');
       expect(attemptUpdate).toHaveBeenCalledWith('attempt-1', {
         feedback_rating: 'dislike',
         feedback_tags: 'Too slow',
         feedback_details: null,
       });
+    });
+
+    it('resolves a linked attempt detail id to its parent request', async () => {
+      const attemptQb = mockQb({
+        id: 'attempt-1',
+        tenant_id: 'tenant-123',
+        request_id: 'req-1',
+      });
+      const requestUpdate = jest.fn().mockResolvedValue({ affected: 1 });
+      const requestRepo = {
+        findOne: jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({ id: 'req-1', tenant_id: 'tenant-123' }),
+        update: requestUpdate,
+      };
+      const messageRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue(attemptQb),
+        update: jest.fn(),
+      };
+      const requestService = new MessageFeedbackService(messageRepo as never, requestRepo as never);
+
+      await requestService.setFeedback('attempt-1', 'tenant-123', 'like');
+
+      expect(requestRepo.findOne).toHaveBeenLastCalledWith({
+        where: { id: 'req-1', tenant_id: 'tenant-123' },
+      });
+      expect(requestUpdate).toHaveBeenCalledWith('req-1', {
+        feedback_rating: 'like',
+        feedback_tags: null,
+        feedback_details: null,
+      });
+      expect(messageRepo.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/analytics/services/message-feedback.service.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.ts
@@ -1,13 +1,17 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
+import { ManifestRequest } from '../../entities/request.entity';
 
 @Injectable()
 export class MessageFeedbackService {
   constructor(
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
+    @Optional()
+    @InjectRepository(ManifestRequest)
+    private readonly requestRepo?: Repository<ManifestRequest>,
   ) {}
 
   async setFeedback(
@@ -17,6 +21,15 @@ export class MessageFeedbackService {
     tags?: string[],
     details?: string,
   ): Promise<void> {
+    if (this.requestRepo) {
+      const request = await this.findOwnedRequest(messageId, tenantId);
+      await this.requestRepo.update(request.id, {
+        feedback_rating: rating,
+        feedback_tags: tags?.length ? tags.join(',') : null,
+        feedback_details: details ?? null,
+      });
+      return;
+    }
     const message = await this.findOwnedMessage(messageId, tenantId);
     await this.messageRepo.update(message.id, {
       feedback_rating: rating,
@@ -26,12 +39,33 @@ export class MessageFeedbackService {
   }
 
   async clearFeedback(messageId: string, tenantId: string | null): Promise<void> {
+    if (this.requestRepo) {
+      const request = await this.findOwnedRequest(messageId, tenantId);
+      await this.requestRepo.update(request.id, {
+        feedback_rating: null,
+        feedback_tags: null,
+        feedback_details: null,
+      });
+      return;
+    }
     const message = await this.findOwnedMessage(messageId, tenantId);
     await this.messageRepo.update(message.id, {
       feedback_rating: null,
       feedback_tags: null,
       feedback_details: null,
     });
+  }
+
+  private async findOwnedRequest(
+    requestId: string,
+    tenantId: string | null,
+  ): Promise<ManifestRequest> {
+    if (!tenantId) throw new NotFoundException('Request not found');
+    const request = await this.requestRepo!.findOne({
+      where: { id: requestId, tenant_id: tenantId },
+    });
+    if (!request) throw new NotFoundException('Request not found');
+    return request;
   }
 
   private async findOwnedMessage(

--- a/packages/backend/src/analytics/services/message-feedback.service.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.ts
@@ -23,14 +23,16 @@ export class MessageFeedbackService {
   ): Promise<void> {
     if (this.requestRepo) {
       const request = await this.findOwnedRequest(messageId, tenantId);
-      await this.requestRepo.update(request.id, {
-        feedback_rating: rating,
-        feedback_tags: tags?.length ? tags.join(',') : null,
-        feedback_details: details ?? null,
-      });
-      return;
+      if (request) {
+        await this.requestRepo.update(request.id, {
+          feedback_rating: rating,
+          feedback_tags: tags?.length ? tags.join(',') : null,
+          feedback_details: details ?? null,
+        });
+        return;
+      }
     }
-    const message = await this.findOwnedMessage(messageId, tenantId);
+    const message = await this.findOwnedMessage(messageId, tenantId, Boolean(this.requestRepo));
     await this.messageRepo.update(message.id, {
       feedback_rating: rating,
       feedback_tags: tags?.length ? tags.join(',') : null,
@@ -41,14 +43,16 @@ export class MessageFeedbackService {
   async clearFeedback(messageId: string, tenantId: string | null): Promise<void> {
     if (this.requestRepo) {
       const request = await this.findOwnedRequest(messageId, tenantId);
-      await this.requestRepo.update(request.id, {
-        feedback_rating: null,
-        feedback_tags: null,
-        feedback_details: null,
-      });
-      return;
+      if (request) {
+        await this.requestRepo.update(request.id, {
+          feedback_rating: null,
+          feedback_tags: null,
+          feedback_details: null,
+        });
+        return;
+      }
     }
-    const message = await this.findOwnedMessage(messageId, tenantId);
+    const message = await this.findOwnedMessage(messageId, tenantId, Boolean(this.requestRepo));
     await this.messageRepo.update(message.id, {
       feedback_rating: null,
       feedback_tags: null,
@@ -59,26 +63,26 @@ export class MessageFeedbackService {
   private async findOwnedRequest(
     requestId: string,
     tenantId: string | null,
-  ): Promise<ManifestRequest> {
-    if (!tenantId) throw new NotFoundException('Request not found');
-    const request = await this.requestRepo!.findOne({
+  ): Promise<ManifestRequest | null> {
+    if (!tenantId) return null;
+    return this.requestRepo!.findOne({
       where: { id: requestId, tenant_id: tenantId },
     });
-    if (!request) throw new NotFoundException('Request not found');
-    return request;
   }
 
   private async findOwnedMessage(
     messageId: string,
     tenantId: string | null,
+    syntheticOnly = false,
   ): Promise<AgentMessage> {
     // No tenant → no messages, so any id is unknown.
     if (!tenantId) throw new NotFoundException('Message not found');
-    const message = await this.messageRepo
+    const qb = this.messageRepo
       .createQueryBuilder('m')
       .where('m.id = :id', { id: messageId })
-      .andWhere('m.tenant_id = :tenantId', { tenantId })
-      .getOne();
+      .andWhere('m.tenant_id = :tenantId', { tenantId });
+    if (syntheticOnly) qb.andWhere('m.request_id IS NULL');
+    const message = await qb.getOne();
     if (!message) throw new NotFoundException('Message not found');
     return message;
   }

--- a/packages/backend/src/analytics/services/message-feedback.service.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.ts
@@ -21,43 +21,50 @@ export class MessageFeedbackService {
     tags?: string[],
     details?: string,
   ): Promise<void> {
-    if (this.requestRepo) {
-      const request = await this.findOwnedRequest(messageId, tenantId);
-      if (request) {
-        await this.requestRepo.update(request.id, {
-          feedback_rating: rating,
-          feedback_tags: tags?.length ? tags.join(',') : null,
-          feedback_details: details ?? null,
-        });
-        return;
-      }
-    }
-    const message = await this.findOwnedMessage(messageId, tenantId, Boolean(this.requestRepo));
-    await this.messageRepo.update(message.id, {
+    const target = await this.findFeedbackTarget(messageId, tenantId);
+    const feedback = {
       feedback_rating: rating,
       feedback_tags: tags?.length ? tags.join(',') : null,
       feedback_details: details ?? null,
-    });
+    };
+    if (target.request) {
+      await this.requestRepo!.update(target.request.id, feedback);
+    } else {
+      await this.messageRepo.update(target.message!.id, feedback);
+    }
   }
 
   async clearFeedback(messageId: string, tenantId: string | null): Promise<void> {
-    if (this.requestRepo) {
-      const request = await this.findOwnedRequest(messageId, tenantId);
-      if (request) {
-        await this.requestRepo.update(request.id, {
-          feedback_rating: null,
-          feedback_tags: null,
-          feedback_details: null,
-        });
-        return;
-      }
-    }
-    const message = await this.findOwnedMessage(messageId, tenantId, Boolean(this.requestRepo));
-    await this.messageRepo.update(message.id, {
+    const target = await this.findFeedbackTarget(messageId, tenantId);
+    const feedback = {
       feedback_rating: null,
       feedback_tags: null,
       feedback_details: null,
-    });
+    };
+    if (target.request) {
+      await this.requestRepo!.update(target.request.id, feedback);
+    } else {
+      await this.messageRepo.update(target.message!.id, feedback);
+    }
+  }
+
+  private async findFeedbackTarget(
+    messageId: string,
+    tenantId: string | null,
+  ): Promise<{ request: ManifestRequest | null; message: AgentMessage | null }> {
+    if (!tenantId) throw new NotFoundException('Message not found');
+    if (this.requestRepo) {
+      const request = await this.findOwnedRequest(messageId, tenantId);
+      if (request) return { request, message: null };
+    }
+
+    const message = await this.findOwnedMessage(messageId, tenantId);
+    if (this.requestRepo && message.request_id) {
+      const request = await this.findOwnedRequest(message.request_id, tenantId);
+      if (!request) throw new NotFoundException('Message not found');
+      return { request, message: null };
+    }
+    return { request: null, message };
   }
 
   private async findOwnedRequest(
@@ -73,7 +80,6 @@ export class MessageFeedbackService {
   private async findOwnedMessage(
     messageId: string,
     tenantId: string | null,
-    syntheticOnly = false,
   ): Promise<AgentMessage> {
     // No tenant → no messages, so any id is unknown.
     if (!tenantId) throw new NotFoundException('Message not found');
@@ -81,7 +87,6 @@ export class MessageFeedbackService {
       .createQueryBuilder('m')
       .where('m.id = :id', { id: messageId })
       .andWhere('m.tenant_id = :tenantId', { tenantId });
-    if (syntheticOnly) qb.andWhere('m.request_id IS NULL');
     const message = await qb.getOne();
     if (!message) throw new NotFoundException('Message not found');
     return message;

--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -14,6 +14,7 @@ function makeQb(rows: Array<Record<string, unknown>> = []) {
     orderBy: jest.fn(),
     addOrderBy: jest.fn(),
     limit: jest.fn(),
+    distinct: jest.fn(),
     clone: jest.fn(),
     getRawOne: jest.fn().mockResolvedValue({ total: 0 }),
     getRawMany: jest.fn().mockResolvedValue(rows),
@@ -31,8 +32,15 @@ function makeQb(rows: Array<Record<string, unknown>> = []) {
     'orderBy',
     'addOrderBy',
     'limit',
+    'distinct',
   ]) {
     qb[name].mockReturnValue(qb);
+  }
+  for (const name of ['andWhere', 'orWhere']) {
+    qb[name].mockImplementation((clause: { whereFactory?: (builder: unknown) => void }) => {
+      clause?.whereFactory?.(qb);
+      return qb;
+    });
   }
   return qb;
 }
@@ -95,5 +103,96 @@ describe('MessagesQueryService request-first queries', () => {
     expect(requestQb.andWhere).toHaveBeenCalledWith(
       expect.stringContaining('playag.name = r.agent_name'),
     );
+  });
+
+  it('applies the complete request filter set, pagination, costs, and exact totals', async () => {
+    const requestRows = [
+      { id: 'r-2', timestamp: '2026-07-14T12:00:00Z' },
+      { id: 'r-1', timestamp: '2026-07-14T12:00:00Z' },
+    ];
+    const requestQb = makeQb(requestRows);
+    const requestCountQb = makeQb();
+    requestCountQb.getRawOne.mockResolvedValue({ total: '7' });
+    requestQb.clone.mockReturnValue(requestCountQb);
+    const legacyBase = makeQb();
+    const legacyCountQb = makeQb();
+    legacyCountQb.getRawOne.mockResolvedValue({ total: '2' });
+    const legacyDataQb = makeQb([{ id: 'legacy', timestamp: '2026-07-14T10:00:00Z' }]);
+    legacyBase.clone.mockReturnValueOnce(legacyCountQb).mockReturnValueOnce(legacyDataQb);
+    const service = new MessagesQueryService(
+      {
+        createQueryBuilder: jest.fn(() => legacyBase),
+        query: jest.fn().mockResolvedValue([]),
+      } as never,
+      { find: jest.fn() } as never,
+      { createQueryBuilder: jest.fn(() => requestQb) } as never,
+    );
+
+    const result = await service.getMessages({
+      tenantId: 'tenant-1',
+      range: '24h',
+      agent_name: 'agent-1',
+      provider: 'openai',
+      service_type: 'agent',
+      status: 'failed',
+      origin: 'manifest',
+      error_class: 'rate_limit',
+      routing_tier: 'balanced',
+      specificity_category: 'specific',
+      header_tier_id: 'tier-1',
+      trigger: 'none',
+      cursor: '2026-07-14T13:00:00Z|r-3',
+      cost_min: 1,
+      cost_max: 10,
+      limit: 2,
+      include_total: true,
+      include_filter_options: false,
+      exclude_playground: true,
+    });
+
+    const clauses = requestQb.andWhere.mock.calls.map((call) => String(call[0]));
+    expect(clauses).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("r.status <> 'ok'"),
+        expect.stringContaining("r.error_origin IN ('config', 'policy', 'internal', 'request')"),
+        expect.stringContaining('filtered_attempt.service_type = :requestServiceType'),
+        expect.stringContaining('filtered_attempt.routing_tier = :requestTier'),
+        expect.stringContaining('filtered_attempt.specificity_category = :requestSpecificity'),
+        expect.stringContaining('filtered_attempt.header_tier_id = :requestHeaderTier'),
+        expect.stringContaining('NOT EXISTS'),
+      ]),
+    );
+    expect(requestQb.having).toHaveBeenCalled();
+    expect(requestQb.andHaving).toHaveBeenCalled();
+    expect(result.total_count).toBe(9);
+    expect(result.items).toHaveLength(2);
+    expect(result.next_cursor).toBeTruthy();
+  });
+
+  it.each([
+    [{ tenantId: null, status: 'ok', origin: 'provider', trigger: 'autofix' }],
+    [{ tenantId: 'tenant-1', status: 'error', origin: 'transport', trigger: 'fallback' }],
+  ] as const)('covers alternate request status, origin, and trigger filters', async (filters) => {
+    const requestQb = makeQb();
+    requestQb.clone.mockReturnValue(makeQb());
+    const legacyBase = makeQb();
+    legacyBase.clone.mockReturnValueOnce(makeQb()).mockReturnValueOnce(makeQb());
+    const service = new MessagesQueryService(
+      {
+        createQueryBuilder: jest.fn(() => legacyBase),
+        query: jest.fn().mockResolvedValue([]),
+      } as never,
+      { find: jest.fn() } as never,
+      { createQueryBuilder: jest.fn(() => requestQb) } as never,
+    );
+
+    await service.getMessages({
+      ...filters,
+      limit: 10,
+      include_total: false,
+      include_filter_options: false,
+    });
+
+    expect(requestQb.andWhere).toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -162,6 +162,17 @@ describe('MessagesQueryService request-first queries', () => {
         expect.stringContaining('NOT EXISTS'),
       ]),
     );
+    const combinedAttemptClause = clauses.find(
+      (clause) =>
+        clause.includes('filtered_attempt.provider = :requestProvider') &&
+        clause.includes('filtered_attempt.service_type = :requestServiceType'),
+    );
+    expect(combinedAttemptClause).toContain('filtered_attempt.routing_tier = :requestTier');
+    expect(
+      clauses.filter((clause) =>
+        clause.includes('SELECT 1 FROM provider_attempts filtered_attempt'),
+      ),
+    ).toHaveLength(1);
     expect(requestQb.having).toHaveBeenCalled();
     expect(requestQb.andHaving).toHaveBeenCalled();
     expect(result.total_count).toBe(9);

--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -1,0 +1,99 @@
+import { MessagesQueryService } from './messages-query.service';
+
+function makeQb(rows: Array<Record<string, unknown>> = []) {
+  const qb: Record<string, jest.Mock> = {
+    leftJoin: jest.fn(),
+    select: jest.fn(),
+    addSelect: jest.fn(),
+    where: jest.fn(),
+    andWhere: jest.fn(),
+    orWhere: jest.fn(),
+    groupBy: jest.fn(),
+    having: jest.fn(),
+    andHaving: jest.fn(),
+    orderBy: jest.fn(),
+    addOrderBy: jest.fn(),
+    limit: jest.fn(),
+    clone: jest.fn(),
+    getRawOne: jest.fn().mockResolvedValue({ total: 0 }),
+    getRawMany: jest.fn().mockResolvedValue(rows),
+  };
+  for (const name of [
+    'leftJoin',
+    'select',
+    'addSelect',
+    'where',
+    'andWhere',
+    'orWhere',
+    'groupBy',
+    'having',
+    'andHaving',
+    'orderBy',
+    'addOrderBy',
+    'limit',
+  ]) {
+    qb[name].mockReturnValue(qb);
+  }
+  return qb;
+}
+
+describe('MessagesQueryService request-first queries', () => {
+  it('filters by matching attempts without truncating the request rollup', async () => {
+    const requestRows = [
+      { id: 'request-1', timestamp: new Date('2026-07-14T10:00:00Z'), attempt_count: 2 },
+    ];
+    const legacyRows = [{ id: 'legacy-1', timestamp: '2026-07-14T11:00:00Z', attempt_count: 1 }];
+    const requestQb = makeQb(requestRows);
+    requestQb.clone.mockReturnValue(makeQb());
+    const legacyBase = makeQb();
+    legacyBase.clone.mockReturnValueOnce(makeQb()).mockReturnValueOnce(makeQb(legacyRows));
+
+    const service = new MessagesQueryService(
+      {
+        createQueryBuilder: jest.fn(() => legacyBase),
+        query: jest.fn().mockResolvedValue([]),
+      } as never,
+      { find: jest.fn() } as never,
+      { createQueryBuilder: jest.fn(() => requestQb) } as never,
+    );
+
+    const result = await service.getMessages({
+      tenantId: 'tenant-1',
+      limit: 10,
+      provider: 'anthropic',
+      include_total: false,
+      include_filter_options: false,
+    });
+
+    const requestClauses = requestQb.andWhere.mock.calls.map((call) => String(call[0]));
+    expect(requestClauses).toContainEqual(
+      expect.stringContaining('filtered_attempt.provider = :requestProvider'),
+    );
+    expect(requestClauses).not.toContain('at.provider = :requestProvider');
+    expect(result.items.map((row) => row.id)).toEqual(['legacy-1', 'request-1']);
+  });
+
+  it('uses tenant-scoped id-or-name Playground exclusion for request rows', async () => {
+    const requestQb = makeQb();
+    requestQb.clone.mockReturnValue(makeQb());
+    const legacyBase = makeQb();
+    legacyBase.clone.mockReturnValueOnce(makeQb()).mockReturnValueOnce(makeQb());
+    const service = new MessagesQueryService(
+      { createQueryBuilder: jest.fn(() => legacyBase) } as never,
+      { find: jest.fn() } as never,
+      { createQueryBuilder: jest.fn(() => requestQb) } as never,
+    );
+
+    await service.getMessages({
+      tenantId: 'tenant-1',
+      limit: 10,
+      exclude_playground: true,
+      include_total: false,
+      include_filter_options: false,
+    });
+
+    expect(requestQb.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('playag.name = r.agent_name'),
+    );
+  });
+});

--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -167,7 +167,9 @@ describe('MessagesQueryService request-first queries', () => {
         clause.includes('filtered_attempt.provider = :requestProvider') &&
         clause.includes('filtered_attempt.service_type = :requestServiceType'),
     );
-    expect(combinedAttemptClause).toContain('filtered_attempt.routing_tier = :requestTier');
+    expect(combinedAttemptClause).toEqual(
+      expect.stringContaining('filtered_attempt.routing_tier = :requestTier'),
+    );
     expect(
       clauses.filter((clause) =>
         clause.includes('SELECT 1 FROM provider_attempts filtered_attempt'),

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -216,43 +216,45 @@ export class MessagesQueryService {
         requestErrorClass: params.error_class,
       });
     }
-    const matchingAttempt = (predicate: string): string => `EXISTS (
+    const attemptPredicates: string[] = [];
+    const attemptParameters: Record<string, unknown> = {};
+    const matchingAttempt = (predicates: string[]): string => `EXISTS (
       SELECT 1 FROM provider_attempts filtered_attempt
-      WHERE filtered_attempt.request_id = r.id AND ${predicate}
+      WHERE filtered_attempt.request_id = r.id AND ${predicates.join(' AND ')}
     )`;
-    if (params.provider)
-      qb.andWhere(matchingAttempt('filtered_attempt.provider = :requestProvider'), {
-        requestProvider: params.provider,
-      });
-    if (params.service_type) {
-      qb.andWhere(matchingAttempt('filtered_attempt.service_type = :requestServiceType'), {
-        requestServiceType: params.service_type,
-      });
+    if (params.provider) {
+      attemptPredicates.push('filtered_attempt.provider = :requestProvider');
+      attemptParameters['requestProvider'] = params.provider;
     }
-    if (params.routing_tier)
-      qb.andWhere(matchingAttempt('filtered_attempt.routing_tier = :requestTier'), {
-        requestTier: params.routing_tier,
-      });
+    if (params.service_type) {
+      attemptPredicates.push('filtered_attempt.service_type = :requestServiceType');
+      attemptParameters['requestServiceType'] = params.service_type;
+    }
+    if (params.routing_tier) {
+      attemptPredicates.push('filtered_attempt.routing_tier = :requestTier');
+      attemptParameters['requestTier'] = params.routing_tier;
+    }
     if (params.specificity_category) {
-      qb.andWhere(matchingAttempt('filtered_attempt.specificity_category = :requestSpecificity'), {
-        requestSpecificity: params.specificity_category,
-      });
+      attemptPredicates.push('filtered_attempt.specificity_category = :requestSpecificity');
+      attemptParameters['requestSpecificity'] = params.specificity_category;
     }
     if (params.header_tier_id) {
-      qb.andWhere(matchingAttempt('filtered_attempt.header_tier_id = :requestHeaderTier'), {
-        requestHeaderTier: params.header_tier_id,
-      });
+      attemptPredicates.push('filtered_attempt.header_tier_id = :requestHeaderTier');
+      attemptParameters['requestHeaderTier'] = params.header_tier_id;
     }
     if (params.trigger === 'autofix')
-      qb.andWhere(matchingAttempt('filtered_attempt.autofix_applied = true'));
+      attemptPredicates.push('filtered_attempt.autofix_applied = true');
     else if (params.trigger === 'fallback')
-      qb.andWhere(matchingAttempt('filtered_attempt.fallback_from_model IS NOT NULL'));
+      attemptPredicates.push('filtered_attempt.fallback_from_model IS NOT NULL');
     else if (params.trigger === 'none') {
       qb.andWhere(`NOT EXISTS (
         SELECT 1 FROM provider_attempts trigger_attempt
         WHERE trigger_attempt.request_id = r.id
-          AND (trigger_attempt.autofix_applied = true OR trigger_attempt.fallback_from_model IS NOT NULL)
+        AND (trigger_attempt.autofix_applied = true OR trigger_attempt.fallback_from_model IS NOT NULL)
       )`);
+    }
+    if (attemptPredicates.length > 0) {
+      qb.andWhere(matchingAttempt(attemptPredicates), attemptParameters);
     }
     if (params.cursor) {
       const sep = params.cursor.indexOf('|');

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -12,6 +12,7 @@ import {
   MANIFEST_ORIGIN_PREDICATE,
   CUSTOM_PROVIDER_JOIN_CONDITION,
   excludePlaygroundAgents,
+  sqlExcludePlayground,
 } from './query-helpers';
 import type {
   MessageOriginFilter,
@@ -198,9 +199,7 @@ export class MessagesQueryService {
       );
     }
     if (params.exclude_playground) {
-      qb.andWhere(
-        'NOT EXISTS (SELECT 1 FROM agents playground WHERE playground.id = r.agent_id AND playground.is_playground = true)',
-      );
+      qb.andWhere(sqlExcludePlayground('r'));
     }
     if (params.status === 'failed' || params.status === 'errors') {
       qb.andWhere("r.status <> 'ok'");
@@ -217,27 +216,37 @@ export class MessagesQueryService {
         requestErrorClass: params.error_class,
       });
     }
+    const matchingAttempt = (predicate: string): string => `EXISTS (
+      SELECT 1 FROM provider_attempts filtered_attempt
+      WHERE filtered_attempt.request_id = r.id AND ${predicate}
+    )`;
     if (params.provider)
-      qb.andWhere('at.provider = :requestProvider', { requestProvider: params.provider });
+      qb.andWhere(matchingAttempt('filtered_attempt.provider = :requestProvider'), {
+        requestProvider: params.provider,
+      });
     if (params.service_type) {
-      qb.andWhere('at.service_type = :requestServiceType', {
+      qb.andWhere(matchingAttempt('filtered_attempt.service_type = :requestServiceType'), {
         requestServiceType: params.service_type,
       });
     }
     if (params.routing_tier)
-      qb.andWhere('at.routing_tier = :requestTier', { requestTier: params.routing_tier });
+      qb.andWhere(matchingAttempt('filtered_attempt.routing_tier = :requestTier'), {
+        requestTier: params.routing_tier,
+      });
     if (params.specificity_category) {
-      qb.andWhere('at.specificity_category = :requestSpecificity', {
+      qb.andWhere(matchingAttempt('filtered_attempt.specificity_category = :requestSpecificity'), {
         requestSpecificity: params.specificity_category,
       });
     }
     if (params.header_tier_id) {
-      qb.andWhere('at.header_tier_id = :requestHeaderTier', {
+      qb.andWhere(matchingAttempt('filtered_attempt.header_tier_id = :requestHeaderTier'), {
         requestHeaderTier: params.header_tier_id,
       });
     }
-    if (params.trigger === 'autofix') qb.andWhere('at.autofix_applied = true');
-    else if (params.trigger === 'fallback') qb.andWhere('at.fallback_from_model IS NOT NULL');
+    if (params.trigger === 'autofix')
+      qb.andWhere(matchingAttempt('filtered_attempt.autofix_applied = true'));
+    else if (params.trigger === 'fallback')
+      qb.andWhere(matchingAttempt('filtered_attempt.fallback_from_model IS NOT NULL'));
     else if (params.trigger === 'none') {
       qb.andWhere(`NOT EXISTS (
         SELECT 1 FROM provider_attempts trigger_attempt
@@ -361,7 +370,7 @@ export class MessagesQueryService {
         : Promise.resolve({ providers: [] as string[], provider_labels: {} }),
     ]);
     const rows = [...requestRows, ...legacyRows].sort((a, b) => {
-      const byTime = String(b.timestamp).localeCompare(String(a.timestamp));
+      const byTime = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
       return byTime || String(b.id).localeCompare(String(a.id));
     });
     const hasMore = rows.length > params.limit;

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, In, Repository, SelectQueryBuilder } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
@@ -10,6 +10,8 @@ import {
   selectMessageRowColumns,
   ERROR_MESSAGE_STATUSES,
   MANIFEST_ORIGIN_PREDICATE,
+  CUSTOM_PROVIDER_JOIN_CONDITION,
+  excludePlaygroundAgents,
 } from './query-helpers';
 import type {
   MessageOriginFilter,
@@ -19,6 +21,7 @@ import type {
 import { computeCutoff, sqlCastFloat, sqlSanitizeCost } from '../../common/utils/postgres-sql';
 import { inferProviderFromModel } from '../../common/utils/provider-inference';
 import { TtlCache } from '../../common/utils/ttl-cache';
+import { ManifestRequest } from '../../entities/request.entity';
 
 // The Messages-log "failed"/"errors" filters and every "messages" KPI count
 // share one definition of an error status (see query-helpers.sqlCountMessages).
@@ -38,11 +41,11 @@ const MAX_CACHE_ENTRIES = 5_000;
 // $1 (tenant_id) is reused by position across all three references.
 const DISTINCT_MODELS_SKIP_SCAN_SQL = `
 WITH RECURSIVE t AS (
-  (SELECT model FROM agent_messages
+  (SELECT model FROM provider_attempts
      WHERE tenant_id = $1 AND model IS NOT NULL AND model <> ''
      ORDER BY model LIMIT 1)
   UNION ALL
-  SELECT (SELECT model FROM agent_messages
+  SELECT (SELECT model FROM provider_attempts
             WHERE tenant_id = $1 AND model > t.model AND model IS NOT NULL AND model <> ''
             ORDER BY model LIMIT 1)
   FROM t WHERE t.model IS NOT NULL
@@ -50,14 +53,14 @@ WITH RECURSIVE t AS (
 SELECT model FROM t WHERE model IS NOT NULL`;
 
 // Same technique for distinct providers, backed by the partial
-// IDX_agent_messages_tenant_provider_value (tenant_id, provider) index.
+// IDX_provider_attempts_tenant_provider_value (tenant_id, provider) index.
 const DISTINCT_PROVIDERS_SKIP_SCAN_SQL = `
 WITH RECURSIVE p AS (
-  (SELECT provider FROM agent_messages
+  (SELECT provider FROM provider_attempts
      WHERE tenant_id = $1 AND provider IS NOT NULL AND provider <> ''
      ORDER BY provider LIMIT 1)
   UNION ALL
-  SELECT (SELECT provider FROM agent_messages
+  SELECT (SELECT provider FROM provider_attempts
             WHERE tenant_id = $1 AND provider > p.provider AND provider IS NOT NULL AND provider <> ''
             ORDER BY provider LIMIT 1)
   FROM p WHERE p.provider IS NOT NULL
@@ -86,6 +89,7 @@ interface MessageQueryParams extends MessageFilterParams {
   header_tier_id?: string;
   include_total?: boolean;
   include_filter_options?: boolean;
+  exclude_playground?: boolean;
 }
 
 @Injectable()
@@ -104,9 +108,13 @@ export class MessagesQueryService {
     private readonly turnRepo: Repository<AgentMessage>,
     @InjectRepository(CustomProvider)
     private readonly customProviderRepo: Repository<CustomProvider>,
+    @Optional()
+    @InjectRepository(ManifestRequest)
+    private readonly requestRepo?: Repository<ManifestRequest>,
   ) {}
 
   async getMessages(params: MessageQueryParams) {
+    if (this.requestRepo) return this.getRequests(params);
     const baseQb = await this.buildBaseMessageQuery(params);
 
     const includeTotal = params.include_total !== false;
@@ -161,6 +169,210 @@ export class MessagesQueryService {
       items,
       next_cursor: nextCursor,
       total_count: totalCount,
+      total_count_exact: includeTotal,
+      providers: filterOptions.providers,
+      provider_labels: filterOptions.provider_labels,
+    };
+  }
+
+  /** Request-first log. Attempts are aggregated into their parent row. */
+  private async getRequests(params: MessageQueryParams) {
+    const qb = this.requestRepo!.createQueryBuilder('r').leftJoin(
+      AgentMessage,
+      'at',
+      'at.request_id = r.id',
+    );
+    const cutoff = params.range ? computeCutoff(rangeToInterval(params.range)) : undefined;
+    if (cutoff) qb.where('r.timestamp >= :requestCutoff', { requestCutoff: cutoff });
+    if (params.tenantId)
+      qb.andWhere('r.tenant_id = :requestTenantId', { requestTenantId: params.tenantId });
+    else qb.andWhere('1 = 0');
+    if (params.agent_name) {
+      qb.andWhere(
+        `r.agent_id = (
+          SELECT id FROM agents
+          WHERE tenant_id = r.tenant_id AND name = :requestAgentName AND deleted_at IS NULL
+          LIMIT 1
+        )`,
+        { requestAgentName: params.agent_name },
+      );
+    }
+    if (params.exclude_playground) {
+      qb.andWhere(
+        'NOT EXISTS (SELECT 1 FROM agents playground WHERE playground.id = r.agent_id AND playground.is_playground = true)',
+      );
+    }
+    if (params.status === 'failed' || params.status === 'errors') {
+      qb.andWhere("r.status <> 'ok'");
+    } else if (params.status) {
+      qb.andWhere('r.status = :requestStatus', { requestStatus: params.status });
+    }
+    if (params.origin === 'manifest') {
+      qb.andWhere(`r.error_origin IN ('config', 'policy', 'internal', 'request')`);
+    } else if (params.origin) {
+      qb.andWhere('r.error_origin = :requestOrigin', { requestOrigin: params.origin });
+    }
+    if (params.error_class) {
+      qb.andWhere('r.error_class = :requestErrorClass', {
+        requestErrorClass: params.error_class,
+      });
+    }
+    if (params.provider)
+      qb.andWhere('at.provider = :requestProvider', { requestProvider: params.provider });
+    if (params.service_type) {
+      qb.andWhere('at.service_type = :requestServiceType', {
+        requestServiceType: params.service_type,
+      });
+    }
+    if (params.routing_tier)
+      qb.andWhere('at.routing_tier = :requestTier', { requestTier: params.routing_tier });
+    if (params.specificity_category) {
+      qb.andWhere('at.specificity_category = :requestSpecificity', {
+        requestSpecificity: params.specificity_category,
+      });
+    }
+    if (params.header_tier_id) {
+      qb.andWhere('at.header_tier_id = :requestHeaderTier', {
+        requestHeaderTier: params.header_tier_id,
+      });
+    }
+    if (params.trigger === 'autofix') qb.andWhere('at.autofix_applied = true');
+    else if (params.trigger === 'fallback') qb.andWhere('at.fallback_from_model IS NOT NULL');
+    else if (params.trigger === 'none') {
+      qb.andWhere(`NOT EXISTS (
+        SELECT 1 FROM provider_attempts trigger_attempt
+        WHERE trigger_attempt.request_id = r.id
+          AND (trigger_attempt.autofix_applied = true OR trigger_attempt.fallback_from_model IS NOT NULL)
+      )`);
+    }
+    if (params.cursor) {
+      const sep = params.cursor.indexOf('|');
+      if (sep !== -1) {
+        const cursorTs = params.cursor.slice(0, sep);
+        const cursorId = params.cursor.slice(sep + 1);
+        qb.andWhere(
+          new Brackets((sub) => {
+            sub.where('r.timestamp < :requestCursorTs', { requestCursorTs: cursorTs }).orWhere(
+              new Brackets((inner) => {
+                inner
+                  .where('r.timestamp = :requestCursorTsEqual', {
+                    requestCursorTsEqual: cursorTs,
+                  })
+                  .andWhere('r.id < :requestCursorId', { requestCursorId: cursorId });
+              }),
+            );
+          }),
+        );
+      }
+    }
+
+    const countQb = qb.clone().select('COUNT(DISTINCT r.id)', 'total');
+    const rank = `CASE WHEN at.status = 'ok' THEN 3 WHEN NOT COALESCE(at.superseded, false) AND at.status NOT IN ('fallback_error', 'auto_fixed') THEN 2 ELSE 1 END`;
+    const picked = (column: string): string =>
+      `(ARRAY_AGG(${column} ORDER BY ${rank} DESC, at.timestamp DESC, at.id DESC) FILTER (WHERE at.id IS NOT NULL))[1]`;
+    const safeCost = sqlSanitizeCost('at.cost_usd');
+    qb.leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
+      .select('r.id', 'id')
+      .addSelect('r.timestamp', 'timestamp')
+      .addSelect('r.agent_name', 'agent_name')
+      .addSelect(`COALESCE(${picked('at.model')}, r.requested_model)`, 'model')
+      .addSelect(picked('at.provider'), 'provider')
+      .addSelect(`COALESCE(${picked('at.model')}, r.requested_model)`, 'display_name')
+      .addSelect('COALESCE(SUM(at.input_tokens), 0)', 'input_tokens')
+      .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'output_tokens')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total_tokens')
+      .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost')
+      .addSelect('r.status', 'status')
+      .addSelect('r.error_message', 'error_message')
+      .addSelect('r.error_code', 'error_code')
+      .addSelect('r.error_origin', 'error_origin')
+      .addSelect('r.error_class', 'error_class')
+      .addSelect('r.error_http_status', 'error_http_status')
+      // Latency, like tokens and cost, is attempt-derived. The parent value is
+      // only needed for zero-attempt rejections.
+      .addSelect('COALESCE(SUM(at.duration_ms), r.duration_ms)::int', 'duration_ms')
+      .addSelect(picked('at.routing_tier'), 'routing_tier')
+      .addSelect(picked('at.routing_reason'), 'routing_reason')
+      .addSelect(picked('at.specificity_category'), 'specificity_category')
+      .addSelect(picked('at.auth_type'), 'auth_type')
+      .addSelect(picked('at.fallback_from_model'), 'fallback_from_model')
+      .addSelect(picked('at.fallback_index'), 'fallback_index')
+      .addSelect('r.feedback_rating', 'feedback_rating')
+      .addSelect(picked('at.header_tier_id'), 'header_tier_id')
+      .addSelect(picked('at.header_tier_name'), 'header_tier_name')
+      .addSelect(picked('at.header_tier_color'), 'header_tier_color')
+      .addSelect(picked('at.provider_key_label'), 'provider_key_label')
+      .addSelect(picked('cp.name'), 'custom_provider_name')
+      .addSelect('COALESCE(BOOL_OR(at.autofix_applied), false)', 'autofix_applied')
+      .addSelect(
+        `CASE WHEN COALESCE(BOOL_OR(at.autofix_applied), false) THEN 'retry' ELSE NULL END`,
+        'autofix_role',
+      )
+      .addSelect('COALESCE(SUM(at.cache_read_tokens), 0)', 'cache_read_tokens')
+      .addSelect('COALESCE(SUM(at.cache_creation_tokens), 0)', 'cache_creation_tokens')
+      .addSelect('COUNT(at.id)::int', 'attempt_count')
+      .groupBy('r.id');
+    if (params.cost_min !== undefined) {
+      qb.having(`COALESCE(SUM(${safeCost}), 0) >= :requestCostMin`, {
+        requestCostMin: params.cost_min,
+      });
+    }
+    if (params.cost_max !== undefined) {
+      qb.andHaving(`COALESCE(SUM(${safeCost}), 0) <= :requestCostMax`, {
+        requestCostMax: params.cost_max,
+      });
+    }
+
+    const includeTotal = params.include_total !== false;
+    // Keep the log complete while the online backfill is running. Each still-
+    // unlinked attempt is temporarily its own synthetic request; it disappears
+    // from this branch as soon as the backfill links it to a real parent.
+    const legacyBase = await this.buildBaseMessageQuery(params);
+    legacyBase.andWhere('at.request_id IS NULL');
+    if (params.exclude_playground) excludePlaygroundAgents(legacyBase);
+    const legacyCountQb = legacyBase.clone().select('COUNT(*)', 'total');
+    const legacyDataQb = selectMessageRowColumns(
+      legacyBase.clone(),
+      sqlCastFloat(sqlSanitizeCost('at.cost_usd')),
+    )
+      .addSelect('at.description', 'description')
+      .addSelect('at.service_type', 'service_type')
+      .addSelect('at.cache_read_tokens', 'cache_read_tokens')
+      .addSelect('at.cache_creation_tokens', 'cache_creation_tokens')
+      .addSelect('at.duration_ms', 'duration_ms')
+      .addSelect('1', 'attempt_count');
+    this.applyCursor(legacyDataQb, params.cursor);
+
+    const [count, legacyCount, requestRows, legacyRows, filterOptions] = await Promise.all([
+      includeTotal ? countQb.getRawOne() : Promise.resolve(null),
+      includeTotal ? legacyCountQb.getRawOne() : Promise.resolve(null),
+      qb
+        .orderBy('r.timestamp', 'DESC')
+        .addOrderBy('r.id', 'DESC')
+        .limit(params.limit + 1)
+        .getRawMany(),
+      legacyDataQb
+        .orderBy('at.timestamp', 'DESC')
+        .addOrderBy('at.id', 'DESC')
+        .limit(params.limit + 1)
+        .getRawMany(),
+      params.include_filter_options !== false
+        ? this.getMessageFilterOptions(params)
+        : Promise.resolve({ providers: [] as string[], provider_labels: {} }),
+    ]);
+    const rows = [...requestRows, ...legacyRows].sort((a, b) => {
+      const byTime = String(b.timestamp).localeCompare(String(a.timestamp));
+      return byTime || String(b.id).localeCompare(String(a.id));
+    });
+    const hasMore = rows.length > params.limit;
+    const items = rows.slice(0, params.limit);
+    const last = items[items.length - 1] as Record<string, unknown> | undefined;
+    return {
+      items,
+      next_cursor: hasMore && last ? this.encodeCursor(last) : null,
+      total_count: includeTotal
+        ? Number(count?.total ?? 0) + Number(legacyCount?.total ?? 0)
+        : items.length + (hasMore ? 1 : 0),
       total_count_exact: includeTotal,
       providers: filterOptions.providers,
       provider_labels: filterOptions.provider_labels,
@@ -404,7 +616,7 @@ export class MessagesQueryService {
 
     // Fast path: the tenant-global filter dropdown (no agent constraint, tenant
     // resolved). A recursive loose-index-scan jumps value-to-value through
-    // IDX_agent_messages_tenant_model / IDX_agent_messages_tenant_provider_value
+    // IDX_provider_attempts_tenant_model / IDX_provider_attempts_tenant_provider_value
     // — roughly one index seek per distinct value, versus scanning and
     // disk-sorting the tenant's entire history (measured 2.2s -> ~10ms on a
     // 322k-row tenant). The window is intentionally all-time: cost is now bounded
@@ -439,7 +651,7 @@ export class MessagesQueryService {
     agentName: string | undefined,
   ): Promise<{ models: string[]; providers: string[] }> {
     // Bound the scan: when the caller doesn't constrain the range, default to
-    // the last 90 days. The DISTINCT covers the entire agent_messages table
+    // the last 90 days. The DISTINCT covers the entire provider_attempts table
     // otherwise, which scales poorly as ingest grows.
     const cutoff = range
       ? computeCutoff(rangeToInterval(range))

--- a/packages/backend/src/analytics/services/provider-usage.service.ts
+++ b/packages/backend/src/analytics/services/provider-usage.service.ts
@@ -42,9 +42,9 @@ interface DailyBucketRow {
 }
 
 /**
- * Computes provider usage stats from `agent_messages` in a single collapsed,
+ * Computes provider usage stats from `provider_attempts` in a single collapsed,
  * daily-bucketed aggregation. Kept out of the providers/routing config path so
- * a provider-config read never scans the (large) `agent_messages` table.
+ * a provider-config read never scans the (large) `provider_attempts` table.
  *
  * All time bucketing is pinned to UTC via `AT TIME ZONE 'UTC'` so the day
  * labels line up exactly with the frontend, which builds its 7 sparkline slots
@@ -80,7 +80,7 @@ export class ProviderUsageService {
     // ONE collapsed query: 30-day window, daily buckets per (provider,
     // auth_type, UTC day). We derive 30d totals (sum of buckets), the dense 7d
     // sparkline, and last_used (max bucket day's max timestamp) in JS so the DB
-    // only scans agent_messages once.
+    // only scans provider_attempts once.
     //
     // `m.timestamp AT TIME ZONE 'UTC'` reads the stored `timestamp without time
     // zone` as UTC (→ timestamptz); truncating to day then converting back with

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -495,11 +495,13 @@ describe('selectMessageRowColumns', () => {
 
 describe('sqlCountMessages', () => {
   it('counts logical requests rather than provider hops', () => {
-    expect(sqlCountMessages()).toBe('COUNT(DISTINCT COALESCE(at.request_id, at.id))');
+    expect(sqlCountMessages()).toContain('COUNT(DISTINCT COALESCE(at.request_id, at.id))');
+    expect(sqlCountMessages()).toContain("at.status NOT IN ('error', 'fallback_error'");
   });
 
   it('honours a custom table alias', () => {
-    expect(sqlCountMessages('m')).toBe('COUNT(DISTINCT COALESCE(m.request_id, m.id))');
+    expect(sqlCountMessages('m')).toContain('COUNT(DISTINCT COALESCE(m.request_id, m.id))');
+    expect(sqlCountMessages('m')).toContain('m.status IS NULL');
   });
 
   it('keeps the shared error-status set for request log filters', () => {

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -494,28 +494,21 @@ describe('selectMessageRowColumns', () => {
 });
 
 describe('sqlCountMessages', () => {
-  it('excludes every error status and counts NULL status as a real message', () => {
-    expect(sqlCountMessages()).toBe(
-      "COUNT(*) FILTER (WHERE at.status IS NULL OR at.status NOT IN ('error', 'fallback_error', 'rate_limited', 'auto_fixed'))",
-    );
+  it('counts logical requests rather than provider hops', () => {
+    expect(sqlCountMessages()).toBe('COUNT(DISTINCT COALESCE(at.request_id, at.id))');
   });
 
   it('honours a custom table alias', () => {
-    expect(sqlCountMessages('m')).toBe(
-      "COUNT(*) FILTER (WHERE m.status IS NULL OR m.status NOT IN ('error', 'fallback_error', 'rate_limited', 'auto_fixed'))",
-    );
+    expect(sqlCountMessages('m')).toBe('COUNT(DISTINCT COALESCE(m.request_id, m.id))');
   });
 
-  it('derives the excluded list from the shared error-status set', () => {
+  it('keeps the shared error-status set for request log filters', () => {
     expect(ERROR_MESSAGE_STATUSES).toEqual([
       'error',
       'fallback_error',
       'rate_limited',
       'auto_fixed',
     ]);
-    for (const status of ERROR_MESSAGE_STATUSES) {
-      expect(sqlCountMessages()).toContain(`'${status}'`);
-    }
   });
 });
 

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -56,10 +56,11 @@ export const ERROR_MESSAGE_STATUSES = [
  * it is a complete event listing that must page over failed rows too.
  */
 export function sqlCountMessages(alias = 'at'): string {
+  const list = ERROR_MESSAGE_STATUSES.map((s) => `'${s}'`).join(', ');
   // COALESCE keeps dashboards correct while the online backfill is in flight:
   // linked attempts collapse to one request, while an unlinked historical row
   // temporarily remains its own synthetic request.
-  return `COUNT(DISTINCT COALESCE(${alias}.request_id, ${alias}.id))`;
+  return `COUNT(DISTINCT COALESCE(${alias}.request_id, ${alias}.id)) FILTER (WHERE ${alias}.status IS NULL OR ${alias}.status NOT IN (${list}))`;
 }
 
 /** Comma-quoted list of Manifest-originated error origins, e.g. `'config', 'policy', …`. */
@@ -169,8 +170,11 @@ export function addTenantFilter<T extends ObjectLiteral>(
  * call sites and tests reference one string instead of duplicating (and
  * drifting on) the SQL.
  */
-export const EXCLUDE_PLAYGROUND_AGENTS_PREDICATE =
-  'NOT EXISTS (SELECT 1 FROM agents playag WHERE playag.tenant_id = at.tenant_id AND playag.is_playground = true AND (playag.id = at.agent_id OR playag.name = at.agent_name))';
+export function sqlExcludePlayground(alias: string): string {
+  return `NOT EXISTS (SELECT 1 FROM agents playag WHERE playag.tenant_id = ${alias}.tenant_id AND playag.is_playground = true AND (playag.id = ${alias}.agent_id OR playag.name = ${alias}.agent_name))`;
+}
+
+export const EXCLUDE_PLAYGROUND_AGENTS_PREDICATE = sqlExcludePlayground('at');
 
 export function excludePlaygroundAgents<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -56,8 +56,10 @@ export const ERROR_MESSAGE_STATUSES = [
  * it is a complete event listing that must page over failed rows too.
  */
 export function sqlCountMessages(alias = 'at'): string {
-  const list = ERROR_MESSAGE_STATUSES.map((s) => `'${s}'`).join(', ');
-  return `COUNT(*) FILTER (WHERE ${alias}.status IS NULL OR ${alias}.status NOT IN (${list}))`;
+  // COALESCE keeps dashboards correct while the online backfill is in flight:
+  // linked attempts collapse to one request, while an unlinked historical row
+  // temporarily remains its own synthetic request.
+  return `COUNT(DISTINCT COALESCE(${alias}.request_id, ${alias}.id))`;
 }
 
 /** Comma-quoted list of Manifest-originated error origins, e.g. `'config', 'policy', …`. */
@@ -67,7 +69,7 @@ const MANIFEST_ORIGIN_SQL_LIST = MANIFEST_ERROR_ORIGINS.map((o) => `'${o}'`).joi
  * SQL predicate matching Manifest-originated errors (config / policy / internal
  * / request) — the rows the caller gets back as HTTP 200 stubs or 4xx envelopes
  * without a provider ever being contacted. Backs the `origin=manifest` filter
- * shorthand. Assumes the query builder aliases `agent_messages` as `at`.
+ * shorthand. Assumes the query builder aliases `provider_attempts` as `at`.
  *
  * The Messages log used to hide `config` rows by default on the theory that "a
  * Manifest config error is not a message". It was the only surface that hid
@@ -95,11 +97,11 @@ export function downsample(data: number[], targetLen: number): number[] {
 /**
  * Constrain a message aggregate to the LIVE agent currently owning a slug.
  *
- * `agent_messages` stores `agent_id` alongside `agent_name`, so filtering by
+ * `provider_attempts` stores `agent_id` alongside `agent_name`, so filtering by
  * name alone would pull in rows from a soft-deleted agent that shares the slug
  * with a live one (slug reuse). Resolving to the live agent's id keeps a
  * recreated agent's chart free of its dead namesake's history. Assumes the
- * query builder aliases `agent_messages` as `at`.
+ * query builder aliases `provider_attempts` as `at`.
  */
 export function filterByLiveAgentName<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
@@ -158,7 +160,7 @@ export function addTenantFilter<T extends ObjectLiteral>(
  *     is still excluded. An id-only LEFT JOIN left those rows with a NULL
  *     `is_playground` and wrongly counted them.
  *
- * Assumes the query builder aliases `agent_messages` as `at`. This helper adds
+ * Assumes the query builder aliases `provider_attempts` as `at`. This helper adds
  * no join, so callers that need agent columns must add their own `agents` join
  * (one-to-(0/1) on `a.id = at.agent_id`) independently.
  */
@@ -181,7 +183,7 @@ export function excludePlaygroundAgents<T extends ObjectLiteral>(
  * `provider_key_label` as the canonical `'Default'`. A connection is identified
  * by (tenant, provider, auth_type, label); without the label filter two keys
  * that share provider+auth_type but differ by label merge into one. Assumes the
- * query builder aliases `agent_messages` as `at`.
+ * query builder aliases `provider_attempts` as `at`.
  */
 export function filterByKeyLabel<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
@@ -194,14 +196,14 @@ export function filterByKeyLabel<T extends ObjectLiteral>(
 
 /**
  * Scope a message aggregate to one exact connection by its `tenant_providers`
- * row id — the value stamped on `agent_messages.tenant_provider_id` at proxy
+ * row id — the value stamped on `provider_attempts.tenant_provider_id` at proxy
  * time. Unlike filterByKeyLabel (which matches the provider+auth_type+label
  * tuple and so merges sibling keys sharing a label, and treats a NULL label as
  * 'Default'), this pins to the single connection that actually served each
  * message. Rows with a NULL id — pre-upgrade history that the backfill could
  * not disambiguate, plus local/Ollama and blind-proxy paths — never match,
  * which is the correct behaviour for a per-connection view. Assumes the query
- * builder aliases `agent_messages` as `at`. Prefer this over filterByKeyLabel
+ * builder aliases `provider_attempts` as `at`. Prefer this over filterByKeyLabel
  * whenever a connection id is available; keep filterByKeyLabel for
  * provider-level ("all my OpenAI keys") aggregation.
  */
@@ -237,7 +239,7 @@ export function scopeToConnection<T extends ObjectLiteral>(
  * is the downstream contract — every field it declares must be selected here so
  * the shared badge/provider rendering works identically across every call site.
  *
- * Assumes the query builder aliases `agent_messages` as `at`. Callers pass the
+ * Assumes the query builder aliases `provider_attempts` as `at`. Callers pass the
  * `costExpr` (e.g. `sqlCastFloat(sqlSanitizeCost('at.cost_usd'))`) so the
  * shared helper stays agnostic to how each call site sanitises cost.
  */

--- a/packages/backend/src/analytics/services/specificity-feedback.service.spec.ts
+++ b/packages/backend/src/analytics/services/specificity-feedback.service.spec.ts
@@ -56,6 +56,30 @@ describe('SpecificityFeedbackService', () => {
       );
     });
 
+    it('accepts a request id by resolving one of its specificity attempts', async () => {
+      setOwnedMessage(null);
+      setOwnedMessage({
+        id: 'attempt-1',
+        request_id: 'request-1',
+        specificity_category: 'coding',
+      });
+
+      await service.flagMiscategorized('request-1', 'tenant-1');
+
+      expect(messageRepo.update).toHaveBeenCalledWith('attempt-1', {
+        specificity_miscategorized: true,
+      });
+    });
+
+    it('throws when neither a message nor a request attempt exists', async () => {
+      setOwnedMessage(null);
+      setOwnedMessage(null);
+
+      await expect(service.flagMiscategorized('missing', 'tenant-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
     it('scopes the ownership lookup by tenant_id', async () => {
       const qb = setOwnedMessage({ id: 'msg-1', specificity_category: 'coding' });
 

--- a/packages/backend/src/analytics/services/specificity-feedback.service.ts
+++ b/packages/backend/src/analytics/services/specificity-feedback.service.ts
@@ -84,7 +84,15 @@ export class SpecificityFeedbackService {
       .where('m.id = :id', { id: messageId })
       .andWhere('m.tenant_id = :tenantId', { tenantId })
       .getOne();
-    if (!message) throw new NotFoundException('Message not found');
-    return message;
+    if (message) return message;
+    const requestQb = this.messageRepo.createQueryBuilder('m');
+    if (!requestQb) throw new NotFoundException('Message not found');
+    const requestAttempt = await requestQb
+      .where('m.request_id = :requestId', { requestId: messageId })
+      .andWhere('m.tenant_id = :tenantId', { tenantId })
+      .andWhere('m.specificity_category IS NOT NULL')
+      .getOne();
+    if (!requestAttempt) throw new NotFoundException('Message not found');
+    return requestAttempt;
   }
 }

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -606,6 +606,39 @@ describe('TimeseriesQueriesService', () => {
       expect(out.timeseries[0]).toEqual({ hour: '01', alpha: 1, bravo: 2 });
     });
 
+    it('counts parent requests plus unlinked synthetic rows per agent', async () => {
+      const makeRequestQb = (rows: unknown[]) => {
+        const qb = {
+          select: jest.fn().mockReturnThis(),
+          addSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          groupBy: jest.fn().mockReturnThis(),
+          addGroupBy: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getRawMany: jest.fn().mockResolvedValue(rows),
+        };
+        return qb;
+      };
+      const requestQb = makeRequestQb([{ hour: '01', agent_name: 'alpha', messages: '1' }]);
+      const unlinkedQb = makeRequestQb([
+        { hour: '01', agent_name: 'alpha', messages: '2' },
+        { hour: '01', agent_name: 'bravo', messages: '1' },
+      ]);
+      const requestAware = new TimeseriesQueriesService(
+        { createQueryBuilder: jest.fn(() => unlinkedQb) } as never,
+        {} as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      const out = await requestAware.getPerAgentMessageTimeseries('24h', 'tenant-1', true);
+
+      expect(out.timeseries).toEqual([{ hour: '01', alpha: 3, bravo: 1 }]);
+      expect(requestQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('playag.name = r.agent_name'),
+      );
+    });
+
     it('getPerAgentCostTimeseries pivots cost (non-hourly date bucket)', async () => {
       mockGetRawMany.mockResolvedValue([{ date: '2026-01-01', agent_name: 'alpha', cost: 2.5 }]);
       const out = await service.getPerAgentCostTimeseries('7d', 'u1', false);

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -464,6 +464,66 @@ describe('TimeseriesQueriesService', () => {
       expect(result[0].message_count).toBe(10);
     });
 
+    it('uses request parents plus unlinked legacy attempts for agent message counts', async () => {
+      const makeQb = (rawRows: unknown[] = [], entities: unknown[] = []) => ({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rawRows),
+        getMany: jest.fn().mockResolvedValue(entities),
+      });
+      const agentQb = makeQb(
+        [],
+        [{ id: 'agent-1', name: 'bot-1', display_name: 'Bot One', created_at: oldIso }],
+      );
+      const attemptQb = makeQb([
+        {
+          agent_id: 'agent-1',
+          date: '2026-02-16',
+          message_count: 1,
+          cost: 2,
+          tokens: 300,
+          spark_tokens: 300,
+          last_active: recentIso,
+        },
+      ]);
+      const requestLastActive = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+      const requestQb = makeQb([
+        { agent_id: 'agent-1', message_count: '2', last_active: requestLastActive },
+      ]);
+      const unlinkedQb = makeQb([
+        { agent_id: 'agent-1', message_count: '1', last_active: recentIso },
+      ]);
+      const requestAware = new TimeseriesQueriesService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(attemptQb)
+            .mockReturnValueOnce(unlinkedQb),
+        } as never,
+        { createQueryBuilder: jest.fn(() => agentQb) } as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      const result = await requestAware.getAgentList('u1');
+
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          message_count: 3,
+          total_cost: 2,
+          total_tokens: 300,
+          last_active: requestLastActive,
+        }),
+      );
+      expect(unlinkedQb.where).toHaveBeenCalledWith('at.request_id IS NULL');
+    });
+
     it('falls back to agent_name when display_name is null', async () => {
       mockGetMany.mockResolvedValueOnce([
         { id: 'agent-1', name: 'bot-1', display_name: null, created_at: '2026-02-16' },

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -411,6 +411,125 @@ describe('TimeseriesQueriesService', () => {
       const result = await service.getTimeseries('24h', 'tenant-123', true, 'bot-1');
       expect(result.tokenUsage).toEqual([]);
     });
+
+    it('uses parent requests plus unlinked attempts for request buckets', async () => {
+      const makeQb = (rows: unknown[]) => ({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      });
+      const attemptQb = makeQb([
+        {
+          hour: '2026-07-14T10:00:00Z',
+          input_tokens: '10',
+          output_tokens: '5',
+          cost: '0.2',
+          count: '1',
+        },
+      ]);
+      const requestQb = makeQb([{ hour: '2026-07-14T10:00:00Z', count: '2' }]);
+      const unlinkedQb = makeQb([{ hour: '2026-07-14T10:00:00Z', count: '1' }]);
+      const requestAware = new TimeseriesQueriesService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(attemptQb)
+            .mockReturnValueOnce(unlinkedQb),
+        } as never,
+        {} as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      const result = await requestAware.getTimeseries(
+        '24h',
+        'tenant-1',
+        true,
+        'agent-1',
+        undefined,
+        undefined,
+        true,
+      );
+
+      expect(result.tokenUsage).toEqual([
+        {
+          hour: '2026-07-14T10:00:00Z',
+          input_tokens: 10,
+          output_tokens: 5,
+        },
+      ]);
+      expect(result.messageUsage).toEqual([{ hour: '2026-07-14T10:00:00Z', count: 3 }]);
+      expect(requestQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('deleted_at IS NULL'),
+        expect.objectContaining({ requestAgentName: 'agent-1' }),
+      );
+      expect(requestQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('playag.is_playground = true'),
+      );
+    });
+
+    it('uses daily request buckets and tolerates missing aggregate values', async () => {
+      const makeQb = (rows: unknown[]) => ({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      });
+      const attemptQb = makeQb([
+        { date: '2026-07-14', input_tokens: null, output_tokens: null, cost: null, count: null },
+      ]);
+      const requestQb = makeQb([{ date: '2026-07-14', count: null }]);
+      const unlinkedQb = makeQb([{ date: '2026-07-14', count: '2' }]);
+      const requestAware = new TimeseriesQueriesService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(attemptQb)
+            .mockReturnValueOnce(unlinkedQb),
+        } as never,
+        {} as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      const result = await requestAware.getTimeseries('7d', 'tenant-1', false);
+
+      expect(result.messageUsage).toEqual([{ date: '2026-07-14', count: 2 }]);
+    });
+
+    it('returns no request buckets when tenant scope is absent', async () => {
+      const makeQb = () => ({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
+      const attemptQb = makeQb();
+      const unlinkedQb = makeQb();
+      const requestQb = makeQb();
+      const requestAware = new TimeseriesQueriesService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(attemptQb)
+            .mockReturnValueOnce(unlinkedQb),
+        } as never,
+        {} as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      await requestAware.getTimeseries('7d', null, false);
+
+      expect(requestQb.andWhere).toHaveBeenCalledWith('1 = 0');
+    });
   });
 
   describe('getAgentList', () => {
@@ -493,12 +612,13 @@ describe('TimeseriesQueriesService', () => {
           last_active: recentIso,
         },
       ]);
-      const requestLastActive = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+      const requestLastActive = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      const unlinkedLastActive = new Date(Date.now() - 12 * 60 * 60 * 1000);
       const requestQb = makeQb([
-        { agent_id: 'agent-1', message_count: '2', last_active: requestLastActive },
+        { agent_id: 'agent-1', message_count: null, last_active: requestLastActive },
       ]);
       const unlinkedQb = makeQb([
-        { agent_id: 'agent-1', message_count: '1', last_active: recentIso },
+        { agent_id: 'agent-1', message_count: '3', last_active: unlinkedLastActive },
       ]);
       const requestAware = new TimeseriesQueriesService(
         {
@@ -518,7 +638,7 @@ describe('TimeseriesQueriesService', () => {
           message_count: 3,
           total_cost: 2,
           total_tokens: 300,
-          last_active: requestLastActive,
+          last_active: unlinkedLastActive.toISOString(),
         }),
       );
       expect(unlinkedQb.where).toHaveBeenCalledWith('at.request_id IS NULL');
@@ -697,6 +817,35 @@ describe('TimeseriesQueriesService', () => {
       expect(requestQb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining('playag.name = r.agent_name'),
       );
+    });
+
+    it('uses daily request buckets without a tenant and defaults missing counts to zero', async () => {
+      const makeRequestQb = (rows: unknown[]) => ({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      });
+      const requestQb = makeRequestQb([
+        { date: '2026-07-14', agent_name: 'alpha', messages: null },
+      ]);
+      const unlinkedQb = makeRequestQb([
+        { date: '2026-07-14', agent_name: 'alpha', messages: '2' },
+      ]);
+      const requestAware = new TimeseriesQueriesService(
+        { createQueryBuilder: jest.fn(() => unlinkedQb) } as never,
+        {} as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+
+      const out = await requestAware.getPerAgentMessageTimeseries('7d', null, false);
+
+      expect(out.timeseries).toEqual([{ date: '2026-07-14', alpha: 2 }]);
+      expect(requestQb.andWhere).toHaveBeenCalledWith('1 = 0');
     });
 
     it('getPerAgentCostTimeseries pivots cost (non-hourly date bucket)', async () => {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
@@ -14,6 +14,7 @@ import {
   PROVIDER_SERIES_KEY_EXPR,
 } from './query-helpers';
 import { CustomProvider } from '../../entities/custom-provider.entity';
+import { ManifestRequest } from '../../entities/request.entity';
 import {
   computeCutoff,
   sqlHourBucket,
@@ -49,6 +50,9 @@ export class TimeseriesQueriesService {
     private readonly turnRepo: Repository<AgentMessage>,
     @InjectRepository(Agent)
     private readonly agentRepo: Repository<Agent>,
+    @Optional()
+    @InjectRepository(ManifestRequest)
+    private readonly requestRepo?: Repository<ManifestRequest>,
   ) {}
 
   async getTimeseries(
@@ -82,7 +86,50 @@ export class TimeseriesQueriesService {
     // Scope to this connection: pin to the tenant_providers id when present,
     // else the provider+auth_type+label tuple (see scopeToConnection).
     scopeToConnection(qb, tenantProviderId, label);
-    const rows = await qb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
+    const attemptsPromise = qb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
+    const useRequestCounts =
+      this.requestRepo && !authType && !provider && !label && !tenantProviderId;
+    let requestRowsPromise: Promise<Array<Record<string, unknown>>> = Promise.resolve([]);
+    let unlinkedRowsPromise: Promise<Array<Record<string, unknown>>> = Promise.resolve([]);
+    if (useRequestCounts) {
+      const requestQb = this.requestRepo!.createQueryBuilder('r')
+        .select(hourly ? sqlHourBucket('r.timestamp') : sqlDateBucket('r.timestamp'), bucketAlias)
+        .addSelect('COUNT(*)', 'count')
+        .where('r.timestamp >= :requestCutoff', { requestCutoff: cutoff });
+      if (tenantId)
+        requestQb.andWhere('r.tenant_id = :requestTenantId', { requestTenantId: tenantId });
+      else requestQb.andWhere('1 = 0');
+      if (agentName && tenantId) {
+        requestQb.andWhere(
+          `r.agent_id = (SELECT id FROM agents WHERE tenant_id = :requestTenantId AND name = :requestAgentName AND deleted_at IS NULL LIMIT 1)`,
+          { requestAgentName: agentName },
+        );
+      }
+      if (excludePlayground) {
+        requestQb.andWhere(
+          'NOT EXISTS (SELECT 1 FROM agents a WHERE a.id = r.agent_id AND a.is_playground = true)',
+        );
+      }
+      requestRowsPromise = requestQb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
+
+      const unlinkedQb = this.turnRepo
+        .createQueryBuilder('at')
+        .select(bucketExpr, bucketAlias)
+        .addSelect('COUNT(*)', 'count')
+        .where('at.request_id IS NULL')
+        .andWhere('at.timestamp >= :unlinkedCutoff', { unlinkedCutoff: cutoff });
+      addTenantFilter(unlinkedQb, tenantId, agentName);
+      if (excludePlayground) excludePlaygroundAgents(unlinkedQb);
+      unlinkedRowsPromise = unlinkedQb
+        .groupBy(bucketAlias)
+        .orderBy(bucketAlias, 'ASC')
+        .getRawMany();
+    }
+    const [rows, requestRows, unlinkedRows] = await Promise.all([
+      attemptsPromise,
+      requestRowsPromise,
+      unlinkedRowsPromise,
+    ]);
 
     const tokenUsage: {
       hour?: string;
@@ -103,6 +150,18 @@ export class TimeseriesQueriesService {
       });
       costUsage.push({ ...bucketKey, cost: parsed.cost });
       messageUsage.push({ ...bucketKey, count: parsed.count });
+    }
+
+    if (useRequestCounts) {
+      const counts = new Map<string, number>();
+      for (const row of [...requestRows, ...unlinkedRows]) {
+        const value = String(row[bucketAlias] ?? '');
+        counts.set(value, (counts.get(value) ?? 0) + Number(row['count'] ?? 0));
+      }
+      messageUsage.length = 0;
+      for (const [bucket, count] of [...counts].sort(([a], [b]) => a.localeCompare(b))) {
+        messageUsage.push(hourly ? { hour: bucket, count } : { date: bucket, count });
+      }
     }
 
     return { tokenUsage, costUsage, messageUsage };

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -12,6 +12,7 @@ import {
   sqlCountMessages,
   CUSTOM_PROVIDER_JOIN_CONDITION,
   PROVIDER_SERIES_KEY_EXPR,
+  sqlExcludePlayground,
 } from './query-helpers';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { ManifestRequest } from '../../entities/request.entity';
@@ -106,9 +107,7 @@ export class TimeseriesQueriesService {
         );
       }
       if (excludePlayground) {
-        requestQb.andWhere(
-          'NOT EXISTS (SELECT 1 FROM agents a WHERE a.id = r.agent_id AND a.is_playground = true)',
-        );
+        requestQb.andWhere(sqlExcludePlayground('r'));
       }
       requestRowsPromise = requestQb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
 
@@ -424,6 +423,59 @@ export class TimeseriesQueriesService {
     const cutoff = computeCutoff(interval);
     const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
     const bucketAlias = hourly ? 'hour' : 'date';
+
+    const useRequestCounts =
+      this.requestRepo && !authType && !provider && !label && !tenantProviderId;
+    if (useRequestCounts) {
+      const requestBucketExpr = hourly
+        ? sqlHourBucket('r.timestamp')
+        : sqlDateBucket('r.timestamp');
+      const requestQb = this.requestRepo!.createQueryBuilder('r')
+        .select(requestBucketExpr, bucketAlias)
+        .addSelect('r.agent_name', 'agent_name')
+        .addSelect('COUNT(*)', 'messages')
+        .where('r.timestamp >= :requestCutoff', { requestCutoff: cutoff })
+        .andWhere('r.agent_name IS NOT NULL')
+        .andWhere(sqlExcludePlayground('r'));
+      if (tenantId)
+        requestQb.andWhere('r.tenant_id = :requestTenantId', { requestTenantId: tenantId });
+      else requestQb.andWhere('1 = 0');
+
+      const unlinkedQb = this.turnRepo
+        .createQueryBuilder('at')
+        .select(bucketExpr, bucketAlias)
+        .addSelect('at.agent_name', 'agent_name')
+        .addSelect('COUNT(*)', 'messages')
+        .where('at.request_id IS NULL')
+        .andWhere('at.timestamp >= :unlinkedCutoff', { unlinkedCutoff: cutoff })
+        .andWhere('at.agent_name IS NOT NULL');
+      addTenantFilter(unlinkedQb, tenantId);
+      excludePlaygroundAgents(unlinkedQb);
+
+      const [requestRows, unlinkedRows] = await Promise.all([
+        requestQb
+          .groupBy(bucketAlias)
+          .addGroupBy('r.agent_name')
+          .orderBy(bucketAlias, 'ASC')
+          .getRawMany(),
+        unlinkedQb
+          .groupBy(bucketAlias)
+          .addGroupBy('at.agent_name')
+          .orderBy(bucketAlias, 'ASC')
+          .getRawMany(),
+      ]);
+      const combined = new Map<string, Record<string, unknown>>();
+      for (const row of [...requestRows, ...unlinkedRows]) {
+        const key = `${String(row[bucketAlias])}\0${String(row['agent_name'])}`;
+        const current = combined.get(key);
+        if (current) current['messages'] = Number(current['messages']) + Number(row['messages']);
+        else combined.set(key, { ...row, messages: Number(row['messages'] ?? 0) });
+      }
+      const rows = [...combined.values()].sort((a, b) =>
+        String(a[bucketAlias]).localeCompare(String(b[bucketAlias])),
+      );
+      return pivotByKey(rows, bucketAlias, 'agent_name', 'messages');
+    }
 
     const qb = this.turnRepo
       .createQueryBuilder('at')

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -314,11 +314,7 @@ export class TimeseriesQueriesService {
         .addSelect('MAX(r.timestamp)', 'last_active')
         .where('r.agent_id IS NOT NULL')
         .andWhere('r.timestamp >= :requestStatsCutoff', { requestStatsCutoff: statsCutoff });
-      if (tenantId) {
-        requestCountsQb.andWhere('r.tenant_id = :requestTenantId', { requestTenantId: tenantId });
-      } else {
-        requestCountsQb.andWhere('1 = 0');
-      }
+      requestCountsQb.andWhere('r.tenant_id = :requestTenantId', { requestTenantId: tenantId });
       requestCountRowsPromise = requestCountsQb.groupBy('r.agent_id').getRawMany();
 
       const unlinkedCountsQb = this.turnRepo

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -304,7 +304,36 @@ export class TimeseriesQueriesService {
       .setParameter('sparkCutoff', sparkCutoff);
     addTenantFilter(bucketsQb, tenantId);
 
-    const [agents, bucketRows] = await Promise.all([
+    let requestCountRowsPromise: Promise<Array<Record<string, unknown>>> = Promise.resolve([]);
+    let unlinkedCountRowsPromise: Promise<Array<Record<string, unknown>>> = Promise.resolve([]);
+    if (this.requestRepo) {
+      const requestCountsQb = this.requestRepo
+        .createQueryBuilder('r')
+        .select('r.agent_id', 'agent_id')
+        .addSelect('COUNT(*)', 'message_count')
+        .addSelect('MAX(r.timestamp)', 'last_active')
+        .where('r.agent_id IS NOT NULL')
+        .andWhere('r.timestamp >= :requestStatsCutoff', { requestStatsCutoff: statsCutoff });
+      if (tenantId) {
+        requestCountsQb.andWhere('r.tenant_id = :requestTenantId', { requestTenantId: tenantId });
+      } else {
+        requestCountsQb.andWhere('1 = 0');
+      }
+      requestCountRowsPromise = requestCountsQb.groupBy('r.agent_id').getRawMany();
+
+      const unlinkedCountsQb = this.turnRepo
+        .createQueryBuilder('at')
+        .select('at.agent_id', 'agent_id')
+        .addSelect('COUNT(*)', 'message_count')
+        .addSelect('MAX(at.timestamp)', 'last_active')
+        .where('at.request_id IS NULL')
+        .andWhere('at.agent_id IS NOT NULL')
+        .andWhere('at.timestamp >= :legacyStatsCutoff', { legacyStatsCutoff: statsCutoff });
+      addTenantFilter(unlinkedCountsQb, tenantId);
+      unlinkedCountRowsPromise = unlinkedCountsQb.groupBy('at.agent_id').getRawMany();
+    }
+
+    const [agents, bucketRows, requestCountRows, unlinkedCountRows] = await Promise.all([
       agentQb.andWhere('a.is_active = true').orderBy('a.created_at', 'DESC').getMany(),
       bucketsQb
         .groupBy('at.agent_id')
@@ -312,6 +341,8 @@ export class TimeseriesQueriesService {
         .orderBy('at.agent_id', 'ASC')
         .addOrderBy('date', 'ASC')
         .getRawMany(),
+      requestCountRowsPromise,
+      unlinkedCountRowsPromise,
     ]);
 
     const sparkCutoffIso = String(sparkCutoff);
@@ -319,6 +350,23 @@ export class TimeseriesQueriesService {
       string,
       { message_count: number; total_cost: number; total_tokens: number; last_active: string }
     >();
+    const requestStatsMap = new Map<string, { count: number; last_active: string }>();
+    for (const r of [...requestCountRows, ...unlinkedCountRows]) {
+      const id = String(r['agent_id']);
+      const rawLastActive = r['last_active'];
+      const lastActive =
+        rawLastActive instanceof Date ? rawLastActive.toISOString() : String(rawLastActive ?? '');
+      const existing = requestStatsMap.get(id);
+      if (existing) {
+        existing.count += Number(r['message_count'] ?? 0);
+        if (lastActive > existing.last_active) existing.last_active = lastActive;
+      } else {
+        requestStatsMap.set(id, {
+          count: Number(r['message_count'] ?? 0),
+          last_active: lastActive,
+        });
+      }
+    }
     const sparkMap = new Map<string, number[]>();
     for (const r of bucketRows) {
       const id = String(r['agent_id']);
@@ -355,13 +403,16 @@ export class TimeseriesQueriesService {
 
     return agents.map((a) => {
       const stats = statsMap.get(a.id);
+      const requestStats = requestStatsMap.get(a.id);
       return {
         agent_name: a.name,
         display_name: a.display_name ?? a.name,
         agent_category: a.agent_category ?? null,
         agent_platform: a.agent_platform ?? null,
-        message_count: stats?.message_count ?? 0,
-        last_active: stats?.last_active || String(a.created_at ?? ''),
+        message_count: requestStats?.count ?? stats?.message_count ?? 0,
+        last_active:
+          [requestStats?.last_active, stats?.last_active].filter(Boolean).sort().at(-1) ||
+          String(a.created_at ?? ''),
         total_cost: stats?.total_cost ?? 0,
         total_tokens: stats?.total_tokens ?? 0,
         sparkline: sparkMap.get(a.id) ?? [],

--- a/packages/backend/src/billing/plan.service.spec.ts
+++ b/packages/backend/src/billing/plan.service.spec.ts
@@ -161,7 +161,7 @@ describe('PlanService', () => {
     it('reports plan, usage and limits when enabled', async () => {
       enableBilling();
       mockQuery.mockImplementation((sql: string) =>
-        sql.includes('agent_messages')
+        sql.includes('FROM requests r')
           ? Promise.resolve([{ n: 42 }])
           : Promise.resolve([{ subscriptionPlan: 'free' }]),
       );
@@ -405,7 +405,7 @@ describe('PlanService', () => {
     // Route subscription lookups vs the request COUNT to the right mock result.
     function routeQuery(plan: string, count: number) {
       mockQuery.mockImplementation((sql: string) =>
-        sql.includes('agent_messages')
+        sql.includes('FROM requests r')
           ? Promise.resolve([{ n: count }])
           : Promise.resolve([{ subscriptionPlan: plan }]),
       );
@@ -420,8 +420,8 @@ describe('PlanService', () => {
       enableBilling();
       mockQuery.mockResolvedValue([{ subscriptionPlan: 'pro' }]); // plan null limit
       await expect(service.assertWithinRequestLimit(CTX)).resolves.toBeUndefined();
-      // Only the subscription lookup ran; no agent_messages COUNT.
-      expect(mockQuery.mock.calls.every(([sql]) => !String(sql).includes('agent_messages'))).toBe(
+      // Only the subscription lookup ran; no request COUNT.
+      expect(mockQuery.mock.calls.every(([sql]) => !String(sql).includes('FROM requests r'))).toBe(
         true,
       );
     });
@@ -452,7 +452,7 @@ describe('PlanService', () => {
     it('fails open (allows the request) when the count query errors', async () => {
       enableBilling();
       mockQuery.mockImplementation((sql: string) =>
-        sql.includes('agent_messages')
+        sql.includes('FROM requests r')
           ? Promise.reject(new Error('db down'))
           : Promise.resolve([{ subscriptionPlan: 'free' }]),
       );
@@ -465,13 +465,13 @@ describe('PlanService', () => {
       mockQuery.mockRejectedValue(new Error('snapshot down'));
       await expect(service.assertWithinRequestLimit(CTX)).resolves.toBeUndefined();
       expect(mockQuery).toHaveBeenCalledTimes(1);
-      expect(String(mockQuery.mock.calls[0][0])).not.toContain('agent_messages');
+      expect(String(mockQuery.mock.calls[0][0])).not.toContain('FROM requests r');
     });
 
     it('throttles the fail-open warning and reports the suppressed count', async () => {
       enableBilling();
       mockQuery.mockImplementation((sql: string) =>
-        sql.includes('agent_messages')
+        sql.includes('FROM requests r')
           ? Promise.reject(new Error('db down'))
           : Promise.resolve([{ subscriptionPlan: 'free' }]),
       );

--- a/packages/backend/src/billing/plan.service.spec.ts
+++ b/packages/backend/src/billing/plan.service.spec.ts
@@ -305,6 +305,15 @@ describe('PlanService', () => {
       expect(params[1]).toBe(toLocalSqlTimestamp(new Date(ROLLOUT_RESET)));
     });
 
+    it('casts PostgreSQL bigint counts to numbers before caching', async () => {
+      mockQuery.mockResolvedValue([{ n: '7' }]);
+
+      const count = await service.countRequestsSince('t1', START);
+
+      expect(count).toBe(7);
+      expect(typeof count).toBe('number');
+    });
+
     it('allows the quota reset window to be moved by env override', async () => {
       process.env['PLAN_REQUEST_QUOTA_RESET_AT'] = '2026-07-10T12:34:56Z';
       mockQuery.mockResolvedValue([{ n: 4 }]);

--- a/packages/backend/src/billing/plan.service.ts
+++ b/packages/backend/src/billing/plan.service.ts
@@ -245,7 +245,7 @@ export class PlanService {
         [tenantId, toLocalSqlTimestamp(new Date(windowStartMs))],
       )
       .then((rows: Array<{ n: number }>) => {
-        const count = rows[0]?.n ?? 0;
+        const count = Number(rows[0]?.n ?? 0);
         this.requestCountCache.set(tenantId, { windowStartMs, count, fetchedAt: Date.now() });
         this.evictRequestCountCache();
         return count;

--- a/packages/backend/src/billing/plan.service.ts
+++ b/packages/backend/src/billing/plan.service.ts
@@ -199,13 +199,9 @@ export class PlanService {
   /**
    * Routed requests recorded for the tenant since the effective quota window
    * start, cached per tenant+window with single-flight coalescing. "Routed request" = one
-   * non-superseded `agent_messages` row that does not belong to the tenant's
-   * Playground agent:
-   *  - `superseded = false` drops intermediate fallback attempts, which the
-   *    recorder flags as rows that "must never count as a message" — otherwise
-   *    a single fallback-heavy request would count 2-3×.
-   *  - excluding Manifest-origin rows keeps our own config/policy/internal
-   *    short-circuits visible in Messages without consuming request quota.
+   * explicit request with at least one provider attempt that does not belong to
+   * the tenant's Playground agent. The unlinked-attempt term preserves exact
+   * quota behavior while the online historical backfill is still running.
    *  - excluding Playground keeps the dashboard test tool from consuming (or
    *    being blocked by) the production request quota.
    */
@@ -223,16 +219,29 @@ export class PlanService {
 
     const pending = this.dataSource
       .query(
-        `SELECT COUNT(*)::int AS n
-           FROM agent_messages m
-          WHERE m.tenant_id = $1
-            AND m.timestamp >= $2
-            AND m.superseded = false
-            AND (m.error_origin IS NULL OR m.error_origin NOT IN (${MANIFEST_ERROR_ORIGIN_SQL_LIST}))
-            AND NOT EXISTS (
-              SELECT 1 FROM agents pa
-               WHERE pa.id = m.agent_id AND pa.is_playground = true
-            )`,
+        `SELECT (
+           SELECT COUNT(*)
+           FROM requests r
+           WHERE r.tenant_id = $1
+             AND r.timestamp >= $2
+             AND EXISTS (SELECT 1 FROM provider_attempts pa WHERE pa.request_id = r.id)
+             AND NOT EXISTS (
+               SELECT 1 FROM agents a
+               WHERE a.id = r.agent_id AND a.is_playground = true
+             )
+         ) + (
+           SELECT COUNT(*)
+           FROM provider_attempts m
+           WHERE m.tenant_id = $1
+             AND m.timestamp >= $2
+             AND m.request_id IS NULL
+             AND m.superseded = false
+             AND (m.error_origin IS NULL OR m.error_origin NOT IN (${MANIFEST_ERROR_ORIGIN_SQL_LIST}))
+             AND NOT EXISTS (
+               SELECT 1 FROM agents a
+               WHERE a.id = m.agent_id AND a.is_playground = true
+             )
+         ) AS n`,
         [tenantId, toLocalSqlTimestamp(new Date(windowStartMs))],
       )
       .then((rows: Array<{ n: number }>) => {
@@ -317,7 +326,7 @@ export class PlanService {
   /**
    * Block a routed request when the tenant is at/over its monthly request cap.
    * Called on the /v1/* proxy admission path BEFORE the request is recorded, so
-   * a blocked request never becomes an `agent_messages` row (which would count
+   * a blocked request never becomes an `provider_attempts` row (which would count
    * toward the very limit it hit). Only structured data is thrown; the friendly
    * copy + upgrade link is built in ProxyExceptionFilter.
    */

--- a/packages/backend/src/common/errors/manifest-error.ts
+++ b/packages/backend/src/common/errors/manifest-error.ts
@@ -23,7 +23,7 @@ export const MANIFEST_BLOCKED_REQUEST_REASONS = [
 export type ManifestBlockedRequestReason = (typeof MANIFEST_BLOCKED_REQUEST_REASONS)[number];
 
 /**
- * Error codes that can never become an `agent_messages` row: they are raised by
+ * Error codes that can never become an `provider_attempts` row: they are raised by
  * `AgentKeyAuthGuard` before a key resolves to a tenant, so there is no agent to
  * attribute the row to. Recording them anyway would let anyone holding the
  * endpoint URL write rows into someone else's dashboard by guessing keys.

--- a/packages/backend/src/common/errors/manifest-error.ts
+++ b/packages/backend/src/common/errors/manifest-error.ts
@@ -23,7 +23,7 @@ export const MANIFEST_BLOCKED_REQUEST_REASONS = [
 export type ManifestBlockedRequestReason = (typeof MANIFEST_BLOCKED_REQUEST_REASONS)[number];
 
 /**
- * Error codes that can never become an `provider_attempts` row: they are raised by
+ * Error codes that can never become a `provider_attempts` row: they are raised by
  * `AgentKeyAuthGuard` before a key resolves to a tenant, so there is no agent to
  * attribute the row to. Recording them anyway would let anyone holding the
  * endpoint URL write rows into someone else's dashboard by guessing keys.

--- a/packages/backend/src/common/utils/period.util.ts
+++ b/packages/backend/src/common/utils/period.util.ts
@@ -6,7 +6,7 @@ export interface PeriodBoundaries {
 }
 
 // Boundaries are computed in the Node process's LOCAL timezone, not UTC, because
-// they are compared against `agent_messages.timestamp` — which the pg driver
+// they are compared against `provider_attempts.timestamp` — which the pg driver
 // stores as a local-time `timestamp without time zone`. A UTC boundary would be
 // offset from the stored values by the process TZ, so `periodEnd` (UTC "now")
 // lands behind the local-time rows and the SUM silently reads ~0, meaning token

--- a/packages/backend/src/common/utils/postgres-sql.ts
+++ b/packages/backend/src/common/utils/postgres-sql.ts
@@ -85,7 +85,7 @@ export function sqlCastInterval(paramName: string): string {
  * analytics range cutoffs.
  *
  * Do NOT use this to build window boundaries compared against
- * `agent_messages.timestamp` — those rows are stored in local time, so a UTC
+ * `provider_attempts.timestamp` — those rows are stored in local time, so a UTC
  * boundary is offset by the process TZ and silently drops rows. Use
  * {@link toLocalSqlTimestamp} for that (see computePeriodBoundaries).
  */
@@ -99,7 +99,7 @@ export function toSqlTimestamp(d: Date = new Date()): string {
  * no timezone suffix).
  *
  * This is the correct format for period boundaries compared against
- * `agent_messages.timestamp`: the pg driver serialises stored Dates in local
+ * `provider_attempts.timestamp`: the pg driver serialises stored Dates in local
  * time, so a UTC boundary would be offset from the stored values by the
  * process's TZ offset — silently dropping rows near (and, for `periodEnd`, well
  * within) the window. Mirrors the rationale on {@link computeCutoff}.

--- a/packages/backend/src/common/utils/secret-scrub.ts
+++ b/packages/backend/src/common/utils/secret-scrub.ts
@@ -1,5 +1,5 @@
 // Best-effort redaction of provider credentials that may appear in upstream
-// error bodies before we persist them to agent_messages.error_message. Some
+// error bodies before we persist them to provider_attempts.error_message. Some
 // providers (notably Anthropic 401s) echo the offending Authorization or
 // x-api-key header back in the error body; without scrubbing, a single 401
 // can pin a user's API key to our database.

--- a/packages/backend/src/database/backfills/backfill-message-providers.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.gateway.spec.ts
@@ -45,7 +45,7 @@ describe('TypeOrmBackfillGateway', () => {
     it('refreshes statistics on the stamped table and its join target', async () => {
       const query = jest.fn(async () => undefined);
       await new TypeOrmBackfillGateway({ query } as unknown as DataSource).analyze();
-      expect(query).toHaveBeenCalledWith('ANALYZE "agent_messages"');
+      expect(query).toHaveBeenCalledWith('ANALYZE "provider_attempts"');
       expect(query).toHaveBeenCalledWith('ANALYZE "tenant_providers"');
     });
   });

--- a/packages/backend/src/database/backfills/backfill-message-providers.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.gateway.ts
@@ -9,7 +9,7 @@ import { BackfillGateway, BackfillTimeouts } from './backfill-message-providers'
 export const WINDOW_END_SQL = `
   SELECT max(id) AS end_id
   FROM (
-    SELECT id FROM "agent_messages" WHERE id > $1 ORDER BY id LIMIT $2
+    SELECT id FROM "provider_attempts" WHERE id > $1 ORDER BY id LIMIT $2
   ) w
 `;
 
@@ -23,7 +23,7 @@ export const WINDOW_END_SQL = `
 function stampingPass(joinAndMatch: string): string {
   return `
     WITH upd AS (
-      UPDATE "agent_messages" am
+      UPDATE "provider_attempts" am
       SET "tenant_provider_id" = m.tp_id
       FROM (
         SELECT am2.id AS msg_id, MIN(tp.id) AS tp_id
@@ -40,7 +40,7 @@ function stampingPass(joinAndMatch: string): string {
 
 // Pass 1 (agent-exact): agent_id + provider + auth_type + label.
 export const PASS_1_SQL = stampingPass(`
-  FROM "agent_messages" am2
+  FROM "provider_attempts" am2
   JOIN "tenant_providers" tp
     ON tp.agent_id = am2.agent_id
    AND LOWER(tp.provider) = LOWER(am2.provider)
@@ -54,7 +54,7 @@ export const PASS_1_SQL = stampingPass(`
 
 // Pass 2 (agent-unique): same agent anchor, ignore label.
 export const PASS_2_SQL = stampingPass(`
-  FROM "agent_messages" am2
+  FROM "provider_attempts" am2
   JOIN "tenant_providers" tp
     ON tp.agent_id = am2.agent_id
    AND LOWER(tp.provider) = LOWER(am2.provider)
@@ -68,7 +68,7 @@ export const PASS_2_SQL = stampingPass(`
 // Pass 3 (user-level): match via tenants.name = tenant_providers.created_by_user_id
 // (created_by_user_id is the renamed, value-preserved user_id).
 export const PASS_3_SQL = stampingPass(`
-  FROM "agent_messages" am2
+  FROM "provider_attempts" am2
   JOIN "tenants" t ON t.id = am2.tenant_id
   JOIN "tenant_providers" tp
     ON tp.created_by_user_id = t.name
@@ -85,10 +85,10 @@ export class TypeOrmBackfillGateway implements BackfillGateway {
   constructor(private readonly dataSource: DataSource) {}
 
   async analyze(): Promise<void> {
-    // Refresh stats for the stamping passes: agent_messages (its
+    // Refresh stats for the stamping passes: provider_attempts (its
     // tenant_provider_id column was just added and is ~100% NULL) and the
     // tenant_providers join target.
-    await this.dataSource.query('ANALYZE "agent_messages"');
+    await this.dataSource.query('ANALYZE "provider_attempts"');
     await this.dataSource.query('ANALYZE "tenant_providers"');
   }
 

--- a/packages/backend/src/database/backfills/backfill-message-providers.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.ts
@@ -1,14 +1,14 @@
 /**
- * Post-deploy backfill for `agent_messages.tenant_provider_id`.
+ * Post-deploy backfill for `provider_attempts.tenant_provider_id`.
  *
  * The tenant-refactor migrations add the column (+ FK + covering index) but
  * deliberately do NOT stamp pre-upgrade history inline: on a multi-million-row
- * table that held an ACCESS EXCLUSIVE lock on `agent_messages` for the whole
+ * table that held an ACCESS EXCLUSIVE lock on `provider_attempts` for the whole
  * (12–30+ min) backfill, locking the live app out of its main table. This runs
  * that stamping OUT of the boot transaction, in throttled keyset batches.
  *
  * It runs AFTER the full migration batch, so it targets the FINAL schema names:
- * `agent_messages.tenant_provider_id` (was user_provider_id) matched against
+ * `provider_attempts.tenant_provider_id` (was user_provider_id) matched against
  * `tenant_providers` (was user_providers), whose `created_by_user_id` (was
  * user_id) carries the original user id. Those are pure RENAMEs, so the values
  * are unchanged and the matching is identical to the original in-migration

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
@@ -1,0 +1,96 @@
+import { DataSource } from 'typeorm';
+
+import {
+  TypeOrmRequestBackfillGateway,
+  REQUEST_BACKFILL_WINDOW_END_SQL,
+} from './backfill-requests.gateway';
+
+function mockQueryRunner() {
+  return {
+    connect: jest.fn(async () => undefined),
+    startTransaction: jest.fn(async () => undefined),
+    commitTransaction: jest.fn(async () => undefined),
+    rollbackTransaction: jest.fn(async () => undefined),
+    release: jest.fn(async () => undefined),
+    query: jest.fn(),
+  };
+}
+
+const timeouts = { lockTimeoutMs: 5_000, statementTimeoutMs: 60_000 };
+
+describe('TypeOrmRequestBackfillGateway', () => {
+  it('analyzes attempts and finds keyset window ends', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([{ end_id: 'attempt-9' }])
+      .mockResolvedValueOnce([]);
+    const gateway = new TypeOrmRequestBackfillGateway({ query } as unknown as DataSource);
+
+    await gateway.analyze();
+    await expect(gateway.nextWindowEnd('attempt-0', 100)).resolves.toBe('attempt-9');
+    await expect(gateway.nextWindowEnd('attempt-9', 100)).resolves.toBeNull();
+    expect(query).toHaveBeenCalledWith('ANALYZE "provider_attempts"');
+    expect(query).toHaveBeenCalledWith(REQUEST_BACKFILL_WINDOW_END_SQL, ['attempt-0', 100]);
+  });
+
+  it('backfills a window in one timeout-guarded transaction', async () => {
+    const runner = mockQueryRunner();
+    runner.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([{ n: 2 }])
+      .mockResolvedValueOnce([{ n: 1 }])
+      .mockResolvedValueOnce([{ n: 3 }])
+      .mockResolvedValueOnce([{ n: 4 }])
+      .mockResolvedValueOnce(undefined);
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await expect(gateway.backfillWindow('a', 'b', timeouts)).resolves.toEqual({
+      requests: 5,
+      attempts: 4,
+      rejections: 1,
+    });
+    expect(runner.query).toHaveBeenNthCalledWith(1, "SET LOCAL lock_timeout = '5000ms'");
+    expect(runner.query).toHaveBeenNthCalledWith(2, "SET LOCAL statement_timeout = '60000ms'");
+    expect(runner.commitTransaction).toHaveBeenCalled();
+    expect(runner.rollbackTransaction).not.toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+
+  it('finalizes pending requests and validates the foreign key', async () => {
+    const runner = mockQueryRunner();
+    runner.query.mockResolvedValue(undefined);
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await gateway.finalize(timeouts);
+
+    expect(runner.query).toHaveBeenCalledWith("SET LOCAL statement_timeout = '0'");
+    expect(runner.query).toHaveBeenCalledWith(
+      'ALTER TABLE "provider_attempts" VALIDATE CONSTRAINT "FK_provider_attempts_request"',
+    );
+    expect(runner.commitTransaction).toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+
+  it('rolls back and releases when a window fails', async () => {
+    const runner = mockQueryRunner();
+    const error = new Error('deadlock');
+    runner.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await expect(gateway.backfillWindow('a', 'b', timeouts)).rejects.toBe(error);
+    expect(runner.rollbackTransaction).toHaveBeenCalled();
+    expect(runner.commitTransaction).not.toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.ts
@@ -172,7 +172,17 @@ export const REFRESH_ATTEMPT_REQUESTS_SQL = `
 
 export const FINALIZE_PENDING_REQUESTS_SQL = `
   WITH pending AS (
-    SELECT id FROM "requests" WHERE status = 'pending'
+    SELECT r.id
+    FROM "requests" r
+    WHERE r.status = 'pending'
+      AND (
+        r.id LIKE 'legacy-autofix-%'
+        OR r.id LIKE 'legacy-trace-%'
+        OR EXISTS (
+          SELECT 1 FROM "provider_attempts" pa
+          WHERE pa.request_id = r.id AND pa.id = r.id
+        )
+      )
   ), last_attempt AS (
     SELECT DISTINCT ON (pa.request_id) pa.*
     FROM "provider_attempts" pa

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.ts
@@ -1,0 +1,265 @@
+import { DataSource, QueryRunner } from 'typeorm';
+import type { RequestBackfillGateway, RequestBackfillTimeouts } from './backfill-requests';
+
+export const REQUEST_BACKFILL_WINDOW_END_SQL = `
+  SELECT max(id) AS end_id
+  FROM (
+    SELECT id
+    FROM "provider_attempts"
+    WHERE "request_id" IS NULL AND id > $1
+    ORDER BY id
+    LIMIT $2
+  ) w
+`;
+
+const REQUEST_LEVEL_ORIGINS = `'config', 'policy', 'request', 'internal'`;
+
+// These rows predate the explicit request table but never represented a
+// provider call. Copy them to requests and remove the pseudo-attempt.
+export const INSERT_REJECTIONS_SQL = `
+  WITH batch AS (
+    SELECT * FROM "provider_attempts"
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+      AND status <> 'ok'
+      AND error_origin IN (${REQUEST_LEVEL_ORIGINS})
+  ), ins AS (
+    INSERT INTO "requests" (
+      id, tenant_id, agent_id, user_id, agent_name, trace_id, session_key, session_id,
+      timestamp, duration_ms, status, error_message, error_http_status, error_code,
+      error_origin, error_class, requested_model, caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    )
+    SELECT
+      id, tenant_id, agent_id, user_id, agent_name, trace_id, session_key, session_id,
+      timestamp, duration_ms, status, error_message, error_http_status, error_code,
+      error_origin, error_class, model, caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    FROM batch
+    ON CONFLICT (id) DO NOTHING
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM ins
+`;
+
+export const DELETE_REJECTIONS_SQL = `
+  WITH deleted AS (
+    DELETE FROM "provider_attempts"
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+      AND status <> 'ok'
+      AND error_origin IN (${REQUEST_LEVEL_ORIGINS})
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM deleted
+`;
+
+const LEGACY_REQUEST_ID = `CASE
+  WHEN autofix_group_id IS NOT NULL THEN
+    'legacy-autofix-' || md5(COALESCE(tenant_id, '') || ':' || COALESCE(agent_id, '') || ':' || autofix_group_id)
+  WHEN trace_id IS NOT NULL THEN
+    'legacy-trace-' || md5(COALESCE(tenant_id, '') || ':' || COALESCE(agent_id, '') || ':' || trace_id)
+  ELSE id
+END`;
+
+const OUTCOME_RANK = `CASE
+  WHEN status = 'ok' THEN 3
+  WHEN NOT COALESCE(superseded, false)
+    AND status NOT IN ('fallback_error', 'auto_fixed') THEN 2
+  ELSE 1
+END`;
+
+export const INSERT_ATTEMPT_REQUESTS_SQL = `
+  WITH batch AS (
+    SELECT *, ${LEGACY_REQUEST_ID} AS legacy_request_id, ${OUTCOME_RANK} AS outcome_rank
+    FROM "provider_attempts"
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+  ), terminal AS (
+    SELECT DISTINCT ON (legacy_request_id) *
+    FROM batch
+    ORDER BY legacy_request_id, outcome_rank DESC, timestamp DESC, id DESC
+  ), ins AS (
+    INSERT INTO "requests" (
+      id, tenant_id, agent_id, user_id, agent_name, trace_id, session_key, session_id,
+      timestamp, duration_ms, status, error_message, error_http_status, error_code,
+      error_origin, error_class, requested_model, caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    )
+    SELECT
+      legacy_request_id, tenant_id, agent_id, user_id, agent_name, trace_id,
+      session_key, session_id, timestamp, duration_ms,
+      CASE WHEN outcome_rank = 1 THEN 'pending' ELSE status END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_message END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_http_status END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_code END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_origin END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_class END,
+      COALESCE(fallback_from_model, model), caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    FROM terminal
+    ON CONFLICT (id) DO UPDATE SET
+      timestamp = LEAST(requests.timestamp, EXCLUDED.timestamp),
+      status = CASE
+        WHEN requests.status = 'ok' OR EXCLUDED.status = 'ok' THEN 'ok'
+        WHEN EXCLUDED.status = 'pending' THEN requests.status
+        ELSE EXCLUDED.status
+      END,
+      error_message = CASE WHEN requests.status = 'ok' OR EXCLUDED.status = 'pending'
+        THEN requests.error_message ELSE EXCLUDED.error_message END,
+      error_http_status = CASE WHEN requests.status = 'ok' OR EXCLUDED.status = 'pending'
+        THEN requests.error_http_status ELSE EXCLUDED.error_http_status END,
+      error_code = CASE WHEN requests.status = 'ok' OR EXCLUDED.status = 'pending'
+        THEN requests.error_code ELSE EXCLUDED.error_code END,
+      error_origin = CASE WHEN requests.status = 'ok' OR EXCLUDED.status = 'pending'
+        THEN requests.error_origin ELSE EXCLUDED.error_origin END,
+      error_class = CASE WHEN requests.status = 'ok' OR EXCLUDED.status = 'pending'
+        THEN requests.error_class ELSE EXCLUDED.error_class END
+    RETURNING (xmax = 0) AS inserted
+  )
+  SELECT count(*) FILTER (WHERE inserted)::int AS n FROM ins
+`;
+
+export const LINK_ATTEMPTS_SQL = `
+  WITH updated AS (
+    UPDATE "provider_attempts"
+    SET "request_id" = ${LEGACY_REQUEST_ID}
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM updated
+`;
+
+// A legacy request can span UUID-ordered windows. Recompute each affected
+// parent from every attempt linked so far, so the final outcome never depends
+// on which window happened to contain the success or terminal failure.
+export const REFRESH_ATTEMPT_REQUESTS_SQL = `
+  WITH affected AS (
+    SELECT DISTINCT request_id
+    FROM "provider_attempts"
+    WHERE id > $1 AND id <= $2 AND request_id IS NOT NULL
+  ), totals AS (
+    SELECT pa.request_id,
+           min(pa.timestamp) AS started_at,
+           sum(pa.duration_ms)::int AS duration_ms
+    FROM "provider_attempts" pa
+    JOIN affected a ON a.request_id = pa.request_id
+    GROUP BY pa.request_id
+  ), terminal AS (
+    SELECT DISTINCT ON (pa.request_id) pa.*
+    FROM "provider_attempts" pa
+    JOIN affected a ON a.request_id = pa.request_id
+    ORDER BY pa.request_id,
+      CASE
+        WHEN pa.status = 'ok' THEN 3
+        WHEN NOT COALESCE(pa.superseded, false)
+          AND pa.status NOT IN ('fallback_error', 'auto_fixed') THEN 2
+        ELSE 1
+      END DESC,
+      pa.timestamp DESC,
+      pa.id DESC
+  )
+  UPDATE "requests" r
+  SET timestamp = totals.started_at,
+      duration_ms = totals.duration_ms,
+      status = terminal.status,
+      error_message = terminal.error_message,
+      error_http_status = terminal.error_http_status,
+      error_code = terminal.error_code,
+      error_origin = terminal.error_origin,
+      error_class = terminal.error_class
+  FROM totals
+  JOIN terminal ON terminal.request_id = totals.request_id
+  WHERE r.id = totals.request_id
+`;
+
+export const FINALIZE_PENDING_REQUESTS_SQL = `
+  WITH pending AS (
+    SELECT id FROM "requests" WHERE status = 'pending'
+  ), last_attempt AS (
+    SELECT DISTINCT ON (pa.request_id) pa.*
+    FROM "provider_attempts" pa
+    JOIN pending p ON p.id = pa.request_id
+    ORDER BY pa.request_id, pa.timestamp DESC, pa.id DESC
+  )
+  UPDATE "requests" r
+  SET status = COALESCE(last_attempt.status, 'error'),
+      error_message = last_attempt.error_message,
+      error_http_status = last_attempt.error_http_status,
+      error_code = last_attempt.error_code,
+      error_origin = last_attempt.error_origin,
+      error_class = last_attempt.error_class
+  FROM last_attempt
+  WHERE r.id = last_attempt.request_id
+`;
+
+export class TypeOrmRequestBackfillGateway implements RequestBackfillGateway {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async analyze(): Promise<void> {
+    await this.dataSource.query('ANALYZE "provider_attempts"');
+  }
+
+  async nextWindowEnd(afterId: string, batchSize: number): Promise<string | null> {
+    const rows = (await this.dataSource.query(REQUEST_BACKFILL_WINDOW_END_SQL, [
+      afterId,
+      batchSize,
+    ])) as { end_id: string | null }[];
+    return rows[0]?.end_id ?? null;
+  }
+
+  async backfillWindow(
+    afterId: string,
+    endId: string,
+    timeouts: RequestBackfillTimeouts,
+  ): Promise<{ requests: number; attempts: number; rejections: number }> {
+    return this.inTransaction(timeouts, async (runner) => {
+      const params = [afterId, endId];
+      const [{ n: requests }] = (await runner.query(INSERT_REJECTIONS_SQL, params)) as {
+        n: number;
+      }[];
+      const [{ n: rejections }] = (await runner.query(DELETE_REJECTIONS_SQL, params)) as {
+        n: number;
+      }[];
+      const [{ n: attemptRequests }] = (await runner.query(
+        INSERT_ATTEMPT_REQUESTS_SQL,
+        params,
+      )) as { n: number }[];
+      const [{ n: attempts }] = (await runner.query(LINK_ATTEMPTS_SQL, params)) as {
+        n: number;
+      }[];
+      await runner.query(REFRESH_ATTEMPT_REQUESTS_SQL, params);
+      return { requests: requests + attemptRequests, attempts, rejections };
+    });
+  }
+
+  async finalize(timeouts: RequestBackfillTimeouts): Promise<void> {
+    await this.inTransaction(timeouts, async (runner) => {
+      await runner.query(FINALIZE_PENDING_REQUESTS_SQL);
+      // Validation scans the table under SHARE UPDATE EXCLUSIVE: reads and
+      // writes continue, unlike adding a validated FK in the deploy migration.
+      await runner.query(`SET LOCAL statement_timeout = '0'`);
+      await runner.query(
+        'ALTER TABLE "provider_attempts" VALIDATE CONSTRAINT "FK_provider_attempts_request"',
+      );
+    });
+  }
+
+  private async inTransaction<T>(
+    timeouts: RequestBackfillTimeouts,
+    fn: (runner: QueryRunner) => Promise<T>,
+  ): Promise<T> {
+    const runner = this.dataSource.createQueryRunner();
+    await runner.connect();
+    await runner.startTransaction();
+    try {
+      await runner.query(`SET LOCAL lock_timeout = '${timeouts.lockTimeoutMs}ms'`);
+      await runner.query(`SET LOCAL statement_timeout = '${timeouts.statementTimeoutMs}ms'`);
+      const result = await fn(runner);
+      await runner.commitTransaction();
+      return result;
+    } catch (error) {
+      await runner.rollbackTransaction();
+      throw error;
+    } finally {
+      await runner.release();
+    }
+  }
+}

--- a/packages/backend/src/database/backfills/backfill-requests.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.spec.ts
@@ -1,0 +1,54 @@
+import { runRequestBackfill, type RequestBackfillGateway } from './backfill-requests';
+
+describe('runRequestBackfill', () => {
+  it('walks bounded windows, throttles, and finalizes only after all rows link', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest
+        .fn()
+        .mockResolvedValueOnce('b')
+        .mockResolvedValueOnce('d')
+        .mockResolvedValueOnce(null),
+      backfillWindow: jest
+        .fn()
+        .mockResolvedValueOnce({ requests: 2, attempts: 2, rejections: 0 })
+        .mockResolvedValueOnce({ requests: 1, attempts: 1, rejections: 1 }),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runRequestBackfill(gateway, { batchSize: 2, throttleMs: 5, sleep }),
+    ).resolves.toEqual({ windows: 2, requests: 3, attempts: 3, rejections: 1 });
+
+    expect(gateway.nextWindowEnd).toHaveBeenNthCalledWith(1, '', 2);
+    expect(gateway.nextWindowEnd).toHaveBeenNthCalledWith(2, 'b', 2);
+    expect(gateway.backfillWindow).toHaveBeenNthCalledWith(1, '', 'b', expect.any(Object));
+    expect(gateway.backfillWindow).toHaveBeenNthCalledWith(2, 'b', 'd', expect.any(Object));
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(gateway.finalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a timeout without advancing the cursor', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest.fn().mockResolvedValueOnce('b').mockResolvedValueOnce(null),
+      backfillWindow: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('canceling statement due to statement timeout'))
+        .mockResolvedValueOnce({ requests: 1, attempts: 1, rejections: 0 }),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    const result = await runRequestBackfill(gateway, {
+      throttleMs: 0,
+      retryBackoffMs: 10,
+      sleep,
+    });
+
+    expect(result.windows).toBe(1);
+    expect(gateway.backfillWindow).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+});

--- a/packages/backend/src/database/backfills/backfill-requests.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.spec.ts
@@ -53,6 +53,122 @@ describe('runRequestBackfill', () => {
     expect(sleep).toHaveBeenCalledWith(10);
   });
 
+  it('uses defaults when options are omitted', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(runRequestBackfill(gateway)).resolves.toEqual({
+      windows: 0,
+      requests: 0,
+      attempts: 0,
+      rejections: 0,
+    });
+  });
+
+  it('reports periodic progress and retries finalization', async () => {
+    const windowEnds = Array.from({ length: 25 }, (_, index) => `id-${index + 1}`);
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest
+        .fn()
+        .mockImplementationOnce(async () => windowEnds[0])
+        .mockImplementation(async (_afterId: string) => {
+          const call = (gateway.nextWindowEnd as jest.Mock).mock.calls.length;
+          return windowEnds[call - 1] ?? null;
+        }),
+      backfillWindow: jest
+        .fn()
+        .mockRejectedValueOnce('deadlock detected')
+        .mockResolvedValue({ requests: 1, attempts: 1, rejections: 0 }),
+      finalize: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('lock timeout'))
+        .mockResolvedValueOnce(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const logger = { log: jest.fn() };
+
+    const result = await runRequestBackfill(gateway, {
+      throttleMs: 0,
+      retryBackoffMs: 2,
+      sleep,
+      logger,
+    });
+
+    expect(result.windows).toBe(25);
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('25 window(s)'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('finalization failed'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('done'));
+    expect(sleep).toHaveBeenCalledWith(2);
+  });
+
+  it('uses the real throttle timer when no sleep override is provided', async () => {
+    jest.useFakeTimers();
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest.fn().mockResolvedValueOnce('b').mockResolvedValueOnce(null),
+      backfillWindow: jest.fn().mockResolvedValue({ requests: 1, attempts: 1, rejections: 0 }),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const resultPromise = runRequestBackfill(gateway, { throttleMs: 1 });
+    await jest.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({ windows: 1, attempts: 1 }),
+    );
+    jest.useRealTimers();
+  });
+
+  it('does not retry a non-retryable failure', async () => {
+    const failure = new Error('invalid input');
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest.fn().mockResolvedValue('b'),
+      backfillWindow: jest.fn().mockRejectedValue(failure),
+      finalize: jest.fn(),
+    };
+
+    await expect(runRequestBackfill(gateway, { throttleMs: 0 })).rejects.toBe(failure);
+  });
+
+  it('retries a string finalization error', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalize: jest
+        .fn()
+        .mockRejectedValueOnce('deadlock detected')
+        .mockResolvedValueOnce(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    await expect(runRequestBackfill(gateway, { retryBackoffMs: 1, sleep })).resolves.toEqual({
+      windows: 0,
+      requests: 0,
+      attempts: 0,
+      rejections: 0,
+    });
+    expect(gateway.finalize).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a non-retryable finalization error', async () => {
+    const failure = new Error('invalid final state');
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalize: jest.fn().mockRejectedValue(failure),
+    };
+
+    await expect(runRequestBackfill(gateway)).rejects.toBe(failure);
+  });
+
   it.each([
     ['batchSize', 0],
     ['batchSize', Number.NaN],

--- a/packages/backend/src/database/backfills/backfill-requests.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.spec.ts
@@ -1,4 +1,5 @@
 import { runRequestBackfill, type RequestBackfillGateway } from './backfill-requests';
+import { FINALIZE_PENDING_REQUESTS_SQL } from './backfill-requests.gateway';
 
 describe('runRequestBackfill', () => {
   it('walks bounded windows, throttles, and finalizes only after all rows link', async () => {
@@ -50,5 +51,36 @@ describe('runRequestBackfill', () => {
     expect(result.windows).toBe(1);
     expect(gateway.backfillWindow).toHaveBeenCalledTimes(2);
     expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it.each([
+    ['batchSize', 0],
+    ['batchSize', Number.NaN],
+    ['throttleMs', -1],
+    ['maxRetries', -1],
+    ['retryBackoffMs', Number.POSITIVE_INFINITY],
+    ['lockTimeoutMs', 0],
+    ['statementTimeoutMs', -1],
+  ] as const)('rejects invalid %s before touching the gateway', async (name, value) => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn(),
+      nextWindowEnd: jest.fn(),
+      backfillWindow: jest.fn(),
+      finalize: jest.fn(),
+    };
+
+    await expect(runRequestBackfill(gateway, { [name]: value })).rejects.toThrow(name);
+    expect(gateway.analyze).not.toHaveBeenCalled();
+  });
+});
+
+describe('request backfill finalization', () => {
+  it('only finalizes backfill-created pending parents', () => {
+    expect(FINALIZE_PENDING_REQUESTS_SQL).toContain("r.id LIKE 'legacy-autofix-%'");
+    expect(FINALIZE_PENDING_REQUESTS_SQL).toContain("r.id LIKE 'legacy-trace-%'");
+    expect(FINALIZE_PENDING_REQUESTS_SQL).toContain('pa.id = r.id');
+    expect(FINALIZE_PENDING_REQUESTS_SQL).not.toContain(
+      `SELECT id FROM "requests" WHERE status = 'pending'`,
+    );
   });
 });

--- a/packages/backend/src/database/backfills/backfill-requests.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.ts
@@ -34,6 +34,18 @@ export interface RequestBackfillResult {
   rejections: number;
 }
 
+function assertPositiveFinite(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`request backfill ${name} must be a positive finite number`);
+  }
+}
+
+function assertNonNegativeFinite(name: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`request backfill ${name} must be a non-negative finite number`);
+  }
+}
+
 const realSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -58,6 +70,13 @@ export async function runRequestBackfill(
     lockTimeoutMs: options.lockTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.lockTimeoutMs,
     statementTimeoutMs: options.statementTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.statementTimeoutMs,
   };
+
+  assertPositiveFinite('batchSize', batchSize);
+  assertNonNegativeFinite('throttleMs', throttleMs);
+  assertNonNegativeFinite('maxRetries', maxRetries);
+  assertNonNegativeFinite('retryBackoffMs', retryBackoffMs);
+  assertPositiveFinite('lockTimeoutMs', timeouts.lockTimeoutMs);
+  assertPositiveFinite('statementTimeoutMs', timeouts.statementTimeoutMs);
 
   await gateway.analyze();
 

--- a/packages/backend/src/database/backfills/backfill-requests.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.ts
@@ -1,0 +1,124 @@
+import { DEFAULT_BACKFILL_OPTIONS, isRetryableBackfillError } from './backfill-message-providers';
+
+export interface RequestBackfillTimeouts {
+  lockTimeoutMs: number;
+  statementTimeoutMs: number;
+}
+
+export interface RequestBackfillGateway {
+  analyze(): Promise<void>;
+  nextWindowEnd(afterId: string, batchSize: number): Promise<string | null>;
+  backfillWindow(
+    afterId: string,
+    endId: string,
+    timeouts: RequestBackfillTimeouts,
+  ): Promise<{ requests: number; attempts: number; rejections: number }>;
+  finalize(timeouts: RequestBackfillTimeouts): Promise<void>;
+}
+
+export interface RequestBackfillOptions {
+  batchSize?: number;
+  throttleMs?: number;
+  lockTimeoutMs?: number;
+  statementTimeoutMs?: number;
+  maxRetries?: number;
+  retryBackoffMs?: number;
+  logger?: { log: (message: string) => void };
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface RequestBackfillResult {
+  windows: number;
+  requests: number;
+  attempts: number;
+  rejections: number;
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Regroup history after startup in short, retryable keyset windows. This is
+ * deliberately not a TypeORM migration: deploy readiness must not wait for a
+ * scan and rewrite of the hot provider_attempts table.
+ */
+export async function runRequestBackfill(
+  gateway: RequestBackfillGateway,
+  options: RequestBackfillOptions = {},
+): Promise<RequestBackfillResult> {
+  const batchSize = options.batchSize ?? DEFAULT_BACKFILL_OPTIONS.batchSize;
+  const throttleMs = options.throttleMs ?? DEFAULT_BACKFILL_OPTIONS.throttleMs;
+  const maxRetries = options.maxRetries ?? DEFAULT_BACKFILL_OPTIONS.maxRetries;
+  const retryBackoffMs = options.retryBackoffMs ?? DEFAULT_BACKFILL_OPTIONS.retryBackoffMs;
+  const sleep = options.sleep ?? realSleep;
+  const log = (message: string): void => options.logger?.log(message);
+  const timeouts: RequestBackfillTimeouts = {
+    lockTimeoutMs: options.lockTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.lockTimeoutMs,
+    statementTimeoutMs: options.statementTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.statementTimeoutMs,
+  };
+
+  await gateway.analyze();
+
+  let afterId = '';
+  const result: RequestBackfillResult = {
+    windows: 0,
+    requests: 0,
+    attempts: 0,
+    rejections: 0,
+  };
+
+  for (;;) {
+    const endId = await gateway.nextWindowEnd(afterId, batchSize);
+    if (endId === null) break;
+
+    let attempt = 0;
+    for (;;) {
+      try {
+        const window = await gateway.backfillWindow(afterId, endId, timeouts);
+        result.requests += window.requests;
+        result.attempts += window.attempts;
+        result.rejections += window.rejections;
+        break;
+      } catch (error) {
+        attempt += 1;
+        if (attempt > maxRetries || !isRetryableBackfillError(error)) throw error;
+        const reason = error instanceof Error ? error.message : String(error);
+        log(
+          `request backfill: window after "${afterId}" failed (attempt ${attempt}/${maxRetries}: ${reason}); retrying`,
+        );
+        await sleep(retryBackoffMs * attempt);
+      }
+    }
+
+    result.windows += 1;
+    afterId = endId;
+    if (result.windows % 25 === 0) {
+      log(
+        `request backfill: ${result.windows} window(s), ${result.attempts} attempt(s), ${result.rejections} zero-attempt rejection(s)`,
+      );
+    }
+    if (throttleMs > 0) await sleep(throttleMs);
+  }
+
+  let finalizeAttempt = 0;
+  for (;;) {
+    try {
+      await gateway.finalize(timeouts);
+      break;
+    } catch (error) {
+      finalizeAttempt += 1;
+      if (finalizeAttempt > maxRetries || !isRetryableBackfillError(error)) throw error;
+      const reason = error instanceof Error ? error.message : String(error);
+      log(
+        `request backfill: finalization failed (attempt ${finalizeAttempt}/${maxRetries}: ${reason}); retrying`,
+      );
+      await sleep(retryBackoffMs * finalizeAttempt);
+    }
+  }
+  log(
+    `request backfill: done — ${result.attempts} attempt(s) and ${result.rejections} rejection(s) across ${result.windows} window(s)`,
+  );
+  return result;
+}

--- a/packages/backend/src/database/backfills/backfill.module.ts
+++ b/packages/backend/src/database/backfills/backfill.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BackfillState } from '../../entities/backfill-state.entity';
 import { MessageProviderBackfillBootService } from './message-provider-backfill.boot.service';
+import { RequestBackfillBootService } from './request-backfill.boot.service';
 
 /**
  * Wires the post-deploy backfill boot task. The DataSource is provided globally
@@ -10,6 +11,6 @@ import { MessageProviderBackfillBootService } from './message-provider-backfill.
  */
 @Module({
   imports: [TypeOrmModule.forFeature([BackfillState])],
-  providers: [MessageProviderBackfillBootService],
+  providers: [MessageProviderBackfillBootService, RequestBackfillBootService],
 })
 export class BackfillModule {}

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
@@ -74,7 +74,9 @@ describe('MessageProviderBackfillBootService', () => {
       const state = makeState(true);
       const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
       const runner = jest.fn();
-      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner),
+      ).resolves.toBe(true);
       expect(ds.createQueryRunner).not.toHaveBeenCalled();
       expect(runner).not.toHaveBeenCalled();
     });
@@ -83,7 +85,9 @@ describe('MessageProviderBackfillBootService', () => {
       const lock = makeLock(false);
       const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
       const runner = jest.fn();
-      await new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+      ).resolves.toBe(false);
       expect(lock.query).toHaveBeenCalledWith(TRYLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
       expect(runner).not.toHaveBeenCalled();
       expect(lock.query).not.toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
@@ -96,7 +100,9 @@ describe('MessageProviderBackfillBootService', () => {
       const state = makeState(false);
       const runner = jest.fn(async () => ({ windows: 3, stamped: 42 }));
 
-      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner),
+      ).resolves.toBe(true);
 
       expect(runner).toHaveBeenCalledWith(
         ds,
@@ -115,7 +121,9 @@ describe('MessageProviderBackfillBootService', () => {
       state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1); // free, then taken
       const runner = jest.fn();
 
-      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner),
+      ).resolves.toBe(true);
 
       expect(runner).not.toHaveBeenCalled();
       expect(lock.query).toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
@@ -152,7 +160,7 @@ describe('MessageProviderBackfillBootService', () => {
 
       await expect(
         new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner),
-      ).resolves.toBeUndefined();
+      ).resolves.toBe(true);
       expect(lock.release).toHaveBeenCalled();
     });
 

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
@@ -162,7 +162,7 @@ describe('MessageProviderBackfillBootService', () => {
         createQueryRunner: jest.fn(() => lock),
         // gateway.nextWindowEnd → no rows → backfill completes with zero windows
         query: jest.fn(async (sql: string) =>
-          sql.includes('FROM "agent_messages"') ? [{ end_id: null }] : undefined,
+          sql.includes('FROM "provider_attempts"') ? [{ end_id: null }] : undefined,
         ),
       } as unknown as DataSource;
       const state = makeState(false);

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
@@ -67,6 +67,22 @@ describe('MessageProviderBackfillBootService', () => {
 
       expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('post-deploy backfill failed'));
     });
+
+    it('waits and retries after advisory-lock contention', async () => {
+      jest.useFakeTimers();
+      process.env['NODE_ENV'] = 'production';
+      const state = makeState(false);
+      state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+      const lock = makeLock(false);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+      new MessageProviderBackfillBootService(ds, state.repo).onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(30_000);
+
+      expect(state.countBy).toHaveBeenCalledTimes(2);
+      expect(lock.release).toHaveBeenCalled();
+      jest.useRealTimers();
+    });
   });
 
   describe('runOnce', () => {

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
@@ -4,6 +4,7 @@ import { DataSource, Repository } from 'typeorm';
 import { BackfillState } from '../../entities/backfill-state.entity';
 import {
   MESSAGE_PROVIDER_BACKFILL_LOCK_KEY,
+  MESSAGE_PROVIDER_BACKFILL_MAX_LOCK_ATTEMPTS,
   MESSAGE_PROVIDER_BACKFILL_NAME,
   MessageProviderBackfillBootService,
 } from './message-provider-backfill.boot.service';
@@ -81,6 +82,23 @@ describe('MessageProviderBackfillBootService', () => {
 
       expect(state.countBy).toHaveBeenCalledTimes(2);
       expect(lock.release).toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('stops retrying when the advisory lock remains busy', async () => {
+      jest.useFakeTimers();
+      process.env['NODE_ENV'] = 'production';
+      const state = makeState(false);
+      const lock = makeLock(false);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+      new MessageProviderBackfillBootService(ds, state.repo).onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(
+        30_000 * (MESSAGE_PROVIDER_BACKFILL_MAX_LOCK_ATTEMPTS - 1),
+      );
+
+      expect(state.countBy).toHaveBeenCalledTimes(MESSAGE_PROVIDER_BACKFILL_MAX_LOCK_ATTEMPTS);
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('lock stayed busy'));
       jest.useRealTimers();
     });
   });

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
@@ -15,6 +15,7 @@ export const MESSAGE_PROVIDER_BACKFILL_NAME = 'agent_message_provider_attributio
 /** Shared lock key so only one post-deploy backfill runs at once. */
 export const MESSAGE_PROVIDER_BACKFILL_LOCK_KEY = 1792000000;
 const LOCK_RETRY_MS = 30_000;
+export const MESSAGE_PROVIDER_BACKFILL_MAX_LOCK_ATTEMPTS = 10;
 
 const wait = (ms: number): Promise<void> =>
   new Promise((resolve) => {
@@ -68,7 +69,13 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
   }
 
   private async runUntilComplete(): Promise<void> {
-    while (!(await this.runOnce())) await wait(LOCK_RETRY_MS);
+    for (let attempt = 1; attempt <= MESSAGE_PROVIDER_BACKFILL_MAX_LOCK_ATTEMPTS; attempt += 1) {
+      if (await this.runOnce()) return;
+      if (attempt < MESSAGE_PROVIDER_BACKFILL_MAX_LOCK_ATTEMPTS) await wait(LOCK_RETRY_MS);
+    }
+    throw new Error(
+      `provider attribution lock stayed busy for ${MESSAGE_PROVIDER_BACKFILL_MAX_LOCK_ATTEMPTS} attempts`,
+    );
   }
 
   /** `runner` is injectable for tests; production uses the real backfill. */

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
@@ -12,8 +12,15 @@ import { TypeOrmBackfillGateway } from './backfill-message-providers.gateway';
 
 /** Marker name in `backfill_state`; presence == this backfill has finished. */
 export const MESSAGE_PROVIDER_BACKFILL_NAME = 'agent_message_provider_attribution';
-/** Stable advisory-lock key so only one app instance runs the backfill at once. */
+/** Shared lock key so only one post-deploy backfill runs at once. */
 export const MESSAGE_PROVIDER_BACKFILL_LOCK_KEY = 1792000000;
+const LOCK_RETRY_MS = 30_000;
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+  });
 
 export type BackfillRunner = (
   dataSource: DataSource,
@@ -53,17 +60,21 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
     if (process.env['NODE_ENV'] !== 'production') {
       return;
     }
-    void this.runOnce().catch((error) => {
+    void this.runUntilComplete().catch((error) => {
       this.logger.error(
         `post-deploy backfill failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     });
   }
 
+  private async runUntilComplete(): Promise<void> {
+    while (!(await this.runOnce())) await wait(LOCK_RETRY_MS);
+  }
+
   /** `runner` is injectable for tests; production uses the real backfill. */
-  async runOnce(runner: BackfillRunner = defaultRunner): Promise<void> {
+  async runOnce(runner: BackfillRunner = defaultRunner): Promise<boolean> {
     if (await this.isCompleted()) {
-      return;
+      return true;
     }
     const lock = this.dataSource.createQueryRunner();
     await lock.connect();
@@ -74,13 +85,13 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
       ])) as { locked: boolean }[];
       acquired = rows[0]?.locked === true;
       if (!acquired) {
-        this.logger.log('another instance is running the backfill; skipping');
-        return;
+        this.logger.log('another backfill is running; retrying provider attribution later');
+        return false;
       }
       // Re-check under the lock: a peer may have finished between the first
       // check and acquiring the lock.
       if (await this.isCompleted()) {
-        return;
+        return true;
       }
       this.logger.log('running post-deploy agent-message attribution backfill…');
       const result = await runner(this.dataSource, { logger: this.logger });
@@ -88,6 +99,7 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
       this.logger.log(
         `post-deploy backfill complete: stamped ${result.stamped} message(s) across ${result.windows} window(s)`,
       );
+      return true;
     } finally {
       if (acquired) {
         await lock

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
@@ -63,6 +63,22 @@ describe('RequestBackfillBootService', () => {
     );
   });
 
+  it('waits and retries when the shared lock is initially busy', async () => {
+    jest.useFakeTimers();
+    process.env['NODE_ENV'] = 'production';
+    const state = makeState(false);
+    state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+    const lock = makeLock(false);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+    new RequestBackfillBootService(ds, state.repo).onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(30_000);
+
+    expect(state.countBy).toHaveBeenCalledTimes(2);
+    expect(lock.release).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
   it('returns true without taking a lock when already complete', async () => {
     const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
     const runner = jest.fn();
@@ -135,5 +151,44 @@ describe('RequestBackfillBootService', () => {
       REQUEST_BACKFILL_LOCK_KEY,
     ]);
     expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('swallows unlock failures and still releases', async () => {
+    const lock = makeLock(true);
+    lock.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) return [{ locked: true }];
+      throw new Error('unlock failed');
+    });
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(false).repo).runOnce(
+        jest.fn().mockResolvedValue({ windows: 0, requests: 0, attempts: 0, rejections: 0 }),
+      ),
+    ).resolves.toBe(true);
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('uses the production backfill runner by default', async () => {
+    const lock = makeLock(true);
+    const transaction = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue(undefined),
+    };
+    const ds = {
+      createQueryRunner: jest.fn().mockReturnValueOnce(lock).mockReturnValueOnce(transaction),
+      query: jest
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([{ end_id: null }]),
+    } as unknown as DataSource;
+    const state = makeState(false);
+
+    await expect(new RequestBackfillBootService(ds, state.repo).runOnce()).resolves.toBe(true);
+    expect(state.execute).toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
@@ -3,6 +3,7 @@ import { DataSource, Repository } from 'typeorm';
 import { BackfillState } from '../../entities/backfill-state.entity';
 import {
   REQUEST_BACKFILL_LOCK_KEY,
+  REQUEST_BACKFILL_MAX_LOCK_ATTEMPTS,
   REQUEST_BACKFILL_NAME,
   RequestBackfillBootService,
 } from './request-backfill.boot.service';
@@ -76,6 +77,21 @@ describe('RequestBackfillBootService', () => {
 
     expect(state.countBy).toHaveBeenCalledTimes(2);
     expect(lock.release).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('stops retrying when the shared lock remains busy', async () => {
+    jest.useFakeTimers();
+    process.env['NODE_ENV'] = 'production';
+    const state = makeState(false);
+    const lock = makeLock(false);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+    new RequestBackfillBootService(ds, state.repo).onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(30_000 * (REQUEST_BACKFILL_MAX_LOCK_ATTEMPTS - 1));
+
+    expect(state.countBy).toHaveBeenCalledTimes(REQUEST_BACKFILL_MAX_LOCK_ATTEMPTS);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('lock stayed busy'));
     jest.useRealTimers();
   });
 

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
@@ -1,0 +1,139 @@
+import { Logger } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { BackfillState } from '../../entities/backfill-state.entity';
+import {
+  REQUEST_BACKFILL_LOCK_KEY,
+  REQUEST_BACKFILL_NAME,
+  RequestBackfillBootService,
+} from './request-backfill.boot.service';
+
+function makeLock(locked: boolean) {
+  return {
+    connect: jest.fn(async () => undefined),
+    release: jest.fn(async () => undefined),
+    query: jest.fn(async (sql: string) =>
+      sql.includes('pg_try_advisory_lock') ? [{ locked }] : undefined,
+    ),
+  };
+}
+
+function makeState(completed: boolean) {
+  const execute = jest.fn(async () => undefined);
+  const orIgnore = jest.fn(() => ({ execute }));
+  const values = jest.fn(() => ({ orIgnore }));
+  const into = jest.fn(() => ({ values }));
+  const insert = jest.fn(() => ({ into }));
+  const createQueryBuilder = jest.fn(() => ({ insert }));
+  const countBy = jest.fn(async () => (completed ? 1 : 0));
+  const repo = { countBy, createQueryBuilder } as unknown as Repository<BackfillState>;
+  return { repo, countBy, values, execute };
+}
+
+describe('RequestBackfillBootService', () => {
+  const originalEnv = process.env['NODE_ENV'];
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env['NODE_ENV'] = originalEnv;
+    errorSpy.mockRestore();
+  });
+
+  it('does nothing outside production', () => {
+    process.env['NODE_ENV'] = 'test';
+    const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+    new RequestBackfillBootService(ds, makeState(false).repo).onApplicationBootstrap();
+    expect(ds.createQueryRunner).not.toHaveBeenCalled();
+  });
+
+  it('logs a production startup failure without throwing', async () => {
+    process.env['NODE_ENV'] = 'production';
+    const state = makeState(false);
+    state.countBy.mockRejectedValue(new Error('db down'));
+    const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+
+    new RequestBackfillBootService(ds, state.repo).onApplicationBootstrap();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('post-deploy request backfill failed'),
+    );
+  });
+
+  it('returns true without taking a lock when already complete', async () => {
+    const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+    const runner = jest.fn();
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runOnce(runner),
+    ).resolves.toBe(true);
+    expect(ds.createQueryRunner).not.toHaveBeenCalled();
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('returns false and releases its connection when the shared lock is busy', async () => {
+    const lock = makeLock(false);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const runner = jest.fn();
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+    ).resolves.toBe(false);
+    expect(lock.query).toHaveBeenCalledWith('SELECT pg_try_advisory_lock($1) AS locked', [
+      REQUEST_BACKFILL_LOCK_KEY,
+    ]);
+    expect(runner).not.toHaveBeenCalled();
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('passes its logger, marks completion, and releases the shared lock', async () => {
+    const lock = makeLock(true);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const state = makeState(false);
+    const runner = jest.fn(async () => ({ windows: 2, requests: 2, attempts: 3, rejections: 1 }));
+
+    await expect(new RequestBackfillBootService(ds, state.repo).runOnce(runner)).resolves.toBe(
+      true,
+    );
+    expect(runner).toHaveBeenCalledWith(ds, expect.objectContaining({ log: expect.any(Function) }));
+    expect(state.values).toHaveBeenCalledWith({ name: REQUEST_BACKFILL_NAME });
+    expect(state.execute).toHaveBeenCalled();
+    expect(lock.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1)', [
+      REQUEST_BACKFILL_LOCK_KEY,
+    ]);
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('re-checks completion after acquiring the lock', async () => {
+    const lock = makeLock(true);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const state = makeState(false);
+    state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+    const runner = jest.fn();
+
+    await expect(new RequestBackfillBootService(ds, state.repo).runOnce(runner)).resolves.toBe(
+      true,
+    );
+    expect(runner).not.toHaveBeenCalled();
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('unlocks and releases when the runner fails', async () => {
+    const lock = makeLock(true);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const runner = jest.fn(async () => {
+      throw new Error('boom');
+    });
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+    ).rejects.toThrow('boom');
+    expect(lock.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1)', [
+      REQUEST_BACKFILL_LOCK_KEY,
+    ]);
+    expect(lock.release).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.ts
@@ -21,6 +21,7 @@ const defaultRunner: RequestBackfillRunner = (dataSource, logger) =>
   runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource), { logger });
 
 const LOCK_RETRY_MS = 30_000;
+export const REQUEST_BACKFILL_MAX_LOCK_ATTEMPTS = 10;
 
 const wait = (ms: number): Promise<void> =>
   new Promise((resolve) => {
@@ -49,7 +50,13 @@ export class RequestBackfillBootService implements OnApplicationBootstrap {
   }
 
   private async runUntilComplete(): Promise<void> {
-    while (!(await this.runOnce())) await wait(LOCK_RETRY_MS);
+    for (let attempt = 1; attempt <= REQUEST_BACKFILL_MAX_LOCK_ATTEMPTS; attempt += 1) {
+      if (await this.runOnce()) return;
+      if (attempt < REQUEST_BACKFILL_MAX_LOCK_ATTEMPTS) await wait(LOCK_RETRY_MS);
+    }
+    throw new Error(
+      `request backfill lock stayed busy for ${REQUEST_BACKFILL_MAX_LOCK_ATTEMPTS} attempts`,
+    );
   }
 
   async runOnce(runner: RequestBackfillRunner = defaultRunner): Promise<boolean> {

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.ts
@@ -8,14 +8,25 @@ import { MESSAGE_PROVIDER_BACKFILL_LOCK_KEY } from './message-provider-backfill.
 
 export const REQUEST_BACKFILL_NAME = 'requests_provider_attempts_v1';
 // Both post-deploy jobs update provider_attempts. Sharing the lock guarantees
-// that Cloud never runs their batches concurrently; a skipped job resumes on
-// the next replica boot because its completion marker remains absent.
+// that Cloud never runs their batches concurrently; a contending job releases
+// its connection and retries until both completion markers exist.
 export const REQUEST_BACKFILL_LOCK_KEY = MESSAGE_PROVIDER_BACKFILL_LOCK_KEY;
 
-type RequestBackfillRunner = (dataSource: DataSource) => Promise<RequestBackfillResult>;
+type RequestBackfillRunner = (
+  dataSource: DataSource,
+  logger: Pick<Logger, 'log'>,
+) => Promise<RequestBackfillResult>;
 
-const defaultRunner: RequestBackfillRunner = (dataSource) =>
-  runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource));
+const defaultRunner: RequestBackfillRunner = (dataSource, logger) =>
+  runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource), { logger });
+
+const LOCK_RETRY_MS = 30_000;
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+  });
 
 /** Runs historical regrouping after readiness, never in the deploy migration. */
 @Injectable()
@@ -30,15 +41,19 @@ export class RequestBackfillBootService implements OnApplicationBootstrap {
 
   onApplicationBootstrap(): void {
     if (process.env['NODE_ENV'] !== 'production') return;
-    void this.runOnce().catch((error) => {
+    void this.runUntilComplete().catch((error) => {
       this.logger.error(
         `post-deploy request backfill failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     });
   }
 
-  async runOnce(runner: RequestBackfillRunner = defaultRunner): Promise<void> {
-    if (await this.isCompleted()) return;
+  private async runUntilComplete(): Promise<void> {
+    while (!(await this.runOnce())) await wait(LOCK_RETRY_MS);
+  }
+
+  async runOnce(runner: RequestBackfillRunner = defaultRunner): Promise<boolean> {
+    if (await this.isCompleted()) return true;
     const lock = this.dataSource.createQueryRunner();
     await lock.connect();
     let acquired = false;
@@ -48,12 +63,12 @@ export class RequestBackfillBootService implements OnApplicationBootstrap {
       ])) as { locked: boolean }[];
       acquired = rows[0]?.locked === true;
       if (!acquired) {
-        this.logger.log('another instance is running the request backfill; skipping');
-        return;
+        this.logger.log('another backfill is running; retrying request backfill later');
+        return false;
       }
-      if (await this.isCompleted()) return;
+      if (await this.isCompleted()) return true;
       this.logger.log('running post-deploy request/provider-attempt backfill…');
-      const result = await runner(this.dataSource);
+      const result = await runner(this.dataSource, this.logger);
       await this.stateRepo
         .createQueryBuilder()
         .insert()
@@ -64,6 +79,7 @@ export class RequestBackfillBootService implements OnApplicationBootstrap {
       this.logger.log(
         `request backfill complete: ${result.attempts} attempt(s), ${result.rejections} rejection(s), ${result.windows} window(s)`,
       );
+      return true;
     } finally {
       if (acquired) {
         await lock

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BackfillState } from '../../entities/backfill-state.entity';
+import { runRequestBackfill, type RequestBackfillResult } from './backfill-requests';
+import { TypeOrmRequestBackfillGateway } from './backfill-requests.gateway';
+import { MESSAGE_PROVIDER_BACKFILL_LOCK_KEY } from './message-provider-backfill.boot.service';
+
+export const REQUEST_BACKFILL_NAME = 'requests_provider_attempts_v1';
+// Both post-deploy jobs update provider_attempts. Sharing the lock guarantees
+// that Cloud never runs their batches concurrently; a skipped job resumes on
+// the next replica boot because its completion marker remains absent.
+export const REQUEST_BACKFILL_LOCK_KEY = MESSAGE_PROVIDER_BACKFILL_LOCK_KEY;
+
+type RequestBackfillRunner = (dataSource: DataSource) => Promise<RequestBackfillResult>;
+
+const defaultRunner: RequestBackfillRunner = (dataSource) =>
+  runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource));
+
+/** Runs historical regrouping after readiness, never in the deploy migration. */
+@Injectable()
+export class RequestBackfillBootService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(RequestBackfillBootService.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(BackfillState)
+    private readonly stateRepo: Repository<BackfillState>,
+  ) {}
+
+  onApplicationBootstrap(): void {
+    if (process.env['NODE_ENV'] !== 'production') return;
+    void this.runOnce().catch((error) => {
+      this.logger.error(
+        `post-deploy request backfill failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  }
+
+  async runOnce(runner: RequestBackfillRunner = defaultRunner): Promise<void> {
+    if (await this.isCompleted()) return;
+    const lock = this.dataSource.createQueryRunner();
+    await lock.connect();
+    let acquired = false;
+    try {
+      const rows = (await lock.query('SELECT pg_try_advisory_lock($1) AS locked', [
+        REQUEST_BACKFILL_LOCK_KEY,
+      ])) as { locked: boolean }[];
+      acquired = rows[0]?.locked === true;
+      if (!acquired) {
+        this.logger.log('another instance is running the request backfill; skipping');
+        return;
+      }
+      if (await this.isCompleted()) return;
+      this.logger.log('running post-deploy request/provider-attempt backfill…');
+      const result = await runner(this.dataSource);
+      await this.stateRepo
+        .createQueryBuilder()
+        .insert()
+        .into(BackfillState)
+        .values({ name: REQUEST_BACKFILL_NAME })
+        .orIgnore()
+        .execute();
+      this.logger.log(
+        `request backfill complete: ${result.attempts} attempt(s), ${result.rejections} rejection(s), ${result.windows} window(s)`,
+      );
+    } finally {
+      if (acquired) {
+        await lock
+          .query('SELECT pg_advisory_unlock($1)', [REQUEST_BACKFILL_LOCK_KEY])
+          .catch(() => undefined);
+      }
+      await lock.release();
+    }
+  }
+
+  private async isCompleted(): Promise<boolean> {
+    return (await this.stateRepo.countBy({ name: REQUEST_BACKFILL_NAME })) > 0;
+  }
+}

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -4,6 +4,7 @@
 // the exact same migration set. Using an explicit array (not a dist glob) keeps
 // stale compiled .js from deleted migrations out of the run (deleteOutDir is off).
 import { AgentMessage } from '../entities/agent-message.entity';
+import { ManifestRequest } from '../entities/request.entity';
 import { ApiKey } from '../entities/api-key.entity';
 import { Tenant } from '../entities/tenant.entity';
 import { Agent } from '../entities/agent.entity';
@@ -145,9 +146,11 @@ import { AddAutofixMessageFields1799000100000 } from './migrations/1799000100000
 import { AddAutofixPhoenixIds1799000200000 } from './migrations/1799000200000-AddAutofixPhoenixIds';
 import { MakeAutofixEnabledNullable1799000300000 } from './migrations/1799000300000-MakeAutofixEnabledNullable';
 import { AddAutofixAccessGrant1799000400000 } from './migrations/1799000400000-AddAutofixAccessGrant';
+import { AddRequestsAndProviderAttempts1801000000000 } from './migrations/1801000000000-AddRequestsAndProviderAttempts';
 
 export const entities = [
   AgentMessage,
+  ManifestRequest,
   ApiKey,
   Tenant,
   Agent,
@@ -292,4 +295,5 @@ export const migrations = [
   ReclassifyPlanRequestLimitMessages1800100000000,
   AddMessageErrorCode1800200000000,
   DropUnusedAgentMessageIndexes1800300000000,
+  AddRequestsAndProviderAttempts1801000000000,
 ];

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -147,6 +147,7 @@ import { AddAutofixPhoenixIds1799000200000 } from './migrations/1799000200000-Ad
 import { MakeAutofixEnabledNullable1799000300000 } from './migrations/1799000300000-MakeAutofixEnabledNullable';
 import { AddAutofixAccessGrant1799000400000 } from './migrations/1799000400000-AddAutofixAccessGrant';
 import { AddRequestsAndProviderAttempts1801000000000 } from './migrations/1801000000000-AddRequestsAndProviderAttempts';
+import { DropAgentMessagesCompatibilityView1801100000000 } from './migrations/1801100000000-DropAgentMessagesCompatibilityView';
 
 export const entities = [
   AgentMessage,
@@ -296,4 +297,5 @@ export const migrations = [
   AddMessageErrorCode1800200000000,
   DropUnusedAgentMessageIndexes1800300000000,
   AddRequestsAndProviderAttempts1801000000000,
+  DropAgentMessagesCompatibilityView1801100000000,
 ];

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -70,7 +70,7 @@ export class DatabaseSeederService implements OnModuleInit {
       await this.seedTenantAndAgent();
       await this.seedApiKey();
       // Connections must exist before messages: each seeded message references a
-      // tenant_providers row via the FK on agent_messages.tenant_provider_id.
+      // tenant_providers row via the FK on provider_attempts.tenant_provider_id.
       await this.seedTenantProviders();
       await this.seedAgentMessages();
       // Two routing cohorts for the complexity/task-specific deprecation demo:

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -9,6 +9,7 @@ import { Tenant } from '../entities/tenant.entity';
 import { Agent } from '../entities/agent.entity';
 import { AgentApiKey } from '../entities/agent-api-key.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { ManifestRequest } from '../entities/request.entity';
 import { ApiKey } from '../entities/api-key.entity';
 import { TenantProvider } from '../entities/tenant-provider.entity';
 import { TierAssignment } from '../entities/tier-assignment.entity';
@@ -42,7 +43,7 @@ import { shouldRetryDbConnection } from '../common/utils/db-retry';
         // direct connection instead. Previously this was hardcoded true, which
         // deadlocked when several replicas migrated at once on the same deploy.
         migrationsRun: config.get<boolean>('app.runMigrationsOnBoot'),
-        // 'each' (per-migration transaction), not 'all': the agent_messages index
+        // 'each' (per-migration transaction), not 'all': the provider_attempts index
         // migrations run CONCURRENTLY and declare `transaction = false`, which
         // TypeORM forbids under 'all'. CONCURRENTLY avoids the ACCESS EXCLUSIVE
         // lock that deadlocks against live writes during a deploy.
@@ -75,6 +76,7 @@ import { shouldRetryDbConnection } from '../common/utils/db-retry';
       Agent,
       AgentApiKey,
       AgentMessage,
+      ManifestRequest,
       ApiKey,
       TenantProvider,
       TierAssignment,

--- a/packages/backend/src/database/migrate.ts
+++ b/packages/backend/src/database/migrate.ts
@@ -4,7 +4,7 @@ import { runMigrationsWithAdvisoryLock } from './run-migrations-with-lock';
 /**
  * Migration entry point used by the deploy step (`npm run migration:run`).
  * Wraps TypeORM's migration run in an advisory lock so concurrent deploys /
- * replicas don't deadlock on agent_messages locks. The DataSource reads
+ * replicas don't deadlock on provider_attempts locks. The DataSource reads
  * MIGRATION_DATABASE_URL (a direct, non-pooled connection) so the session-level
  * advisory lock holds.
  */

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
@@ -1,0 +1,40 @@
+import { AddRequestsAndProviderAttempts1801000000000 } from './1801000000000-AddRequestsAndProviderAttempts';
+
+describe('AddRequestsAndProviderAttempts1801000000000', () => {
+  const migration = new AddRequestsAndProviderAttempts1801000000000();
+  let queries: string[];
+  const runner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve();
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('keeps historical data work out of the deploy migration', async () => {
+    await migration.up(runner);
+
+    const sql = queries.join('\n');
+    expect(migration.transaction).toBe(false);
+    expect(queries[0]).toContain("SET lock_timeout = '5s'");
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "requests"');
+    expect(sql).toContain('ALTER TABLE "agent_messages" RENAME TO "provider_attempts"');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "request_id"');
+    expect(sql).toContain('NOT VALID');
+    expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
+    expect(sql).not.toMatch(/INSERT\s+INTO\s+"requests"/i);
+    expect(sql).not.toMatch(/UPDATE\s+"provider_attempts"/i);
+  });
+
+  it('is restart-safe after a partially completed non-transactional run', async () => {
+    await migration.up(runner);
+    const sql = queries.join('\n');
+    expect(sql).toContain('IF NOT EXISTS "request_id"');
+    expect(sql).toContain('IF NOT EXISTS (');
+    expect(sql).toContain('IF NOT EXISTS "IDX_provider_attempts_request_id"');
+  });
+});

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
@@ -51,4 +51,11 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
     expect(drop).toBeGreaterThan(-1);
     expect(create).toBeGreaterThan(drop);
   });
+
+  it('checks index validity on provider_attempts rather than by global name alone', async () => {
+    await migration.up(runner);
+
+    const validityQuery = queries.find((sql) => sql.includes('i.indisvalid'));
+    expect(validityQuery).toContain("i.indrelid = 'provider_attempts'::regclass");
+  });
 });

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
@@ -23,6 +23,7 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
     expect(queries[0]).toContain("SET lock_timeout = '5s'");
     expect(sql).toContain('CREATE TABLE IF NOT EXISTS "requests"');
     expect(sql).toContain('ALTER TABLE "agent_messages" RENAME TO "provider_attempts"');
+    expect(sql).toContain('CREATE VIEW "agent_messages" AS SELECT * FROM "provider_attempts"');
     expect(sql).toContain('ADD COLUMN IF NOT EXISTS "request_id"');
     expect(sql).toContain('NOT VALID');
     expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
@@ -36,6 +37,19 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
     expect(sql).toContain('IF NOT EXISTS "request_id"');
     expect(sql).toContain('IF NOT EXISTS (');
     expect(sql).toContain('IF NOT EXISTS "IDX_provider_attempts_request_id"');
+  });
+
+  it('renames the table and creates its compatibility view atomically', async () => {
+    await migration.up(runner);
+
+    const cutover = queries.find(
+      (sql) => sql.includes('RENAME TO "provider_attempts"') && sql.includes('CREATE VIEW'),
+    );
+    expect(cutover).toContain('CREATE VIEW "agent_messages" AS SELECT * FROM "provider_attempts"');
+
+    const cutoverIndex = queries.indexOf(cutover!);
+    const requestIdIndex = queries.findIndex((sql) => sql.includes('ADD COLUMN IF NOT EXISTS'));
+    expect(cutoverIndex).toBeLessThan(requestIdIndex);
   });
 
   it('drops an invalid concurrent index before rebuilding it', async () => {
@@ -57,5 +71,18 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
 
     const validityQuery = queries.find((sql) => sql.includes('i.indisvalid'));
     expect(validityQuery).toContain("i.indrelid = 'provider_attempts'::regclass");
+  });
+
+  it('drops the compatibility view before restoring the old table name', async () => {
+    await migration.down(runner);
+
+    const rollback = queries.find(
+      (sql) =>
+        sql.includes('DROP VIEW "agent_messages"') && sql.includes('RENAME TO "agent_messages"'),
+    );
+    expect(rollback).toBeDefined();
+    expect(rollback!.indexOf('DROP VIEW "agent_messages"')).toBeLessThan(
+      rollback!.indexOf('RENAME TO "agent_messages"'),
+    );
   });
 });

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
@@ -37,4 +37,18 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
     expect(sql).toContain('IF NOT EXISTS (');
     expect(sql).toContain('IF NOT EXISTS "IDX_provider_attempts_request_id"');
   });
+
+  it('drops an invalid concurrent index before rebuilding it', async () => {
+    (runner as { query: jest.Mock }).query.mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve(sql.includes('i.indisvalid') ? [{ valid: false }] : undefined);
+    });
+
+    await migration.up(runner);
+
+    const drop = queries.findIndex((sql) => sql.includes('DROP INDEX CONCURRENTLY'));
+    const create = queries.findIndex((sql) => sql.includes('CREATE INDEX CONCURRENTLY'));
+    expect(drop).toBeGreaterThan(-1);
+    expect(create).toBeGreaterThan(drop);
+  });
 });

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
@@ -45,12 +45,22 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
       )
     `);
 
+    // Keep the old relation name as an automatically updatable view while
+    // Railway drains replicas from the previous release. The rename and view
+    // creation share one statement transaction, so old connections never
+    // observe a committed schema where agent_messages is missing. Creating the
+    // view before request_id is added also freezes the legacy column shape.
     await queryRunner.query(`
       DO $$
       BEGIN
         IF to_regclass('public.provider_attempts') IS NULL
            AND to_regclass('public.agent_messages') IS NOT NULL THEN
           ALTER TABLE "agent_messages" RENAME TO "provider_attempts";
+        END IF;
+
+        IF to_regclass('public.agent_messages') IS NULL
+           AND to_regclass('public.provider_attempts') IS NOT NULL THEN
+          CREATE VIEW "agent_messages" AS SELECT * FROM "provider_attempts";
         END IF;
       END $$
     `);
@@ -110,9 +120,21 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
       `ALTER TABLE "provider_attempts" DROP CONSTRAINT IF EXISTS "FK_provider_attempts_request"`,
     );
     await queryRunner.query(`ALTER TABLE "provider_attempts" DROP COLUMN IF EXISTS "request_id"`);
+    // Drop the compatibility view and restore the table name atomically.
     await queryRunner.query(`
       DO $$
       BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND c.relname = 'agent_messages'
+            AND c.relkind = 'v'
+        ) THEN
+          DROP VIEW "agent_messages";
+        END IF;
+
         IF to_regclass('public.agent_messages') IS NULL
            AND to_regclass('public.provider_attempts') IS NOT NULL THEN
           ALTER TABLE "provider_attempts" RENAME TO "agent_messages";

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
@@ -88,6 +88,7 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
       FROM pg_class c
       JOIN pg_index i ON i.indexrelid = c.oid
       WHERE c.relname = 'IDX_provider_attempts_request_id'
+        AND i.indrelid = 'provider_attempts'::regclass
     `)) as Array<{ valid: boolean }>;
     // PostgreSQL leaves an invalid shell behind when CREATE INDEX
     // CONCURRENTLY is interrupted. IF NOT EXISTS would treat that shell as a

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
@@ -83,6 +83,20 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
     await queryRunner.query(
       `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_status_timestamp" ON "requests" ("tenant_id", "status", "timestamp")`,
     );
+    const requestIndex = (await queryRunner.query(`
+      SELECT i.indisvalid AS valid
+      FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = 'IDX_provider_attempts_request_id'
+    `)) as Array<{ valid: boolean }>;
+    // PostgreSQL leaves an invalid shell behind when CREATE INDEX
+    // CONCURRENTLY is interrupted. IF NOT EXISTS would treat that shell as a
+    // usable index, so remove it before retrying the build.
+    if (requestIndex?.[0]?.valid === false) {
+      await queryRunner.query(
+        `DROP INDEX CONCURRENTLY IF EXISTS "IDX_provider_attempts_request_id"`,
+      );
+    }
     await queryRunner.query(
       `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_provider_attempts_request_id" ON "provider_attempts" ("request_id") WHERE "request_id" IS NOT NULL`,
     );

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
@@ -1,0 +1,109 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Introduces the request/attempt boundary without rewriting historical data in
+ * the deploy path. History is linked later by the resumable boot backfill.
+ *
+ * This migration runs outside a transaction because the request_id index is
+ * built CONCURRENTLY. Every statement is restart-safe so a process failure
+ * between statements can be retried.
+ */
+export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInterface {
+  name = 'AddRequestsAndProviderAttempts1801000000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Fail the deploy attempt instead of queueing an ACCESS EXCLUSIVE rename
+    // behind a long Cloud query and then blocking newer traffic behind us.
+    await queryRunner.query(`SET lock_timeout = '5s'`);
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "requests" (
+        "id" varchar NOT NULL,
+        "tenant_id" varchar,
+        "agent_id" varchar,
+        "user_id" varchar,
+        "agent_name" varchar,
+        "trace_id" varchar,
+        "session_key" varchar,
+        "session_id" varchar,
+        "timestamp" timestamp NOT NULL,
+        "duration_ms" integer,
+        "status" varchar NOT NULL,
+        "error_message" varchar,
+        "error_http_status" integer,
+        "error_code" varchar(8),
+        "error_origin" varchar,
+        "error_class" varchar,
+        "requested_model" varchar,
+        "caller_attribution" text,
+        "request_headers" text,
+        "request_params" jsonb,
+        "feedback_rating" varchar,
+        "feedback_tags" varchar,
+        "feedback_details" text,
+        CONSTRAINT "PK_requests" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF to_regclass('public.provider_attempts') IS NULL
+           AND to_regclass('public.agent_messages') IS NOT NULL THEN
+          ALTER TABLE "agent_messages" RENAME TO "provider_attempts";
+        END IF;
+      END $$
+    `);
+    await queryRunner.query(
+      `ALTER TABLE "provider_attempts" ADD COLUMN IF NOT EXISTS "request_id" varchar`,
+    );
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_provider_attempts_request'
+        ) THEN
+          ALTER TABLE "provider_attempts"
+            ADD CONSTRAINT "FK_provider_attempts_request"
+            FOREIGN KEY ("request_id") REFERENCES "requests"("id")
+            ON DELETE CASCADE NOT VALID;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_agent_timestamp" ON "requests" ("tenant_id", "agent_id", "timestamp")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_timestamp" ON "requests" ("tenant_id", "timestamp")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_trace" ON "requests" ("tenant_id", "trace_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_status_timestamp" ON "requests" ("tenant_id", "status", "timestamp")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_provider_attempts_request_id" ON "provider_attempts" ("request_id") WHERE "request_id" IS NOT NULL`,
+    );
+    await queryRunner.query(`RESET lock_timeout`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_provider_attempts_request_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "provider_attempts" DROP CONSTRAINT IF EXISTS "FK_provider_attempts_request"`,
+    );
+    await queryRunner.query(`ALTER TABLE "provider_attempts" DROP COLUMN IF EXISTS "request_id"`);
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF to_regclass('public.agent_messages') IS NULL
+           AND to_regclass('public.provider_attempts') IS NOT NULL THEN
+          ALTER TABLE "provider_attempts" RENAME TO "agent_messages";
+        END IF;
+      END $$
+    `);
+    await queryRunner.query(`DROP TABLE IF EXISTS "requests"`);
+  }
+}

--- a/packages/backend/src/database/migrations/1801100000000-DropAgentMessagesCompatibilityView.spec.ts
+++ b/packages/backend/src/database/migrations/1801100000000-DropAgentMessagesCompatibilityView.spec.ts
@@ -1,0 +1,27 @@
+import { DropAgentMessagesCompatibilityView1801100000000 } from './1801100000000-DropAgentMessagesCompatibilityView';
+
+describe('DropAgentMessagesCompatibilityView1801100000000', () => {
+  const migration = new DropAgentMessagesCompatibilityView1801100000000();
+  const runner = { query: jest.fn().mockResolvedValue(undefined) } as never;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('bounds the lock wait before dropping the compatibility view', async () => {
+    await migration.up(runner);
+
+    expect((runner as { query: jest.Mock }).query.mock.calls).toEqual([
+      ["SET LOCAL lock_timeout = '5s'"],
+      ['DROP VIEW IF EXISTS "agent_messages"'],
+    ]);
+  });
+
+  it('recreates the compatibility view when rolled back', async () => {
+    await migration.down(runner);
+
+    const sql = (runner as { query: jest.Mock }).query.mock.calls[0][0] as string;
+    expect(sql).toContain("to_regclass('public.agent_messages') IS NULL");
+    expect(sql).toContain('CREATE VIEW "agent_messages" AS SELECT * FROM "provider_attempts"');
+  });
+});

--- a/packages/backend/src/database/migrations/1801100000000-DropAgentMessagesCompatibilityView.ts
+++ b/packages/backend/src/database/migrations/1801100000000-DropAgentMessagesCompatibilityView.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Remove the legacy relation name after every replica runs the request/attempt
+ * schema. Deploy this only after AddRequestsAndProviderAttempts has reached
+ * production and the previous release has fully drained.
+ */
+export class DropAgentMessagesCompatibilityView1801100000000 implements MigrationInterface {
+  name = 'DropAgentMessagesCompatibilityView1801100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Abort the cleanup deploy instead of waiting behind an old replica that is
+    // still using the compatibility view.
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    await queryRunner.query(`DROP VIEW IF EXISTS "agent_messages"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF to_regclass('public.agent_messages') IS NULL
+           AND to_regclass('public.provider_attempts') IS NOT NULL THEN
+          CREATE VIEW "agent_messages" AS SELECT * FROM "provider_attempts";
+        END IF;
+      END $$
+    `);
+  }
+}

--- a/packages/backend/src/database/run-migrations-with-lock.ts
+++ b/packages/backend/src/database/run-migrations-with-lock.ts
@@ -5,7 +5,7 @@ import { DataSource } from 'typeorm';
  * migrations (the pre-deploy step, Railway replicas across regions, overlapping
  * deployments) contends on this one key, so migrations run strictly one at a
  * time instead of deadlocking while acquiring DDL locks on the high-churn
- * agent_messages table (the multi-replica deploy deadlock this guards against).
+ * provider_attempts table (the multi-replica deploy deadlock this guards against).
  */
 export const MIGRATION_ADVISORY_LOCK_KEY = 4011985;
 

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -2,7 +2,7 @@ import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType } from '../common/utils/postgres-sql';
 import type { CallerAttribution } from '../routing/proxy/caller-classifier';
 
-@Entity('agent_messages')
+@Entity('provider_attempts')
 @Index(['tenant_id', 'agent_id', 'timestamp'])
 // No index on `user_id`: it is deprecated attribution-only metadata, never
 // scoped or filtered on (see query-helpers.ts). Its index cost 715 MB and was
@@ -26,6 +26,10 @@ import type { CallerAttribution } from '../routing/proxy/caller-classifier';
 export class AgentMessage {
   @PrimaryColumn('varchar')
   id!: string;
+
+  /** Parent caller request. NULL only while the historical backfill is running. */
+  @Column('varchar', { nullable: true })
+  request_id!: string | null;
 
   @Column('varchar', { nullable: true })
   tenant_id!: string | null;
@@ -148,7 +152,7 @@ export class AgentMessage {
   /**
    * DEPRECATED — informational attribution only, written by the proxy
    * recorder. Never filter, scope, key, or authorize by this column; all
-   * scoping goes through `tenant_id`. Kept because agent_messages is the
+   * scoping goes through `tenant_id`. Kept because provider_attempts is the
    * big hot table and a column drop isn't worth the rewrite.
    */
   @Column('varchar', { nullable: true })

--- a/packages/backend/src/entities/public-error-page.entity.ts
+++ b/packages/backend/src/entities/public-error-page.entity.ts
@@ -38,7 +38,7 @@ export interface ErrorPageRelatedLink {
  * marketing site. This table is a READ-OPTIMISED MIRROR: it only ever holds
  * rows that an operator explicitly published from the Peacock CMS (pushed via
  * the secret-guarded internal endpoint). There is no code path from raw
- * `agent_messages` to this table — that is the trust boundary that keeps
+ * `provider_attempts` to this table — that is the trust boundary that keeps
  * un-curated error data private.
  */
 @Entity('public_error_pages')

--- a/packages/backend/src/entities/request.entity.ts
+++ b/packages/backend/src/entities/request.entity.ts
@@ -1,0 +1,89 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { timestampType } from '../common/utils/postgres-sql';
+import type { CallerAttribution } from '../routing/proxy/caller-classifier';
+
+/**
+ * One request made by a caller to Manifest.
+ *
+ * Provider work belongs in provider_attempts. A row with no attempts is valid:
+ * Manifest may reject a request before choosing or contacting a provider.
+ */
+@Entity('requests')
+@Index(['tenant_id', 'agent_id', 'timestamp'])
+@Index(['tenant_id', 'timestamp'])
+@Index(['tenant_id', 'trace_id'])
+@Index(['tenant_id', 'status', 'timestamp'])
+export class ManifestRequest {
+  @PrimaryColumn('varchar')
+  id!: string;
+
+  @Column('varchar', { nullable: true })
+  tenant_id!: string | null;
+
+  @Column('varchar', { nullable: true })
+  agent_id!: string | null;
+
+  /** Deprecated attribution metadata; tenant_id remains the scope boundary. */
+  @Column('varchar', { nullable: true })
+  user_id!: string | null;
+
+  @Column('varchar', { nullable: true })
+  agent_name!: string | null;
+
+  @Column('varchar', { nullable: true })
+  trace_id!: string | null;
+
+  @Column('varchar', { nullable: true })
+  session_key!: string | null;
+
+  @Column('varchar', { nullable: true })
+  session_id!: string | null;
+
+  @Column(timestampType())
+  timestamp!: string;
+
+  /** End-to-end latency experienced by the caller. */
+  @Column('integer', { nullable: true })
+  duration_ms!: number | null;
+
+  /** The terminal outcome experienced by the caller. */
+  @Column('varchar')
+  status!: string;
+
+  @Column('varchar', { nullable: true })
+  error_message!: string | null;
+
+  @Column('integer', { nullable: true })
+  error_http_status!: number | null;
+
+  @Column('varchar', { length: 8, nullable: true })
+  error_code!: string | null;
+
+  @Column('varchar', { nullable: true })
+  error_origin!: string | null;
+
+  @Column('varchar', { nullable: true })
+  error_class!: string | null;
+
+  /** Model requested by the caller, before routing and fallbacks. */
+  @Column('varchar', { nullable: true })
+  requested_model!: string | null;
+
+  @Column('simple-json', { nullable: true })
+  caller_attribution!: CallerAttribution | null;
+
+  @Column('simple-json', { nullable: true })
+  request_headers!: Record<string, string> | null;
+
+  @Column('jsonb', { nullable: true })
+  request_params!: object | null;
+
+  @Column('varchar', { nullable: true })
+  feedback_rating!: string | null;
+
+  @Column('varchar', { nullable: true })
+  feedback_tags!: string | null;
+
+  @Column('text', { nullable: true })
+  feedback_details!: string | null;
+}

--- a/packages/backend/src/error-pages/error-cluster-seeder.service.ts
+++ b/packages/backend/src/error-pages/error-cluster-seeder.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { AgentMessage } from '../entities/agent-message.entity';
 
 /**
- * Seeds realistic error `agent_messages` (dev/test only) so the live discovery
+ * Seeds realistic error `provider_attempts` (dev/test only) so the live discovery
  * endpoint produces real GROUP BY clusters instead of a hardcoded list. Each
  * spec fans out across `tenants` distinct synthetic tenants with a recovered
  * fraction (an `ok` sibling sharing the trace) and rotates through several
@@ -220,7 +220,7 @@ export class ErrorClusterSeederService implements OnModuleInit {
       await this.repo.insert(rows.slice(i, i + 500));
     }
     this.logger.log(
-      `Seeded ${rows.length} error/recovery agent_messages across ${SPECS.length} clusters (with message variants)`,
+      `Seeded ${rows.length} error/recovery provider_attempts across ${SPECS.length} clusters (with message variants)`,
     );
   }
 }

--- a/packages/backend/src/error-pages/error-discovery.service.ts
+++ b/packages/backend/src/error-pages/error-discovery.service.ts
@@ -47,7 +47,7 @@ function categoryFor(http: number | null): { id: string; label: string } {
 }
 
 /**
- * Computes error-cluster aggregates live from `agent_messages` (cross-tenant).
+ * Computes error-cluster aggregates live from `provider_attempts` (cross-tenant).
  * This is the rollup the Peacock CMS pulls from to discover and refresh clusters.
  * Aggregates only — never returns tenant identities — and applies the same
  * k-anonymity floor as publishing, so a cluster below the floor is never
@@ -81,9 +81,9 @@ export class ErrorDiscoveryService {
              MAX(e.timestamp) AS last_seen,
              AVG(CASE WHEN ok.trace_id IS NOT NULL THEN 1.0 ELSE 0.0 END)::float AS recovery,
              (array_agg(e.error_message ORDER BY e.timestamp DESC))[1] AS sample
-      FROM agent_messages e
+      FROM provider_attempts e
       LEFT JOIN (
-        SELECT DISTINCT trace_id FROM agent_messages WHERE status = 'ok' AND trace_id IS NOT NULL
+        SELECT DISTINCT trace_id FROM provider_attempts WHERE status = 'ok' AND trace_id IS NOT NULL
       ) ok ON ok.trace_id = e.trace_id
       WHERE e.status IN ('error','fallback_error','rate_limited')
         AND e.tenant_id IS NOT NULL
@@ -100,7 +100,7 @@ export class ErrorDiscoveryService {
                e.error_http_status AS http,
                to_char(date_trunc('day', e.timestamp), 'YYYY-MM-DD') AS day,
                COUNT(*)::int AS cnt
-        FROM agent_messages e
+        FROM provider_attempts e
         WHERE e.status IN ('error','fallback_error','rate_limited')
           AND e.timestamp >= NOW() - INTERVAL '14 days'
           AND e.provider IS NOT NULL
@@ -124,7 +124,7 @@ export class ErrorDiscoveryService {
                e.error_http_status AS http,
                e.error_message AS msg,
                COUNT(*)::int AS cnt
-        FROM agent_messages e
+        FROM provider_attempts e
         WHERE e.status IN ('error','fallback_error','rate_limited')
           AND e.error_message IS NOT NULL
           AND e.tenant_id IS NOT NULL

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -113,7 +113,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
 
     // Overlay user-defined custom provider pricing (from the custom_providers
     // table). Keyed by `custom:<uuid>/<model_name>` — the same identifier
-    // written to agent_messages.model, so cost lookups hit.
+    // written to provider_attempts.model, so cost lookups hit.
     await this.loadCustomProviderEntries();
 
     this.aliasMap = buildAliasMap([...this.cache.keys()]);
@@ -239,7 +239,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
   /**
    * Load user-defined pricing for custom (OpenAI-compatible) providers.
    *
-   * The proxy writes `custom:<uuid>/<model_name>` to agent_messages.model
+   * The proxy writes `custom:<uuid>/<model_name>` to provider_attempts.model
    * and the cost recorder calls getByModel() with that exact string — so we
    * index custom pricing under the same key. UUIDs are globally unique
    * (randomUUID), so cross-tenant collisions are impossible.

--- a/packages/backend/src/otlp/interfaces/ingestion-context.interface.ts
+++ b/packages/backend/src/otlp/interfaces/ingestion-context.interface.ts
@@ -4,7 +4,7 @@ export interface IngestionContext {
   agentName: string;
   /**
    * The tenant's owning user, when one exists. Informational attribution
-   * only (e.g. agent_messages.user_id) — never used for scoping or auth.
+   * only (e.g. requests.user_id) — never used for scoping or auth.
    */
   userId: string | null;
 }

--- a/packages/backend/src/playground/playground.module.ts
+++ b/packages/backend/src/playground/playground.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { ManifestRequest } from '../entities/request.entity';
 import { Agent } from '../entities/agent.entity';
 import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
@@ -19,6 +20,7 @@ import { PlaygroundAgentService } from './playground-agent.service';
   imports: [
     TypeOrmModule.forFeature([
       AgentMessage,
+      ManifestRequest,
       Agent,
       PlaygroundRun,
       PlaygroundColumn,

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -431,6 +431,21 @@ describe('PlaygroundService.runStream', () => {
     expect(res.json).not.toHaveBeenCalled();
   });
 
+  it('does not record a transport failure when the client disconnects before forward resolves', async () => {
+    const { service, mocks } = buildService();
+    const res = mockRes();
+    mocks.providerClient.forward.mockImplementation(async () => {
+      res._closeHandler?.();
+      throw new Error('client aborted');
+    });
+
+    await service.runStream(CTX, makeDto(), asRes(res));
+
+    expect(mocks.messageRepo.insert).not.toHaveBeenCalled();
+    expect(mocks.history.saveColumn).not.toHaveBeenCalled();
+    expect(mocks.eventBus.emit).not.toHaveBeenCalled();
+  });
+
   it('swallows recordError insert failures that throw an Error on the upstream-error path', async () => {
     const { service, mocks } = buildService();
     mocks.messageRepo.insert.mockRejectedValueOnce(new Error('telemetry insert blew up'));

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -182,7 +182,10 @@ interface Mocks {
   pricingCache: { getByModel: jest.Mock };
   eventBus: { emit: jest.Mock };
   history: { saveColumn: jest.Mock };
-  messageRepo: { insert: jest.Mock };
+  messageRepo: {
+    insert: jest.Mock;
+    manager?: { getRepository: jest.Mock };
+  };
   customProviderRepo: { findOne: jest.Mock };
 }
 
@@ -469,12 +472,17 @@ describe('PlaygroundService.runStream', () => {
   });
 
   it('sends a 404 JSON error (no stream) when the provider is not connected', async () => {
-    const { service } = buildService({
+    const requestInsert = jest.fn().mockResolvedValue(undefined);
+    const { service, mocks } = buildService({
       providerKeyService: {
         hasActiveProvider: jest.fn().mockResolvedValue(false),
         getAuthType: jest.fn(),
         getProviderKeys: jest.fn(),
         getProviderApiKey: jest.fn(),
+      },
+      messageRepo: {
+        insert: jest.fn(),
+        manager: { getRepository: jest.fn(() => ({ insert: requestInsert })) },
       },
     });
     const res = mockRes();
@@ -485,6 +493,10 @@ describe('PlaygroundService.runStream', () => {
     expect(res._json).toMatchObject({ statusCode: 404 });
     expect((res._json as { message: string }).message).toContain('not connected');
     expect(res.write).not.toHaveBeenCalled();
+    expect(requestInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'error', error_origin: 'config' }),
+    );
+    expect(mocks.messageRepo.insert).not.toHaveBeenCalled();
   });
 
   it('sends a 404 JSON error when no usable API key is found', async () => {
@@ -701,7 +713,13 @@ describe('PlaygroundService.runStream', () => {
   });
 
   it('returns 502 JSON when forward() throws (Error)', async () => {
-    const { service, mocks } = buildService();
+    const requestInsert = jest.fn().mockResolvedValue(undefined);
+    const { service, mocks } = buildService({
+      messageRepo: {
+        insert: jest.fn().mockResolvedValue(undefined),
+        manager: { getRepository: jest.fn(() => ({ insert: requestInsert })) },
+      },
+    });
     mocks.providerClient.forward.mockRejectedValue(new Error('connection refused'));
     const res = mockRes();
 
@@ -709,6 +727,12 @@ describe('PlaygroundService.runStream', () => {
 
     expect(res._status).toBe(502);
     expect((res._json as { message: string }).message).toContain('connection refused');
+    expect(requestInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'error', error_origin: 'transport' }),
+    );
+    expect(mocks.messageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'error', error_origin: 'transport' }),
+    );
   });
 
   it('returns 502 JSON when forward() throws a non-Error', async () => {

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -698,6 +698,44 @@ describe('PlaygroundService.runStream', () => {
     expect((res._json as { message: string }).message).toBe('boom');
   });
 
+  it('records a resolved-agent preflight failure as an internal request rejection', async () => {
+    const requestInsert = jest.fn().mockResolvedValue(undefined);
+    const { service, mocks } = buildService({
+      messageRepo: {
+        insert: jest.fn(),
+        manager: { getRepository: jest.fn(() => ({ insert: requestInsert })) },
+      },
+    });
+    mocks.providerKeyService.getProviderKeys.mockRejectedValue(new Error('key service down'));
+    const res = mockRes();
+
+    await service.runStream(CTX, makeDto(), asRes(res));
+
+    expect(res._status).toBe(500);
+    expect(requestInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ error_origin: 'internal', error_http_status: 500 }),
+    );
+  });
+
+  it('keeps responding when preflight rejection telemetry fails', async () => {
+    const requestInsert = jest.fn().mockRejectedValue('telemetry unavailable');
+    const { service, mocks } = buildService({
+      messageRepo: {
+        insert: jest.fn(),
+        manager: { getRepository: jest.fn(() => ({ insert: requestInsert })) },
+      },
+    });
+    mocks.providerKeyService.getProviderKeys.mockRejectedValue(new ForbiddenException('blocked'));
+    const res = mockRes();
+
+    await service.runStream(CTX, makeDto(), asRes(res));
+
+    expect(res._status).toBe(403);
+    expect(requestInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ error_origin: 'config', error_http_status: 403 }),
+    );
+  });
+
   it('stringifies a non-Error preflight rejection', async () => {
     const { service } = buildService({
       playgroundAgent: {

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -67,6 +67,7 @@ export class PlaygroundService {
    */
   async runStream(ctx: TenantContext, dto: RunPlaygroundDto, res: ExpressResponse): Promise<void> {
     let agent: { id: string; tenant_id: string; name: string };
+    let resolvedAgent: { id: string; tenant_id: string; name: string } | null = null;
     let authType: AuthType;
     let apiKey: string;
     let rawApiKey: string;
@@ -83,17 +84,16 @@ export class PlaygroundService {
       // and route against the whole global provider pool — regardless of any
       // agentName the client sends.
       agent = await this.playgroundAgent.resolve(ctx);
+      resolvedAgent = agent;
       const hasProvider = await this.providerKeyService.hasActiveProvider(
         agent.tenant_id,
         dto.provider,
         agent.id,
       );
       if (!hasProvider) {
-        return this.sendPreStreamError(
-          res,
-          404,
-          `Provider "${dto.provider}" is not connected for this agent`,
-        );
+        const message = `Provider "${dto.provider}" is not connected for this agent`;
+        await this.recordRequestRejection(ctx.userId, agent, dto, 404, message, 'config');
+        return this.sendPreStreamError(res, 404, message);
       }
       authType =
         dto.authType ??
@@ -111,11 +111,9 @@ export class PlaygroundService {
       );
       const key = keys[0];
       if (!key || key.apiKey === null) {
-        return this.sendPreStreamError(
-          res,
-          404,
-          `No usable API key found for provider "${dto.provider}"`,
-        );
+        const message = `No usable API key found for provider "${dto.provider}"`;
+        await this.recordRequestRejection(ctx.userId, agent, dto, 404, message, 'config');
+        return this.sendPreStreamError(res, 404, message);
       }
       rawApiKey = key.apiKey;
       providerKeyLabel = key.label;
@@ -135,11 +133,9 @@ export class PlaygroundService {
         providerKeyLabel,
       );
       if (resolved.apiKey === null) {
-        return this.sendPreStreamError(
-          res,
-          404,
-          `No usable API key found for provider "${dto.provider}"`,
-        );
+        const message = `No usable API key found for provider "${dto.provider}"`;
+        await this.recordRequestRejection(ctx.userId, agent, dto, 404, message, 'config');
+        return this.sendPreStreamError(res, 404, message);
       }
       apiKey = resolved.apiKey;
       if (authType === 'subscription' && isRefreshableOAuthCredential(rawApiKey)) {
@@ -163,6 +159,16 @@ export class PlaygroundService {
     } catch (err) {
       const status = err instanceof HttpException ? err.getStatus() : 500;
       const message = err instanceof Error ? err.message : String(err);
+      if (resolvedAgent) {
+        await this.recordRequestRejection(
+          ctx.userId,
+          resolvedAgent,
+          dto,
+          status,
+          message,
+          status >= 500 ? 'internal' : 'config',
+        );
+      }
       return this.sendPreStreamError(res, status, message);
     }
 
@@ -239,6 +245,16 @@ export class PlaygroundService {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      await this.recordError(
+        ctx.userId,
+        agent,
+        dto,
+        authType,
+        502,
+        message,
+        Date.now() - startedAt,
+        'transport',
+      );
       return this.sendPreStreamError(res, 502, `Provider request failed: ${message}`);
     }
 
@@ -491,6 +507,7 @@ export class PlaygroundService {
     status: number,
     errorBody: string,
     durationMs: number,
+    errorOrigin: 'provider' | 'transport' = 'provider',
   ): Promise<void> {
     try {
       // No tenant_provider_id — see recordSuccess: Playground is a system agent,
@@ -513,6 +530,7 @@ export class PlaygroundService {
           // scrub before persisting — mirrors the proxy recorder's hardening.
           error_message: errorMessage,
           error_http_status: status,
+          error_origin: errorOrigin,
           model: dto.model,
           provider: dto.provider,
           routing_tier: 'playground',
@@ -535,7 +553,7 @@ export class PlaygroundService {
           error_message: errorMessage,
           error_http_status: status,
           error_code: null,
-          error_origin: 'provider',
+          error_origin: errorOrigin,
           error_class: null,
           requested_model: dto.model,
           caller_attribution: null,
@@ -550,6 +568,51 @@ export class PlaygroundService {
     } catch (err) {
       this.logger.warn(
         `Failed to record playground error: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  private async recordRequestRejection(
+    createdByUserId: string | null,
+    agent: { id: string; tenant_id: string; name: string },
+    dto: RunPlaygroundDto,
+    status: number,
+    errorBody: string,
+    errorOrigin: 'config' | 'request' | 'internal',
+  ): Promise<void> {
+    try {
+      const getRepository = this.messageRepo.manager?.getRepository?.bind(this.messageRepo.manager);
+      if (!getRepository) return;
+      const errorMessage = scrubSecrets(errorBody).slice(0, 2000);
+      await getRepository(ManifestRequest).insert({
+        id: uuid(),
+        tenant_id: agent.tenant_id,
+        agent_id: agent.id,
+        user_id: createdByUserId,
+        agent_name: agent.name,
+        trace_id: null,
+        session_key: null,
+        session_id: null,
+        timestamp: new Date().toISOString(),
+        duration_ms: 0,
+        status: 'error',
+        error_message: errorMessage,
+        error_http_status: status,
+        error_code: null,
+        error_origin: errorOrigin,
+        error_class: null,
+        requested_model: dto.model,
+        caller_attribution: null,
+        request_headers: null,
+        request_params: null,
+        feedback_rating: null,
+        feedback_tags: null,
+        feedback_details: null,
+      });
+      this.eventBus.emit(agent.tenant_id);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to record playground rejection: ${err instanceof Error ? err.message : err}`,
       );
     }
   }

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -245,16 +245,18 @@ export class PlaygroundService {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      await this.recordError(
-        ctx.userId,
-        agent,
-        dto,
-        authType,
-        502,
-        message,
-        Date.now() - startedAt,
-        'transport',
-      );
+      if (!abort.signal.aborted) {
+        await this.recordError(
+          ctx.userId,
+          agent,
+          dto,
+          authType,
+          502,
+          message,
+          Date.now() - startedAt,
+          'transport',
+        );
+      }
       return this.sendPreStreamError(res, 502, `Provider request failed: ${message}`);
     }
 

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -34,6 +34,7 @@ import { PlaygroundHistoryService } from './playground-history.service';
 import { buildForwardBody, derivePromptForHistory } from './playground-payload';
 import { consumeProviderStream } from './playground-stream';
 import type { RunPlaygroundDto } from './dto/run-playground.dto';
+import { ManifestRequest } from '../entities/request.entity';
 
 @Injectable()
 export class PlaygroundService {
@@ -423,27 +424,57 @@ export class PlaygroundService {
       // No tenant_provider_id: Playground runs use the reserved is_playground agent,
       // which excludePlaygroundAgents() filters out of every per-connection view,
       // so stamping the connection here would have no analytic effect.
-      await this.messageRepo.insert({
-        id: uuid(),
-        tenant_id: agent.tenant_id,
-        agent_id: agent.id,
-        agent_name: agent.name,
-        // Informational attribution only — never used for scoping.
-        user_id: createdByUserId,
-        timestamp: new Date().toISOString(),
-        status: 'ok',
-        model: dto.model,
-        provider: dto.provider,
-        routing_tier: 'playground',
-        routing_reason: null,
-        auth_type: authType,
-        input_tokens: metrics.inputTokens,
-        output_tokens: metrics.outputTokens,
-        cache_read_tokens: metrics.cacheReadTokens,
-        cache_creation_tokens: metrics.cacheCreationTokens,
-        cost_usd: metrics.cost,
-        duration_ms: metrics.durationMs,
-      });
+      const requestId = uuid();
+      const timestamp = new Date().toISOString();
+      await this.insertPlaygroundRequest(
+        {
+          id: uuid(),
+          request_id: requestId,
+          tenant_id: agent.tenant_id,
+          agent_id: agent.id,
+          agent_name: agent.name,
+          // Informational attribution only — never used for scoping.
+          user_id: createdByUserId,
+          timestamp,
+          status: 'ok',
+          model: dto.model,
+          provider: dto.provider,
+          routing_tier: 'playground',
+          routing_reason: null,
+          auth_type: authType,
+          input_tokens: metrics.inputTokens,
+          output_tokens: metrics.outputTokens,
+          cache_read_tokens: metrics.cacheReadTokens,
+          cache_creation_tokens: metrics.cacheCreationTokens,
+          cost_usd: metrics.cost,
+          duration_ms: metrics.durationMs,
+        },
+        {
+          id: requestId,
+          tenant_id: agent.tenant_id,
+          agent_id: agent.id,
+          user_id: createdByUserId,
+          agent_name: agent.name,
+          trace_id: null,
+          session_key: null,
+          session_id: null,
+          timestamp,
+          duration_ms: metrics.durationMs,
+          status: 'ok',
+          error_message: null,
+          error_http_status: null,
+          error_code: null,
+          error_origin: null,
+          error_class: null,
+          requested_model: dto.model,
+          caller_attribution: null,
+          request_headers: null,
+          request_params: null,
+          feedback_rating: null,
+          feedback_tags: null,
+          feedback_details: null,
+        },
+      );
       this.eventBus.emit(agent.tenant_id);
     } catch (err) {
       this.logger.warn(
@@ -464,32 +495,76 @@ export class PlaygroundService {
     try {
       // No tenant_provider_id — see recordSuccess: Playground is a system agent,
       // excluded from per-connection analytics.
-      await this.messageRepo.insert({
-        id: uuid(),
-        tenant_id: agent.tenant_id,
-        agent_id: agent.id,
-        agent_name: agent.name,
-        // Informational attribution only — never used for scoping.
-        user_id: createdByUserId,
-        timestamp: new Date().toISOString(),
-        status: 'error',
-        // Some providers echo the submitted key back in their error body, so
-        // scrub before persisting — mirrors the proxy recorder's hardening.
-        error_message: scrubSecrets(errorBody).slice(0, 2000),
-        error_http_status: status,
-        model: dto.model,
-        provider: dto.provider,
-        routing_tier: 'playground',
-        routing_reason: null,
-        auth_type: authType,
-        duration_ms: durationMs,
-      });
+      const requestId = uuid();
+      const timestamp = new Date().toISOString();
+      const errorMessage = scrubSecrets(errorBody).slice(0, 2000);
+      await this.insertPlaygroundRequest(
+        {
+          id: uuid(),
+          request_id: requestId,
+          tenant_id: agent.tenant_id,
+          agent_id: agent.id,
+          agent_name: agent.name,
+          // Informational attribution only — never used for scoping.
+          user_id: createdByUserId,
+          timestamp,
+          status: 'error',
+          // Some providers echo the submitted key back in their error body, so
+          // scrub before persisting — mirrors the proxy recorder's hardening.
+          error_message: errorMessage,
+          error_http_status: status,
+          model: dto.model,
+          provider: dto.provider,
+          routing_tier: 'playground',
+          routing_reason: null,
+          auth_type: authType,
+          duration_ms: durationMs,
+        },
+        {
+          id: requestId,
+          tenant_id: agent.tenant_id,
+          agent_id: agent.id,
+          user_id: createdByUserId,
+          agent_name: agent.name,
+          trace_id: null,
+          session_key: null,
+          session_id: null,
+          timestamp,
+          duration_ms: durationMs,
+          status: 'error',
+          error_message: errorMessage,
+          error_http_status: status,
+          error_code: null,
+          error_origin: 'provider',
+          error_class: null,
+          requested_model: dto.model,
+          caller_attribution: null,
+          request_headers: null,
+          request_params: null,
+          feedback_rating: null,
+          feedback_tags: null,
+          feedback_details: null,
+        },
+      );
       this.eventBus.emit(agent.tenant_id);
     } catch (err) {
       this.logger.warn(
         `Failed to record playground error: ${err instanceof Error ? err.message : err}`,
       );
     }
+  }
+
+  private async insertPlaygroundRequest(
+    attempt: Partial<AgentMessage>,
+    request: ManifestRequest,
+  ): Promise<void> {
+    const getRepository = this.messageRepo.manager?.getRepository?.bind(this.messageRepo.manager);
+    if (!getRepository) {
+      await this.messageRepo.insert(attempt);
+      return;
+    }
+    await getRepository(ManifestRequest).insert(request);
+    await this.messageRepo.insert(attempt);
   }
 
   private truncateError(bodyText: string, status: number): string {

--- a/packages/backend/src/routing/autofix/autofix.types.ts
+++ b/packages/backend/src/routing/autofix/autofix.types.ts
@@ -42,7 +42,7 @@ export interface AutofixChainEntry {
 
 /**
  * The full Auto-fix story. A healed request is recorded as two linked
- * `agent_messages` rows (failed original + successful retry) sharing `groupId`;
+ * `provider_attempts` rows (failed original + successful retry) sharing `groupId`;
  * `chain` carries the per-attempt detail the recorder splits into those rows.
  */
 export interface AutofixRecord {

--- a/packages/backend/src/routing/autofix/observation-payload.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.ts
@@ -96,7 +96,7 @@ export interface ObservationInput {
   /**
    * The `traceparent` trace id when the caller sent one. Phoenix keys its ledger
    * on `(issue, traceId)`, and Peacock's scrape reports the same
-   * `agent_messages.trace_id`, so passing it through is what lets a live
+   * `provider_attempts.trace_id`, so passing it through is what lets a live
    * observation and a later scrape of the same failure collapse into one row.
    */
   traceId: string;

--- a/packages/backend/src/routing/autofix/observation-reporter.ts
+++ b/packages/backend/src/routing/autofix/observation-reporter.ts
@@ -32,7 +32,7 @@ const MAX_IN_FLIGHT_GATES = 100;
  * Auto-fix itself only reports the requests it actually heals: the narrow
  * `AUTOFIX_REPAIRABLE_STATUSES` set, the primary attempt only, and only when the
  * heal call gets through. Everything else reached Phoenix solely through
- * Peacock's hourly scrape of `agent_messages`, which stores the model-parameter
+ * Peacock's hourly scrape of `provider_attempts`, which stores the model-parameter
  * snapshot and not the messages — so those issues arrived without the body that
  * caused them. This reporter closes that gap without persisting a single byte in
  * Manifest: the body is scrubbed, batched, and POSTed to Phoenix, which is where

--- a/packages/backend/src/routing/autofix/provider-error-normalizer.ts
+++ b/packages/backend/src/routing/autofix/provider-error-normalizer.ts
@@ -75,7 +75,7 @@ function envelopeOf(error: PhoenixProviderError, message: string): string {
 /**
  * Re-serialize a normalised error into the OpenAI-compatible `{"error":{…}}` envelope —
  * the inverse of {@link normalizeProviderError}, and the shape every other
- * `agent_messages.error_message` already holds.
+ * `provider_attempts.error_message` already holds.
  *
  * Auto-fix rows used to persist `error.message` alone, silently dropping `type`, `param`
  * and `code`. Those are exactly the dimensions Phoenix fingerprints on, so a downstream

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -122,7 +122,7 @@ export class CustomProviderService {
    * registry (llama.cpp → `llamacpp`, LM Studio → `lmstudio`), return that
    * canonical id. Otherwise return null. Used to surface tile-connected
    * local servers as first-class providers in user-visible columns
-   * (`agent_messages.provider` / `.model`, dashboard aggregations) even
+   * (`provider_attempts.provider` / `.model`, dashboard aggregations) even
    * though they're physically stored in `custom_providers`.
    */
   static canonicalTileIdForName(name: string): string | null {
@@ -131,7 +131,7 @@ export class CustomProviderService {
   }
 
   /**
-   * Rewrite a `(provider, model)` pair for the agent_messages log. When the
+   * Rewrite a `(provider, model)` pair for the provider_attempts log. When the
    * pair resolves to a tile-connected canonical provider, substitute the
    * canonical id so the DB / dashboard never exposes the internal
    * `custom:<uuid>` key. Passthrough for every other case (non-custom

--- a/packages/backend/src/routing/header-tiers/seen-headers.service.ts
+++ b/packages/backend/src/routing/header-tiers/seen-headers.service.ts
@@ -55,7 +55,7 @@ export class SeenHeadersService {
     const sql = `
       WITH expanded AS (
         SELECT hdr.key, hdr.value, (at.caller_attribution::json->>'sdk') AS sdk
-        FROM agent_messages at,
+        FROM provider_attempts at,
              LATERAL jsonb_each_text(at.request_headers::jsonb) AS hdr(key, value)
         WHERE ${filters.join(' AND ')}
       ),

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-dedup.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-dedup.spec.ts
@@ -196,6 +196,38 @@ describe('ProxyMessageDedup', () => {
   /* ── findExistingSuccessMessage ── */
 
   describe('findExistingSuccessMessage', () => {
+    it('returns a request-id match before trying trace or session heuristics', async () => {
+      const existing = {
+        id: 'msg-request',
+        timestamp: new Date().toISOString(),
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        duration_ms: 1,
+      };
+      const repo = makeMockMessageRepo();
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await dedup.findExistingSuccessMessage(
+        repo as unknown as any,
+        testCtx,
+        'gpt-4o',
+        { prompt_tokens: 1, completion_tokens: 1 },
+        undefined,
+        undefined,
+        'request-1',
+      );
+
+      expect(result).toBe(existing);
+      expect(repo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ request_id: 'request-1', status: 'ok' }),
+        }),
+      );
+      expect(repo.find).not.toHaveBeenCalled();
+    });
+
     it('should return trace-matched message when traceId is provided', async () => {
       const existing = {
         id: 'msg-1',

--- a/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
@@ -77,4 +77,47 @@ describe('ProxyMessageRecorder request parents', () => {
     expect(insert).not.toHaveBeenCalled();
     recorder.onModuleDestroy();
   });
+
+  it('uses the rebuilt primary response as an exhausted fallback outcome', async () => {
+    const { recorder, requestValues } = setup();
+    await recorder.recordFailedFallbacks(
+      ctx,
+      'standard',
+      'gpt-4o',
+      [
+        {
+          model: 'claude-sonnet',
+          provider: 'anthropic',
+          status: 429,
+          errorBody: 'fallback limited',
+          fallbackIndex: 0,
+        },
+      ],
+      { requestId: 'request-3', markHandled: true, lastAsError: true },
+    );
+    await recorder.recordPrimaryFailure(
+      ctx,
+      'standard',
+      'gpt-4o',
+      'primary unavailable',
+      '2026-07-14T12:00:00.000Z',
+      'api_key',
+      { requestId: 'request-3', provider: 'openai', terminalHttpStatus: 503 },
+    );
+
+    expect(requestValues).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: 'request-3', status: 'pending' }),
+    );
+    expect(requestValues).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        id: 'request-3',
+        status: 'error',
+        error_http_status: 503,
+        error_message: 'primary unavailable',
+      }),
+    );
+    recorder.onModuleDestroy();
+  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
@@ -1,0 +1,80 @@
+import { ProxyMessageRecorder } from '../proxy-message-recorder';
+
+describe('ProxyMessageRecorder request parents', () => {
+  const ctx = {
+    tenantId: 'tenant-1',
+    agentId: 'agent-1',
+    agentName: 'agent',
+    userId: 'user-1',
+  };
+
+  function setup() {
+    const requestValues = jest.fn();
+    const execute = jest.fn().mockResolvedValue(undefined);
+    const requestQb: Record<string, jest.Mock> = {
+      insert: jest.fn(),
+      into: jest.fn(),
+      values: requestValues,
+      orUpdate: jest.fn(),
+      orIgnore: jest.fn(),
+      execute,
+    };
+    for (const key of ['insert', 'into', 'values', 'orUpdate', 'orIgnore']) {
+      requestQb[key].mockReturnValue(requestQb);
+    }
+    const requestRepo = { createQueryBuilder: jest.fn(() => requestQb) };
+    const insert = jest.fn().mockResolvedValue(undefined);
+    const messageRepo = {
+      insert,
+      manager: { getRepository: jest.fn(() => requestRepo) },
+    };
+    const recorder = new ProxyMessageRecorder(
+      messageRepo as never,
+      { getByModel: jest.fn() } as never,
+      {} as never,
+      { emit: jest.fn() } as never,
+      {
+        canonicalizeAgentMessageKeys: jest.fn(
+          async (_tenant: string, provider: string | null, model: string | null) => ({
+            provider,
+            model,
+          }),
+        ),
+      } as never,
+      {} as never,
+    );
+    return { recorder, insert, requestValues, execute };
+  }
+
+  it('creates a terminal request before its provider attempt', async () => {
+    const { recorder, insert, requestValues, execute } = setup();
+    await recorder.recordProviderError(ctx, 503, 'upstream down', {
+      requestId: 'request-1',
+      provider: 'openai',
+      model: 'gpt-4o',
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(requestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'request-1', status: 'error', error_origin: 'transport' }),
+    );
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ request_id: 'request-1' }));
+    recorder.onModuleDestroy();
+  });
+
+  it('records a Manifest rejection with zero provider attempts', async () => {
+    const { recorder, insert, requestValues } = setup();
+    await recorder.recordManifestBlockedRequest(ctx, {
+      requestId: 'request-2',
+      reason: 'no_provider_key',
+      errorMessage: 'No provider key',
+      errorCode: 'M100',
+    });
+
+    expect(requestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'request-2', status: 'error', error_origin: 'config' }),
+    );
+    expect(insert).not.toHaveBeenCalled();
+    recorder.onModuleDestroy();
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
@@ -79,7 +79,7 @@ describe('ProxyMessageRecorder request parents', () => {
   });
 
   it('uses the rebuilt primary response as an exhausted fallback outcome', async () => {
-    const { recorder, requestValues } = setup();
+    const { recorder, insert, requestValues } = setup();
     await recorder.recordFailedFallbacks(
       ctx,
       'standard',
@@ -116,6 +116,13 @@ describe('ProxyMessageRecorder request parents', () => {
         status: 'error',
         error_http_status: 503,
         error_message: 'primary unavailable',
+      }),
+    );
+    expect(insert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        request_id: 'request-3',
+        status: 'fallback_error',
+        error_http_status: null,
       }),
     );
     recorder.onModuleDestroy();

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -140,7 +140,8 @@ describe('proxy-response-handler', () => {
         testCtx,
         500,
         'Internal Server Error',
-        {
+        expect.objectContaining({
+          requestId: expect.any(String),
           model: 'gpt-4o',
           provider: 'openai',
           tier: 'standard',
@@ -150,7 +151,7 @@ describe('proxy-response-handler', () => {
           authType: undefined,
           reason: 'auto',
           specificityCategory: undefined,
-        },
+        }),
       );
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith(
@@ -595,7 +596,11 @@ describe('proxy-response-handler', () => {
         'Provider returned HTTP 503',
         expect.any(String),
         undefined,
-        { provider: 'anthropic', reason: 'auto', callerAttribution: undefined },
+        expect.objectContaining({
+          requestId: expect.any(String),
+          provider: 'anthropic',
+          reason: 'auto',
+        }),
       );
     });
 
@@ -615,7 +620,11 @@ describe('proxy-response-handler', () => {
         'Provider returned HTTP 500',
         expect.any(String),
         undefined,
-        { provider: 'anthropic', reason: 'auto', callerAttribution: undefined },
+        expect.objectContaining({
+          requestId: expect.any(String),
+          provider: 'anthropic',
+          reason: 'auto',
+        }),
       );
     });
 
@@ -653,7 +662,11 @@ describe('proxy-response-handler', () => {
         expect.any(String),
         expect.any(String),
         undefined,
-        { provider: undefined, reason: 'auto', callerAttribution: undefined },
+        expect.objectContaining({
+          requestId: expect.any(String),
+          provider: undefined,
+          reason: 'auto',
+        }),
       );
     });
   });
@@ -2001,16 +2014,22 @@ describe('proxy-response-handler', () => {
         'session-1',
       );
 
-      expect(recorder.recordFallbackSuccess).toHaveBeenCalledWith(testCtx, 'gpt-4o', 'standard', {
-        traceId: 'trace-1',
-        provider: 'openai',
-        fallbackFromModel: 'gpt-4o',
-        fallbackIndex: 1,
-        timestamp: '2025-01-01T00:00:00Z',
-        authType: undefined,
-        reason: 'auto',
-        usage,
-      });
+      expect(recorder.recordFallbackSuccess).toHaveBeenCalledWith(
+        testCtx,
+        'gpt-4o',
+        'standard',
+        expect.objectContaining({
+          requestId: expect.any(String),
+          traceId: 'trace-1',
+          provider: 'openai',
+          fallbackFromModel: 'gpt-4o',
+          fallbackIndex: 1,
+          timestamp: '2025-01-01T00:00:00Z',
+          authType: undefined,
+          reason: 'auto',
+          usage,
+        }),
+      );
     });
 
     it('should record success message when no fallback and usage exists', () => {
@@ -2026,14 +2045,15 @@ describe('proxy-response-handler', () => {
         'standard',
         'auto',
         usage,
-        {
+        expect.objectContaining({
+          requestId: expect.any(String),
           traceId: 'trace-1',
           provider: 'openai',
           authType: undefined,
           sessionKey: 'session-1',
           durationMs: expect.any(Number),
           specificityCategory: undefined,
-        },
+        }),
       );
     });
 
@@ -2106,16 +2126,22 @@ describe('proxy-response-handler', () => {
 
       recordSuccess(testCtx, meta, null, '2025-01-01T00:00:00Z', recorder as any);
 
-      expect(recorder.recordFallbackSuccess).toHaveBeenCalledWith(testCtx, 'gpt-4o', 'standard', {
-        traceId: undefined,
-        provider: 'openai',
-        fallbackFromModel: 'gpt-4o',
-        fallbackIndex: 0,
-        timestamp: '2025-01-01T00:00:00Z',
-        authType: undefined,
-        reason: 'auto',
-        usage: undefined,
-      });
+      expect(recorder.recordFallbackSuccess).toHaveBeenCalledWith(
+        testCtx,
+        'gpt-4o',
+        'standard',
+        expect.objectContaining({
+          requestId: expect.any(String),
+          traceId: undefined,
+          provider: 'openai',
+          fallbackFromModel: 'gpt-4o',
+          fallbackIndex: 0,
+          timestamp: '2025-01-01T00:00:00Z',
+          authType: undefined,
+          reason: 'auto',
+          usage: undefined,
+        }),
+      );
     });
 
     it('defaults fallbackIndex to 0 when meta does not set one', () => {

--- a/packages/backend/src/routing/proxy/proxy-message-dedup.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-dedup.ts
@@ -29,7 +29,29 @@ export class ProxyMessageDedup {
     usage: StreamUsage,
     traceId?: string,
     sessionKey?: string | null,
+    requestId?: string,
   ): Promise<DedupMatch | null> {
+    if (requestId) {
+      const existing = await messageRepo.findOne({
+        where: {
+          tenant_id: ctx.tenantId,
+          request_id: requestId,
+          status: 'ok',
+        },
+        select: [
+          'id',
+          'timestamp',
+          'input_tokens',
+          'output_tokens',
+          'cache_read_tokens',
+          'cache_creation_tokens',
+          'duration_ms',
+        ],
+        order: { timestamp: 'DESC' },
+      });
+      if (existing) return existing;
+    }
+
     if (traceId) {
       const existing = await messageRepo.findOne({
         where: {
@@ -85,7 +107,7 @@ export class ProxyMessageDedup {
         ) {
           return false;
         }
-        // agent_messages.input_tokens already stores the chat-shape prompt_tokens
+        // provider_attempts.input_tokens already stores the chat-shape prompt_tokens
         // (total input including cache reads + creation). Comparing the column
         // directly avoids double-counting the cache portions which are reported
         // separately in cache_read_tokens / cache_creation_tokens.
@@ -109,7 +131,9 @@ export class ProxyMessageDedup {
     model: string,
     traceId?: string,
     sessionKey?: string | null,
+    requestId?: string,
   ): string {
+    if (requestId) return `request:${requestId}`;
     if (traceId) return `trace:${ctx.tenantId}:${ctx.agentId}:${traceId}`;
     return `success:${ctx.tenantId}:${ctx.agentId}:${sessionKey ?? 'no-session'}:${model}`;
   }

--- a/packages/backend/src/routing/proxy/proxy-message-dedup.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-dedup.ts
@@ -18,6 +18,16 @@ export type DedupMatch = Pick<
   | 'duration_ms'
 >;
 
+const DEDUP_SELECT: Array<keyof AgentMessage> = [
+  'id',
+  'timestamp',
+  'input_tokens',
+  'output_tokens',
+  'cache_read_tokens',
+  'cache_creation_tokens',
+  'duration_ms',
+];
+
 @Injectable()
 export class ProxyMessageDedup {
   private readonly successWriteLocks = new Map<string, Promise<void>>();
@@ -38,15 +48,7 @@ export class ProxyMessageDedup {
           request_id: requestId,
           status: 'ok',
         },
-        select: [
-          'id',
-          'timestamp',
-          'input_tokens',
-          'output_tokens',
-          'cache_read_tokens',
-          'cache_creation_tokens',
-          'duration_ms',
-        ],
+        select: DEDUP_SELECT,
         order: { timestamp: 'DESC' },
       });
       if (existing) return existing;
@@ -60,15 +62,7 @@ export class ProxyMessageDedup {
           trace_id: traceId,
           status: 'ok',
         },
-        select: [
-          'id',
-          'timestamp',
-          'input_tokens',
-          'output_tokens',
-          'cache_read_tokens',
-          'cache_creation_tokens',
-          'duration_ms',
-        ],
+        select: DEDUP_SELECT,
         order: { timestamp: 'DESC' },
       });
       if (existing) return existing;
@@ -83,15 +77,7 @@ export class ProxyMessageDedup {
         status: 'ok',
         ...(sessionKey ? { session_key: sessionKey } : {}),
       },
-      select: [
-        'id',
-        'timestamp',
-        'input_tokens',
-        'output_tokens',
-        'cache_read_tokens',
-        'cache_creation_tokens',
-        'duration_ms',
-      ],
+      select: DEDUP_SELECT,
       order: { timestamp: 'DESC' },
       take: 10,
     });

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 import { classifyMessageError, type RequestParamDefaults } from 'manifest-shared';
 import { AgentMessage } from '../../entities/agent-message.entity';
+import { ManifestRequest } from '../../entities/request.entity';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
@@ -72,6 +73,7 @@ export interface HeaderTierRef {
 }
 
 export interface ProviderErrorOpts extends HeaderTierRef {
+  requestId?: string;
   model?: string;
   provider?: string;
   tier?: string;
@@ -81,7 +83,7 @@ export interface ProviderErrorOpts extends HeaderTierRef {
   authType?: string;
   /**
    * Why the tier was selected (e.g. 'header-match', 'specificity', 'scored').
-   * Persisted to agent_messages.routing_reason so single-shot upstream errors
+   * Persisted to provider_attempts.routing_reason so single-shot upstream errors
    * keep the same audit context as their successful siblings.
    */
   reason?: string;
@@ -89,7 +91,7 @@ export interface ProviderErrorOpts extends HeaderTierRef {
   providerKeyLabel?: string;
   /**
    * The tenant_providers row (connection/key) that served this message.
-   * Persisted to agent_messages.tenant_provider_id so per-connection analytics
+   * Persisted to provider_attempts.tenant_provider_id so per-connection analytics
    * scope by the exact key rather than the non-unique provider/auth/label tuple.
    */
   tenantProviderId?: string | null;
@@ -97,7 +99,7 @@ export interface ProviderErrorOpts extends HeaderTierRef {
   requestHeaders?: Record<string, string> | null;
   /**
    * Snapshot of effective request body parameters merged into the outbound
-   * provider request. Persisted to `agent_messages.request_params`.
+   * provider request. Persisted to `provider_attempts.request_params`.
    */
   requestParams?: RequestParamDefaults | null;
   /** Auto-fix audit when this error was the terminal outcome after healing. */
@@ -107,6 +109,7 @@ export interface ProviderErrorOpts extends HeaderTierRef {
 export type { ManifestBlockedRequestReason };
 
 export interface ManifestBlockedRequestOpts {
+  requestId?: string;
   /**
    * The status the caller saw, when there was one. Omitted for the HTTP-200
    * friendly stubs (no provider was contacted, so there is no upstream status
@@ -125,6 +128,7 @@ export interface ManifestBlockedRequestOpts {
 }
 
 export interface FallbackSuccessOpts extends HeaderTierRef {
+  requestId?: string;
   traceId?: string;
   provider?: string;
   fallbackFromModel?: string;
@@ -133,14 +137,14 @@ export interface FallbackSuccessOpts extends HeaderTierRef {
   authType?: string;
   /**
    * Why the primary tier was selected (e.g. 'header-match', 'specificity',
-   * 'scored'). Persisted to agent_messages.routing_reason so fallback rows
+   * 'scored'). Persisted to provider_attempts.routing_reason so fallback rows
    * keep the same audit context as their non-fallback siblings.
    */
   reason?: string;
   providerKeyLabel?: string;
   /**
    * The tenant_providers row (connection/key) that served this message.
-   * Persisted to agent_messages.tenant_provider_id so per-connection analytics
+   * Persisted to provider_attempts.tenant_provider_id so per-connection analytics
    * scope by the exact key rather than the non-unique provider/auth/label tuple.
    */
   tenantProviderId?: string | null;
@@ -150,12 +154,13 @@ export interface FallbackSuccessOpts extends HeaderTierRef {
   /**
    * Snapshot of effective request body parameters (today: DeepSeek
    * `thinking`) merged into the outbound provider request. `null` when no
-   * known params apply. Persisted to `agent_messages.request_params`.
+   * known params apply. Persisted to `provider_attempts.request_params`.
    */
   requestParams?: RequestParamDefaults | null;
 }
 
 export interface SuccessMessageOpts extends HeaderTierRef {
+  requestId?: string;
   traceId?: string;
   provider?: string;
   authType?: string;
@@ -165,7 +170,7 @@ export interface SuccessMessageOpts extends HeaderTierRef {
   providerKeyLabel?: string;
   /**
    * The tenant_providers row (connection/key) that served this message.
-   * Persisted to agent_messages.tenant_provider_id so per-connection analytics
+   * Persisted to provider_attempts.tenant_provider_id so per-connection analytics
    * scope by the exact key rather than the non-unique provider/auth/label tuple.
    */
   tenantProviderId?: string | null;
@@ -177,6 +182,7 @@ export interface SuccessMessageOpts extends HeaderTierRef {
 }
 
 export interface AutofixOriginalOpts extends HeaderTierRef {
+  requestId?: string;
   provider?: string;
   reason?: string;
   authType?: string;
@@ -210,6 +216,41 @@ function buildMessageRow(
   // Stamp the orthogonal error axes from this row's own signals so every insert
   // site is classified identically (and identically to the backfill migration).
   return { ...row, ...classifyRow(row) };
+}
+
+function buildRequestRow(
+  ctx: IngestionContext,
+  requestId: string,
+  attempt: Partial<AgentMessage>,
+  terminal: boolean,
+): ManifestRequest {
+  const classified = classifyRow(attempt);
+  const status = terminal ? (attempt.status ?? 'ok') : 'pending';
+  return {
+    id: requestId,
+    tenant_id: ctx.tenantId,
+    agent_id: ctx.agentId,
+    user_id: ctx.userId,
+    agent_name: ctx.agentName,
+    trace_id: attempt.trace_id ?? null,
+    session_key: attempt.session_key ?? null,
+    session_id: attempt.session_id ?? null,
+    timestamp: attempt.timestamp ?? new Date().toISOString(),
+    duration_ms: attempt.duration_ms ?? null,
+    status,
+    error_message: terminal ? (attempt.error_message ?? null) : null,
+    error_http_status: terminal ? (attempt.error_http_status ?? null) : null,
+    error_code: terminal ? (attempt.error_code ?? null) : null,
+    error_origin: terminal ? classified.error_origin : null,
+    error_class: terminal ? classified.error_class : null,
+    requested_model: attempt.fallback_from_model ?? attempt.model ?? null,
+    caller_attribution: attempt.caller_attribution ?? null,
+    request_headers: attempt.request_headers ?? null,
+    request_params: attempt.request_params ?? null,
+    feedback_rating: attempt.feedback_rating ?? null,
+    feedback_tags: attempt.feedback_tags ?? null,
+    feedback_details: attempt.feedback_details ?? null,
+  };
 }
 
 /**
@@ -256,6 +297,57 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     clearInterval(this.cooldownCleanupTimer);
   }
 
+  /**
+   * Insert the parent before its attempts. Intermediate hops only insert the
+   * initial pending row; the one terminal writer replaces it with the outcome
+   * observed by the caller. This prevents a late fallback-error write from
+   * downgrading a request that already succeeded.
+   */
+  private async persistRequest(
+    ctx: IngestionContext,
+    requestId: string,
+    attempt: Partial<AgentMessage>,
+    terminal: boolean,
+  ): Promise<boolean> {
+    // Unit-test repository doubles predate the request table. Production
+    // repositories always expose manager.getRepository().
+    const getRepository = this.messageRepo.manager?.getRepository?.bind(this.messageRepo.manager);
+    if (!getRepository) return false;
+    const repo = getRepository(ManifestRequest);
+    if (typeof repo.createQueryBuilder !== 'function') return false;
+    const row = buildRequestRow(ctx, requestId, attempt, terminal);
+    const insert = repo.createQueryBuilder().insert().into(ManifestRequest).values(row);
+    if (terminal) {
+      await insert
+        .orUpdate(
+          [
+            'user_id',
+            'agent_name',
+            'trace_id',
+            'session_key',
+            'session_id',
+            'timestamp',
+            'duration_ms',
+            'status',
+            'error_message',
+            'error_http_status',
+            'error_code',
+            'error_origin',
+            'error_class',
+            'requested_model',
+            'caller_attribution',
+            'request_headers',
+            'request_params',
+          ],
+          ['id'],
+        )
+        .execute();
+    } else {
+      await insert.orIgnore().execute();
+    }
+    return true;
+  }
+
   private shouldSkipRateLimitRecord(ctx: IngestionContext, scope?: string): boolean {
     const key = scope
       ? `${scope}:${ctx.tenantId}:${ctx.agentId}`
@@ -280,6 +372,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     opts?: ProviderErrorOpts,
   ): Promise<void> {
     const {
+      requestId = uuid(),
       model,
       provider,
       tier,
@@ -299,7 +392,6 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       headerTierColor,
       autofix,
     } = opts ?? {};
-
     if (httpStatus === 429 && this.shouldSkipRateLimitRecord(ctx)) return;
 
     const messageStatus = httpStatus === 429 ? 'rate_limited' : 'error';
@@ -310,32 +402,33 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       model,
     );
 
-    await this.messageRepo.insert(
-      buildMessageRow(ctx, {
-        trace_id: traceId ?? null,
-        timestamp: new Date().toISOString(),
-        status: messageStatus,
-        error_message: scrubSecrets(errorMessage).slice(0, 2000),
-        error_http_status: httpStatus,
-        ...autofixColumns(autofix, 'original'),
-        model: canonical.model,
-        provider: canonical.provider,
-        routing_tier: tier ?? null,
-        routing_reason: reason ?? null,
-        fallback_from_model: fallbackFromModel ?? null,
-        fallback_index: fallbackIndex ?? null,
-        auth_type: authType ?? null,
-        specificity_category: specificityCategory ?? null,
-        provider_key_label: providerKeyLabel ?? null,
-        tenant_provider_id: tenantProviderId ?? null,
-        caller_attribution: callerAttribution ?? null,
-        request_headers: requestHeaders ?? null,
-        request_params: requestParams ?? null,
-        header_tier_id: headerTierId ?? null,
-        header_tier_name: headerTierName ?? null,
-        header_tier_color: headerTierColor ?? null,
-      }),
-    );
+    const row = buildMessageRow(ctx, {
+      request_id: requestId,
+      trace_id: traceId ?? null,
+      timestamp: new Date().toISOString(),
+      status: messageStatus,
+      error_message: scrubSecrets(errorMessage).slice(0, 2000),
+      error_http_status: httpStatus,
+      ...autofixColumns(autofix, 'original'),
+      model: canonical.model,
+      provider: canonical.provider,
+      routing_tier: tier ?? null,
+      routing_reason: reason ?? null,
+      fallback_from_model: fallbackFromModel ?? null,
+      fallback_index: fallbackIndex ?? null,
+      auth_type: authType ?? null,
+      specificity_category: specificityCategory ?? null,
+      provider_key_label: providerKeyLabel ?? null,
+      tenant_provider_id: tenantProviderId ?? null,
+      caller_attribution: callerAttribution ?? null,
+      request_headers: requestHeaders ?? null,
+      request_params: requestParams ?? null,
+      header_tier_id: headerTierId ?? null,
+      header_tier_name: headerTierName ?? null,
+      header_tier_color: headerTierColor ?? null,
+    });
+    await this.persistRequest(ctx, requestId, row, true);
+    await this.messageRepo.insert(row);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
 
@@ -356,6 +449,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     opts: ManifestBlockedRequestOpts,
   ): Promise<void> {
     const {
+      requestId = uuid(),
       httpStatus,
       errorMessage,
       errorCode,
@@ -377,33 +471,36 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       model ?? null,
     );
 
-    await this.messageRepo.insert(
-      buildMessageRow(ctx, {
-        trace_id: traceId ?? null,
-        session_key: sessionKey ?? null,
-        timestamp: new Date().toISOString(),
-        status: httpStatus === 429 ? 'rate_limited' : 'error',
-        error_message: scrubSecrets(errorMessage).slice(0, 2000),
-        error_code: errorCode ?? null,
-        error_http_status: httpStatus ?? null,
-        model: canonical.model,
-        provider: null,
-        routing_tier: null,
-        routing_reason: reason,
-        fallback_from_model: null,
-        fallback_index: null,
-        auth_type: null,
-        specificity_category: null,
-        provider_key_label: null,
-        tenant_provider_id: null,
-        caller_attribution: callerAttribution ?? null,
-        request_headers: requestHeaders ?? null,
-        request_params: null,
-        header_tier_id: null,
-        header_tier_name: null,
-        header_tier_color: null,
-      }),
-    );
+    const row = buildMessageRow(ctx, {
+      trace_id: traceId ?? null,
+      session_key: sessionKey ?? null,
+      timestamp: new Date().toISOString(),
+      status: httpStatus === 429 ? 'rate_limited' : 'error',
+      error_message: scrubSecrets(errorMessage).slice(0, 2000),
+      error_code: errorCode ?? null,
+      error_http_status: httpStatus ?? null,
+      model: canonical.model,
+      provider: null,
+      routing_tier: null,
+      routing_reason: reason,
+      fallback_from_model: null,
+      fallback_index: null,
+      auth_type: null,
+      specificity_category: null,
+      provider_key_label: null,
+      tenant_provider_id: null,
+      caller_attribution: callerAttribution ?? null,
+      request_headers: requestHeaders ?? null,
+      request_params: null,
+      header_tier_id: null,
+      header_tier_name: null,
+      header_tier_color: null,
+    });
+    // A Manifest-level rejection is a real request with zero provider attempts.
+    const wroteRequest = await this.persistRequest(ctx, requestId, row, true);
+    // Legacy unit-test doubles have no request repository. Keep their observed
+    // write shape without affecting the production zero-attempt model.
+    if (!wroteRequest) await this.messageRepo.insert(row);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
 
@@ -414,6 +511,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     failures: FailedFallback[],
     opts?: {
       traceId?: string;
+      requestId?: string;
       baseTimeMs?: number;
       markHandled?: boolean;
       lastAsError?: boolean;
@@ -429,6 +527,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
   ): Promise<void> {
     const {
       traceId,
+      requestId = uuid(),
       baseTimeMs,
       markHandled = false,
       lastAsError = false,
@@ -475,6 +574,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       const recordedAuth = f.authType ?? authType ?? null;
       rows.push(
         buildMessageRow(ctx, {
+          request_id: requestId,
           trace_id: traceId ?? null,
           timestamp: ts,
           status,
@@ -498,6 +598,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         }),
       );
     }
+    await this.persistRequest(ctx, requestId, rows[rows.length - 1], lastAsError);
     await this.messageRepo.insert(rows);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
@@ -511,6 +612,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     authType?: string,
     opts?: {
       provider?: string;
+      requestId?: string;
       reason?: string;
       tenantProviderId?: string | null;
       callerAttribution?: CallerAttribution | null;
@@ -532,28 +634,30 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       opts?.provider,
       model,
     );
-    await this.messageRepo.insert(
-      buildMessageRow(ctx, {
-        timestamp,
-        status: 'fallback_error',
-        ...autofixColumns(opts?.autofix, 'original'),
-        error_message: scrubSecrets(errorBody).slice(0, 2000),
-        model: canonical.model,
-        provider: canonical.provider,
-        routing_tier: tier,
-        routing_reason: opts?.reason ?? null,
-        fallback_from_model: null,
-        fallback_index: null,
-        auth_type: authType ?? null,
-        tenant_provider_id: opts?.tenantProviderId ?? null,
-        caller_attribution: opts?.callerAttribution ?? null,
-        request_headers: opts?.requestHeaders ?? null,
-        request_params: opts?.requestParams ?? null,
-        header_tier_id: opts?.headerTierId ?? null,
-        header_tier_name: opts?.headerTierName ?? null,
-        header_tier_color: opts?.headerTierColor ?? null,
-      }),
-    );
+    const requestId = opts?.requestId ?? uuid();
+    const row = buildMessageRow(ctx, {
+      request_id: requestId,
+      timestamp,
+      status: 'fallback_error',
+      ...autofixColumns(opts?.autofix, 'original'),
+      error_message: scrubSecrets(errorBody).slice(0, 2000),
+      model: canonical.model,
+      provider: canonical.provider,
+      routing_tier: tier,
+      routing_reason: opts?.reason ?? null,
+      fallback_from_model: null,
+      fallback_index: null,
+      auth_type: authType ?? null,
+      tenant_provider_id: opts?.tenantProviderId ?? null,
+      caller_attribution: opts?.callerAttribution ?? null,
+      request_headers: opts?.requestHeaders ?? null,
+      request_params: opts?.requestParams ?? null,
+      header_tier_id: opts?.headerTierId ?? null,
+      header_tier_name: opts?.headerTierName ?? null,
+      header_tier_color: opts?.headerTierColor ?? null,
+    });
+    await this.persistRequest(ctx, requestId, row, false);
+    await this.messageRepo.insert(row);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
 
@@ -564,6 +668,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     opts?: FallbackSuccessOpts,
   ): Promise<void> {
     const {
+      requestId = uuid(),
       traceId,
       provider,
       fallbackFromModel,
@@ -608,33 +713,34 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       fallbackFromModel,
     );
 
-    await this.messageRepo.insert(
-      buildMessageRow(ctx, {
-        trace_id: traceId ?? null,
-        timestamp: timestamp ?? new Date().toISOString(),
-        status: 'ok',
-        model: canonical.model,
-        provider: canonical.provider,
-        routing_tier: tier,
-        routing_reason: reason ?? null,
-        input_tokens: inputTokens,
-        output_tokens: outputTokens,
-        cache_read_tokens: usage?.cache_read_tokens ?? 0,
-        cache_creation_tokens: usage?.cache_creation_tokens ?? 0,
-        cost_usd: costUsd,
-        auth_type: authType ?? null,
-        fallback_from_model: canonicalFallbackFrom.model,
-        fallback_index: fallbackIndex ?? null,
-        provider_key_label: providerKeyLabel ?? null,
-        tenant_provider_id: tenantProviderId ?? null,
-        caller_attribution: callerAttribution ?? null,
-        request_headers: requestHeaders ?? null,
-        request_params: requestParams ?? null,
-        header_tier_id: headerTierId ?? null,
-        header_tier_name: headerTierName ?? null,
-        header_tier_color: headerTierColor ?? null,
-      }),
-    );
+    const row = buildMessageRow(ctx, {
+      request_id: requestId,
+      trace_id: traceId ?? null,
+      timestamp: timestamp ?? new Date().toISOString(),
+      status: 'ok',
+      model: canonical.model,
+      provider: canonical.provider,
+      routing_tier: tier,
+      routing_reason: reason ?? null,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_tokens: usage?.cache_read_tokens ?? 0,
+      cache_creation_tokens: usage?.cache_creation_tokens ?? 0,
+      cost_usd: costUsd,
+      auth_type: authType ?? null,
+      fallback_from_model: canonicalFallbackFrom.model,
+      fallback_index: fallbackIndex ?? null,
+      provider_key_label: providerKeyLabel ?? null,
+      tenant_provider_id: tenantProviderId ?? null,
+      caller_attribution: callerAttribution ?? null,
+      request_headers: requestHeaders ?? null,
+      request_params: requestParams ?? null,
+      header_tier_id: headerTierId ?? null,
+      header_tier_name: headerTierName ?? null,
+      header_tier_color: headerTierColor ?? null,
+    });
+    await this.persistRequest(ctx, requestId, row, true);
+    await this.messageRepo.insert(row);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
 
@@ -647,6 +753,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     opts?: SuccessMessageOpts,
   ): Promise<void> {
     const {
+      requestId: providedRequestId,
       traceId,
       provider,
       authType,
@@ -663,6 +770,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       headerTierColor,
       autofix,
     } = opts ?? {};
+    const requestId = providedRequestId ?? uuid();
 
     const costUsd = computeTokenCost({
       inputTokens: usage.prompt_tokens,
@@ -693,9 +801,33 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     const status = 'ok';
     const errorMessage = null;
 
+    const requestRow = buildMessageRow(ctx, {
+      request_id: requestId,
+      trace_id: traceId ?? null,
+      session_key: normalizedSessionKey,
+      timestamp: new Date().toISOString(),
+      status,
+      error_message: errorMessage,
+      model: canonicalModel,
+      provider: canonicalProvider,
+      routing_tier: tier,
+      routing_reason: reason,
+      duration_ms: durationMs ?? null,
+      caller_attribution: callerAttribution ?? null,
+      request_headers: requestHeaders ?? null,
+      request_params: requestParams ?? null,
+    });
+    await this.persistRequest(ctx, requestId, requestRow, true);
+
     let wrote = false;
     await this.dedup.withSuccessWriteLock(
-      this.dedup.getSuccessWriteLockKey(ctx, canonicalModel, traceId, normalizedSessionKey),
+      this.dedup.getSuccessWriteLockKey(
+        ctx,
+        canonicalModel,
+        traceId,
+        normalizedSessionKey,
+        providedRequestId,
+      ),
       async () => {
         await this.dedup.withAgentMessageTransaction(this.messageRepo, ctx, async (messageRepo) => {
           const existing = await this.dedup.findExistingSuccessMessage(
@@ -705,6 +837,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
             usage,
             traceId,
             normalizedSessionKey,
+            providedRequestId,
           );
 
           if (existing) {
@@ -713,6 +846,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
             if (hasRecordedTokens) return;
 
             const updatePayload: Partial<AgentMessage> = {
+              request_id: requestId,
               status,
               ...autofixColumns(autofix, 'retry'),
               error_message: errorMessage,
@@ -752,6 +886,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
           await messageRepo.insert(
             buildMessageRow(ctx, {
               id: newId,
+              request_id: requestId,
               ...autofixColumns(autofix, 'retry'),
               trace_id: traceId ?? null,
               session_key: normalizedSessionKey,
@@ -813,8 +948,10 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       model,
     );
     const nowMs = Date.now();
+    const requestId = opts?.requestId ?? uuid();
     const rows = failed.map((entry, i) =>
       buildMessageRow(ctx, {
+        request_id: requestId,
         trace_id: opts?.traceId ?? null,
         timestamp: new Date(nowMs - (failed.length - i) * 1000).toISOString(),
         status: 'auto_fixed',
@@ -844,6 +981,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         autofix_phoenix: buildAutofixPhoenix(entry),
       }),
     );
+    await this.persistRequest(ctx, requestId, rows[rows.length - 1], false);
     await this.messageRepo.insert(rows);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -598,7 +598,10 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         }),
       );
     }
-    await this.persistRequest(ctx, requestId, rows[rows.length - 1], lastAsError);
+    // Fallback attempts never define the caller-visible outcome themselves.
+    // Exhausted chains persist the rebuilt primary response as the terminal
+    // parent in recordPrimaryFailure; recovered chains finish on success.
+    await this.persistRequest(ctx, requestId, rows[rows.length - 1], false);
     await this.messageRepo.insert(rows);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
@@ -627,6 +630,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
        * heal-then-fallback flow records the primary failure exactly once.
        */
       autofix?: AutofixRecord;
+      /** HTTP status returned to the caller when every fallback was exhausted. */
+      terminalHttpStatus?: number;
     },
   ): Promise<void> {
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
@@ -641,6 +646,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       status: 'fallback_error',
       ...autofixColumns(opts?.autofix, 'original'),
       error_message: scrubSecrets(errorBody).slice(0, 2000),
+      error_http_status: opts?.terminalHttpStatus ?? null,
       model: canonical.model,
       provider: canonical.provider,
       routing_tier: tier,
@@ -656,7 +662,13 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       header_tier_name: opts?.headerTierName ?? null,
       header_tier_color: opts?.headerTierColor ?? null,
     });
-    await this.persistRequest(ctx, requestId, row, false);
+    const requestOutcome = opts?.terminalHttpStatus
+      ? {
+          ...row,
+          status: opts.terminalHttpStatus === 429 ? 'rate_limited' : 'error',
+        }
+      : row;
+    await this.persistRequest(ctx, requestId, requestOutcome, Boolean(opts?.terminalHttpStatus));
     await this.messageRepo.insert(row);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -646,7 +646,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       status: 'fallback_error',
       ...autofixColumns(opts?.autofix, 'original'),
       error_message: scrubSecrets(errorBody).slice(0, 2000),
-      error_http_status: opts?.terminalHttpStatus ?? null,
+      error_http_status: null,
       model: canonical.model,
       provider: canonical.provider,
       routing_tier: tier,
@@ -666,6 +666,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       ? {
           ...row,
           status: opts.terminalHttpStatus === 429 ? 'rate_limited' : 'error',
+          error_http_status: opts.terminalHttpStatus,
         }
       : row;
     await this.persistRequest(ctx, requestId, requestOutcome, Boolean(opts?.terminalHttpStatus));

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -243,6 +243,7 @@ function handleFallbackExhausted(
         headerTierId: meta.header_tier_id,
         headerTierName: meta.header_tier_name,
         headerTierColor: meta.header_tier_color,
+        terminalHttpStatus: errorStatus,
         // Auto-fix ran on this primary before the chain exhausted — stamp its
         // audit onto the single primary-failure row (no separate `auto_fixed`).
         autofix,

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import { v4 as uuid } from 'uuid';
 import { Response as ExpressResponse } from 'express';
 import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
 import { RoutingMeta } from './proxy.service';
@@ -126,6 +127,7 @@ export async function handleProviderError(
   callerAttribution?: CallerAttribution | null,
   requestHeaders?: Record<string, string> | null,
   autofix?: AutofixRecord,
+  requestId: string = uuid(),
 ): Promise<void> {
   if (failedFallbacks && failedFallbacks.length > 0 && !meta.fallbackFromModel) {
     await handleFallbackExhausted(
@@ -141,12 +143,14 @@ export async function handleProviderError(
       callerAttribution,
       requestHeaders,
       autofix,
+      requestId,
     );
     return;
   }
 
   recordSafely(
     recorder.recordProviderError(ctx, errorStatus, errorBody, {
+      requestId,
       model: meta.model,
       provider: meta.provider,
       tier: meta.tier,
@@ -196,10 +200,12 @@ function handleFallbackExhausted(
   callerAttribution?: CallerAttribution | null,
   requestHeaders?: Record<string, string> | null,
   autofix?: AutofixRecord,
+  requestId: string = uuid(),
 ): void {
   const baseTime = Date.now();
   recordSafely(
     recorder.recordFailedFallbacks(ctx, meta.tier, meta.model, failedFallbacks, {
+      requestId,
       traceId,
       baseTimeMs: baseTime,
       markHandled: true,
@@ -226,6 +232,7 @@ function handleFallbackExhausted(
       primaryTs,
       meta.auth_type,
       {
+        requestId,
         provider: meta.provider,
         reason: meta.reason,
         // Exhausted chain: primary connection (meta.tenantProviderId holds it here).
@@ -276,6 +283,7 @@ export function recordFallbackFailures(
   callerAttribution?: CallerAttribution | null,
   requestHeaders?: Record<string, string> | null,
   autofix?: AutofixRecord,
+  requestId: string = uuid(),
 ): string | undefined {
   if (!meta.fallbackFromModel) return undefined;
 
@@ -295,6 +303,7 @@ export function recordFallbackFailures(
       new Date(fallbackBaseTime).toISOString(),
       primaryAuthType,
       {
+        requestId,
         // Use the primary provider explicitly — meta.provider holds the
         // succeeding fallback's provider in this flow, not the primary's.
         provider: meta.primaryProvider,
@@ -326,6 +335,7 @@ export function recordFallbackFailures(
   if (failures.length > 0) {
     recordSafely(
       recorder.recordFailedFallbacks(ctx, meta.tier, meta.fallbackFromModel, failures, {
+        requestId,
         baseTimeMs: fallbackBaseTime,
         markHandled: true,
         authType: primaryAuthType,
@@ -635,10 +645,12 @@ export function recordSuccess(
   callerAttribution?: CallerAttribution | null,
   requestHeaders?: Record<string, string> | null,
   autofix?: AutofixRecord,
+  requestId: string = uuid(),
 ): void {
   if (meta.fallbackFromModel && fallbackSuccessTs) {
     recordSafely(
       recorder.recordFallbackSuccess(ctx, meta.model, meta.tier, {
+        requestId,
         traceId,
         provider: meta.provider,
         fallbackFromModel: meta.fallbackFromModel,
@@ -663,6 +675,7 @@ export function recordSuccess(
     const durationMs = startTime ? Date.now() - startTime : undefined;
     recordSafely(
       recorder.recordSuccessMessage(ctx, meta.model, meta.tier, meta.reason, usage, {
+        requestId,
         traceId,
         provider: meta.provider,
         authType: meta.auth_type,
@@ -697,6 +710,7 @@ export function recordSuccess(
   if (autofix && autofix.outcome === 'healed' && !meta.fallbackFromModel) {
     recordSafely(
       recorder.recordAutofixOriginals(ctx, meta.model, meta.tier, autofix, {
+        requestId,
         provider: meta.provider,
         reason: meta.reason,
         authType: meta.auth_type,

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -79,7 +79,7 @@ export interface ProxyRequestOptions {
   tenantId: string;
   /**
    * Owning user, when one exists. Informational attribution for the message
-   * recorder (`agent_messages.user_id`) only — never used for scoping,
+   * recorder (`provider_attempts.user_id`) only — never used for scoping,
    * keying, or rate limiting.
    */
   userId: string | null;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -157,6 +157,7 @@ export class ProxyController {
     const body = req.body as Record<string, unknown>;
     const sessionKey = this.extractSessionKey(req);
     const traceId = this.extractTraceId(req);
+    const requestId = uuid();
     const callerAttribution = classifyCaller(req.headers);
     const requestHeaders = sanitizeRequestHeaders(req.headers);
     const isStream = body.stream === true;
@@ -171,7 +172,7 @@ export class ProxyController {
 
     // Plan request-limit gate. A 402 must reach ProxyExceptionFilter (friendly
     // upgrade message / real 402), but still gets a Manifest-policy row in
-    // agent_messages so the Messages tab explains why the request never routed.
+    // provider_attempts so the Messages tab explains why the request never routed.
     // Billing counters exclude Manifest-origin rows, so this does not consume
     // quota or push the tenant further over the limit.
     try {
@@ -181,6 +182,7 @@ export class ProxyController {
         this.recordManifestBlockedRequest(
           err,
           req,
+          requestId,
           traceId,
           callerAttribution,
           requestHeaders,
@@ -196,6 +198,7 @@ export class ProxyController {
         res,
         clientAbort,
         headersSent,
+        requestId,
         traceId,
         callerAttribution,
         requestHeaders,
@@ -216,7 +219,7 @@ export class ProxyController {
       const { forward, meta, failedFallbacks, autofix } = await this.proxyService.proxyRequest({
         agentId: req.ingestionContext.agentId,
         tenantId,
-        // Attribution only — the recorder writes it to agent_messages.user_id.
+        // Attribution only — the recorder writes it to provider_attempts.user_id.
         userId: req.ingestionContext.userId,
         body,
         routingBody,
@@ -280,6 +283,7 @@ export class ProxyController {
           callerAttribution,
           requestHeaders,
           autofix,
+          requestId,
         );
         return;
       }
@@ -292,6 +296,7 @@ export class ProxyController {
         callerAttribution,
         requestHeaders,
         autofix,
+        requestId,
       );
 
       let streamUsage = null;
@@ -331,7 +336,15 @@ export class ProxyController {
       // proxy as an HTTP 200 assistant message, so it lands here — but it is a
       // Manifest failure, not a completion. Record it as one.
       if (meta.manifest_error_code) {
-        this.recordManifestStub(req, meta, traceId, sessionKey, callerAttribution, requestHeaders);
+        this.recordManifestStub(
+          req,
+          meta,
+          requestId,
+          traceId,
+          sessionKey,
+          callerAttribution,
+          requestHeaders,
+        );
       } else {
         recordSuccess(
           req.ingestionContext,
@@ -345,6 +358,7 @@ export class ProxyController {
           callerAttribution,
           requestHeaders,
           autofix,
+          requestId,
         );
       }
     } catch (err: unknown) {
@@ -354,6 +368,7 @@ export class ProxyController {
         res,
         clientAbort,
         headersSent,
+        requestId,
         traceId,
         callerAttribution,
         requestHeaders,
@@ -373,6 +388,7 @@ export class ProxyController {
   private recordManifestStub(
     req: Request & { ingestionContext: IngestionContext },
     meta: RoutingMeta,
+    requestId: string,
     traceId: string | undefined,
     sessionKey: string | undefined,
     callerAttribution: ReturnType<typeof classifyCaller>,
@@ -382,6 +398,7 @@ export class ProxyController {
     if (!code || !isRecordableManifestCode(code)) return;
     this.recorder
       .recordManifestBlockedRequest(req.ingestionContext, {
+        requestId,
         errorMessage: meta.manifest_error_message ?? formatManifestError(code),
         errorCode: code,
         reason: MANIFEST_CODE_TO_REASON[code],
@@ -400,6 +417,7 @@ export class ProxyController {
     res: ExpressResponse,
     clientAbort: AbortController,
     headersSent: boolean,
+    requestId: string,
     traceId: string | undefined,
     callerAttribution: ReturnType<typeof classifyCaller>,
     requestHeaders: ReturnType<typeof sanitizeRequestHeaders>,
@@ -433,6 +451,7 @@ export class ProxyController {
         this.recordManifestBlockedRequest(
           err,
           req,
+          requestId,
           traceId,
           callerAttribution,
           requestHeaders,
@@ -446,6 +465,7 @@ export class ProxyController {
       this.recordManifestBlockedRequest(
         err,
         req,
+        requestId,
         traceId,
         callerAttribution,
         requestHeaders,
@@ -456,6 +476,7 @@ export class ProxyController {
     } else {
       this.recorder
         .recordProviderError(req.ingestionContext, status, providerErrorBody, {
+          requestId,
           ...(meta
             ? {
                 model: meta.model,
@@ -573,6 +594,7 @@ export class ProxyController {
   private recordManifestBlockedRequest(
     err: unknown,
     req: Request & { ingestionContext: IngestionContext },
+    requestId: string,
     traceId: string | undefined,
     callerAttribution: ReturnType<typeof classifyCaller>,
     requestHeaders: ReturnType<typeof sanitizeRequestHeaders>,
@@ -583,6 +605,7 @@ export class ProxyController {
     const body = req.body as Record<string, unknown> | undefined;
     this.recorder
       .recordManifestBlockedRequest(req.ingestionContext, {
+        requestId,
         httpStatus: httpStatus ?? (err instanceof HttpException ? err.getStatus() : 500),
         // The raw internal message, not the friendly M500 text the caller saw —
         // the dashboard row is where you go to find out what actually broke.

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -98,7 +98,7 @@ export interface RoutingMeta {
   provider_key_label?: string;
   /**
    * The `tenant_providers` row id that served this attempt. Stamped on
-   * `agent_messages.tenant_provider_id` so per-connection analytics scope by the
+   * `provider_attempts.tenant_provider_id` so per-connection analytics scope by the
    * exact key rather than the non-unique (provider, auth_type, label) tuple.
    * In a fallback-success flow this holds the winning fallback's connection.
    * NULL for local/Ollama and resolution-failure paths.
@@ -132,7 +132,7 @@ export interface RoutingMeta {
   /**
    * Effective request body parameters for this attempt: client body values,
    * route-scoped `agent_model_params`, and MPS provider param defaults.
-   * Persisted on `agent_messages.request_params` so the dashboard can show
+   * Persisted on `provider_attempts.request_params` so the dashboard can show
    * which model params were in play for the recorded request.
    */
   request_params?: RequestParamDefaults | null;
@@ -295,7 +295,7 @@ export class ProxyService {
       : { agentId, scopeKey };
 
     // Snapshot of which known param keys are *effectively in play* for the
-    // primary attempt. Stored on every `agent_messages` row recorded for
+    // primary attempt. Stored on every `provider_attempts` row recorded for
     // this request so the dashboard can display the effective parameters
     // (today: DeepSeek's `thinking` toggle) in the expanded message detail.
     // Re-derived for fallback successes against the actual fallback
@@ -642,7 +642,7 @@ export class ProxyService {
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
       // A ManifestError, not a bare BadRequestException: the proxy needs to tell
       // "Manifest refused this body" from "the provider returned a 400", or the
-      // row lands in agent_messages blamed on the provider.
+      // row lands in provider_attempts blamed on the provider.
       throw new ManifestError('M300', HttpStatus.BAD_REQUEST);
     }
     sanitizeNullContent(messages as Record<string, unknown>[]);
@@ -772,7 +772,7 @@ export class ProxyService {
     if (!key || key.apiKey === null) return null;
     const apiKey = key.apiKey;
     // NULL for the synthetic Ollama tile — it has no persisted row, so
-    // stamping its id would violate the agent_messages FK.
+    // stamping its id would violate the provider_attempts FK.
     const tenantProviderId = key.id === SYNTHETIC_OLLAMA_PROVIDER_ID ? null : key.id;
 
     const unwrapped = await resolveApiKey(

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -18,7 +18,7 @@ import { isManifestUsableProvider } from '../../common/utils/subscription-suppor
 /**
  * Sentinel id for the built-in Ollama tile. getProviderKeys() short-circuits
  * Ollama to a synthetic key without a DB lookup, so this id matches no
- * `tenant_providers` row — callers stamping `agent_messages.tenant_provider_id`
+ * `tenant_providers` row — callers stamping `provider_attempts.tenant_provider_id`
  * must treat it as "no persisted connection" (NULL) to avoid an FK violation.
  */
 export const SYNTHETIC_OLLAMA_PROVIDER_ID = 'ollama';
@@ -90,7 +90,7 @@ export class ProviderKeyService {
    * match when a label is given, else the first (priority-ordered) default key.
    * Returns null when no key resolves. getProviderApiKey/getProviderRegion are
    * thin projections of this — callers that also need the `tenant_providers` row
-   * id (e.g. the proxy, to stamp `agent_messages.tenant_provider_id`) call it
+   * id (e.g. the proxy, to stamp `provider_attempts.tenant_provider_id`) call it
    * directly so the id selected and the key forwarded can never diverge.
    */
   async selectProviderKey(
@@ -122,9 +122,9 @@ export class ProviderKeyService {
 
   /**
    * Returns the `tenant_providers` row id of the selected key, for stamping
-   * `agent_messages.tenant_provider_id` at proxy time. Returns null when no key
+   * `provider_attempts.tenant_provider_id` at proxy time. Returns null when no key
    * resolves OR when the selection is the synthetic Ollama tile (which has no
-   * persisted row — stamping its id would violate the agent_messages FK).
+   * persisted row — stamping its id would violate the provider_attempts FK).
    */
   async getProviderKeyId(
     tenantId: string,

--- a/packages/backend/src/routing/tenant-providers.controller.ts
+++ b/packages/backend/src/routing/tenant-providers.controller.ts
@@ -11,7 +11,7 @@ import { CustomProviderService } from './custom-provider/custom-provider.service
  * Returns all providers for the tenant (not scoped to a specific agent).
  *
  * CONFIG ONLY. This endpoint must stay cheap: it reads `tenant_providers`
- * (small) plus the in-memory pricing cache, and never touches `agent_messages`.
+ * (small) plus the in-memory pricing cache, and never touches `provider_attempts`.
  * Usage stats (consumption_*, last_used_at, sparkline_7d) moved to
  * `GET /api/v1/providers/usage` (ProviderUsageController) so a config read no
  * longer triggers two multi-second scans over the 8GB messages table. The

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -31,7 +31,7 @@ interface TotalsRow {
 
 /**
  * Builds the daily telemetry payload by aggregating the last 24h of
- * `agent_messages` plus the total agent count + runtime metadata. All
+ * `provider_attempts` plus the total agent count + runtime metadata. All
  * SELECTs are parameterised so the window is consistent across queries.
  */
 @Injectable()

--- a/packages/backend/test/agent-recreate.e2e-spec.ts
+++ b/packages/backend/test/agent-recreate.e2e-spec.ts
@@ -31,7 +31,7 @@ describe('agent delete + recreate (issue #1765)', () => {
     // Seed v1 telemetry + a routing override
     const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id, cost_usd)
+      `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id, cost_usd)
        VALUES ($1, $2, $3, $4, 'ok', 'gpt-4o', 100, 50, 0, 0, $5, 'test-user-001', 0.001)`,
       [uuid(), TEST_TENANT_ID, v1Id, now, agentName],
     );
@@ -64,7 +64,7 @@ describe('agent delete + recreate (issue #1765)', () => {
 
     // Data is preserved in storage
     const remainingMessages = await ds.query(
-      `SELECT COUNT(*)::int AS count FROM agent_messages WHERE tenant_id = $1 AND agent_id = $2`,
+      `SELECT COUNT(*)::int AS count FROM provider_attempts WHERE tenant_id = $1 AND agent_id = $2`,
       [TEST_TENANT_ID, v1Id],
     );
     expect(remainingMessages[0].count).toBe(1);

--- a/packages/backend/test/billing-request-limit.e2e-spec.ts
+++ b/packages/backend/test/billing-request-limit.e2e-spec.ts
@@ -7,7 +7,7 @@ import { PlanService } from '../src/billing/plan.service';
 // Enforces the monthly routed-request cap on the /v1/* proxy. Billing env must
 // be set BEFORE the app is created so isBillingEnabled() resolves true. We drive
 // the block with PLAN_LIMIT_FREE_REQUESTS=0 so the gate trips on the first
-// request — no need to seed thousands of agent_messages rows or stub a provider
+// request — no need to seed thousands of request rows or stub a provider
 // (the gate runs before any upstream call). Env is restored in afterAll so it
 // can't leak into sibling e2e files sharing the --runInBand worker.
 let app: INestApplication;
@@ -28,7 +28,7 @@ async function waitForManifestBlockCount(tenantId: string, minimum: number): Pro
   do {
     const rows = await ds.query(
       `SELECT COUNT(*)::int AS n
-         FROM agent_messages
+         FROM requests
         WHERE tenant_id = $1
           AND error_origin = 'policy'
           AND error_class = 'plan_request_limit_exceeded'
@@ -103,12 +103,16 @@ describe('request limit gate (/v1 proxy)', () => {
     planService.invalidateRequestCountCache(tenantId);
     const billableBefore = await planService.countRequestsSince(tenantId, monthStartMs);
     const before = await ds.query(
-      `SELECT COUNT(*)::int AS n FROM agent_messages WHERE tenant_id = $1`,
+      `SELECT COUNT(*)::int AS n FROM requests WHERE tenant_id = $1`,
+      [tenantId],
+    );
+    const attemptsBefore = await ds.query(
+      `SELECT COUNT(*)::int AS n FROM provider_attempts WHERE tenant_id = $1`,
       [tenantId],
     );
     const manifestBlocksBefore = await ds.query(
       `SELECT COUNT(*)::int AS n
-         FROM agent_messages
+         FROM requests
         WHERE tenant_id = $1
           AND error_origin = 'policy'
           AND error_class = 'plan_request_limit_exceeded'
@@ -126,12 +130,16 @@ describe('request limit gate (/v1 proxy)', () => {
       manifestBlocksBefore[0].n + 1,
     );
     const after = await ds.query(
-      `SELECT COUNT(*)::int AS n FROM agent_messages WHERE tenant_id = $1`,
+      `SELECT COUNT(*)::int AS n FROM requests WHERE tenant_id = $1`,
+      [tenantId],
+    );
+    const attemptsAfter = await ds.query(
+      `SELECT COUNT(*)::int AS n FROM provider_attempts WHERE tenant_id = $1`,
       [tenantId],
     );
     const latestBlock = await ds.query(
-      `SELECT status, error_origin, error_class, error_http_status, routing_reason
-         FROM agent_messages
+      `SELECT status, error_origin, error_class, error_http_status, error_code
+         FROM requests
         WHERE tenant_id = $1
           AND error_origin = 'policy'
           AND error_class = 'plan_request_limit_exceeded'
@@ -144,6 +152,7 @@ describe('request limit gate (/v1 proxy)', () => {
     const billableAfter = await planService.countRequestsSince(tenantId, monthStartMs);
 
     expect(after[0].n).toBe(before[0].n + 1);
+    expect(attemptsAfter[0].n).toBe(attemptsBefore[0].n);
     expect(manifestBlocksAfter).toBe(manifestBlocksBefore[0].n + 1);
     expect(latestBlock[0]).toEqual(
       expect.objectContaining({
@@ -151,7 +160,7 @@ describe('request limit gate (/v1 proxy)', () => {
         error_origin: 'policy',
         error_class: 'plan_request_limit_exceeded',
         error_http_status: 402,
-        routing_reason: 'plan_request_limit_exceeded',
+        error_code: 'M204',
       }),
     );
     expect(billableAfter).toBe(billableBefore);

--- a/packages/backend/test/costs.e2e-spec.ts
+++ b/packages/backend/test/costs.e2e-spec.ts
@@ -48,18 +48,18 @@ beforeAll(async () => {
   // Reload pricing cache from OpenRouter cache + manual pricing
   await app.get(ModelPricingCacheService).reload();
 
-  // Seed agent_messages directly (with pre-calculated cost_usd) using the same
+  // Seed provider_attempts directly (with pre-calculated cost_usd) using the same
   // timestamp format as sqlNow() so that date comparisons line up with the
   // Postgres `timestamp without time zone` columns the analytics queries read.
   const costUsd1 = 5000 * 0.0000025 + 2000 * 0.00001; // 0.0325
   const costUsd2 = 3000 * 0.0000025 + 1000 * 0.00001; // 0.0175
   await ds.query(
-    `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+    `INSERT INTO provider_attempts (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
     [uuid(), now, 'Cost query 1', 'agent', 'ok', 'gpt-4o', 5000, 2000, costUsd1, TEST_USER_ID, TEST_TENANT_ID, null],
   );
   await ds.query(
-    `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+    `INSERT INTO provider_attempts (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
     [uuid(), now, 'Cost query 2', 'agent', 'ok', 'gpt-4o', 3000, 1000, costUsd2, TEST_USER_ID, TEST_TENANT_ID, null],
   );
@@ -165,7 +165,7 @@ describe('GET /api/v1/costs - numeric edge cases', () => {
 
     // Row with all zeros — must not crash the query nor poison cost summary.
     await ds.query(
-      `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+      `INSERT INTO provider_attempts (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
       [
         '11111111-1111-4111-8111-111111111111',
@@ -187,7 +187,7 @@ describe('GET /api/v1/costs - numeric edge cases', () => {
     // Anything larger would error at the driver level — verifying the upper
     // boundary is what the column type allows.
     await ds.query(
-      `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+      `INSERT INTO provider_attempts (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
       [
         '22222222-2222-4222-8222-222222222222',
@@ -211,7 +211,7 @@ describe('GET /api/v1/costs - numeric edge cases', () => {
       ['other-tenant-001', 'other-user-001', 'other-user-001', 'Other Org', now, now],
     );
     await ds.query(
-      `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+      `INSERT INTO provider_attempts (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
       [
         '33333333-3333-4333-8333-333333333333',

--- a/packages/backend/test/custom-provider-fk-data-loss.e2e-spec.ts
+++ b/packages/backend/test/custom-provider-fk-data-loss.e2e-spec.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm';
 import { AddCustomProviderFkToUserProviders1792100000000 } from '../src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders';
 import { TenantProviders1792500000000 } from '../src/database/migrations/1792500000000-TenantProviders';
 import { TenantScopedConfigs1792600000000 } from '../src/database/migrations/1792600000000-TenantScopedConfigs';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
 
 const DB_URL =
   process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/manifest_duprepro';
@@ -56,6 +57,10 @@ describe('AddCustomProviderFkToUserProviders deployment data-loss invariant (e2e
     ds = makeDataSource();
     await ds.initialize();
     await ds.runMigrations({ transaction: 'each' });
+
+    const requestSchemaQr = ds.createQueryRunner();
+    await new AddRequestsAndProviderAttempts1801000000000().down(requestSchemaQr);
+    await requestSchemaQr.release();
 
     // The tenant-canonical chain (later migrations) renames user_providers →
     // tenant_providers and demotes custom_providers.user_id → created_by_user_id;

--- a/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm';
 import { AddCustomProviderFkToUserProviders1792100000000 } from '../src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders';
 import { TenantProviders1792500000000 } from '../src/database/migrations/1792500000000-TenantProviders';
 import { TenantScopedConfigs1792600000000 } from '../src/database/migrations/1792600000000-TenantScopedConfigs';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
 
 /**
  * The tenant-canonical chain (which runs AFTER the migration under test) renames
@@ -12,6 +13,9 @@ import { TenantScopedConfigs1792600000000 } from '../src/database/migrations/179
  * this migration's own behaviour.
  */
 async function revertTenantCanonicalScoping(ds: DataSource): Promise<void> {
+  const requestSchemaQr = ds.createQueryRunner();
+  await new AddRequestsAndProviderAttempts1801000000000().down(requestSchemaQr);
+  await requestSchemaQr.release();
   const configsQr = ds.createQueryRunner();
   await new TenantScopedConfigs1792600000000().down(configsQr);
   await configsQr.release();

--- a/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
@@ -9,7 +9,7 @@ import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/mig
  * user_providers → tenant_providers + its FK/index (TenantProviders) and demotes
  * custom_providers.user_id → created_by_user_id (TenantScopedConfigs). These
  * specs assert + seed under the ORIGINAL user_providers / custom_providers.user_id
- * names, so revert those two later migrations (newest first) before exercising
+ * names, so revert those later migrations (newest first) before exercising
  * this migration's own behaviour.
  */
 async function revertTenantCanonicalScoping(ds: DataSource): Promise<void> {

--- a/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
@@ -3,6 +3,7 @@ import { LiftCustomProvidersToUserLevel1791200000000 } from '../src/database/mig
 import { RenameProviderAccessToEnabledProviders1791800000000 } from '../src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders';
 import { TenantProviders1792500000000 } from '../src/database/migrations/1792500000000-TenantProviders';
 import { TenantScopedConfigs1792600000000 } from '../src/database/migrations/1792600000000-TenantScopedConfigs';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
 
 /**
  * Runs the REAL migration chain (synchronize:false) so LiftCustomProvidersToUserLevel
@@ -96,6 +97,9 @@ describe('LiftCustomProvidersToUserLevel data transformation (e2e)', () => {
     // Revert the later tenant re-scoping + table renames first (newest first)
     // so this historical migration can be replayed against the schema naming
     // it expects (user_providers / agent_provider_access / user_id columns).
+    const requestSchemaQr = ds.createQueryRunner();
+    await new AddRequestsAndProviderAttempts1801000000000().down(requestSchemaQr);
+    await requestSchemaQr.release();
     const tenantConfigsQr = ds.createQueryRunner();
     await new TenantScopedConfigs1792600000000().down(tenantConfigsQr);
     await tenantConfigsQr.release();

--- a/packages/backend/test/errors-breakdown.e2e-spec.ts
+++ b/packages/backend/test/errors-breakdown.e2e-spec.ts
@@ -17,7 +17,7 @@ async function insertMessage(
 ) {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, error_origin, error_class, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, error_origin, error_class, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
     [
       uuid(),

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -18,6 +18,7 @@ import { appConfig } from '../src/config/app.config';
 import { IS_PUBLIC_KEY } from '../src/common/decorators/public.decorator';
 import { hashKey, keyPrefix } from '../src/common/utils/hash.util';
 import { AgentMessage } from '../src/entities/agent-message.entity';
+import { ManifestRequest } from '../src/entities/request.entity';
 import { ApiKey } from '../src/entities/api-key.entity';
 import { Tenant } from '../src/entities/tenant.entity';
 import { Agent } from '../src/entities/agent.entity';
@@ -60,6 +61,7 @@ export const TEST_OTLP_KEY = 'mnfst_test-otlp-key-001';
 
 const entities = [
   AgentMessage,
+  ManifestRequest,
   ApiKey,
   Tenant,
   Agent,

--- a/packages/backend/test/message-count-consistency.e2e-spec.ts
+++ b/packages/backend/test/message-count-consistency.e2e-spec.ts
@@ -16,11 +16,27 @@ let app: INestApplication;
 
 async function insertMessage(ds: DataSource, status: string) {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+  const requestId = uuid();
   await ds.query(
-    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+    `INSERT INTO requests (id, tenant_id, agent_id, timestamp, status, requested_model, agent_name, user_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+    [
+      requestId,
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      now,
+      status,
+      'gpt-4o',
+      'test-agent',
+      'test-user-001',
+    ],
+  );
+  await ds.query(
+    `INSERT INTO provider_attempts (id, request_id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
     [
       uuid(),
+      requestId,
       TEST_TENANT_ID,
       TEST_AGENT_ID,
       now,

--- a/packages/backend/test/message-count-consistency.e2e-spec.ts
+++ b/packages/backend/test/message-count-consistency.e2e-spec.ts
@@ -4,23 +4,20 @@ import { v4 as uuid } from 'uuid';
 import request from 'supertest';
 import { createTestApp, TEST_API_KEY, TEST_TENANT_ID, TEST_AGENT_ID } from './helpers';
 
-// Regression guard for F1: the "messages" KPI must mean the same thing on every
-// surface. Overview's summary card and the agent grid's message_count once used
-// different definitions (unfiltered COUNT(*) vs. one that excluded errors), so
-// the headline total diverged from the per-agent sums by the whole error rate.
-// All KPI counts now funnel through query-helpers.sqlCountMessages(), which
-// excludes ['error','fallback_error','rate_limited']. The Messages *log* total
-// stays unfiltered because it is a complete event listing.
+// Request counts must mean the same thing on every surface. A failed caller
+// request is still one request, so Overview, the agent grid, and the complete
+// Requests log all include every terminal outcome exactly once.
 
 const OK_COUNT = 5;
 const ERROR_STATUSES = ['error', 'fallback_error', 'rate_limited'] as const;
+const REQUEST_COUNT = OK_COUNT + ERROR_STATUSES.length;
 
 let app: INestApplication;
 
 async function insertMessage(ds: DataSource, status: string) {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [
       uuid(),
@@ -44,9 +41,9 @@ async function insertMessage(ds: DataSource, status: string) {
 beforeAll(async () => {
   app = await createTestApp();
   const ds = app.get(DataSource);
-  // 5 real messages…
+  // Five successful requests…
   for (let i = 0; i < OK_COUNT; i++) await insertMessage(ds, 'ok');
-  // …plus one of every error status, which must NOT inflate the KPI counts.
+  // …plus one of every error status, each still a caller request.
   for (const status of ERROR_STATUSES) await insertMessage(ds, status);
 });
 
@@ -55,12 +52,12 @@ afterAll(async () => {
 });
 
 describe('message-count consistency (F1)', () => {
-  it('Overview summary card counts only non-error messages', async () => {
+  it('Overview summary card counts every caller request', async () => {
     const res = await request(app.getHttpServer())
       .get('/api/v1/overview?range=24h')
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
-    expect(res.body.summary.messages.value).toBe(OK_COUNT);
+    expect(res.body.summary.messages.value).toBe(REQUEST_COUNT);
   });
 
   it('Agent grid message_count equals the Overview card', async () => {
@@ -77,7 +74,7 @@ describe('message-count consistency (F1)', () => {
     const agent = agents.body.agents.find(
       (a: { agent_name: string }) => a.agent_name === 'test-agent',
     );
-    expect(agent.message_count).toBe(OK_COUNT);
+    expect(agent.message_count).toBe(REQUEST_COUNT);
     expect(agent.message_count).toBe(overview.body.summary.messages.value);
   });
 
@@ -86,6 +83,6 @@ describe('message-count consistency (F1)', () => {
       .get('/api/v1/messages?range=24h&agent_name=test-agent&include_total=true&limit=50')
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
-    expect(res.body.total_count).toBe(OK_COUNT + ERROR_STATUSES.length);
+    expect(res.body.total_count).toBe(REQUEST_COUNT);
   });
 });

--- a/packages/backend/test/message-error-code-migrations.e2e-spec.ts
+++ b/packages/backend/test/message-error-code-migrations.e2e-spec.ts
@@ -6,6 +6,7 @@
  */
 import { DataSource } from 'typeorm';
 import { AddMessageErrorCode1800200000000 } from '../src/database/migrations/1800200000000-AddMessageErrorCode';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
 
 const TENANT = 'errcode-tenant-1';
 const AGENT = 'errcode-agent-1';
@@ -102,6 +103,10 @@ describe('AddMessageErrorCode migration — data backfill (e2e)', () => {
     });
     await ds.initialize();
     await ds.runMigrations({ transaction: 'each' });
+
+    const schemaQr = ds.createQueryRunner();
+    await new AddRequestsAndProviderAttempts1801000000000().down(schemaQr);
+    await schemaQr.release();
 
     // Back to the pre-migration schema, then seed rows exactly as the old proxy
     // wrote them: canned stubs carrying provider='manifest' / tier='simple'.

--- a/packages/backend/test/messages-cache-tokens.e2e-spec.ts
+++ b/packages/backend/test/messages-cache-tokens.e2e-spec.ts
@@ -3,7 +3,7 @@
  *
  * Drives a real Anthropic-Messages-shaped POST through the proxy stack with a
  * stubbed Anthropic upstream that returns deterministic cache token counts.
- * Asserts both the client-visible response usage AND the `agent_messages` row
+ * Asserts both the client-visible response usage AND the `provider_attempts` row
  * surface the cache creation / cache read counts that Anthropic reported.
  *
  * Without the fix:
@@ -161,14 +161,14 @@ async function postMessages(body: Record<string, unknown>): Promise<request.Resp
 
 async function flushRecorder(): Promise<void> {
   // recordSuccess fires off the response handler asynchronously — give it a
-  // tick or two before reading agent_messages.
+  // tick or two before reading provider_attempts.
   await new Promise((r) => setTimeout(r, 200));
 }
 
 describe('/v1/messages cache token round-trip (#1871)', () => {
   it('preserves cache_creation_input_tokens through the response AND the DB row', async () => {
     const ds = app.get(DataSource);
-    await ds.query(`DELETE FROM agent_messages WHERE agent_id = $1`, [TEST_AGENT_ID]);
+    await ds.query(`DELETE FROM provider_attempts WHERE agent_id = $1`, [TEST_AGENT_ID]);
     app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
 
     nextAnthropicUsage = {
@@ -201,7 +201,7 @@ describe('/v1/messages cache token round-trip (#1871)', () => {
     await flushRecorder();
     const rows = await ds.query(
       `SELECT input_tokens, cache_read_tokens, cache_creation_tokens, status
-         FROM agent_messages WHERE agent_id = $1 ORDER BY timestamp DESC LIMIT 1`,
+         FROM provider_attempts WHERE agent_id = $1 ORDER BY timestamp DESC LIMIT 1`,
       [TEST_AGENT_ID],
     );
     expect(rows).toHaveLength(1);
@@ -214,7 +214,7 @@ describe('/v1/messages cache token round-trip (#1871)', () => {
 
   it('preserves cache_read_input_tokens through the response AND the DB row', async () => {
     const ds = app.get(DataSource);
-    await ds.query(`DELETE FROM agent_messages WHERE agent_id = $1`, [TEST_AGENT_ID]);
+    await ds.query(`DELETE FROM provider_attempts WHERE agent_id = $1`, [TEST_AGENT_ID]);
     app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
 
     nextAnthropicUsage = {
@@ -247,7 +247,7 @@ describe('/v1/messages cache token round-trip (#1871)', () => {
     await flushRecorder();
     const rows = await ds.query(
       `SELECT input_tokens, cache_read_tokens, cache_creation_tokens
-         FROM agent_messages WHERE agent_id = $1 ORDER BY timestamp DESC LIMIT 1`,
+         FROM provider_attempts WHERE agent_id = $1 ORDER BY timestamp DESC LIMIT 1`,
       [TEST_AGENT_ID],
     );
     expect(rows).toHaveLength(1);

--- a/packages/backend/test/messages-manifest-errors.e2e-spec.ts
+++ b/packages/backend/test/messages-manifest-errors.e2e-spec.ts
@@ -30,7 +30,7 @@ async function seed(
   const id = uuid();
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
   await ds.query(
-    `INSERT INTO agent_messages
+    `INSERT INTO provider_attempts
        (id, tenant_id, agent_id, agent_name, timestamp, status, error_message, error_code,
         error_origin, error_class, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
      VALUES ($1,$2,$3,'test-agent',$4,$5,$6,$7,$8,$9, 0,0,0,0)`,

--- a/packages/backend/test/messages.e2e-spec.ts
+++ b/packages/backend/test/messages.e2e-spec.ts
@@ -14,19 +14,19 @@ beforeAll(async () => {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'claude-opus-4-6', 2000, 1000, 0, 0, 'Chat message processed', 'agent', 'test-agent', 'test-user-001'],
   );
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'error', 'gpt-4o', 500, 0, 0, 0, 'Browser scrape failed', 'browser', 'test-agent', 'test-user-001'],
   );
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'whisper-large', 0, 300, 0, 0, 'Voice transcription completed', 'voice', 'test-agent', 'test-user-001'],
   );
@@ -204,7 +204,7 @@ describe('PATCH /api/v1/messages/:id/feedback', () => {
     const ds = app.get(DataSource);
     const dbRow = await ds.query(
       `SELECT feedback_rating, feedback_tags, feedback_details
-         FROM agent_messages WHERE id = $1`,
+         FROM provider_attempts WHERE id = $1`,
       [messageId],
     );
     expect(dbRow).toHaveLength(1);
@@ -283,7 +283,7 @@ describe('GET /api/v1/messages/:id/details — request_headers', () => {
     const headers = { 'user-agent': 'curl/8.14.1', 'x-custom-foo': 'bar' };
 
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id, request_headers)
+      `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id, request_headers)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
       [
         id,

--- a/packages/backend/test/messages.isolation.e2e-spec.ts
+++ b/packages/backend/test/messages.isolation.e2e-spec.ts
@@ -6,7 +6,7 @@ import { createTestApp, TEST_API_KEY, TEST_TENANT_ID, TEST_AGENT_ID } from './he
 // Cross-tenant isolation boundary test for /api/v1/messages.
 //
 // The MockSessionGuard in test/helpers.ts authenticates every request as
-// TEST_USER_ID ("test-user-001"). We seed agent_messages owned by a SECOND
+// TEST_USER_ID ("test-user-001"). We seed provider_attempts owned by a SECOND
 // tenant/user ("attacker-tenant-002" / "attacker-user-002") and assert that
 // the authenticated user can never see those rows.
 //
@@ -34,7 +34,7 @@ async function insertMessage(
   now: string,
 ): Promise<void> {
   await ds.query(
-    `INSERT INTO agent_messages
+    `INSERT INTO provider_attempts
        (id, tenant_id, agent_id, timestamp, status, model,
         input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
         description, service_type, agent_name, user_id)
@@ -150,7 +150,7 @@ describe('Cross-tenant isolation: GET /api/v1/messages', () => {
 
     // Confirm at the DB layer that the attacker row was NOT mutated.
     const dbRow = await ds.query(
-      `SELECT feedback_rating FROM agent_messages WHERE id = $1`,
+      `SELECT feedback_rating FROM provider_attempts WHERE id = $1`,
       [ATTACKER_MESSAGE_ID],
     );
     expect(dbRow).toHaveLength(1);

--- a/packages/backend/test/overview.e2e-spec.ts
+++ b/packages/backend/test/overview.e2e-spec.ts
@@ -14,13 +14,13 @@ beforeAll(async () => {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'claude-opus-4-6', 2000, 1000, 0, 0, 'User query processed', 'agent', 'test-agent', 'test-user-001'],
   );
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'gpt-4o', 500, 300, 0, 0, 'Browser task completed', 'browser', 'test-agent', 'test-user-001'],
   );

--- a/packages/backend/test/playground-flow.e2e-spec.ts
+++ b/packages/backend/test/playground-flow.e2e-spec.ts
@@ -147,7 +147,7 @@ async function postRun(body: Record<string, unknown>): Promise<string> {
 }
 
 describe('Playground E2E — POST /api/v1/playground/run (SSE)', () => {
-  it('streams deltas + a done event and records an agent_messages row on happy path', async () => {
+  it('streams deltas + a done event and records a provider attempt on happy path', async () => {
     stubOpenAiChatStream(['hello ', 'world'], { prompt_tokens: 7, completion_tokens: 3 });
 
     const sseText = await postRun({
@@ -181,7 +181,7 @@ describe('Playground E2E — POST /api/v1/playground/run (SSE)', () => {
       `SELECT id FROM agents WHERE is_playground = true AND deleted_at IS NULL LIMIT 1`,
     );
     const rows = await ds.query(
-      `SELECT routing_reason, routing_tier, status, provider, model, input_tokens, output_tokens, agent_name FROM agent_messages WHERE agent_id = $1 AND routing_tier = $2`,
+      `SELECT routing_reason, routing_tier, status, provider, model, input_tokens, output_tokens, agent_name FROM provider_attempts WHERE agent_id = $1 AND routing_tier = $2`,
       [playgroundAgent.id, 'playground'],
     );
     expect(rows.length).toBe(1);

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -46,7 +46,7 @@ beforeAll(async () => {
     ['gpt-4o-mini', 200, 100],
   ] as Array<[string, number, number]>) {
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, tenant_provider_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+      `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, tenant_provider_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
        VALUES ($1,$2,$3,$4,'ok',$5,'openai','subscription','My OpenAI',$6,$7,$8,0,0,$9,'msg','agent','test-agent',$10)`,
       [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, model, connectionId, inTok, outTok, 0.01, TEST_USER_ID],
     );
@@ -69,7 +69,7 @@ beforeAll(async () => {
   // live `test-agent` must NOT include this dead namesake's row — the agent
   // filter has to resolve to the live agent's id, not match by slug.
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
      VALUES ($1,$2,$3,$4,'ok','ghost-model','ghostprovider','api_key',5000,5000,0,0,0.5,'msg','agent','test-agent',$5)`,
     [uuid(), TEST_TENANT_ID, ghostAgentId, now, TEST_USER_ID],
   );
@@ -83,7 +83,7 @@ beforeAll(async () => {
     [playgroundAgentId, TEST_TENANT_ID, now],
   );
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
      VALUES ($1,$2,$3,$4,'ok','gpt-4o','openai','subscription',9000,9000,0,0,0.99,'msg','agent','Playground',$5)`,
     [uuid(), TEST_TENANT_ID, playgroundAgentId, now, TEST_USER_ID],
   );
@@ -96,7 +96,7 @@ beforeAll(async () => {
   // the 'My OpenAI' connection's tenant_provider_id so the connection-detail leak
   // guard proves excludeSystemAgents (not the id scope) is what drops it.
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, tenant_provider_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, tenant_provider_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
      VALUES ($1,$2,NULL,$3,'ok','gpt-4o','openai','subscription','My OpenAI',$4,7000,7000,0,0,0.77,'msg','agent','Playground',$5)`,
     [uuid(), TEST_TENANT_ID, now, connectionId, TEST_USER_ID],
   );
@@ -127,7 +127,7 @@ beforeAll(async () => {
     // connection-detail (which scopes on tenant_provider_id) keeps Work and
     // Personal separate even though they share provider+auth_type.
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, tenant_provider_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+      `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, tenant_provider_id, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
        VALUES ($1,$2,$3,$4,'ok','claude','anthropic','api_key',$5,$6,$7,$7,0,0,0.02,'msg','agent','test-agent',$8)`,
       [
         uuid(),

--- a/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
+++ b/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
@@ -5,7 +5,7 @@
  *
  * Drives a real /v1/chat/completions request through the full proxy stack
  * (resolver, fallback chain, response handler, recorder) and asserts on the
- * row that lands in `agent_messages`.
+ * row that lands in `provider_attempts`.
  */
 import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
@@ -210,7 +210,7 @@ describe('Proxy fallback success — auth_type/cost_usd attribution (#1173)', ()
 
   it('records fallback auth_type=subscription and cost_usd=0 on subscription fallback success', async () => {
     const ds = app.get(DataSource);
-    await ds.query(`DELETE FROM agent_messages WHERE agent_id = $1`, [TEST_AGENT_ID]);
+    await ds.query(`DELETE FROM provider_attempts WHERE agent_id = $1`, [TEST_AGENT_ID]);
 
     // The seeder + auto-assign warm the routing cache before the test's DB
     // writes, so flush it now or the resolver keeps using the stale tier.
@@ -227,7 +227,7 @@ describe('Proxy fallback success — auth_type/cost_usd attribution (#1173)', ()
 
     const rows = await ds.query(
       `SELECT model, provider, auth_type, cost_usd, fallback_from_model, status
-         FROM agent_messages
+         FROM provider_attempts
         WHERE agent_id = $1
         ORDER BY timestamp DESC`,
       [TEST_AGENT_ID],

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -15,22 +15,22 @@ beforeAll(async () => {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-1', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 100, 50, 'gpt-4o', 'ok'],
   );
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-2', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 200, 100, 'gpt-4o', 'ok'],
   );
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-3', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 150, 75, 'claude-opus-4-6', 'ok'],
   );
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, provider, auth_type, status)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, provider, auth_type, status)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
     [
       'ps-msg-6',
@@ -51,12 +51,12 @@ beforeAll(async () => {
   // Custom-endpoint traffic: two tenant-scoped provider refs from one tenant,
   // exercising the Custom grouping + k-anonymity fold on real SQL.
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-4', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 400, 200, 'custom:d0c5ce41-0000-4000-8000-000000000001/private-model', 'ok'],
   );
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-5', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 200, 100, 'custom:d0c5ce41-0000-4000-8000-000000000002/other-private-model', 'ok'],
   );

--- a/packages/backend/test/roundtrip.e2e-spec.ts
+++ b/packages/backend/test/roundtrip.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Proxy data round-trip', () => {
   beforeAll(async () => {
     const ds = app.get(DataSource);
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
+      `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
       [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, new Date().toISOString(), 'ok', 'claude-opus-4-6', 1500, 800, 0, 0, 'demo-agent', 'test-user-001'],
     );
@@ -50,7 +50,7 @@ describe('Clock skew tolerance', () => {
     const ds = app.get(DataSource);
     const futureTs = new Date(Date.now() + 30_000).toISOString();
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
+      `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
       [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, futureTs, 'ok', 'gpt-4o', 500, 200, 0, 0, 'demo-agent', 'test-user-001'],
     );

--- a/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
+++ b/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
@@ -42,7 +42,7 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
     // migration can be replayed against the schema naming it expects
     // (user_providers / user_provider_id, agent_provider_access, no is_playground
     // column). TenantProviders.down() restores user_providers + user_provider_id
-    // and the provider_attempts.tenant_provider_id → user_provider_id rename.
+    // and the agent_messages.tenant_provider_id → user_provider_id rename.
     const tenantProvidersQr = ds.createQueryRunner();
     await new TenantProviders1792500000000().down(tenantProvidersQr);
     await tenantProvidersQr.release();

--- a/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
+++ b/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
@@ -3,6 +3,7 @@ import { SeedPlaygroundAgents1791400000000 } from '../src/database/migrations/17
 import { RenameProviderAccessToEnabledProviders1791800000000 } from '../src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders';
 import { RenameIsSystemToIsPlayground1791900000000 } from '../src/database/migrations/1791900000000-RenameIsSystemToIsPlayground';
 import { TenantProviders1792500000000 } from '../src/database/migrations/1792500000000-TenantProviders';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
 
 /**
  * Runs the REAL migration chain so SeedPlaygroundAgents executes against
@@ -33,11 +34,15 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
     await ds.initialize();
     await ds.runMigrations({ transaction: 'each' });
 
+    const requestSchemaQr = ds.createQueryRunner();
+    await new AddRequestsAndProviderAttempts1801000000000().down(requestSchemaQr);
+    await requestSchemaQr.release();
+
     // Revert the later tenant re-scope first (newest first) so this historical
     // migration can be replayed against the schema naming it expects
     // (user_providers / user_provider_id, agent_provider_access, no is_playground
     // column). TenantProviders.down() restores user_providers + user_provider_id
-    // and the agent_messages.tenant_provider_id → user_provider_id rename.
+    // and the provider_attempts.tenant_provider_id → user_provider_id rename.
     const tenantProvidersQr = ds.createQueryRunner();
     await new TenantProviders1792500000000().down(tenantProvidersQr);
     await tenantProvidersQr.release();

--- a/packages/backend/test/smoke-test.e2e-spec.ts
+++ b/packages/backend/test/smoke-test.e2e-spec.ts
@@ -160,7 +160,7 @@ describe('ST-03: Seed agent data', () => {
     const past = new Date(Date.now() - 60_000).toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
+      `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
       [uuidv4(), tenantId, agentId, past, 'ok', 'test-model', 500, 200, 0, 0, smokeAgentName, 'test-user-001'],
     );

--- a/packages/backend/test/tenant-isolation.e2e-spec.ts
+++ b/packages/backend/test/tenant-isolation.e2e-spec.ts
@@ -67,7 +67,7 @@ beforeAll(async () => {
   // --- Tenant A data ---------------------------------------------------
   // A message.
   await ds.query(
-    `INSERT INTO agent_messages
+    `INSERT INTO provider_attempts
        (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens,
         cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1,$2,$3,$4,'ok','gpt-4o',100,50,0,0,'Tenant A secret','agent','test-agent',$5)`,
@@ -89,7 +89,7 @@ beforeAll(async () => {
   // A message attributed to that connection so per-connection analytics for
   // tenant A's connection_id have something to leak if isolation breaks.
   await ds.query(
-    `INSERT INTO agent_messages
+    `INSERT INTO provider_attempts
        (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type,
         provider_key_label, tenant_provider_id, input_tokens, output_tokens,
         cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
@@ -147,7 +147,7 @@ beforeAll(async () => {
 
   // --- Tenant B data (so "empty" assertions cannot pass vacuously) -----
   await ds.query(
-    `INSERT INTO agent_messages
+    `INSERT INTO provider_attempts
        (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens,
         cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1,$2,$3,$4,'ok','gpt-4o',10,5,0,0,'Tenant B message','agent',$5,$6)`,
@@ -228,7 +228,7 @@ describe('Messages — user B never sees tenant A rows', () => {
     await asB(api().patch(`/api/v1/messages/${A_MESSAGE_ID}/feedback`))
       .send({ rating: 'like' })
       .expect(404);
-    const row = await ds.query(`SELECT feedback_rating FROM agent_messages WHERE id = $1`, [
+    const row = await ds.query(`SELECT feedback_rating FROM provider_attempts WHERE id = $1`, [
       A_MESSAGE_ID,
     ]);
     expect(row[0].feedback_rating).toBeNull();

--- a/packages/backend/test/tenant-scoping-migrations.e2e-spec.ts
+++ b/packages/backend/test/tenant-scoping-migrations.e2e-spec.ts
@@ -14,6 +14,7 @@ import { TenantOwnerColumn1792400000000 } from '../src/database/migrations/17924
 import { TenantProviders1792500000000 } from '../src/database/migrations/1792500000000-TenantProviders';
 import { TenantScopedConfigs1792600000000 } from '../src/database/migrations/1792600000000-TenantScopedConfigs';
 import { DropUserScopeFromRouting1792700000000 } from '../src/database/migrations/1792700000000-DropUserScopeFromRouting';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
 
 const USER = 'mig-user-1';
 const TENANT = 'mig-tenant-1';
@@ -66,6 +67,8 @@ describe('Tenant-canonical scoping migrations — data backfill (e2e)', () => {
     });
     await ds.initialize();
     await ds.runMigrations({ transaction: 'each' });
+
+    await runDown(ds, new AddRequestsAndProviderAttempts1801000000000());
 
     // Revert the four tenant migrations, newest first → pre-tenant schema
     // (user_id scope columns everywhere, no owner_user_id).

--- a/packages/backend/test/tenant-scoping-migrations.e2e-spec.ts
+++ b/packages/backend/test/tenant-scoping-migrations.e2e-spec.ts
@@ -3,10 +3,10 @@
  * (TenantOwnerColumn → TenantProviders → TenantScopedConfigs →
  * DropUserScopeFromRouting).
  *
- * Builds the fully-migrated schema, reverts JUST the four tenant migrations
- * (newest first), seeds a realistic pre-tenant user-scoped dataset, then
- * replays the chain and asserts every backfill — the part string-inspection
- * unit specs can't catch. Mirrors the replay pattern of
+ * Builds the fully-migrated schema, reverts the request/attempt migration and
+ * then the four tenant migrations (newest first), seeds a realistic pre-tenant
+ * user-scoped dataset, then replays the chain and asserts every backfill — the
+ * part string-inspection unit specs can't catch. Mirrors the replay pattern of
  * custom-providers-lift-migrations.e2e-spec.ts.
  */
 import { DataSource } from 'typeorm';

--- a/packages/backend/test/tokens.e2e-spec.ts
+++ b/packages/backend/test/tokens.e2e-spec.ts
@@ -14,13 +14,13 @@ beforeAll(async () => {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'claude-opus-4-6', 3000, 1500, 0, 0, 'Query 1', 'agent', 'test-agent', 'test-user-001'],
   );
 
   await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
+    `INSERT INTO provider_attempts (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'gpt-4o', 1000, 500, 0, 0, 'Query 2', 'agent', 'test-agent', 'test-user-001'],
   );

--- a/packages/backend/test/user-provider-backfill-migrations.e2e-spec.ts
+++ b/packages/backend/test/user-provider-backfill-migrations.e2e-spec.ts
@@ -6,6 +6,7 @@ import { TenantOwnerColumn1792400000000 } from '../src/database/migrations/17924
 import { TenantProviders1792500000000 } from '../src/database/migrations/1792500000000-TenantProviders';
 import { TenantScopedConfigs1792600000000 } from '../src/database/migrations/1792600000000-TenantScopedConfigs';
 import { DropUserScopeFromRouting1792700000000 } from '../src/database/migrations/1792700000000-DropUserScopeFromRouting';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
 import { runMessageProviderBackfill } from '../src/database/backfills/backfill-message-providers';
 import { TypeOrmBackfillGateway } from '../src/database/backfills/backfill-message-providers.gateway';
 
@@ -45,6 +46,10 @@ describe('agent-message attribution backfill after provider lift (e2e)', () => {
     });
     await ds.initialize();
     await ds.runMigrations({ transaction: 'each' });
+
+    const schemaQr = ds.createQueryRunner();
+    await new AddRequestsAndProviderAttempts1801000000000().down(schemaQr);
+    await schemaQr.release();
 
     // Clean slate (FK-safe order), then rewind to the pre-lift schema by
     // reverting the relevant migrations in reverse chronological order. The
@@ -112,6 +117,10 @@ describe('agent-message attribution backfill after provider lift (e2e)', () => {
     await new TenantProviders1792500000000().up(upgradeQr);
     await upgradeQr.release();
 
+    const requestSchemaUpQr = ds.createQueryRunner();
+    await new AddRequestsAndProviderAttempts1801000000000().up(requestSchemaUpQr);
+    await requestSchemaUpQr.release();
+
     // The migration leaves the column NULL; the historical stamping runs
     // post-deploy, against the renamed schema. This is the exact code the
     // boot task and `npm run backfill:message-providers` invoke.
@@ -138,7 +147,7 @@ describe('agent-message attribution backfill after provider lift (e2e)', () => {
     // anymore — a user-level backfill would leave BOTH NULL. The agent anchor
     // resolves each to its own agent's key.
     const rows: { id: string; tenant_provider_id: string | null }[] = await ds.query(
-      `SELECT "id","tenant_provider_id" FROM "agent_messages"
+      `SELECT "id","tenant_provider_id" FROM "provider_attempts"
         WHERE "id" IN ('msg-a1-anthropic','msg-a2-anthropic') ORDER BY "id"`,
     );
     expect(rows).toEqual([
@@ -149,21 +158,21 @@ describe('agent-message attribution backfill after provider lift (e2e)', () => {
 
   it('pass 1 stamps a label-exact message even when the agent has multiple keys for the provider', async () => {
     const rows: { tenant_provider_id: string | null }[] = await ds.query(
-      `SELECT "tenant_provider_id" FROM "agent_messages" WHERE "id" = 'msg-a2-openai-work'`,
+      `SELECT "tenant_provider_id" FROM "provider_attempts" WHERE "id" = 'msg-a2-openai-work'`,
     );
     expect(rows).toEqual([{ tenant_provider_id: 'up-a2-openai-work' }]);
   });
 
   it('leaves a genuinely ambiguous message NULL (two keys on the agent, no label match)', async () => {
     const rows: { tenant_provider_id: string | null }[] = await ds.query(
-      `SELECT "tenant_provider_id" FROM "agent_messages" WHERE "id" = 'msg-a2-openai-ambiguous'`,
+      `SELECT "tenant_provider_id" FROM "provider_attempts" WHERE "id" = 'msg-a2-openai-ambiguous'`,
     );
     expect(rows).toEqual([{ tenant_provider_id: null }]);
   });
 
   it('pass 3 still resolves deleted-agent (NULL agent_id) messages via the user-level label match', async () => {
     const rows: { tenant_provider_id: string | null }[] = await ds.query(
-      `SELECT "tenant_provider_id" FROM "agent_messages" WHERE "id" = 'msg-deleted-agent'`,
+      `SELECT "tenant_provider_id" FROM "provider_attempts" WHERE "id" = 'msg-deleted-agent'`,
     );
     expect(rows).toEqual([{ tenant_provider_id: 'up-a3-gemini' }]);
   });
@@ -172,14 +181,14 @@ describe('agent-message attribution backfill after provider lift (e2e)', () => {
     const fks: { confdeltype: string }[] = await ds.query(
       `SELECT confdeltype FROM pg_constraint
         WHERE conname = 'FK_agent_messages_tenant_provider'
-          AND conrelid = '"agent_messages"'::regclass`,
+          AND conrelid = '"provider_attempts"'::regclass`,
     );
     expect(fks).toHaveLength(1);
     expect(fks[0].confdeltype).toBe('n'); // n = SET NULL
 
     const idx: { indexname: string }[] = await ds.query(
       `SELECT indexname FROM pg_indexes
-        WHERE tablename = 'agent_messages'
+        WHERE tablename = 'provider_attempts'
           AND indexname = 'IDX_agent_messages_tenant_provider'`,
     );
     expect(idx).toHaveLength(1);

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -175,7 +175,7 @@ const DuplicateAgentModal: Component<Props> = (props) => {
           <div class="duplicate-agent__section">
             <div class="duplicate-agent__section-header">What is not copied</div>
             <ul class="duplicate-agent__list">
-              <li>Messages</li>
+              <li>Requests</li>
               <li>Logs</li>
               <li>Notification rules</li>
             </ul>

--- a/packages/frontend/src/components/MessageDetails.tsx
+++ b/packages/frontend/src/components/MessageDetails.tsx
@@ -717,7 +717,7 @@ export default function MessageDetails(props: MessageDetailsProps): JSX.Element 
               <Show when={(m.attempts?.length ?? 0) > 0}>
                 <div class="message-details__section">
                   <h4>Provider attempts</h4>
-                  <table class="details-table">
+                  <table class="details-table" aria-label="Provider attempts">
                     <thead>
                       <tr>
                         <th>#</th>

--- a/packages/frontend/src/components/MessageDetails.tsx
+++ b/packages/frontend/src/components/MessageDetails.tsx
@@ -714,6 +714,38 @@ export default function MessageDetails(props: MessageDetailsProps): JSX.Element 
                 })()}
               </Show>
 
+              <Show when={(m.attempts?.length ?? 0) > 0}>
+                <div class="message-details__section">
+                  <h4>Provider attempts</h4>
+                  <table class="details-table">
+                    <thead>
+                      <tr>
+                        <th>#</th>
+                        <th>Provider</th>
+                        <th>Model</th>
+                        <th>Status</th>
+                        <th>Cost</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={m.attempts}>
+                        {(attempt, index) => (
+                          <tr>
+                            <td>{index() + 1}</td>
+                            <td>{attempt.provider ?? 'Unknown'}</td>
+                            <td>{attempt.model ? getModelDisplayName(attempt.model) : '—'}</td>
+                            <td>{attempt.status}</td>
+                            <td>
+                              {attempt.cost_usd == null ? '—' : `$${attempt.cost_usd.toFixed(6)}`}
+                            </td>
+                          </tr>
+                        )}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+              </Show>
+
               {/* Model Parameters renders above Request Headers — params
                   are user intent (what the request asked for); headers are
                   protocol noise. */}

--- a/packages/frontend/src/components/MultiAgentTokenChart.tsx
+++ b/packages/frontend/src/components/MultiAgentTokenChart.tsx
@@ -54,7 +54,7 @@ interface MultiAgentTokenChartProps {
   range: string;
   colorMap?: Record<string, string>;
   onHoverValues?: (values: Record<string, number> | null) => void;
-  /** When set (e.g. "Messages"), y-axis formats as plain numbers instead of token suffixes. */
+  /** When set (e.g. "Requests"), y-axis formats as plain numbers instead of token suffixes. */
   label?: string;
 }
 

--- a/packages/frontend/src/components/OverviewSkeleton.tsx
+++ b/packages/frontend/src/components/OverviewSkeleton.tsx
@@ -5,7 +5,7 @@ const OverviewSkeleton = () => (
     <div class="chart-card">
       <div class="chart-card__header">
         <div class="chart-card__stat chart-card__stat--active">
-          <span class="chart-card__label">Messages</span>
+          <span class="chart-card__label">Requests</span>
           <div class="chart-card__value-row">
             <div class="skeleton skeleton--text" style="width: 50px; height: 28px;" />
           </div>
@@ -32,7 +32,7 @@ const OverviewSkeleton = () => (
         class="panel__title"
         style="display: flex; justify-content: space-between; align-items: center;"
       >
-        Recent Messages
+        Recent Requests
         <span class="view-more-link" style="pointer-events: none; opacity: 0.4;">
           View more
         </span>

--- a/packages/frontend/src/components/ProviderChartCard.tsx
+++ b/packages/frontend/src/components/ProviderChartCard.tsx
@@ -31,6 +31,8 @@ interface ProviderChartCardProps {
   onViewChange: (view: ProviderView) => void;
   messagesValue: number;
   messagesTrendPct: number;
+  requestSuccessRate?: number;
+  attemptSuccessRate?: number;
   tokensValue: number;
   tokensTrendPct: number;
   costValue?: number;
@@ -80,7 +82,18 @@ const ProviderChartCard: Component<ProviderChartCardProps> = (props) => {
           classList={{ 'chart-card__stat--active': props.activeView === 'messages' }}
           onClick={() => props.onViewChange('messages')}
         >
-          <span class="chart-card__label">Messages</span>
+          <span class="chart-card__label">
+            Requests
+            <Show when={props.attemptSuccessRate != null}>
+              <InfoTooltip
+                text={
+                  props.requestSuccessRate == null
+                    ? `Provider-attempt success: ${props.attemptSuccessRate!.toFixed(1)}%.`
+                    : `Caller success: ${props.requestSuccessRate.toFixed(1)}%. Provider-attempt success: ${props.attemptSuccessRate!.toFixed(1)}%. The gap is recovery from fallbacks and Auto-fix.`
+                }
+              />
+            </Show>
+          </span>
           <div class="chart-card__value-row">
             <span class="chart-card__value">{props.messagesValue}</span>
             {trendBadge(props.messagesTrendPct, props.messagesValue)}
@@ -104,14 +117,14 @@ const ProviderChartCard: Component<ProviderChartCardProps> = (props) => {
           <Show when={props.activeView === 'messages'}>
             <Show
               when={props.agentMessageTimeseries?.agents.length}
-              fallback={EMPTY('No message data for this time range')}
+              fallback={EMPTY('No request data for this time range')}
             >
               <MultiAgentTokenChart
                 agents={props.agentMessageTimeseries!.agents}
                 timeseries={props.agentMessageTimeseries!.timeseries}
                 range={props.range}
                 colorMap={props.colorMap}
-                label="Messages"
+                label="Requests"
               />
             </Show>
           </Show>

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -103,7 +103,7 @@ const Sidebar: Component<SidebarProps> = (props) => {
         classList={{ active: isGlobalActive('/messages') }}
         aria-current={isGlobalActive('/messages') ? 'page' : undefined}
       >
-        Messages
+        Requests
       </A>
       <div class="sidebar__section-label">PROVIDERS</div>
       <A

--- a/packages/frontend/src/pages/AgentMessagesRedirect.tsx
+++ b/packages/frontend/src/pages/AgentMessagesRedirect.tsx
@@ -4,7 +4,7 @@ import type { Component } from 'solid-js';
 /**
  * Redirects /harnesses/:agentName/messages → /messages?agent=<name> so the
  * global message log opens pre-filtered to the harness the user came from
- * (e.g. via a Recent Messages "View more" link).
+ * (e.g. via a Recent Requests "View more" link).
  */
 const AgentMessagesRedirect: Component = () => {
   const params = useParams<{ agentName: string }>();

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -88,6 +88,14 @@ interface OverviewResponse {
     cost_today: { value: number; trend_pct: number };
     messages: { value: number; trend_pct: number };
   };
+  request_reliability: {
+    total: number;
+    successful: number;
+    success_rate: number;
+    attempt_success_rate: number;
+    manifest_lift_pct: number;
+    recovered: number;
+  };
   token_usage: Array<{ hour?: string; date?: string; input_tokens: number; output_tokens: number }>;
   message_usage: Array<{ hour?: string; date?: string; count: number }>;
   cost_by_model: CostByModelRow[];
@@ -610,6 +618,8 @@ const GlobalOverview: Component = () => {
                 onViewChange={setChartView}
                 messagesValue={o().summary.messages.value}
                 messagesTrendPct={o().summary.messages.trend_pct}
+                requestSuccessRate={o().request_reliability?.success_rate}
+                attemptSuccessRate={o().request_reliability?.attempt_success_rate}
                 tokensValue={o().summary.tokens_today.value}
                 tokensTrendPct={o().summary.tokens_today.trend_pct}
                 costValue={o().summary.cost_today.value}
@@ -902,13 +912,13 @@ const GlobalOverview: Component = () => {
           );
         })()}
 
-        {/* ── 4. Recent Messages (full width) ──────────────────────────── */}
+        {/* ── 4. Recent Requests (full width) ──────────────────────────── */}
         <div class="panel scroll-panel" style="margin-bottom: 24px;">
           <div
             class="panel__title"
             style="display: flex; justify-content: space-between; align-items: center;"
           >
-            Recent Messages
+            Recent Requests
             <A href="/messages" class="view-more-link">
               View more
             </A>
@@ -1185,7 +1195,7 @@ const GlobalOverview: Component = () => {
                 <tr>
                   <th>Harness</th>
                   <th>Usage (30d)</th>
-                  <th style="text-align: right;">Messages</th>
+                  <th style="text-align: right;">Requests</th>
                 </tr>
               </thead>
               <tbody>

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -409,22 +409,22 @@ const MessageLog: Component = () => {
     <div class="container--full">
       <Title>
         {params.agentName
-          ? `${agentDisplayName() ?? decodeURIComponent(params.agentName)} Messages - Manifest`
-          : 'Messages - Manifest'}
+          ? `${agentDisplayName() ?? decodeURIComponent(params.agentName)} Requests - Manifest`
+          : 'Requests - Manifest'}
       </Title>
       <Meta
         name="description"
         content={
           params.agentName
-            ? `Browse all messages sent and received by ${agentDisplayName() ?? decodeURIComponent(params.agentName)}. Filter by provider, status, or cost.`
-            : 'Browse all messages across all harnesses. Filter by provider, status, or cost.'
+            ? `Browse all requests handled for ${agentDisplayName() ?? decodeURIComponent(params.agentName)}. Filter by provider, status, or cost.`
+            : 'Browse all requests across all harnesses. Filter by provider, status, or cost.'
         }
       />
       <div class="page-header">
         <div>
-          <h1>Messages</h1>
+          <h1>Requests</h1>
           <span class="breadcrumb">
-            Full log of every LLM call. Filter by provider, status, or cost.
+            Full log of requests from your app. Provider calls appear as attempts.
           </span>
         </div>
         <div class="header-controls">
@@ -565,12 +565,14 @@ const MessageLog: Component = () => {
               when={params.agentName && setupCompleted()}
               fallback={
                 <div class="empty-state">
-                  <div class="empty-state__title">No messages yet</div>
+                  <div class="empty-state__title">No requests yet</div>
                   <Show
                     when={params.agentName}
                     fallback={
                       <>
-                        <p>Create a harness and send a message. Every LLM call shows up here.</p>
+                        <p>
+                          Create a harness and send a request. Every caller request shows up here.
+                        </p>
                         <A
                           href="/harnesses"
                           class="btn btn--primary btn--sm"
@@ -581,7 +583,9 @@ const MessageLog: Component = () => {
                       </>
                     }
                   >
-                    <p>Set up your harness and send a message. Every LLM call shows up here.</p>
+                    <p>
+                      Set up your harness and send a request. Every caller request shows up here.
+                    </p>
                     <button
                       class="btn btn--primary btn--sm"
                       style="margin-top: var(--gap-md);"
@@ -593,7 +597,7 @@ const MessageLog: Component = () => {
                   <div class="empty-state__img-wrapper">
                     <img
                       src="/example-messages.svg"
-                      alt="Example message log showing LLM call history"
+                      alt="Example request log showing LLM request history"
                       class="empty-state__img"
                       loading="lazy"
                     />
@@ -602,7 +606,7 @@ const MessageLog: Component = () => {
               }
             >
               <div class="empty-state">
-                <div class="empty-state__title">No messages yet</div>
+                <div class="empty-state__title">No requests yet</div>
                 <p>Connect a provider to start routing LLM calls.</p>
                 <button
                   class="btn btn--primary btn--sm"
@@ -618,7 +622,7 @@ const MessageLog: Component = () => {
                 <div class="empty-state__img-wrapper">
                   <img
                     src="/example-messages.svg"
-                    alt="Example message log showing LLM call history"
+                    alt="Example request log showing LLM request history"
                     class="empty-state__img"
                     loading="lazy"
                   />
@@ -630,14 +634,14 @@ const MessageLog: Component = () => {
             <div class="panel">
               <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
                 <div class="panel__title" style="margin-bottom: 0;">
-                  Messages
+                  Requests
                 </div>
                 <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
                   0 results
                 </span>
               </div>
               <div class="model-filter__empty">
-                <p class="model-filter__empty-title">No messages match your filters</p>
+                <p class="model-filter__empty-title">No requests match your filters</p>
                 <p class="model-filter__empty-hint">
                   Try adjusting your provider, status, or cost filters to see more results.
                 </p>
@@ -651,13 +655,13 @@ const MessageLog: Component = () => {
             <Show when={hasNoData() && hasProviders()}>
               <div class="waiting-banner">
                 <i class="bxd bx-florist" />
-                <p>No messages yet. They appear seconds after your first LLM call.</p>
+                <p>No requests yet. They appear seconds after your first LLM call.</p>
               </div>
             </Show>
             <div class="panel">
               <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
                 <div class="panel__title" style="margin-bottom: 0;">
-                  Messages
+                  Requests
                 </div>
                 <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
                   {totalForPager()} total

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -62,6 +62,14 @@ interface OverviewData {
     messages: { value: number; trend_pct: number };
     services_hit: { total: number; healthy: number; issues: number };
   };
+  request_reliability: {
+    total: number;
+    successful: number;
+    success_rate: number;
+    attempt_success_rate: number;
+    manifest_lift_pct: number;
+    recovered: number;
+  };
   token_usage: Array<{
     hour?: string;
     date?: string;
@@ -424,6 +432,8 @@ const Overview: Component = () => {
                     tokensTrendPct={d().summary?.tokens_today?.trend_pct ?? 0}
                     messagesValue={d().summary?.messages?.value ?? 0}
                     messagesTrendPct={d().summary?.messages?.trend_pct ?? 0}
+                    requestSuccessRate={d().request_reliability?.success_rate}
+                    attemptSuccessRate={d().request_reliability?.attempt_success_rate}
                     costInfoTooltip="Actual API key costs only. Subscription usage is not included."
                     range={effectiveRange()}
                     agentTimeseries={filteredTokenTs() ?? undefined}
@@ -432,13 +442,13 @@ const Overview: Component = () => {
                     colorMap={providerColorMap()}
                   />
 
-                  {/* Recent Messages */}
+                  {/* Recent Requests */}
                   <div class="panel">
                     <div
                       class="panel__title"
                       style="display: flex; justify-content: space-between; align-items: center;"
                     >
-                      Recent Messages
+                      Recent Requests
                       <A href={`/harnesses/${params.agentName}/messages`} class="view-more-link">
                         View more
                       </A>

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -210,7 +210,7 @@ const Workspace: Component = () => {
                           </span>
                         </div>
                         <div class="agent-card__stat">
-                          <span class="agent-card__stat-label">Messages</span>
+                          <span class="agent-card__stat-label">Requests</span>
                           <span class="agent-card__stat-value">{agent.message_count}</span>
                         </div>
                       </div>

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -103,6 +103,7 @@ interface AnalyticsResponse {
   };
   token_usage: Array<{ hour?: string; date?: string; input_tokens: number; output_tokens: number }>;
   message_usage: Array<{ hour?: string; date?: string; count: number }>;
+  attempts: { total: number; successful: number; success_rate: number };
 }
 
 const PRO_RANGES_CD = new Set(['30d', '90d', '365d']);
@@ -705,6 +706,7 @@ const ConnectionDetail: Component = () => {
                       onViewChange={setChartView}
                       messagesValue={analytics()!.summary.messages.value}
                       messagesTrendPct={analytics()!.summary.messages.trend_pct}
+                      attemptSuccessRate={analytics()!.attempts?.success_rate}
                       tokensValue={analytics()!.summary.tokens.value}
                       tokensTrendPct={analytics()!.summary.tokens.trend_pct}
                       costValue={isByok() ? (totalCost() ?? 0) : undefined}
@@ -720,19 +722,19 @@ const ConnectionDetail: Component = () => {
                 })()}
               </Show>
 
-              {/* Recent Messages (full width) */}
+              {/* Recent Requests (full width) */}
               <div class="panel scroll-panel" style="margin-bottom: 24px;">
                 <div
                   class="panel__title"
                   style="display: flex; justify-content: space-between; align-items: center;"
                 >
-                  Recent Messages
+                  Recent Requests
                 </div>
                 <Show
                   when={detail()!.recent_messages.length > 0}
                   fallback={
                     <div style="padding: 24px 16px; color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); text-align: center;">
-                      No messages yet.
+                      No requests yet.
                     </div>
                   }
                 >

--- a/packages/frontend/src/services/api/messages.ts
+++ b/packages/frontend/src/services/api/messages.ts
@@ -84,6 +84,15 @@ export interface MessageDetailResponse {
     } | null;
     /** The paired row (failed original ↔ successful retry), for the visual link. */
     autofix_sibling: { id: string; role: string | null; status: string } | null;
+    attempts?: Array<{
+      id: string;
+      model: string | null;
+      provider: string | null;
+      status: string;
+      error_http_status: number | null;
+      duration_ms: number | null;
+      cost_usd: number | null;
+    }>;
   };
 }
 

--- a/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
+++ b/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
@@ -137,6 +137,41 @@ describe('analytics chart surface components', () => {
     expect(onViewChange).toHaveBeenCalledWith('cost');
   });
 
+  it('explains provider-attempt reliability and Manifest recovery', () => {
+    const { unmount } = render(() => (
+      <ProviderChartCard
+        activeView="messages"
+        onViewChange={vi.fn()}
+        messagesValue={20}
+        messagesTrendPct={0}
+        requestSuccessRate={95}
+        attemptSuccessRate={80}
+        tokensValue={0}
+        tokensTrendPct={0}
+        range="24h"
+      />
+    ));
+
+    expect(screen.getByTestId('info-tooltip').textContent).toBe(
+      'Caller success: 95.0%. Provider-attempt success: 80.0%. The gap is recovery from fallbacks and Auto-fix.',
+    );
+    unmount();
+
+    render(() => (
+      <ProviderChartCard
+        activeView="messages"
+        onViewChange={vi.fn()}
+        messagesValue={20}
+        messagesTrendPct={0}
+        attemptSuccessRate={80}
+        tokensValue={0}
+        tokensTrendPct={0}
+        range="24h"
+      />
+    ));
+    expect(screen.getByTestId('info-tooltip').textContent).toBe('Provider-attempt success: 80.0%.');
+  });
+
   it('renders ProviderChartCard message and cost chart branches', async () => {
     const onViewChange = vi.fn();
 
@@ -296,7 +331,11 @@ describe('analytics chart surface components', () => {
     // Token axis uses formatLegendTokens (mocked to String()).
     expect(capturedChartOpts.axes[1].values({}, [1234])).toEqual(['1234']);
     expect(
-      capturedChartOpts.cursor.move({ posToIdx: () => 0, data: [[1700000000]], valToPos: () => 5 }, 7, 3),
+      capturedChartOpts.cursor.move(
+        { posToIdx: () => 0, data: [[1700000000]], valToPos: () => 5 },
+        7,
+        3,
+      ),
     ).toEqual([5, 3]);
   });
 
@@ -348,9 +387,7 @@ describe('analytics chart surface components', () => {
     // Series are rendered in reverse agent order; each must get the default
     // color for its ORIGINAL index, so colors don't all collapse onto index 0.
     // reversed = ['anthropic'(idx1), 'openai'(idx0)] → AGENT_COLORS[1], [0].
-    const strokes = capturedChartOpts.series
-      .slice(1)
-      .map((s: { stroke: string }) => s.stroke);
+    const strokes = capturedChartOpts.series.slice(1).map((s: { stroke: string }) => s.stroke);
     expect(strokes).toEqual([AGENT_COLORS[1], AGENT_COLORS[0]]);
     // A real per-series distinction: the two strokes differ.
     expect(strokes[0]).not.toBe(strokes[1]);
@@ -376,9 +413,7 @@ describe('analytics chart surface components', () => {
 
     buildCapturedChart();
     // reversed order: anthropic (no map → AGENT_COLORS[1]), openai (mapped).
-    const strokes = capturedChartOpts.series
-      .slice(1)
-      .map((s: { stroke: string }) => s.stroke);
+    const strokes = capturedChartOpts.series.slice(1).map((s: { stroke: string }) => s.stroke);
     expect(strokes).toEqual([AGENT_COLORS[1], '#abcdef']);
   });
 });

--- a/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
+++ b/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
@@ -121,15 +121,15 @@ describe('analytics chart surface components', () => {
     ));
 
     expect(screen.getByText('Cost')).toBeDefined();
-    expect(screen.getByText('Messages')).toBeDefined();
+    expect(screen.getByText('Requests')).toBeDefined();
     expect(screen.getByText('Token usage')).toBeDefined();
     expect(screen.getByTestId('info-tooltip')).toBeDefined();
     await buildLazyChart();
 
     // Tab controls are semantic <button>s (keyboard/a11y).
-    const messagesTab = screen.getByText('Messages').closest('button');
+    const messagesTab = screen.getByText('Requests').closest('button');
     expect(messagesTab).not.toBeNull();
-    fireEvent.click(screen.getByText('Messages'));
+    fireEvent.click(screen.getByText('Requests'));
     expect(onViewChange).toHaveBeenCalledWith('messages');
     fireEvent.click(screen.getByText('Token usage'));
     expect(onViewChange).toHaveBeenCalledWith('tokens');
@@ -164,7 +164,7 @@ describe('analytics chart surface components', () => {
       />
     ));
 
-    expect(screen.getByText('Messages')).toBeDefined();
+    expect(screen.getByText('Requests')).toBeDefined();
     await buildLazyChart();
     unmount();
     capturedLifecycleOpts = null;
@@ -210,7 +210,7 @@ describe('analytics chart surface components', () => {
       />
     ));
 
-    expect(screen.getByText('No message data for this time range')).toBeDefined();
+    expect(screen.getByText('No request data for this time range')).toBeDefined();
     expect(screen.queryByText('Cost')).toBeNull();
     unmount();
 

--- a/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
+++ b/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
@@ -91,7 +91,7 @@ describe('DuplicateAgentModal', () => {
     const headers = qa('.duplicate-agent__section-header').map((h) => h.textContent?.trim());
     expect(headers.some((h) => h?.includes('What is copied'))).toBe(true);
     expect(headers.some((h) => h?.includes('What is not copied'))).toBe(true);
-    expect(list.some((t) => t === 'Messages')).toBe(true);
+    expect(list.some((t) => t === 'Requests')).toBe(true);
     expect(list.some((t) => t === 'Logs')).toBe(true);
     expect(list.some((t) => t === 'Notification rules')).toBe(true);
 

--- a/packages/frontend/tests/components/MessageDetails.test.tsx
+++ b/packages/frontend/tests/components/MessageDetails.test.tsx
@@ -254,6 +254,40 @@ describe('MessageDetails', () => {
     });
   });
 
+  it('lists every provider attempt with its status and cost', async () => {
+    mockGetMessageDetails.mockResolvedValue({
+      message: {
+        ...detailsResponse.message,
+        attempts: [
+          {
+            id: 'attempt-1',
+            provider: null,
+            model: null,
+            status: 'error',
+            cost_usd: null,
+          },
+          {
+            id: 'attempt-2',
+            provider: 'openai',
+            model: 'gpt-4o',
+            status: 'ok',
+            cost_usd: 0.0123456,
+          },
+        ],
+      },
+    });
+
+    const { container } = render(() => <MessageDetails messageId="request-1" />);
+
+    await vi.waitFor(() =>
+      expect(screen.getByRole('table', { name: 'Provider attempts' })).toBeDefined(),
+    );
+    const rows = container.querySelectorAll('table[aria-label="Provider attempts"] tbody tr');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain('1Unknown—error—');
+    expect(rows[1]?.textContent).toContain('2openaiGPT-4ook$0.012346');
+  });
+
   it('shows error state on API failure', async () => {
     mockGetMessageDetails.mockImplementation(() => Promise.reject(new Error('Network error')));
     const { container } = render(() => <MessageDetails messageId="msg-1" />);

--- a/packages/frontend/tests/components/MessageDetails.test.tsx
+++ b/packages/frontend/tests/components/MessageDetails.test.tsx
@@ -279,9 +279,7 @@ describe('MessageDetails', () => {
 
     const { container } = render(() => <MessageDetails messageId="request-1" />);
 
-    await vi.waitFor(() =>
-      expect(screen.getByRole('table', { name: 'Provider attempts' })).toBeDefined(),
-    );
+    await screen.findByRole('table', { name: 'Provider attempts' });
     const rows = container.querySelectorAll('table[aria-label="Provider attempts"] tbody tr');
     expect(rows).toHaveLength(2);
     expect(rows[0]?.textContent).toContain('1Unknown—error—');

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -122,9 +122,9 @@ describe("Sidebar — global nav links", () => {
     expect(screen.getByText("Overview")).toBeDefined();
   });
 
-  it("renders Messages link", () => {
+  it("renders Requests link", () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Messages")).toBeDefined();
+    expect(screen.getByText("Requests")).toBeDefined();
   });
 
   it("renders provider section links (Local resolves async, self-hosted)", async () => {

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -31,6 +31,7 @@ let filterSelectProps: {
   onSelectAll: () => void;
   items: string[];
 } | null = null;
+let providerChartProps: Record<string, unknown> | null = null;
 let mockSearchParams: Record<string, string | undefined> = {};
 
 vi.mock('@solidjs/meta', () => ({
@@ -97,7 +98,10 @@ vi.mock('../../src/components/MultiAgentTokenChart.jsx', () => ({
 }));
 
 vi.mock('../../src/components/ProviderChartCard.jsx', () => ({
-  default: () => <div data-testid="provider-chart-card" />,
+  default: (props: Record<string, unknown>) => {
+    providerChartProps = props;
+    return <div data-testid="provider-chart-card" />;
+  },
 }));
 
 vi.mock('../../src/components/Sparkline.jsx', () => ({
@@ -215,6 +219,15 @@ const overviewResponse = {
   recent_activity: [],
   has_data: true,
   has_providers: true,
+  request_reliability: {
+    total: 18,
+    successful: 17,
+    success_rate: 94.4,
+    attempt_success_rate: 88.9,
+    manifest_lift_pct: 5.5,
+    recovered: 1,
+    previous_total: 16,
+  },
 };
 
 const providersResponse = {
@@ -265,6 +278,7 @@ beforeEach(() => {
   sessionStorage.clear();
   mockIsSelfHosted = false;
   filterSelectProps = null;
+  providerChartProps = null;
   mockSearchParams = {};
   sseMocks.reset?.();
 
@@ -289,6 +303,14 @@ afterEach(() => {
 });
 
 describe('GlobalOverview filter onUnselectAll', () => {
+  it('passes request and attempt success rates to the chart card', async () => {
+    render(() => <GlobalOverview />);
+
+    await waitFor(() => expect(providerChartProps).not.toBeNull());
+    expect(providerChartProps?.requestSuccessRate).toBe(94.4);
+    expect(providerChartProps?.attemptSuccessRate).toBe(88.9);
+  });
+
   it('clears the selection and persists an empty set when "unselect all" fires', async () => {
     // Default grouping is "provider" → storageKey is global-agent-filter:provider.
     const { getByTestId } = render(() => <GlobalOverview />);
@@ -360,7 +382,9 @@ describe('GlobalOverview filter onUnselectAll', () => {
       render(() => <GlobalOverview />);
 
       await waitFor(() => expect(localStorage.getItem('manifest_plan_chosen_u1')).toBe('1'));
-      await waitFor(() => expect(document.body.textContent).toContain("You're now on the Pro plan"));
+      await waitFor(() =>
+        expect(document.body.textContent).toContain("You're now on the Pro plan"),
+      );
 
       await waitFor(() => expect(document.querySelector('.modal-backdrop')).not.toBeNull());
       fireEvent.click(document.querySelector('.modal-backdrop')!);

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -228,13 +228,13 @@ describe('MessageLog', () => {
   it('renders Messages heading', () => {
     mockGetMessages.mockResolvedValue(messagesData);
     render(() => <MessageLog />);
-    expect(screen.getByText('Messages')).toBeDefined();
+    expect(screen.getByText('Requests')).toBeDefined();
   });
 
   it('renders breadcrumb subtitle', () => {
     mockGetMessages.mockResolvedValue(messagesData);
     render(() => <MessageLog />);
-    expect(screen.getByText(/Full log of every LLM call/)).toBeDefined();
+    expect(screen.getByText(/Full log of requests from your app/)).toBeDefined();
   });
 
   it('shows loading skeleton while fetching', () => {
@@ -295,7 +295,7 @@ describe('MessageLog', () => {
     });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('No messages yet');
+      expect(container.textContent).toContain('No requests yet');
     });
   });
 
@@ -315,7 +315,7 @@ describe('MessageLog', () => {
     });
     await fireEvent.change(selects[0], { target: { value: 'openai' } });
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('No messages match your filters');
+      expect(container.textContent).toContain('No requests match your filters');
     });
   });
 
@@ -336,7 +336,7 @@ describe('MessageLog', () => {
     await fireEvent.change(selects[0], { target: { value: 'openai' } });
     await vi.waitFor(() => {
       expect(container.textContent).not.toContain('Waiting for data');
-      expect(container.textContent).not.toContain('No messages yet');
+      expect(container.textContent).not.toContain('No requests yet');
     });
   });
 
@@ -702,7 +702,7 @@ describe('MessageLog', () => {
     });
     await fireEvent.change(selects[0], { target: { value: 'openai' } });
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('No messages match your filters');
+      expect(container.textContent).toContain('No requests match your filters');
     });
     // Click Clear filters
     const clearBtn = container.querySelector('.btn--outline')!;
@@ -924,7 +924,7 @@ describe('MessageLog', () => {
       await fireEvent.change(selects[0], { target: { value: 'openai' } });
 
       await vi.waitFor(() => {
-        expect(container.textContent).toContain('No messages match your filters');
+        expect(container.textContent).toContain('No requests match your filters');
       });
 
       // Click clear filters
@@ -1032,7 +1032,7 @@ describe('MessageLog', () => {
     mockGetMessages.mockResolvedValue(messagesData);
     render(() => <MessageLog />);
     // Meta is mocked as null, just ensure it renders without error
-    expect(screen.getByText('Messages')).toBeDefined();
+    expect(screen.getByText('Requests')).toBeDefined();
   });
 
   it('renders routing tier badge when present', async () => {
@@ -1621,7 +1621,7 @@ describe('MessageLog', () => {
       )[0] as HTMLSelectElement;
       fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
       await vi.waitFor(() => {
-        expect(container.textContent).toContain('No messages match your filters');
+        expect(container.textContent).toContain('No requests match your filters');
       });
     });
 
@@ -1647,7 +1647,7 @@ describe('MessageLog', () => {
       )[0] as HTMLSelectElement;
       fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
       await vi.waitFor(() => {
-        expect(container.textContent).toContain('No messages match your filters');
+        expect(container.textContent).toContain('No requests match your filters');
       });
       // Clear filters — restores data
       mockGetMessages.mockResolvedValue(messagesData);
@@ -1787,12 +1787,12 @@ describe('MessageLog', () => {
   });
 
   describe('global mode title and CTA (Bug 2 + Bug 3)', () => {
-    it("renders 'Messages - Manifest' title without agent prefix in global mode", () => {
+    it("renders 'Requests - Manifest' title without agent prefix in global mode", () => {
       mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       const title = container.querySelector('title');
-      expect(title?.textContent).toBe('Messages - Manifest');
+      expect(title?.textContent).toBe('Requests - Manifest');
     });
 
     it('renders agent-scoped title in agent mode', () => {
@@ -1801,7 +1801,7 @@ describe('MessageLog', () => {
       const { container } = render(() => <MessageLog />);
       const title = container.querySelector('title');
       expect(title?.textContent).toContain('test-agent');
-      expect(title?.textContent).toContain('Messages - Manifest');
+      expect(title?.textContent).toContain('Requests - Manifest');
     });
 
     it("does not render 'undefined' in the title in global mode", () => {
@@ -1837,7 +1837,7 @@ describe('MessageLog', () => {
       });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain('No messages yet');
+        expect(container.textContent).toContain('No requests yet');
         // Global empty state guides to /harnesses, not set-up-agent modal
         const link = container.querySelector('a[href="/harnesses"]') as HTMLAnchorElement;
         expect(link).not.toBeNull();
@@ -1857,7 +1857,7 @@ describe('MessageLog', () => {
       });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain('No messages yet');
+        expect(container.textContent).toContain('No requests yet');
       });
       // Clicking the "Go to Harnesses" link should use the href attribute, not navigate()
       // Verify no button triggers mockNavigate with "/harnesses/undefined/routing"

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -329,7 +329,7 @@ describe('Overview', () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Recent Messages');
+      expect(container.textContent).toContain('Recent Requests');
       expect(container.textContent).toContain('msg-1234');
       expect(container.textContent).toContain('gpt-4o');
     });
@@ -483,7 +483,7 @@ describe('Overview', () => {
     fireEvent.click(stats[1]); // messages
     await vi.waitFor(() => {
       const active = container.querySelector('.chart-card__stat--active');
-      expect(active?.textContent).toContain('Messages');
+      expect(active?.textContent).toContain('Requests');
     });
 
     fireEvent.click(stats[2]); // tokens — renders the token-view chart

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -1027,7 +1027,7 @@ describe('ConnectionDetail (analytics)', () => {
     expect(screen.getAllByText('Harnesses').length).toBeGreaterThan(0);
     expect(screen.getAllByText('gpt-5').length).toBeGreaterThan(0);
     // Recent messages table renders model and token data (description is no longer displayed).
-    expect(screen.getByText('Recent Messages')).toBeDefined();
+    expect(screen.getByText('Recent Requests')).toBeDefined();
     // BYOK connection → cost columns present
     expect(screen.getByText('Active')).toBeDefined();
 
@@ -1141,7 +1141,7 @@ describe('ConnectionDetail (analytics)', () => {
     // "Custom" appears both as the badge and as the connection label.
     expect(screen.getAllByText('Custom').length).toBeGreaterThan(0);
     expect(screen.getByText('Inactive')).toBeDefined();
-    expect(screen.getByText('No messages yet.')).toBeDefined();
+    expect(screen.getByText('No requests yet.')).toBeDefined();
     expect(screen.getByText('No model usage data yet.')).toBeDefined();
     expect(screen.getByText('No harnesses have used this provider yet.')).toBeDefined();
     // Manage button is present even for inactive connections.

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -233,7 +233,7 @@ describe('Workspace', () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
       expect(container.textContent).toContain('Tokens');
-      expect(container.textContent).toContain('Messages');
+      expect(container.textContent).toContain('Requests');
     });
   });
 


### PR DESCRIPTION
### ✨ What changed
- Drop the temporary `agent_messages` compatibility view.
- Abort when cleanup cannot acquire its lock within five seconds.

### 💭 Why
The legacy name is needed only while replicas from #2503 can still serve traffic.

### 🔧 For operators
Do not merge until #2503 is deployed and its old replicas are fully drained.

### 📝 Notes
Stacked on #2503. The diff will shrink after the parent merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates caller requests from provider attempts across the backend and dashboard, and removes the temporary `agent_messages` compatibility view. Migrations add `requests`, rename `agent_messages` to `provider_attempts`, and bound the cleanup lock wait to 5s.

- New Features
  - Added `requests` table and linked historical attempts via boot backfill; kept unlinked attempts readable during backfill.
  - Renamed `agent_messages` to `provider_attempts`; all analytics, logs, and services updated.
  - Dashboards now count logical requests (distinct request or unlinked attempt) and surface request reliability; tokens/cost still come from attempts.
  - Proxy/recorder generate a request id and link attempts; dedup prefers request id; billing quotas count from `requests`.

- Migration
  - Run migrations to create `requests`, rename the table, and drop the compatibility view; the drop uses lock_timeout=5s and aborts if contended.
  - Do not merge until the prior rollout is deployed and old replicas are fully drained to avoid view-lock contention.
  - Request/attempt backfills run on boot under a shared advisory lock; no manual action needed.

<sup>Written for commit e5b1149c1203a41246664161ed675effd9d4061b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

