### PR TITLE
test: poll the attempt count in the billing-limit e2e to close a CI race

### DIFF
--- a/packages/backend/test/billing-request-limit.e2e-spec.ts
+++ b/packages/backend/test/billing-request-limit.e2e-spec.ts
@@ -21,24 +21,30 @@ const BILLING_ENV_VARS = [
   'PLAN_LIMIT_FREE_REQUESTS',
 ];
 
-async function waitForManifestBlockCount(tenantId: string, minimum: number): Promise<number> {
+/** Poll a COUNT query until it reaches `minimum` (the blocked-request rows are
+ *  written asynchronously, after the 402 has already been sent). Returns the
+ *  last observed count either way so assertions still fail loudly on timeout. */
+async function waitForCount(sql: string, params: unknown[], minimum: number): Promise<number> {
   const deadline = Date.now() + 1000;
   let count = 0;
   do {
-    const rows = await ds.query(
-      `SELECT COUNT(*)::int AS n
-         FROM requests
-        WHERE tenant_id = $1
-          AND error_origin = 'policy'
-          AND error_class = 'plan_request_limit_exceeded'
-          AND error_http_status = 402`,
-      [tenantId],
-    );
+    const rows = await ds.query(sql, params);
     count = rows[0].n;
     if (count >= minimum) return count;
     await new Promise((resolve) => setTimeout(resolve, 25));
   } while (Date.now() < deadline);
   return count;
+}
+
+const MANIFEST_BLOCK_COUNT_SQL = `SELECT COUNT(*)::int AS n
+     FROM requests
+    WHERE tenant_id = $1
+      AND error_origin = 'policy'
+      AND error_class = 'plan_request_limit_exceeded'
+      AND error_http_status = 402`;
+
+async function waitForManifestBlockCount(tenantId: string, minimum: number): Promise<number> {
+  return waitForCount(MANIFEST_BLOCK_COUNT_SQL, [tenantId], minimum);
 }
 
 beforeAll(async () => {
@@ -154,9 +160,13 @@ describe('request limit gate (/v1 proxy)', () => {
     const after = await ds.query(`SELECT COUNT(*)::int AS n FROM requests WHERE tenant_id = $1`, [
       tenantId,
     ]);
-    const attemptsAfter = await ds.query(
+    // The attempt row is a separate asynchronous insert from the requests row
+    // the block-count wait already covered — poll it too, or a slow runner
+    // reads 1 attempt where 2 have been ordered (the CI flake this fixes).
+    const attemptsAfterN = await waitForCount(
       `SELECT COUNT(*)::int AS n FROM agent_messages WHERE tenant_id = $1`,
       [tenantId],
+      attemptsBefore[0].n + 1,
     );
     const latestBlock = await ds.query(
       `SELECT status, error_origin, error_class, error_http_status, error_code
@@ -172,7 +182,7 @@ describe('request limit gate (/v1 proxy)', () => {
     const billableAfter = await planService.countRequestsSince(tenantId, monthStartMs);
 
     expect(after[0].n).toBe(before[0].n + 1);
-    expect(attemptsAfter[0].n).toBe(attemptsBefore[0].n + 1);
+    expect(attemptsAfterN).toBe(attemptsBefore[0].n + 1);
     expect(manifestBlocksAfter).toBe(manifestBlocksBefore[0].n + 1);
     expect(latestBlock[0]).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
## What

Fixes the recurring `Backend (PostgreSQL)` CI failure that hits unrelated PRs (seen on #2607 and #2688):

```
billing-request-limit.e2e-spec.ts
● records the blocked request as a visible Manifest failure without counting it toward quota
Expected: 2 / Received: 1   (attempt count)
```

## Why it flakes

A plan-limit block writes its `requests` row and its `agent_messages` attempt row asynchronously, after the 402 has already been sent, as two separate inserts. The test's `waitForManifestBlockCount` helper polls only the `requests` count; the very next query counts `agent_messages` with no wait, so on a slow runner it reads one row short. A rerun always passes.

## Fix

Test-only change. The helper generalizes to `waitForCount(sql, params, minimum)` (same 25ms poll / 1s deadline) and the test now polls the attempt count too before asserting. A genuinely missing row still fails: the poll times out and returns the short count to the same assertion.

Validated by running the spec three times locally against a fresh PostgreSQL: 3/3 green.
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the billing-limit e2e CI flake by polling the attempt count so the test waits for both async inserts after the 402.
Generalizes the helper to `waitForCount` and uses it for manifest block and `agent_messages` counts with the same 25ms poll/1s timeout; test-only change and real misses still fail.

<sup>Written for commit 4493522534bf4b84ef2aa461c42ce40aa0aaed46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
