### PR TITLE
fix: preserve structured provider errors

### DIFF
--- a/.changeset/preserve-provider-error-details.md
+++ b/.changeset/preserve-provider-error-details.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve redacted structured provider error details in proxy responses.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -820,7 +820,10 @@ describe('proxy-response-handler', () => {
       });
     });
 
-    it('uses the Anthropic api_error type for generic Messages server errors', async () => {
+    it.each([
+      [500, 'api_error'],
+      [529, 'overloaded_error'],
+    ])('maps a Messages %i response to Anthropic %s', async (status, type) => {
       const { res } = mockResponse();
       const recorder = mockRecorder();
       const meta = makeMeta({ provider: 'anthropic', model: 'claude-opus-4-1' });
@@ -830,7 +833,7 @@ describe('proxy-response-handler', () => {
         testCtx,
         meta,
         buildMetaHeaders(meta),
-        500,
+        status,
         'Internal Server Error',
         undefined,
         recorder as any,
@@ -846,8 +849,8 @@ describe('proxy-response-handler', () => {
       expect(res.json).toHaveBeenCalledWith({
         type: 'error',
         error: expect.objectContaining({
-          type: 'api_error',
-          status: 500,
+          type,
+          status,
           source: 'provider',
         }),
       });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -345,7 +345,7 @@ describe('proxy-response-handler', () => {
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           error: expect.objectContaining({
-            type: 'server_error',
+            type: 'api_error',
             code: 'fallback_exhausted',
             source: 'manifest',
             primary_model: 'gpt-4o',
@@ -815,6 +815,39 @@ describe('proxy-response-handler', () => {
           message: 'Invalid API key',
           type: 'invalid_request_error',
           status: 401,
+          source: 'provider',
+        }),
+      });
+    });
+
+    it('uses the Anthropic api_error type for generic Messages server errors', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta({ provider: 'anthropic', model: 'claude-opus-4-1' });
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        500,
+        'Internal Server Error',
+        undefined,
+        recorder as any,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'messages',
+      );
+
+      expect(res.json).toHaveBeenCalledWith({
+        type: 'error',
+        error: expect.objectContaining({
+          type: 'api_error',
+          status: 500,
           source: 'provider',
         }),
       });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -498,6 +498,86 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('attributes a code-less structured fallback error to the provider', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta({ provider: 'anthropic', model: 'claude-opus-4-1' });
+      const failedFallbacks: FailedFallback[] = [
+        {
+          model: 'claude-sonnet-4-6',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          status: 400,
+          errorBody: 'also rejected',
+        },
+      ];
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        400,
+        JSON.stringify({
+          error: {
+            message: '`temperature` is deprecated for this model.',
+            type: 'invalid_request_error',
+          },
+        }),
+        failedFallbacks,
+        recorder as any,
+      );
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            code: 'fallback_exhausted',
+            source: 'provider',
+          }),
+        }),
+      );
+    });
+
+    it('uses an Anthropic error envelope when Messages fallbacks are exhausted', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta({ provider: 'anthropic', model: 'claude-opus-4-1' });
+      const failedFallbacks: FailedFallback[] = [
+        {
+          model: 'claude-sonnet-4-6',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          status: 400,
+          errorBody: 'also rejected',
+        },
+      ];
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        400,
+        JSON.stringify({ error: { message: 'Invalid request', type: 'invalid_request_error' } }),
+        failedFallbacks,
+        recorder as any,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'messages',
+      );
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          error: expect.objectContaining({ source: 'provider' }),
+        }),
+      );
+    });
+
     it('should record simple error when failedFallbacks present but meta has fallbackFromModel', async () => {
       const { res } = mockResponse();
       const recorder = mockRecorder();

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -609,6 +609,61 @@ describe('proxy-response-handler', () => {
         }
       }
     });
+
+    it('preserves structured provider 4xx fields in production', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        const { res } = mockResponse();
+        const recorder = mockRecorder();
+        const meta = makeMeta({ provider: 'anthropic', model: 'claude-opus-4-1' });
+
+        await handleProviderError(
+          res as any,
+          testCtx,
+          meta,
+          buildMetaHeaders(meta),
+          400,
+          JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'request_validation_error',
+              message: '`temperature` is deprecated for this model.',
+              param: 'temperature',
+              code: 'deprecated_parameter',
+            },
+          }),
+          undefined,
+          recorder as any,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'messages',
+        );
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({
+          type: 'error',
+          error: expect.objectContaining({
+            message: '`temperature` is deprecated for this model.',
+            type: 'request_validation_error',
+            param: 'temperature',
+            code: 'deprecated_parameter',
+            status: 400,
+            source: 'provider',
+          }),
+        });
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = originalEnv;
+        }
+      }
+    });
   });
 
   /* ── recordFallbackFailures ── */

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -664,6 +664,38 @@ describe('proxy-response-handler', () => {
         }
       }
     });
