### PR TITLE
fix: preserve cooldown attempt ordering

### DIFF
--- a/.changeset/fix-cooldown-attempt-order.md
+++ b/.changeset/fix-cooldown-attempt-order.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep provider-cooldown skips and successful fallbacks as separate ordered Attempts in Request timelines.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -61,7 +61,7 @@ When a Request with at least one Attempt succeeds, its Last Attempt must also be
 
 The Last Attempt is the final Provider Attempt within a Request: the Attempt with the highest `attempt_number`. For a completed Request, it is also the Attempt that concluded the Request: the successful Attempt when the Request succeeded, otherwise the terminal non-superseded failure. A zero-attempt Request has no Last Attempt.
 
-Attempt numbers are positive, unique within their Request, and increase in the order Manifest starts provider calls. Do not derive Attempt order from timestamps. `agent_messages.timestamp` records the real provider-call start time, and `agent_messages.duration_ms` records measured elapsed time once the Attempt is terminal. Neither may be fabricated to create an ordering. Superseded Attempts are never the Last Attempt of a completed Request.
+Attempt numbers are positive, unique within their Request, and increase in the order Manifest evaluates routes. Do not derive Attempt order from timestamps. `agent_messages.timestamp` records the real route-evaluation or provider-call start time, and `agent_messages.duration_ms` records measured elapsed time once the Attempt is terminal. Neither may be fabricated to create an ordering. Superseded Attempts are never the Last Attempt of a completed Request.
 
 Historical Attempts linked during the migration may have a null `attempt_number` when their order could not be reconstructed safely. Readers may use the legacy compatibility ranking (successful outcome, then non-superseded failure, then timestamp and id) to select a representative terminal Attempt, but must not present that inferred position as an Attempt number. All newly recorded Attempts require a positive `attempt_number`.
 

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -33,8 +33,8 @@ export class AgentMessage {
   request_id!: string | null;
 
   /**
-   * Positive provider-call start order within the parent Request. NULL only for
-   * legacy rows that have not been assigned an unambiguous order.
+   * Positive route-attempt order within the parent Request. NULL only for legacy
+   * rows that have not been assigned an unambiguous order.
    */
   @Column('integer', { nullable: true })
   attempt_number!: number | null;

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -15,6 +15,7 @@ import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+import type { StartProviderAttempt } from '../proxy-types';
 
 /**
  * Status-code-driven fallback chain behavior for tryFallbacks().
@@ -222,6 +223,70 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
     expect(second.response.headers.get('retry-after')).toBe('120');
     expect(await second.response.text()).toContain('temporarily cooling down');
     expect(providerClient.forward).toHaveBeenCalledTimes(1);
+  });
+
+  it('reserves attempt order for a cooldown before trying the real fallback', async () => {
+    providerClient.forward
+      .mockResolvedValueOnce({
+        response: new Response('rate limit', {
+          status: 429,
+          headers: { 'retry-after': '120' },
+        }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+    const cooledRoute = {
+      provider: 'anthropic',
+      apiKey: 'sk-ant-oat-token',
+      model: 'claude-sonnet-4-6',
+      body,
+      stream: false,
+      sessionKey: 'sess-1',
+      agentId: 'agent-1',
+      providerKeyLabel: 'Claude Code',
+      authType: 'subscription',
+    };
+    await service.tryForwardToProvider(cooledRoute);
+
+    let attemptNumber = 0;
+    const startProviderAttempt: StartProviderAttempt = jest.fn((start) => ({
+      id: `attempt-${attemptNumber + 1}`,
+      attemptNumber: ++attemptNumber,
+      startedAtMs: Date.now(),
+      startedAt: new Date().toISOString(),
+      pendingWrite: Promise.resolve(start.providerCallStarted !== false),
+    }));
+
+    const cooldown = await service.tryForwardToProvider({
+      ...cooledRoute,
+      startProviderAttempt,
+    });
+    const fallback = await service.tryForwardToProvider({
+      ...cooledRoute,
+      provider: 'openai',
+      model: 'gpt-4o',
+      authType: 'api_key',
+      providerKeyLabel: 'OpenAI',
+      startProviderAttempt,
+    });
+
+    expect(cooldown.providerCallStarted).toBe(false);
+    expect(cooldown.attempt?.attemptNumber).toBe(1);
+    expect(fallback.providerCallStarted).toBe(true);
+    expect(fallback.attempt?.attemptNumber).toBe(2);
+    expect(startProviderAttempt).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ provider: 'anthropic', providerCallStarted: false }),
+    );
+    expect(providerClient.forward).toHaveBeenCalledTimes(2);
   });
 
   it('evicts an active cooldown when the cooldown cache is full', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -673,6 +673,65 @@ describe('ProxyController', () => {
     );
   });
 
+  it('reserves cooldown order without inserting a pending provider-call row', async () => {
+    const pendingAttempt = jest.spyOn(recorder, 'recordPendingProviderAttempt');
+    let cooldownAttemptNumber: number | undefined;
+    let fallbackAttemptNumber: number | undefined;
+    proxyService.proxyRequest.mockImplementation(
+      async (options: { startProviderAttempt: StartProviderAttempt }) => {
+        const cooldown = options.startProviderAttempt({
+          provider: 'anthropic',
+          model: 'claude-opus-5',
+          authType: 'subscription',
+          providerCallStarted: false,
+        });
+        const fallback = options.startProviderAttempt({
+          provider: 'deepseek',
+          model: 'deepseek-v4-flash',
+          authType: 'api_key',
+        });
+        cooldownAttemptNumber = cooldown.attemptNumber;
+        fallbackAttemptNumber = fallback.attemptNumber;
+        return {
+          forward: {
+            response: new Response('{"choices":[]}', {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+            isGoogle: false,
+            isAnthropic: false,
+            isChatGpt: false,
+            attempt: fallback,
+          },
+          meta: {
+            tier: 'default',
+            model: 'deepseek-v4-flash',
+            provider: 'deepseek',
+            confidence: 0.9,
+            reason: 'scored',
+            attempt: fallback,
+          },
+        };
+      },
+    );
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(
+      mockRequest({ model: 'auto', messages: [{ role: 'user', content: 'hi' }] }) as never,
+      res as never,
+    );
+
+    expect(cooldownAttemptNumber).toBe(1);
+    expect(fallbackAttemptNumber).toBe(2);
+    expect(pendingAttempt).toHaveBeenCalledTimes(1);
+    expect(pendingAttempt).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.objectContaining({ attemptNumber: 2 }),
+      expect.objectContaining({ provider: 'deepseek' }),
+    );
+  });
+
   it('keeps Auto-fix original and retry payloads on separate Provider Attempts', async () => {
     recordingCache.isRecording.mockResolvedValue(true);
     const originalBody = { model: 'gpt-4o', messages: [], unsupported: true };

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -489,6 +489,15 @@ export class ProxyFallbackService {
     opts: ForwardProviderOptions,
     expiresAt: number,
   ): ForwardResult {
+    const attempt = opts.startProviderAttempt?.({
+      provider: opts.provider,
+      model: opts.model,
+      authType: opts.authType,
+      tenantProviderId: opts.tenantProviderId,
+      keyLabel: opts.providerKeyLabel,
+      providerCallStarted: false,
+    });
+    if (attempt) attempt.completedAtMs = Date.now();
     const retryAfterSeconds = Math.max(1, Math.ceil((expiresAt - Date.now()) / 1000));
     const message =
       `Provider route temporarily cooling down after an upstream 429: ` +
@@ -505,6 +514,7 @@ export class ProxyFallbackService {
       isAnthropic: false,
       isChatGpt: false,
       providerCallStarted: false,
+      attempt,
     };
   }
 

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -46,6 +46,8 @@ export interface ProviderAttemptStart {
   model: string;
   authType?: string;
   tenantProviderId?: string | null;
+  /** Reserve ordering for a Manifest-local route failure without a pending provider-call row. */
+  providerCallStarted?: boolean;
   /**
    * Label of the connection serving this attempt. Carried from the start so a
    * row that never reaches a terminal writer (a cancelled request) still names
@@ -54,7 +56,7 @@ export interface ProviderAttemptStart {
   keyLabel?: string;
 }
 
-/** Identity and measured start of one persisted pending Provider Attempt. */
+/** Identity and measured start of one Attempt. */
 export interface ProviderAttemptRef {
   id: string;
   attemptNumber: number;
@@ -147,6 +149,6 @@ export interface ProxyRequestOptions {
   specificityOverride?: string;
   callerAttribution?: CallerAttribution | null;
   headers?: IncomingHttpHeaders;
-  /** Called immediately before Manifest invokes one upstream provider transport. */
+  /** Allocates the next Attempt; local route failures set providerCallStarted=false. */
   startProviderAttempt?: StartProviderAttempt;
 }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -288,6 +288,13 @@ export class ProxyController {
         startedAt: new Date(startedAtMs).toISOString(),
         pendingWrite: Promise.resolve(false),
       };
+      currentAttempt = attempt;
+      currentAttemptStart = start;
+      // Cooldown skips still need a unique position in the routing chain, but
+      // must not look like an in-flight provider call or trigger provider-call
+      // accounting before their terminal policy row is written.
+      if (start.providerCallStarted === false) return attempt;
+
       let recordingFinished = false;
       attempt.startRecording = ({ requestBody, wireFormat }) => {
         if (!recordingEnabled || !this.attemptRecording || attempt.recordingCapture) {
@@ -310,8 +317,6 @@ export class ProxyController {
           .save(tenantId, requestId, attempt.id, capture.buildRecording())
           .catch((e) => this.logger.warn(`Failed to finish Provider Attempt recording: ${e}`));
       };
-      currentAttempt = attempt;
-      currentAttemptStart = start;
       attempt.pendingWrite = this.recorder
         .recordPendingProviderAttempt(req.ingestionContext, requestId, attempt, start)
         .catch((e) => {


### PR DESCRIPTION
### ✨ What changed
- Reserve an Attempt number for provider-cooldown skips.
- Skip pending provider rows when no upstream call starts.
- Cover cooldown followed by a successful fallback.

### 💭 Why
Cooldown skips and live fallbacks could share one attempt number. PostgreSQL kept only the successful fallback row.

### 👤 For users
Request timelines show the cooled route before the fallback that recovered the Request.

### 📝 Notes
Follow-up to https://github.com/mnfst/manifest/pull/2683

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve attempt ordering when a provider route is cooled down (429). We now reserve an Attempt number without inserting a pending provider-call row, so timelines show the cooldown before the fallback and no rows are lost.

- **Bug Fixes**
  - Reserve an Attempt for cooldowns using `startProviderAttempt({ providerCallStarted: false })`, and mark it completed immediately.
  - Do not call `recordPendingProviderAttempt` for cooldown-only attempts; only the terminal policy row is written.
  - Fallback provider calls take the next Attempt number (e.g., cooldown = 1, fallback = 2), verified by new tests.
  - Docs clarify that Attempt order follows route evaluation, not timestamps; updated field comments for clarity.

<sup>Written for commit a7f4f0e5b2fb8726e92ee7532fb4702104a36e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

