### PR TITLE
fix: remove unavailable Code Assist models

### DIFF
--- a/.changeset/trim-codeassist-models.md
+++ b/.changeset/trim-codeassist-models.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop advertising Gemini 3.1 Pro Preview and Gemini 3 Flash Preview for Google Code Assist subscriptions because the Code Assist API returns model-not-found responses for both routes.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2259,12 +2259,12 @@ describe('ModelDiscoveryService', () => {
           },
         ],
         [
-          'google/gemini-3.1-pro-preview',
+          'google/gemini-3.1-flash-lite',
           {
             input: 0.000002,
             output: 0.000012,
             contextWindow: 1000000,
-            displayName: 'Gemini 3.1 Pro Preview',
+            displayName: 'Gemini 3.1 Flash Lite',
           },
         ],
         // Suffixed variants — should be EXCLUDED in exact mode
@@ -2297,7 +2297,7 @@ describe('ModelDiscoveryService', () => {
       // Exact matches included
       expect(ids).toContain('gemini-2.5-pro');
       expect(ids).toContain('gemini-2.5-flash');
-      expect(ids).toContain('gemini-3.1-pro-preview');
+      expect(ids).toContain('gemini-3.1-flash-lite');
       // Suffixed preview NOT included (exact match mode)
       expect(ids).not.toContain('gemini-2.5-pro-preview-06-05');
       // Non-gemini models excluded
@@ -2360,10 +2360,10 @@ describe('ModelDiscoveryService', () => {
       // knownModels not in cache added as zero-cost
       expect(ids).toContain('gemini-2.5-pro');
       expect(ids).toContain('gemini-2.5-flash-lite');
-      expect(ids).toContain('gemini-3.1-pro-preview');
-      expect(ids).toContain('gemini-3-flash-preview');
       expect(ids).toContain('gemini-3.1-flash-lite');
       expect(ids).toContain('gemini-3.1-flash-lite-preview');
+      expect(ids).not.toContain('gemini-3.1-pro-preview');
+      expect(ids).not.toContain('gemini-3-flash-preview');
       expect(fetcher.fetch).not.toHaveBeenCalled();
     });
   });

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -371,6 +371,8 @@ describe('supplementWithKnownModels', () => {
 
     expect(ids).toContain('gemini-3.1-flash-lite');
     expect(ids).toContain('gemini-3.1-flash-lite-preview');
+    expect(ids).not.toContain('gemini-3.1-pro-preview');
+    expect(ids).not.toContain('gemini-3-flash-preview');
   });
 });
 

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -263,8 +263,6 @@ describe('getSubscriptionProviderConfig', () => {
     });
     expect(config?.knownModels).toEqual(
       expect.arrayContaining([
-        'gemini-3.1-pro-preview',
-        'gemini-3-flash-preview',
         'gemini-3.1-flash-lite',
         'gemini-3.1-flash-lite-preview',
         'gemini-2.5-pro',
@@ -272,6 +270,8 @@ describe('getSubscriptionProviderConfig', () => {
         'gemini-2.5-flash-lite',
       ]),
     );
+    expect(config?.knownModels).not.toContain('gemini-3.1-pro-preview');
+    expect(config?.knownModels).not.toContain('gemini-3-flash-preview');
     expect(config?.subscriptionCapabilities).toMatchObject({
       maxContextWindow: 1000000,
       supportsPromptCaching: true,
@@ -423,13 +423,13 @@ describe('getSubscriptionKnownModels', () => {
 
   it('returns known models for gemini', () => {
     const models = getSubscriptionKnownModels('gemini');
-    expect(models).toContain('gemini-3.1-pro-preview');
-    expect(models).toContain('gemini-3-flash-preview');
     expect(models).toContain('gemini-3.1-flash-lite');
     expect(models).toContain('gemini-3.1-flash-lite-preview');
     expect(models).toContain('gemini-2.5-pro');
     expect(models).toContain('gemini-2.5-flash');
     expect(models).toContain('gemini-2.5-flash-lite');
+    expect(models).not.toContain('gemini-3.1-pro-preview');
+    expect(models).not.toContain('gemini-3-flash-preview');
   });
 
   it('returns known models for xai', () => {

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -253,8 +253,6 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     // the CodeAssist route recognizes; some current Gemini API model IDs still
     // 404 on the CodeAssist API.
     knownModels: Object.freeze([
-      'gemini-3.1-pro-preview',
-      'gemini-3-flash-preview',
       'gemini-3.1-flash-lite',
       'gemini-3.1-flash-lite-preview',
       'gemini-2.5-pro',


### PR DESCRIPTION
### ✨ What changed

- Remove two Code Assist models that return provider 404s.
- Keep five subscription models recognized by the Code Assist API.
- Add catalog and discovery regression coverage.

### 💭 Why

The fixed Code Assist catalog advertised routes unavailable to connected Google accounts.

### 👤 For users

Gemini subscription model pickers no longer offer routes that always fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed two unavailable Google Code Assist models from our catalog to prevent 404 errors and bad routes in model pickers. Kept the five models recognized by the Code Assist API and added regression tests.

- Bug Fixes
  - Removed gemini-3.1-pro-preview and gemini-3-flash-preview from Code Assist known models and discovery.
  - Updated discovery/fallback to only include supported models (e.g., gemini-2.5-* and gemini-3.1-flash-lite*).
  - Added catalog, discovery, and subscription tests to ensure unsupported models stay excluded.

<sup>Written for commit fe8435916cadf8b5a57a075534393dea02a73ee2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