+
+    it('preserves a structured provider type for authentication errors', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta();
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        401,
+        JSON.stringify({
+          error: {
+            message: 'Invalid API key',
+            type: 'invalid_request_error',
+          },
+        }),
+        undefined,
+        recorder as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        error: expect.objectContaining({
+          message: 'Invalid API key',
+          type: 'invalid_request_error',
+          status: 401,
+          source: 'provider',
+        }),
+      });
+    });
   });
 
   /* ── recordFallbackFailures ── */

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -455,6 +455,49 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('preserves a structured provider code when fallback chain is exhausted', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta({ provider: 'anthropic', model: 'claude-opus-4-1' });
+      const failedFallbacks: FailedFallback[] = [
+        {
+          model: 'claude-sonnet-4-6',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          status: 400,
+          errorBody: 'also rejected',
+        },
+      ];
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        400,
+        JSON.stringify({
+          error: {
+            message: '`temperature` is deprecated for this model.',
+            type: 'invalid_request_error',
+            code: 'deprecated_parameter',
+          },
+        }),
+        failedFallbacks,
+        recorder as any,
+      );
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: '`temperature` is deprecated for this model.',
+            type: 'invalid_request_error',
+            code: 'deprecated_parameter',
+            source: 'provider',
+          }),
+        }),
+      );
+    });
+
     it('should record simple error when failedFallbacks present but meta has fallbackFromModel', async () => {
       const { res } = mockResponse();
       const recorder = mockRecorder();

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -1142,6 +1142,65 @@ describe('ProxyController', () => {
     expect(json.usage).toMatchObject({ input_tokens: 4, output_tokens: 2 });
   });
 
+  it('preserves an Anthropic 400 diagnostic on /v1/messages in production', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const providerError = {
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message: '`temperature` is deprecated for this model.',
+        },
+      };
+      proxyService.proxyRequest.mockResolvedValue({
+        forward: {
+          response: new Response(JSON.stringify(providerError), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+          isGoogle: false,
+          isAnthropic: true,
+          isChatGpt: false,
+        },
+        meta: {
+          tier: 'complex',
+          model: 'claude-opus-4-1',
+          provider: 'Anthropic',
+          confidence: 1,
+          reason: 'explicit-model',
+        },
+      });
+
+      const req = mockRequest({
+        model: 'claude-opus-4-1',
+        max_tokens: 64,
+        temperature: 0.1,
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const { res } = mockResponse();
+
+      await controller.messages(req as never, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        type: 'error',
+        error: expect.objectContaining({
+          type: 'invalid_request_error',
+          message: '`temperature` is deprecated for this model.',
+          status: 400,
+          source: 'provider',
+        }),
+      });
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalEnv;
+      }
+    }
+  });
+
   it('should pass through native Responses JSON bodies', async () => {
     const responseBody = {
       id: 'resp_1',
@@ -1788,7 +1847,7 @@ describe('ProxyController', () => {
       error: expect.objectContaining({
         message: 'Model unavailable',
         type: 'invalid_request_error',
-        code: null,
+        code: 'model_not_found',
         status: 404,
         source: 'provider',
       }),

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -175,6 +175,36 @@ describe('sanitizeProviderError', () => {
     expect(sanitizeProviderError(401, body, 'production')).toBe('Invalid Bearer [REDACTED]');
   });
 
+  it.each(['"opaque credential value"', "'opaque credential value'"])(
+    'redacts quoted Bearer credentials: %s',
+    (credential) => {
+      const body = JSON.stringify({ error: { message: `Invalid Bearer ${credential}` } });
+      expect(sanitizeProviderError(401, body, 'production')).toBe('Invalid Bearer [REDACTED]');
+    },
+  );
+
+  it('redacts credential fields from escaped serialized JSON', () => {
+    const credential = 'opaque credential value';
+    const body = JSON.stringify({
+      error: { message: `Serialized request: {\\"apiKey\\":\\"${credential}\\"}` },
+    });
+
+    const result = sanitizeProviderError(401, body, 'production');
+    expect(result).toContain('{\\"apiKey\\":\\"[REDACTED]\\"}');
+    expect(result).not.toContain(credential);
+  });
+
+  it('preserves generic key-value prose', () => {
+    const message = 'Provider expected key: value for routing';
+    const body = JSON.stringify({ error: { message } });
+    expect(sanitizeProviderError(400, body, 'production')).toBe(message);
+  });
+
+  it('still redacts unquoted apiKey values after narrowing generic key matching', () => {
+    const body = JSON.stringify({ error: { message: 'Invalid apiKey:opaque-secret' } });
+    expect(sanitizeProviderError(401, body, 'production')).toBe('Invalid apiKey:[REDACTED]');
+  });
+
   it('does not treat key substrings inside words as credential fields', () => {
     const body = JSON.stringify({ error: { message: 'Provider says monkey:banana' } });
     expect(sanitizeProviderError(400, body, 'production')).toBe('Provider says monkey:banana');

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -134,6 +134,17 @@ describe('sanitizeProviderError', () => {
     expect(result).not.toContain(token);
   });
 
+  it.each(['apiKey', 'api_key'])('redacts opaque %s values from structured diagnostics', (name) => {
+    const credential = 'opaque-credential-value';
+    const body = JSON.stringify({
+      error: { message: `Invalid credential: ${name}=${credential}` },
+    });
+
+    const result = sanitizeProviderError(401, body, 'production');
+    expect(result).toContain(`${name}=[REDACTED]`);
+    expect(result).not.toContain(credential);
+  });
+
   it('defaults to production behavior when nodeEnv is omitted', () => {
     const body = JSON.stringify({ error: { message: 'Should not leak' } });
     expect(sanitizeProviderError(500, body)).toBe('Upstream provider internal error');

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -145,6 +145,20 @@ describe('sanitizeProviderError', () => {
     expect(result).not.toContain(credential);
   });
 
+  it.each(['apiKey', 'key'])(
+    'redacts quoted JSON %s fields from structured diagnostics',
+    (name) => {
+      const credential = 'opaque-credential-value';
+      const body = JSON.stringify({
+        error: { message: `Invalid credential: "${name}":"${credential}"` },
+      });
+
+      const result = sanitizeProviderError(401, body, 'production');
+      expect(result).toContain(`"${name}":"[REDACTED]"`);
+      expect(result).not.toContain(credential);
+    },
+  );
+
   it('defaults to production behavior when nodeEnv is omitted', () => {
     const body = JSON.stringify({ error: { message: 'Should not leak' } });
     expect(sanitizeProviderError(500, body)).toBe('Upstream provider internal error');

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -106,6 +106,34 @@ describe('sanitizeProviderError', () => {
     expect(sanitizeProviderError(500, body, 'production')).toBe('Upstream provider internal error');
   });
 
+  it('preserves a structured provider 4xx diagnostic in production', () => {
+    const body = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: '`temperature` is deprecated for this model.',
+      },
+    });
+
+    expect(sanitizeProviderError(400, body, 'production')).toBe(
+      '`temperature` is deprecated for this model.',
+    );
+  });
+
+  it('redacts credentials from structured provider 4xx diagnostics in production', () => {
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+    const body = JSON.stringify({
+      error: {
+        type: 'authentication_error',
+        message: `Invalid Authorization: Bearer ${token}`,
+      },
+    });
+
+    const result = sanitizeProviderError(401, body, 'production');
+    expect(result).toContain('Invalid Authorization');
+    expect(result).not.toContain(token);
+  });
+
   it('defaults to production behavior when nodeEnv is omitted', () => {
     const body = JSON.stringify({ error: { message: 'Should not leak' } });
     expect(sanitizeProviderError(500, body)).toBe('Upstream provider internal error');
@@ -117,7 +145,7 @@ describe('sanitizeProviderError', () => {
       const body = JSON.stringify({ error: { message: `Invalid key: ${key}` } });
       const result = sanitizeProviderError(401, body, 'development');
       expect(result).not.toContain(key);
-      expect(result).toContain('sk-***');
+      expect(result).toContain('[REDACTED]');
     });
 
     it('redacts Anthropic API keys from error messages', () => {
@@ -125,7 +153,7 @@ describe('sanitizeProviderError', () => {
       const body = JSON.stringify({ error: { message: `Auth failed: ${key}` } });
       const result = sanitizeProviderError(401, body, 'development');
       expect(result).not.toContain(key);
-      expect(result).toContain('sk-ant-***');
+      expect(result).toContain('[REDACTED]');
     });
 
     it('redacts key= query parameters from error messages', () => {
@@ -134,7 +162,7 @@ describe('sanitizeProviderError', () => {
       });
       const result = sanitizeProviderError(400, body, 'development');
       expect(result).not.toContain('AIzaSyAbcdef123456789');
-      expect(result).toContain('key=***');
+      expect(result).toContain('key=[REDACTED]');
     });
 
     it('redacts Bearer tokens from error messages', () => {
@@ -143,7 +171,7 @@ describe('sanitizeProviderError', () => {
       });
       const result = sanitizeProviderError(401, body, 'development');
       expect(result).not.toContain('eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp');
-      expect(result).toContain('Bearer ***');
+      expect(result).toContain('Bearer [REDACTED]');
     });
 
     it('redacts lowercase bearer tokens from error messages', () => {
@@ -152,14 +180,14 @@ describe('sanitizeProviderError', () => {
       });
       const result = sanitizeProviderError(401, body, 'development');
       expect(result).not.toContain('eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp');
-      expect(result).toContain('Bearer ***');
+      expect(result).toContain('Bearer [REDACTED]');
     });
 
-    it('does not redact patterns in production mode', () => {
+    it('redacts patterns in structured production 4xx responses', () => {
       const key = 'sk-proj-abcdefghijklmnopqrstuvwxyz';
       const body = JSON.stringify({ error: { message: `Invalid key: ${key}` } });
       const result = sanitizeProviderError(401, body, 'production');
-      expect(result).toBe('Authentication failed with upstream provider');
+      expect(result).toBe('Invalid key: [REDACTED]');
     });
   });
 });
@@ -264,7 +292,7 @@ describe('classifyProviderError', () => {
           },
         }),
       )?.message,
-    ).toBe('Maximum context length exceeded for key=*** and Bearer ***');
+    ).toBe('Maximum context length exceeded for key=[REDACTED] and Bearer [REDACTED]');
   });
 
   it('does not classify generic input length validation errors as context overflow', () => {

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -194,6 +194,23 @@ describe('sanitizeProviderError', () => {
     expect(result).not.toContain(credential);
   });
 
+  it.each([
+    ['JSON', (value: string) => JSON.stringify({ apiKey: value })],
+    [
+      'escaped serialized JSON',
+      (value: string) => JSON.stringify({ apiKey: value }).replace(/"/g, '\\"'),
+    ],
+  ])('fully redacts credential values containing escaped quotes in %s', (_format, diagnostic) => {
+    const credential = 'opaque"secret tail';
+    const body = JSON.stringify({
+      error: { message: `Serialized request: ${diagnostic(credential)}` },
+    });
+
+    const result = sanitizeProviderError(401, body, 'production');
+    expect(result).toContain('[REDACTED]');
+    expect(result).not.toContain('secret tail');
+  });
+
   it('preserves generic key-value prose', () => {
     const message = 'Provider expected key: value for routing';
     const body = JSON.stringify({ error: { message } });

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -159,6 +159,27 @@ describe('sanitizeProviderError', () => {
     },
   );
 
+  it('redacts quoted credential values containing whitespace', () => {
+    const credential = 'opaque credential value';
+    const body = JSON.stringify({
+      error: { message: `Invalid credential: "apiKey":"${credential}"` },
+    });
+
+    const result = sanitizeProviderError(401, body, 'production');
+    expect(result).toContain('"apiKey":"[REDACTED]"');
+    expect(result).not.toContain(credential);
+  });
+
+  it('redacts short Bearer credentials containing punctuation', () => {
+    const body = JSON.stringify({ error: { message: 'Invalid Bearer a!b@c:' } });
+    expect(sanitizeProviderError(401, body, 'production')).toBe('Invalid Bearer [REDACTED]');
+  });
+
+  it('does not treat key substrings inside words as credential fields', () => {
+    const body = JSON.stringify({ error: { message: 'Provider says monkey:banana' } });
+    expect(sanitizeProviderError(400, body, 'production')).toBe('Provider says monkey:banana');
+  });
+
   it('defaults to production behavior when nodeEnv is omitted', () => {
     const body = JSON.stringify({ error: { message: 'Should not leak' } });
     expect(sanitizeProviderError(500, body)).toBe('Upstream provider internal error');

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -1,3 +1,5 @@
+import { scrubSecrets } from '../../common/utils/secret-scrub';
+
 const KNOWN_ERROR_MESSAGES: Record<number, string> = {
   400: 'Bad request to upstream provider',
   401: 'Authentication failed with upstream provider',
@@ -26,6 +28,13 @@ export interface ClassifiedProviderError {
   source: 'provider';
 }
 
+export interface StructuredProviderError {
+  message: string;
+  type: string | null;
+  param: string | null;
+  code: string | null;
+}
+
 const KNOWN_CONTEXT_ERROR_CODES = new Set(['context_length_exceeded']);
 
 const KNOWN_CONTEXT_ERROR_MESSAGE_PATTERNS = [
@@ -34,11 +43,7 @@ const KNOWN_CONTEXT_ERROR_MESSAGE_PATTERNS = [
 ];
 
 function sanitizeSensitivePatterns(msg: string): string {
-  return msg
-    .replace(/sk-ant-[a-zA-Z0-9_-]{20,}/g, 'sk-ant-***')
-    .replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***')
-    .replace(/key=[^&\s"]+/g, 'key=***')
-    .replace(/Bearer\s+[^\s"]+/gi, 'Bearer ***');
+  return scrubSecrets(msg).replace(/\bkey=[^&\s"]+/g, 'key=[REDACTED]');
 }
 
 function normalizeErrorMessage(message: string): string {
@@ -51,6 +56,45 @@ function extractProviderMessage(rawBody: string): string | null {
     const error = parsed.error as Record<string, unknown> | undefined;
     const message = error?.message ?? parsed.message;
     return typeof message === 'string' && message.length > 0 ? message : null;
+  } catch {
+    return null;
+  }
+}
+
+function errorField(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const normalized = normalizeErrorMessage(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+/**
+ * Extract the allow-listed fields from a structured provider 4xx response.
+ * Server errors and unstructured bodies keep the generic production message.
+ */
+export function parseStructuredProviderError(
+  status: number,
+  rawBody: string,
+): StructuredProviderError | null {
+  if (status < 400 || status >= 500) return null;
+
+  try {
+    const parsed = JSON.parse(rawBody) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const root = parsed as Record<string, unknown>;
+    const nested = root.error;
+    const error =
+      nested && typeof nested === 'object' && !Array.isArray(nested)
+        ? (nested as Record<string, unknown>)
+        : root;
+    const message = errorField(error.message ?? root.message);
+    if (!message) return null;
+
+    return {
+      message,
+      type: errorField(error.type),
+      param: errorField(error.param),
+      code: errorField(error.code),
+    };
   } catch {
     return null;
   }
@@ -136,8 +180,10 @@ export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?:
   if (endpointError) return endpointError;
   const classified = classifyProviderError(status, rawBody);
   if (classified) return classified.message;
+  const structured = parseStructuredProviderError(status, rawBody);
+  if (structured) return structured.message;
 
-  // In production, only return generic error messages to avoid leaking provider internals
+  // In production, unstructured and 5xx responses stay generic to avoid leaking internals.
   if ((nodeEnv ?? 'production') === 'production') return generic;
 
   const message = extractProviderMessage(rawBody);

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -43,7 +43,7 @@ const KNOWN_CONTEXT_ERROR_MESSAGE_PATTERNS = [
 ];
 
 function sanitizeSensitivePatterns(msg: string): string {
-  return scrubSecrets(msg).replace(/\bkey=[^&\s"]+/g, 'key=[REDACTED]');
+  return scrubSecrets(msg).replace(/(\b(?:api[_-]?)?key)=[^&\s"']+/gi, '$1=[REDACTED]');
 }
 
 function normalizeErrorMessage(message: string): string {

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -43,11 +43,19 @@ const KNOWN_CONTEXT_ERROR_MESSAGE_PATTERNS = [
 ];
 
 function sanitizeSensitivePatterns(msg: string): string {
-  return scrubSecrets(msg)
-    .replace(/Bearer\s+[^\s"']+/gi, 'Bearer [REDACTED]')
-    .replace(/(["']?)\b(api[_-]?key|key)\b\1(\s*[:=]\s*)"[^"]*"/gi, '$1$2$1$3"[REDACTED]"')
-    .replace(/(["']?)\b(api[_-]?key|key)\b\1(\s*[:=]\s*)'[^']*'/gi, "$1$2$1$3'[REDACTED]'")
-    .replace(/(["']?)\b(api[_-]?key|key)\b\1(\s*[:=]\s*)[^\s"',}&]+/gi, '$1$2$1$3[REDACTED]');
+  return scrubSecrets(msg.replace(/Bearer\s+(?:"[^"]*"|'[^']*'|[^\s"']+)/gi, 'Bearer [REDACTED]'))
+    .replace(
+      /\\"(api[_-]?key|key)\\"(\s*:\s*)\\"(?:[^"\\]|\\(?!"))*\\"/gi,
+      '\\"$1\\"$2\\"[REDACTED]\\"',
+    )
+    .replace(/"(api[_-]?key|key)"(\s*:\s*)"[^"]*"/gi, '"$1"$2"[REDACTED]"')
+    .replace(/'(api[_-]?key|key)'(\s*:\s*)'[^']*'/gi, "'$1'$2'[REDACTED]'")
+    .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)"[^"]*"/gi, '$1$2"[REDACTED]"')
+    .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)'[^']*'/gi, "$1$2'[REDACTED]'")
+    .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)[^\s"',}&]+/gi, '$1$2[REDACTED]')
+    .replace(/\b(key)\b(\s*=\s*)"[^"]*"/gi, '$1$2"[REDACTED]"')
+    .replace(/\b(key)\b(\s*=\s*)'[^']*'/gi, "$1$2'[REDACTED]'")
+    .replace(/\b(key)\b(\s*=\s*)[^\s"',}&]+/gi, '$1$2[REDACTED]');
 }
 
 function normalizeErrorMessage(message: string): string {

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -43,7 +43,10 @@ const KNOWN_CONTEXT_ERROR_MESSAGE_PATTERNS = [
 ];
 
 function sanitizeSensitivePatterns(msg: string): string {
-  return scrubSecrets(msg).replace(/(\b(?:api[_-]?)?key)=[^&\s"']+/gi, '$1=[REDACTED]');
+  return scrubSecrets(msg).replace(
+    /(["']?)(api[_-]?key|key)\1(\s*[:=]\s*)(["']?)[^"',}&\s]+\4/gi,
+    '$1$2$1$3$4[REDACTED]$4',
+  );
 }
 
 function normalizeErrorMessage(message: string): string {

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -43,18 +43,20 @@ const KNOWN_CONTEXT_ERROR_MESSAGE_PATTERNS = [
 ];
 
 function sanitizeSensitivePatterns(msg: string): string {
-  return scrubSecrets(msg.replace(/Bearer\s+(?:"[^"]*"|'[^']*'|[^\s"']+)/gi, 'Bearer [REDACTED]'))
+  return scrubSecrets(
+    msg.replace(/Bearer\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s"']+)/gi, 'Bearer [REDACTED]'),
+  )
     .replace(
-      /\\"(api[_-]?key|key)\\"(\s*:\s*)\\"(?:[^"\\]|\\(?!"))*\\"/gi,
+      /\\"(api[_-]?key|key)\\"(\s*:\s*)\\"(?:\\\\"|[^"\\]|\\(?!"))*\\"/gi,
       '\\"$1\\"$2\\"[REDACTED]\\"',
     )
-    .replace(/"(api[_-]?key|key)"(\s*:\s*)"[^"]*"/gi, '"$1"$2"[REDACTED]"')
-    .replace(/'(api[_-]?key|key)'(\s*:\s*)'[^']*'/gi, "'$1'$2'[REDACTED]'")
-    .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)"[^"]*"/gi, '$1$2"[REDACTED]"')
-    .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)'[^']*'/gi, "$1$2'[REDACTED]'")
+    .replace(/"(api[_-]?key|key)"(\s*:\s*)"(?:\\.|[^"\\])*"/gi, '"$1"$2"[REDACTED]"')
+    .replace(/'(api[_-]?key|key)'(\s*:\s*)'(?:\\.|[^'\\])*'/gi, "'$1'$2'[REDACTED]'")
+    .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)"(?:\\.|[^"\\])*"/gi, '$1$2"[REDACTED]"')
+    .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)'(?:\\.|[^'\\])*'/gi, "$1$2'[REDACTED]'")
     .replace(/\b(api[_-]?key)\b(\s*[:=]\s*)[^\s"',}&]+/gi, '$1$2[REDACTED]')
-    .replace(/\b(key)\b(\s*=\s*)"[^"]*"/gi, '$1$2"[REDACTED]"')
-    .replace(/\b(key)\b(\s*=\s*)'[^']*'/gi, "$1$2'[REDACTED]'")
+    .replace(/\b(key)\b(\s*=\s*)"(?:\\.|[^"\\])*"/gi, '$1$2"[REDACTED]"')
+    .replace(/\b(key)\b(\s*=\s*)'(?:\\.|[^'\\])*'/gi, "$1$2'[REDACTED]'")
     .replace(/\b(key)\b(\s*=\s*)[^\s"',}&]+/gi, '$1$2[REDACTED]');
 }
 

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -43,10 +43,11 @@ const KNOWN_CONTEXT_ERROR_MESSAGE_PATTERNS = [
 ];
 
 function sanitizeSensitivePatterns(msg: string): string {
-  return scrubSecrets(msg).replace(
-    /(["']?)(api[_-]?key|key)\1(\s*[:=]\s*)(["']?)[^"',}&\s]+\4/gi,
-    '$1$2$1$3$4[REDACTED]$4',
-  );
+  return scrubSecrets(msg)
+    .replace(/Bearer\s+[^\s"']+/gi, 'Bearer [REDACTED]')
+    .replace(/(["']?)\b(api[_-]?key|key)\b\1(\s*[:=]\s*)"[^"]*"/gi, '$1$2$1$3"[REDACTED]"')
+    .replace(/(["']?)\b(api[_-]?key|key)\b\1(\s*[:=]\s*)'[^']*'/gi, "$1$2$1$3'[REDACTED]'")
+    .replace(/(["']?)\b(api[_-]?key|key)\b\1(\s*[:=]\s*)[^\s"',}&]+/gi, '$1$2$1$3[REDACTED]');
 }
 
 function normalizeErrorMessage(message: string): string {

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -389,13 +389,15 @@ function handleFallbackExhausted(
 
   logger.warn(`Fallback chain exhausted: ${errorBody.slice(0, 200)}`);
   const classified = classifyProviderError(errorStatus, errorBody);
+  const structured = parseStructuredProviderError(errorStatus, errorBody);
+  const structuredCode = structured?.code;
   res.status(errorStatus);
   setHeaders(res, metaHeaders);
   res.setHeader('X-Manifest-Fallback-Exhausted', 'true');
   const responseBody = {
     error: buildOpenAiCompatibleError(errorStatus, errorBody, {
-      source: classified?.source ?? 'manifest',
-      code: classified?.code ?? 'fallback_exhausted',
+      source: classified?.source ?? (structuredCode ? 'provider' : 'manifest'),
+      code: classified?.code ?? structuredCode ?? 'fallback_exhausted',
       provider: meta.provider,
       model: meta.model,
       extra: {

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -390,14 +390,15 @@ function handleFallbackExhausted(
   logger.warn(`Fallback chain exhausted: ${errorBody.slice(0, 200)}`);
   const classified = classifyProviderError(errorStatus, errorBody);
   const structured = parseStructuredProviderError(errorStatus, errorBody);
-  const structuredCode = structured?.code;
+  const providerCode = classified?.code ?? structured?.code;
   res.status(errorStatus);
   setHeaders(res, metaHeaders);
   res.setHeader('X-Manifest-Fallback-Exhausted', 'true');
   const responseBody = {
+    ...(apiMode === 'messages' ? { type: 'error' } : {}),
     error: buildOpenAiCompatibleError(errorStatus, errorBody, {
-      source: classified?.source ?? (structuredCode ? 'provider' : 'manifest'),
-      code: classified?.code ?? structuredCode ?? 'fallback_exhausted',
+      source: classified?.source ?? (structured ? 'provider' : 'manifest'),
+      code: providerCode ?? 'fallback_exhausted',
       provider: meta.provider,
       model: meta.model,
       extra: {

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -209,7 +209,9 @@ export function buildOpenAiCompatibleError(
       classified?.type ??
       structured?.type ??
       (opts.apiMode === 'messages' && status >= 500
-        ? 'api_error'
+        ? status === 529
+          ? 'overloaded_error'
+          : 'api_error'
         : openAiErrorTypeForStatus(status)),
     param: structured?.param ?? null,
     code: opts.code !== undefined ? opts.code : (classified?.code ?? structured?.code ?? null),

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -194,6 +194,7 @@ export function buildOpenAiCompatibleError(
     code?: string | null;
     provider?: string;
     model?: string;
+    apiMode?: ProxyApiMode;
     extra?: Record<string, unknown>;
   } = {},
 ): Record<string, unknown> {
@@ -204,7 +205,12 @@ export function buildOpenAiCompatibleError(
       classified?.message ??
       structured?.message ??
       sanitizeProviderError(status, errorBody, process.env.NODE_ENV),
-    type: classified?.type ?? structured?.type ?? openAiErrorTypeForStatus(status),
+    type:
+      classified?.type ??
+      structured?.type ??
+      (opts.apiMode === 'messages' && status >= 500
+        ? 'api_error'
+        : openAiErrorTypeForStatus(status)),
     param: structured?.param ?? null,
     code: opts.code !== undefined ? opts.code : (classified?.code ?? structured?.code ?? null),
     status,
@@ -305,6 +311,7 @@ export async function handleProviderError(
       source: 'provider',
       provider: meta.provider,
       model: meta.model,
+      apiMode,
     }),
   };
   res.json(responseBody);
@@ -401,6 +408,7 @@ function handleFallbackExhausted(
       code: providerCode ?? 'fallback_exhausted',
       provider: meta.provider,
       model: meta.model,
+      apiMode,
       extra: {
         primary_model: meta.model,
         primary_provider: meta.provider,

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -19,6 +19,7 @@ import { createSsePayloadParser } from './sse-parser';
 import {
   classifyProviderError,
   openAiErrorTypeForStatus,
+  parseStructuredProviderError,
   sanitizeProviderError,
 } from './proxy-error-sanitizer';
 import {
@@ -197,11 +198,15 @@ export function buildOpenAiCompatibleError(
   } = {},
 ): Record<string, unknown> {
   const classified = classifyProviderError(status, errorBody);
+  const structured = parseStructuredProviderError(status, errorBody);
   return {
-    message: classified?.message ?? sanitizeProviderError(status, errorBody, process.env.NODE_ENV),
-    type: classified?.type ?? openAiErrorTypeForStatus(status),
-    param: null,
-    code: opts.code !== undefined ? opts.code : (classified?.code ?? null),
+    message:
+      classified?.message ??
+      structured?.message ??
+      sanitizeProviderError(status, errorBody, process.env.NODE_ENV),
+    type: classified?.type ?? structured?.type ?? openAiErrorTypeForStatus(status),
+    param: structured?.param ?? null,
+    code: opts.code !== undefined ? opts.code : (classified?.code ?? structured?.code ?? null),
     status,
     source: opts.source ?? classified?.source ?? 'provider',
     ...(opts.provider ? { provider: opts.provider } : {}),
@@ -295,6 +300,7 @@ export async function handleProviderError(
   res.status(errorStatus);
   setHeaders(res, metaHeaders);
   const responseBody = {
+    ...(apiMode === 'messages' ? { type: 'error' } : {}),
     error: buildOpenAiCompatibleError(errorStatus, errorBody, {
       source: 'provider',
       provider: meta.provider,

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -250,12 +250,9 @@ describe('Proxy E2E — /v1/chat/completions', () => {
       expect(res.headers['x-manifest-tier']).toBeDefined();
       expect(res.headers['x-manifest-model']).toBeDefined();
       expect(res.headers['x-manifest-provider']).toBeDefined();
-      // Body shape from handleProviderError() with the forwarded status echoed
-      // in `error.status`. A guard 401 would have type='auth_error', so this
-      // also discriminates the two paths.
-      expect(res.body?.error?.type).toBe(
-        res.status === 401 ? 'authentication_error' : 'permission_error',
-      );
+      // Body shape from handleProviderError() with the forwarded status and
+      // source echoed in the error. Provider-defined error types are preserved,
+      // so `source` discriminates this path from the guard's Manifest error.
       expect(res.body?.error?.status).toBe(res.status);
       expect(res.body?.error?.source).toBe('provider');
     } else if (res.status >= 500) {


### PR DESCRIPTION
### ✨ What changed
- Forward redacted structured provider 4xx fields to callers.
- Keep Anthropic error envelopes on `/v1/messages`.

### 💭 Why
Provider validation details were replaced with generic messages in production.

### 👤 For users
Provider errors keep actionable fields without exposing known credential formats.

### 📝 Notes
Closes #2686

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves structured provider 4xx diagnostics (incl. auth) in proxy responses and keeps `type: 'error'` envelopes on `/v1/messages`, with stronger secret redaction (incl. escaped JSON). Also carries provider error codes and attribution through fallback exhaustion for clearer debugging. Closes #2686.

- **Bug Fixes**
  - Forward provider `message`, `type`, `param`, and `code` for 4xx (incl. 401) with `error.status` and `source: 'provider'` in direct errors and exhausted fallbacks, in production too (sanitized).
  - On fallback exhaustion: prefer the provider `code`; if structured but code-less, set `code: 'fallback_exhausted'` with `source: 'provider'`, otherwise use `source: 'manifest'`.
  - Harden scrubbing: redact Bearer tokens and `apiKey`/`api_key`/`key` values in prose and JSON (quoted or escaped, incl. embedded quotes/whitespace) as `[REDACTED]`, and avoid false positives via `scrubSecrets`.
  - For `/v1/messages`, keep top-level `type: 'error'` and map server errors to Anthropic types: 5xx → `api_error` (529 → `overloaded_error`).

<sup>Written for commit 9b5723d01591acfbd7693c1cdd23dcdd05b25942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

