### PR TITLE
fix: route Bedrock GPT-5 responses correctly

### DIFF
--- a/.changeset/bedrock-openai-responses-path.md
+++ b/.changeset/bedrock-openai-responses-path.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route Bedrock GPT-5.4, GPT-5.5, and GPT-5.6 models through the namespaced OpenAI Responses API path.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -437,19 +437,25 @@ describe('ProviderClient', () => {
       expect(result.isGoogle).toBe(false);
     });
 
-    it('routes Bedrock OpenAI models through the Responses API', async () => {
+    it.each([
+      'openai.gpt-5.4',
+      'openai.gpt-5.5',
+      'openai.gpt-5.6-sol',
+      'openai.gpt-5.6-terra',
+      'openai.gpt-5.6-luna',
+    ])('routes Bedrock %s through the namespaced Responses API', async (model) => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const result = await client.forward({
         provider: 'bedrock',
         apiKey: 'bedrock-api-key-test',
-        model: 'openai.gpt-5.6-luna',
+        model,
         body: { ...body, max_tokens: 1024 },
         stream: false,
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://bedrock-mantle.us-east-1.api.aws/v1/responses',
+        'https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses',
         expect.objectContaining({
           method: 'POST',
           headers: {
@@ -460,7 +466,7 @@ describe('ProviderClient', () => {
       );
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.model).toBe('openai.gpt-5.6-luna');
+      expect(sentBody.model).toBe(model);
       expect(sentBody.input).toEqual([
         { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
       ]);
@@ -481,13 +487,13 @@ describe('ProviderClient', () => {
         body: { ...body, max_tokens: 1024 },
         stream: false,
         customEndpoint: buildEndpointOverride(
-          'https://bedrock-mantle.eu-west-1.api.aws',
+          'https://bedrock-mantle.us-west-2.api.aws',
           'bedrock-responses',
         ),
       });
 
       expect(mockFetch.mock.calls[0][0]).toBe(
-        'https://bedrock-mantle.eu-west-1.api.aws/v1/responses',
+        'https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses',
       );
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.max_output_tokens).toBe(1024);

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -251,22 +251,27 @@ describe('resolveBedrockEndpointKey', () => {
 
 describe('PROVIDER_ENDPOINTS', () => {
   it.each([
+    'openai.gpt-5',
+    'openai.gpt-5.1',
     'openai.gpt-5.4',
     'openai.gpt-5.4-2026-03-05',
     'openai.gpt-5.5',
     'openai.gpt-5.6-sol',
     'openai.gpt-5.6-terra',
     'openai.gpt-5.6-luna',
+    'openai.gpt-5.99-future',
+    'us.openai.gpt-5.6-luna',
     'bedrock/openai.gpt-5.6-luna',
   ])('uses the namespaced Bedrock Responses path for %s', (model) => {
     expect(PROVIDER_ENDPOINTS['bedrock-responses'].buildPath(model)).toBe('/openai/v1/responses');
   });
 
-  it('keeps Bedrock GPT OSS models on the generic Responses path', () => {
-    expect(PROVIDER_ENDPOINTS['bedrock-responses'].buildPath('openai.gpt-oss-120b')).toBe(
-      '/v1/responses',
-    );
-  });
+  it.each(['openai.gpt-oss-120b', 'openai.gpt-50'])(
+    'keeps non-GPT-5 Bedrock model %s on the generic Responses path',
+    (model) => {
+      expect(PROVIDER_ENDPOINTS['bedrock-responses'].buildPath(model)).toBe('/v1/responses');
+    },
+  );
 
   it('routes Gemini Free through the configured LiteLLM gateway', () => {
     process.env['CREDITS_BASE_URL'] = 'https://credits.test/';

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -250,6 +250,24 @@ describe('resolveBedrockEndpointKey', () => {
 });
 
 describe('PROVIDER_ENDPOINTS', () => {
+  it.each([
+    'openai.gpt-5.4',
+    'openai.gpt-5.4-2026-03-05',
+    'openai.gpt-5.5',
+    'openai.gpt-5.6-sol',
+    'openai.gpt-5.6-terra',
+    'openai.gpt-5.6-luna',
+    'bedrock/openai.gpt-5.6-luna',
+  ])('uses the namespaced Bedrock Responses path for %s', (model) => {
+    expect(PROVIDER_ENDPOINTS['bedrock-responses'].buildPath(model)).toBe('/openai/v1/responses');
+  });
+
+  it('keeps Bedrock GPT OSS models on the generic Responses path', () => {
+    expect(PROVIDER_ENDPOINTS['bedrock-responses'].buildPath('openai.gpt-oss-120b')).toBe(
+      '/v1/responses',
+    );
+  });
+
   it('routes Gemini Free through the configured LiteLLM gateway', () => {
     process.env['CREDITS_BASE_URL'] = 'https://credits.test/';
     const endpoint = PROVIDER_ENDPOINTS['gemini-free'];

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -176,12 +176,12 @@ describe('resolveForwardEndpoint', () => {
       provider: 'bedrock',
       authType: 'api_key',
       model: 'openai.gpt-5.6-luna',
-      providerRegion: 'eu-west-1',
+      providerRegion: 'us-west-2',
     });
 
-    expect(out.customEndpoint?.baseUrl).toBe('https://bedrock-mantle.eu-west-1.api.aws');
+    expect(out.customEndpoint?.baseUrl).toBe('https://bedrock-mantle.us-west-2.api.aws');
     expect(out.customEndpoint?.format).toBe('chatgpt');
-    expect(out.customEndpoint?.buildPath(out.forwardModel)).toBe('/v1/responses');
+    expect(out.customEndpoint?.buildPath(out.forwardModel)).toBe('/openai/v1/responses');
   });
 
   it('keeps the selected Bedrock region for Anthropic Messages models', () => {

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -80,7 +80,13 @@ const pioneerHeaders = (apiKey: string) => ({
 
 const openaiPath = () => '/v1/chat/completions';
 const BEDROCK_OPENAI_MODEL_RE = /(?:^|\.)openai\./i;
+const BEDROCK_NAMESPACED_RESPONSES_MODEL_RE = /(?:^|\.)openai\.gpt-5\.(?:4|5|6)(?:[.-]|$)/i;
 const BEDROCK_ANTHROPIC_MODEL_RE = /(?:^|\.)anthropic\./i;
+
+const bedrockResponsesPath = (model: string) =>
+  BEDROCK_NAMESPACED_RESPONSES_MODEL_RE.test(stripVendorPrefix(model))
+    ? '/openai/v1/responses'
+    : '/v1/responses';
 
 export function resolveBedrockEndpointKey(
   model: string,
@@ -201,7 +207,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   'bedrock-responses': {
     baseUrl: getBedrockMantleBaseUrl(),
     buildHeaders: openaiHeaders,
-    buildPath: () => '/v1/responses',
+    buildPath: bedrockResponsesPath,
     format: 'chatgpt',
     forwardResponsesStream: true,
     acceptsMaxOutputTokens: true,

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -80,13 +80,11 @@ const pioneerHeaders = (apiKey: string) => ({
 
 const openaiPath = () => '/v1/chat/completions';
 const BEDROCK_OPENAI_MODEL_RE = /(?:^|\.)openai\./i;
-const BEDROCK_NAMESPACED_RESPONSES_MODEL_RE = /(?:^|\.)openai\.gpt-5\.(?:4|5|6)(?:[.-]|$)/i;
+const BEDROCK_GPT_5_MODEL_RE = /(?:^|\.)openai\.gpt-5(?:[.-]|$)/i;
 const BEDROCK_ANTHROPIC_MODEL_RE = /(?:^|\.)anthropic\./i;
 
 const bedrockResponsesPath = (model: string) =>
-  BEDROCK_NAMESPACED_RESPONSES_MODEL_RE.test(stripVendorPrefix(model))
-    ? '/openai/v1/responses'
-    : '/v1/responses';
+  BEDROCK_GPT_5_MODEL_RE.test(stripVendorPrefix(model)) ? '/openai/v1/responses' : '/v1/responses';
 
 export function resolveBedrockEndpointKey(
   model: string,


### PR DESCRIPTION
### ✨ What changed
- Route the Bedrock GPT-5 model family through namespaced Responses.
- Keep Bedrock GPT OSS models on the generic Responses path.
- Add family-boundary and forwarding regressions.

### 💭 Why
Bedrock GPT-5 models reject `/v1/responses`. They require `/openai/v1/responses`.

### 👤 For users
Bedrock GPT-5 requests through Manifest no longer fail at endpoint routing.
