### PR TITLE
chore: design-token diff check + PostToolUse hook for frontend styling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in */packages/frontend/src/*.css|*/packages/frontend/src/*.tsx|*/packages/frontend/src/*.ts) d=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$d/scripts/check-design-tokens.mjs\" ] || exit 0; out=$(cd \"$d\" && node scripts/check-design-tokens.mjs 2>&1) || printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":%s}}' \"$(printf 'Design-token check after your edit (tokens only, see packages/frontend/src/styles/tokens.css):\\n%s' \"$out\" | head -c 4000 | jq -Rs .)\";; esac; }",
+            "timeout": 30,
+            "statusMessage": "Checking design tokens"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Diff-only design-token check for packages/frontend.
+//
+// Scans the ADDED lines of the current diff for styling values that bypass
+// the design tokens (packages/frontend/src/styles/tokens.css): raw hex
+// colors, hsl()/rgb() literals not going through var(--token), and
+// font-family literals. Token definitions themselves (--foo: lines) are
+// exempt, so adding a new token never trips the check.
+//
+// Usage:  node scripts/check-design-tokens.mjs [base-ref]
+//   base-ref defaults to the merge-base with origin/main; the diff includes
+//   uncommitted changes, so it works mid-implementation as well as on a PR.
+//
+// Review tool, not a CI gate: exit 1 on findings so verifier agents can
+// treat findings as a failed step; a human judges intentional exceptions
+// (justify them in the PR description).
+
+import { execSync } from 'node:child_process';
+
+const run = (cmd) =>
+  execSync(cmd, { maxBuffer: 128 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] })
+    .toString();
+
+let base = process.argv[2];
+if (!base) {
+  try {
+    base = run('git merge-base HEAD origin/main').trim();
+  } catch {
+    base = 'origin/main';
+  }
+}
+
+// Only frontend source is checked.
+const INCLUDED = /^packages\/frontend\/src\//;
+
+const EXCLUDED_PATHS = [
+  /^packages\/frontend\/src\/styles\/tokens\.css$/, // the tokens live here
+  /ProviderIcon\.tsx$/,          // provider BRAND colors (data, not design) — sole color allowlist
+  /provider-icons\//,            // future brand-icon library (same rationale)
+  /\.svg$/,
+  /\.md$/,
+];
+
+const CHECKED_EXT = /\.(css|tsx|ts)$/;
+
+// A line that DEFINES a custom property is the one legitimate home for raw values.
+const TOKEN_DEF = /^\s*--[\w-]+\s*:/;
+// Raw hex colors: #fff, #ffffff, #ffffff80.
+const RAW_HEX = /#[0-9a-fA-F]{3,8}\b/;
+// hsl(38 92% 50%) / hsla(...) literals — the #1 bypass in this codebase.
+// hsl(var(--x)) and hsl(var(--x) / 0.5) stay legal.
+const HSL_LITERAL = /hsla?\(\s*[\d.]/;
+// rgb()/rgba() literals.
+const RGB_LITERAL = /rgba?\(\s*[\d.]/;
+// font-family literals are only allowed when they reference a token.
+const FONT_FAMILY = /font-family\s*:/;
+const FONT_OK = /font-family\s*:\s*(var\(--|inherit)/;
+
+let diff;
+try {
+  diff = run(`git diff --unified=0 ${base} -- packages/frontend/src`);
+} catch (e) {
+  console.error(`Could not diff against ${base}: ${e.message}`);
+  process.exit(2);
+}
+
+const findings = [];
+let file = null;
+let skip = true;
+let lineNo = 0;
+
+for (const raw of diff.split('\n')) {
+  if (raw.startsWith('+++ b/')) {
+    file = raw.slice(6);
+    skip =
+      !INCLUDED.test(file) ||
+      !CHECKED_EXT.test(file) ||
+      EXCLUDED_PATHS.some((re) => re.test(file));
+    continue;
+  }
+  if (raw.startsWith('@@')) {
+    const m = raw.match(/\+(\d+)/);
+    lineNo = m ? Number(m[1]) - 1 : 0;
+    continue;
+  }
+  if (!raw.startsWith('+') || raw.startsWith('+++')) continue;
+  lineNo += 1;
+  if (skip) continue;
+
+  const line = raw.slice(1);
+  if (TOKEN_DEF.test(line)) continue;
+
+  if (RAW_HEX.test(line)) {
+    findings.push({ file, lineNo, line: line.trim(), rule: 'raw hex color — use hsl(var(--token))' });
+  } else if (HSL_LITERAL.test(line)) {
+    findings.push({ file, lineNo, line: line.trim(), rule: 'hsl() literal — use hsl(var(--token))' });
+  } else if (RGB_LITERAL.test(line)) {
+    findings.push({ file, lineNo, line: line.trim(), rule: 'rgb()/rgba() literal — use hsl(var(--token) / alpha)' });
+  }
+  if (FONT_FAMILY.test(line) && !FONT_OK.test(line)) {
+    findings.push({ file, lineNo, line: line.trim(), rule: 'font-family literal — use var(--font-*)' });
+  }
+}
+
+if (findings.length === 0) {
+  console.log(`✓ design-token check clean (diff vs ${base.slice(0, 12)})`);
+  process.exit(0);
+}
+
+// Generated or repeated template lines: group by identical offending content
+// so one source bug reads as one finding.
+const groups = new Map();
+for (const f of findings) {
+  const key = `${f.rule}::${f.line}`;
+  const g = groups.get(key) ?? { ...f, count: 0, files: new Set() };
+  g.count += 1;
+  g.files.add(f.file);
+  groups.set(key, g);
+}
+const sorted = [...groups.values()].sort((a, b) => b.count - a.count);
+
+const verbose = process.argv.includes('--all');
+console.log(
+  `✗ ${findings.length} added line(s) bypass the design tokens — ${sorted.length} distinct violation(s) (diff vs ${base.slice(0, 12)}):\n`,
+);
+for (const g of sorted) {
+  console.log(`  ×${g.count} in ${g.files.size} file(s)  [${g.rule}]  e.g. ${g.file}:${g.lineNo}`);
+  console.log(`      ${g.line.slice(0, 140)}`);
+}
+if (verbose) {
+  console.log('\nFull list:');
+  for (const f of findings) console.log(`  ${f.file}:${f.lineNo}  ${f.line.slice(0, 120)}`);
+}
+console.log('\nFix: use the tokens from packages/frontend/src/styles/tokens.css.');
+console.log('Intentional exception? Justify it in the PR description. Re-run with --all for every line.');
+process.exit(1);


### PR DESCRIPTION
### ✨ What changed
- `scripts/check-design-tokens.mjs`: scans the diff's ADDED lines in `packages/frontend/src` for raw hex colors, `hsl()`/`rgb()` literals bypassing `hsl(var(--token))`, and `font-family` literals. Token definition lines are exempt; identical violations are grouped. Exit 1 on findings.
- `.claude/settings.json`: PostToolUse hook. After any Claude Code edit of frontend css/tsx/ts, the check runs and its report is injected back into the agent's session. Non-blocking, 30s timeout, no-op on branches without the script.

### 💭 Why
Baseline measured on main: 180 raw hex, 130 hsl() literals, 73 rgba() outside tokens. The check freezes that debt: nothing new gets added unnoticed, and agents correct themselves mid-task instead of at review. Same setup already running on mnfst/website (87 distinct violations → 1 in a day).

### 👤 For users
Nothing user-visible.

### 🔧 For operators
Review tool, not a CI gate. Run manually: `node scripts/check-design-tokens.mjs [base-ref]`. `ProviderIcon.tsx` is the only color allowlist (brand colors are data). Already-open Claude sessions need /hooks or a restart to load the hook.

### 📝 Notes
- Step 2 of the platform design-system plan, after #2687 (single-source tokens).
- font-size and z-index rules land once the missing token scales are decided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a diff-only design-token check for the frontend and a PostToolUse hook that runs it after edits. This prevents new hard-coded colors and fonts and nudges use of tokens.

- **New Features**
  - `scripts/check-design-tokens.mjs` scans added lines in `packages/frontend/src` for raw hex, `hsl()/rgb()` not using `hsl(var(--token))`, and `font-family` literals. Token definitions are exempt, identical findings are grouped, and the script exits 1 on violations.
  - `.claude/settings.json` adds a PostToolUse command that runs the check after edits to `*.css`, `*.tsx`, and `*.ts`, then injects a short report. 30s timeout; no-op if the script is missing.
  - Brand colors in `ProviderIcon.tsx` are allowlisted. Tokens live in `packages/frontend/src/styles/tokens.css`. Manual run: `node scripts/check-design-tokens.mjs [base-ref]`.

<sup>Written for commit 8741f2b8aa28190e70822a2e66b3c0de2118d3bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

