### PR TITLE
feat(providers): add Meta Model API

### DIFF
--- a/.changeset/add-meta-model-api.md
+++ b/.changeset/add-meta-model-api.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add Meta Model API support for Muse Spark 1.1, Muse Spark 1.2, and the Contributor route.

--- a/packages/backend/src/common/constants/providers.spec.ts
+++ b/packages/backend/src/common/constants/providers.spec.ts
@@ -179,6 +179,17 @@ describe('PROVIDER_REGISTRY', () => {
     expect(pioneer!.keyPrefix).toBe('pio_sk_');
     expect(pioneer!.keyPlaceholder).toBe('pio_sk_...');
   });
+
+  it('meta is registered as an API-key provider with an OpenRouter fallback prefix', () => {
+    const meta = PROVIDER_REGISTRY.find((p) => p.id === 'meta');
+    expect(meta).toBeDefined();
+    expect(meta!.displayName).toBe('Meta');
+    expect(meta!.openRouterPrefixes).toEqual(['meta']);
+    expect(meta!.requiresApiKey).toBe(true);
+    expect(meta!.localOnly).toBe(false);
+    expect(meta!.keyPrefix).toBe('LLM_');
+    expect(meta!.keyPlaceholder).toBe('LLM_...');
+  });
 });
 
 describe('PROVIDER_BY_ID', () => {

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -141,6 +141,31 @@ describe('buildFallbackModels', () => {
 
     expect(result[0].displayName).toBe('gpt-4o');
   });
+
+  it('should limit Meta fallback discovery to the shared Muse Spark catalog', () => {
+    const cache = new Map([
+      ['meta/muse-spark-1.2', { input: 0.0000004, output: 0.0000016 }],
+      ['meta/muse-spark-1.2-contributor', { input: 0.0000002, output: 0.0000008 }],
+      ['meta/muse-spark-1.1', { input: 0.0000004, output: 0.0000016 }],
+      ['meta/unrelated-model', { input: 0.01, output: 0.02 }],
+    ]);
+
+    const result = buildFallbackModels(makePricingSync(cache), 'meta');
+
+    expect(result.map((model) => model.id)).toEqual([
+      'muse-spark-1.2',
+      'muse-spark-1.2-contributor',
+      'muse-spark-1.1',
+    ]);
+    expect(result[1]).toMatchObject({
+      displayName: 'Muse Spark 1.2 Contributor (inputs and outputs may train Meta)',
+      contextWindow: 1_048_576,
+      capabilityReasoning: true,
+      capabilityCode: true,
+      inputModalities: ['text', 'image', 'audio', 'video'],
+      outputModalities: ['text'],
+    });
+  });
 });
 
 describe('findOpenRouterPrefix', () => {
@@ -162,6 +187,10 @@ describe('findOpenRouterPrefix', () => {
 
   it('should resolve via display name', () => {
     expect(findOpenRouterPrefix('Mistral')).toBeTruthy();
+  });
+
+  it('should resolve the Meta OpenRouter prefix', () => {
+    expect(findOpenRouterPrefix('meta')).toBe('meta');
   });
 });
 

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -7,6 +7,8 @@ import {
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
   getSubscriptionCapabilities,
+  META_MODEL_API_CONTEXT_WINDOW,
+  META_MODEL_API_MODEL_BY_ID,
   type SubscriptionCapabilities,
 } from 'manifest-shared';
 import { normalizeAnthropicShortModelId } from '../common/utils/anthropic-model-id';
@@ -61,6 +63,8 @@ const OPENROUTER_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
   ['open-mistral-nemo', 'mistral-nemo'], // Mistral renamed open-mistral-nemo → mistral-nemo
   ['mistral-tiny', 'open-mistral-7b'], // mistral-tiny was internal codename for Mistral 7B
 ]);
+
+const META_FALLBACK_MODEL_IDS = new Set(META_MODEL_API_MODEL_BY_ID.keys());
 
 /**
  * Look up pricing with name normalization variants.
@@ -243,6 +247,7 @@ export function buildFallbackModels(
 
   const orPrefix = findOpenRouterPrefix(providerId);
   if (!orPrefix) return [];
+  const isMeta = providerId.toLowerCase() === 'meta';
 
   for (const [fullId, entry] of pricingSync.getAll()) {
     if (!fullId.startsWith(`${orPrefix}/`)) continue;
@@ -250,17 +255,26 @@ export function buildFallbackModels(
     if (seen.has(modelId)) continue;
 
     if (hasConfirmed && !confirmedModels!.has(modelId.toLowerCase())) continue;
+    if (isMeta && !META_FALLBACK_MODEL_IDS.has(modelId)) continue;
 
     seen.add(modelId);
+    const metaModel = isMeta ? META_MODEL_API_MODEL_BY_ID.get(modelId) : undefined;
     models.push({
       id: modelId,
-      displayName: entry.displayName || modelId,
+      displayName: metaModel?.displayName ?? entry.displayName ?? modelId,
       provider: providerId,
-      contextWindow: entry.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+      contextWindow:
+        entry.contextWindow ?? (metaModel ? META_MODEL_API_CONTEXT_WINDOW : DEFAULT_CONTEXT_WINDOW),
       inputPricePerToken: entry.input,
       outputPricePerToken: entry.output,
-      capabilityReasoning: false,
-      capabilityCode: false,
+      capabilityReasoning: !!metaModel,
+      capabilityCode: !!metaModel,
+      ...(metaModel
+        ? {
+            inputModalities: ['text', 'image', 'audio', 'video'] as const,
+            outputModalities: ['text'] as const,
+          }
+        : {}),
       qualityScore: 3,
     });
   }

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -36,6 +36,7 @@ describe('ProviderModelFetcherService', () => {
       'nvidia',
       'xai',
       'minimax',
+      'meta',
       'minimax-subscription',
       'xiaomi',
       'xiaomi-subscription',
@@ -772,6 +773,45 @@ describe('ProviderModelFetcherService', () => {
       );
       expect(result.map((m) => m.id)).toEqual(['grok-3', 'grok-4']);
       expect(result.every((m) => m.provider === 'xai')).toBe(true);
+    });
+  });
+
+  describe('meta provider', () => {
+    it('discovers only current Muse Spark models with their native capabilities', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'muse-spark-1.2' },
+            { id: 'muse-spark-1.2-contributor' },
+            { id: 'muse-spark-1.1' },
+            { id: 'retired-or-unrelated-model' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('meta', 'LLM_test-meta-key-value');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.meta.ai/v1/models',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer LLM_test-meta-key-value' },
+        }),
+      );
+      expect(result.map((model) => model.id)).toEqual([
+        'muse-spark-1.2',
+        'muse-spark-1.2-contributor',
+        'muse-spark-1.1',
+      ]);
+      expect(result[1]).toMatchObject({
+        displayName: 'Muse Spark 1.2 Contributor (inputs and outputs may train Meta)',
+        provider: 'meta',
+        contextWindow: 1_048_576,
+        capabilityReasoning: true,
+        capabilityCode: true,
+        inputModalities: ['text', 'image', 'audio', 'video'],
+        outputModalities: ['text'],
+      });
     });
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -32,6 +32,8 @@ import {
 import {
   getSubscriptionCapabilities,
   getSubscriptionKnownModels,
+  META_MODEL_API_CONTEXT_WINDOW,
+  META_MODEL_API_MODEL_BY_ID,
   MODEL_MODALITIES,
   type ModelCapability,
   type ModelModality,
@@ -57,6 +59,7 @@ const NOUS_PORTAL_MODELS_URL = 'https://inference-api.nousresearch.com/v1/models
 const OPENCODE_GO_MODELS_URL = 'https://opencode.ai/zen/go/v1/models';
 const PIONEER_MODELS_URL = 'https://api.pioneer.ai/v1/models';
 const PIONEER_BASE_MODELS_URL = 'https://api.pioneer.ai/base-models';
+const META_MODELS_URL = 'https://api.meta.ai/v1/models';
 
 /* ── Generic parser factory ── */
 
@@ -68,7 +71,10 @@ interface ModelParserConfig<T> {
   contextWindow?: number | ((entry: T) => number);
   inputPricePerToken?: number | null;
   outputPricePerToken?: number | null;
+  capabilityReasoning?: boolean;
   capabilityCode?: boolean | ((entry: T) => boolean);
+  inputModalities?: readonly ModelModality[];
+  outputModalities?: readonly ModelModality[];
   supportedEndpoints?: (entry: T) => readonly string[] | undefined;
   qualityScore?: number;
 }
@@ -93,11 +99,13 @@ function createModelParser<T>(
           contextWindow: typeof ctxVal === 'function' ? ctxVal(entry) : ctxVal,
           inputPricePerToken: config.inputPricePerToken ?? null,
           outputPricePerToken: config.outputPricePerToken ?? null,
-          capabilityReasoning: false,
+          capabilityReasoning: config.capabilityReasoning ?? false,
           capabilityCode:
             typeof config.capabilityCode === 'function'
               ? config.capabilityCode(entry)
               : (config.capabilityCode ?? false),
+          ...(config.inputModalities ? { inputModalities: config.inputModalities } : {}),
+          ...(config.outputModalities ? { outputModalities: config.outputModalities } : {}),
           ...(supportedEndpoints && supportedEndpoints.length > 0 ? { supportedEndpoints } : {}),
           qualityScore: config.qualityScore ?? 3,
         };
@@ -346,6 +354,18 @@ const parseXiaomiMimo = createModelParser<OpenAIModelEntry>({
   getDisplayName: (_entry, id) => id,
   contextWindow: (entry) => XIAOMI_MIMO_CONTEXT_WINDOWS.get(entry.id) ?? DEFAULT_CONTEXT_WINDOW,
   capabilityCode: true,
+});
+
+const parseMeta = createModelParser<OpenAIModelEntry>({
+  arrayKey: 'data',
+  filter: (entry) => typeof entry.id === 'string' && META_MODEL_API_MODEL_BY_ID.has(entry.id),
+  getId: (entry) => entry.id,
+  getDisplayName: (_entry, id) => META_MODEL_API_MODEL_BY_ID.get(id)?.displayName ?? id,
+  contextWindow: META_MODEL_API_CONTEXT_WINDOW,
+  capabilityReasoning: true,
+  capabilityCode: true,
+  inputModalities: ['text', 'image', 'audio', 'video'],
+  outputModalities: ['text'],
 });
 
 /* ── OpenAI-specific structural filters (not non-chat) ── */
@@ -850,6 +870,11 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     endpoint: 'https://api.minimaxi.chat/v1/models',
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
+  },
+  meta: {
+    endpoint: META_MODELS_URL,
+    buildHeaders: bearerHeaders,
+    parse: parseMeta,
   },
   'minimax-subscription': {
     endpoint: MINIMAX_SUBSCRIPTION_MODELS_URL,

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -160,6 +160,7 @@ describe('resolveEndpointKey', () => {
     expect(known).toContain('cerebras');
     expect(known).toContain('cline-pass');
     expect(known).toContain('pioneer');
+    expect(known).toContain('meta');
     expect(known).toContain('google');
     expect(known).toContain('qwen');
     expect(known).toContain('copilot');
@@ -293,6 +294,18 @@ describe('PROVIDER_ENDPOINTS', () => {
       Authorization: 'Bearer hf_test_token',
       'Content-Type': 'application/json',
     });
+    expect(endpoint.streamUsageReporting).toBe('openai_stream_options');
+  });
+
+  it('meta uses the Model API OpenAI-compatible chat endpoint', () => {
+    const endpoint = PROVIDER_ENDPOINTS['meta'];
+    expect(endpoint.baseUrl).toBe('https://api.meta.ai');
+    expect(endpoint.buildPath('muse-spark-1.2')).toBe('/v1/chat/completions');
+    expect(endpoint.buildHeaders('LLM_test-meta-key-value')).toEqual({
+      Authorization: 'Bearer LLM_test-meta-key-value',
+      'Content-Type': 'application/json',
+    });
+    expect(endpoint.format).toBe('openai');
     expect(endpoint.streamUsageReporting).toBe('openai_stream_options');
   });
 
@@ -768,6 +781,7 @@ describe('PROVIDER_ENDPOINTS', () => {
       'mistral',
       'xai',
       'minimax',
+      'meta',
       'xiaomi',
       'moonshot',
       'nous',

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -145,6 +145,7 @@ const NVIDIA_NIM_BASE = 'https://integrate.api.nvidia.com';
 const FIREWORKS_INFERENCE_BASE = 'https://api.fireworks.ai/inference';
 const HUGGING_FACE_INFERENCE_BASE = 'https://router.huggingface.co';
 const PIONEER_BASE = 'https://api.pioneer.ai';
+const META_BASE = 'https://api.meta.ai';
 const chatgptSubscriptionHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -329,6 +330,13 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   },
   minimax: {
     baseUrl: 'https://api.minimax.io',
+    buildHeaders: openaiHeaders,
+    buildPath: openaiPath,
+    format: 'openai',
+    ...openaiStreamUsage,
+  },
+  meta: {
+    baseUrl: META_BASE,
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -14,6 +14,7 @@ export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   groq: 'https://console.groq.com/keys',
   huggingface: 'https://huggingface.co/settings/tokens',
   kilo: 'https://app.kilo.ai',
+  meta: 'https://dev.meta.ai/',
   minimax: 'https://platform.minimax.io/user-center/basic-information/interface-key',
   mistral: 'https://console.mistral.ai/api-keys/',
   moonshot: 'https://platform.moonshot.ai/',

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -1,6 +1,10 @@
 /* ── LLM Provider definitions (shared by Routing page) ── */
 
-import { SHARED_PROVIDER_BY_ID, type SharedProviderEntry } from 'manifest-shared';
+import {
+  META_MODEL_API_MODELS,
+  SHARED_PROVIDER_BY_ID,
+  type SharedProviderEntry,
+} from 'manifest-shared';
 
 export interface SubscriptionEndpointRegion {
   value: string;
@@ -322,6 +326,14 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     },
     models: [],
   },
+  meta: {
+    initial: 'Me',
+    subtitle: 'Muse Spark 1.2, Contributor, and 1.1',
+    models: META_MODEL_API_MODELS.map((model) => ({
+      label: model.displayName,
+      value: model.id,
+    })),
+  },
   xiaomi: {
     initial: 'Mi',
     subtitle: 'MiMo V2.5 Pro, V2.5, Flash',
@@ -504,6 +516,7 @@ const PROVIDER_ORDER = [
   'kiro',
   'llamacpp',
   'lmstudio',
+  'meta',
   'minimax',
   'mistral',
   'moonshot',

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -192,6 +192,24 @@ describe('validateApiKey', () => {
     expect(validateApiKey(xiaomi, `sk-${'a'.repeat(47)}`)).toEqual({ valid: true });
   });
 
+  it('validates Meta Model API key prefix and length', () => {
+    const meta = getProvider('meta')!;
+    expect(meta.keyPlaceholder).toBe('LLM_...');
+    expect(validateApiKey(meta, '')).toEqual({
+      valid: false,
+      error: 'API key is required',
+    });
+    expect(validateApiKey(meta, 'wrong-prefix-key-that-is-long-enough')).toEqual({
+      valid: false,
+      error: 'Meta keys start with "LLM_"',
+    });
+    expect(validateApiKey(meta, 'LLM_short')).toEqual({
+      valid: false,
+      error: 'Key is too short (minimum 20 characters)',
+    });
+    expect(validateApiKey(meta, `LLM_${'a'.repeat(20)}`)).toEqual({ valid: true });
+  });
+
   it('validates NVIDIA NIM key length without enforcing an undocumented prefix', () => {
     const nvidia = getProvider('nvidia')!;
     expect(nvidia.keyPlaceholder).toBe('nvapi-...');
@@ -476,6 +494,18 @@ describe('PROVIDERS', () => {
     expect(getRoutingProviderApiKeyUrl('gemini-free')).toBe(
       'https://calendly.com/sebastien-manifest/30min',
     );
+  });
+
+  it('exposes the current Meta Muse Spark catalog and Contributor warning', () => {
+    const meta = PROVIDERS.find((provider) => provider.id === 'meta')!;
+    expect(meta.name).toBe('Meta');
+    expect(meta.models.map((model) => model.value)).toEqual([
+      'muse-spark-1.2',
+      'muse-spark-1.2-contributor',
+      'muse-spark-1.1',
+    ]);
+    expect(meta.models[1].label).toMatch(/may train Meta/);
+    expect(getRoutingProviderApiKeyUrl('meta')).toBe('https://dev.meta.ai/');
   });
 
   it('each provider has required fields', () => {

--- a/packages/shared/__tests__/providers.spec.ts
+++ b/packages/shared/__tests__/providers.spec.ts
@@ -3,6 +3,9 @@ import {
   SHARED_PROVIDER_BY_ID,
   SHARED_PROVIDER_BY_ID_OR_ALIAS,
   LOCAL_SERVER_HINTS,
+  META_MODEL_API_CONTEXT_WINDOW,
+  META_MODEL_API_MODELS,
+  META_MODEL_API_MODEL_BY_ID,
   normalizeProviderName,
 } from '../src/providers';
 
@@ -250,6 +253,25 @@ describe('SHARED_PROVIDER_BY_ID', () => {
     expect(xiaomi!.keyPrefix).toBe('sk-');
     expect(xiaomi!.minKeyLength).toBe(50);
     expect(xiaomi!.keyPlaceholder).toBe('sk-xxxxx');
+  });
+
+  it('meta exposes Model API credentials and the current Muse Spark catalog', () => {
+    const meta = SHARED_PROVIDER_BY_ID.get('meta');
+    expect(meta).toBeDefined();
+    expect(meta!.displayName).toBe('Meta');
+    expect(meta!.openRouterPrefixes).toEqual(['meta']);
+    expect(meta!.keyPrefix).toBe('LLM_');
+    expect(meta!.minKeyLength).toBe(20);
+    expect(meta!.keyPlaceholder).toBe('LLM_...');
+    expect(META_MODEL_API_CONTEXT_WINDOW).toBe(1_048_576);
+    expect(META_MODEL_API_MODELS.map((model) => model.id)).toEqual([
+      'muse-spark-1.2',
+      'muse-spark-1.2-contributor',
+      'muse-spark-1.1',
+    ]);
+    expect(META_MODEL_API_MODEL_BY_ID.get('muse-spark-1.2-contributor')?.displayName).toMatch(
+      /may train Meta/,
+    );
   });
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -137,9 +137,12 @@ export {
   SHARED_PROVIDER_BY_ID_OR_ALIAS,
   CANONICAL_LOCAL_IDS,
   LOCAL_SERVER_HINTS,
+  META_MODEL_API_CONTEXT_WINDOW,
+  META_MODEL_API_MODELS,
+  META_MODEL_API_MODEL_BY_ID,
   normalizeProviderName,
 } from './providers';
-export type { SharedProviderEntry, LocalServerHint } from './providers';
+export type { SharedProviderEntry, LocalServerHint, MetaModelApiModel } from './providers';
 export type { ResolveResponse } from './resolve-response';
 export {
   SUBSCRIPTION_PROVIDER_CONFIGS,

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -45,6 +45,26 @@ export interface SharedProviderEntry {
   tileOnly?: boolean;
 }
 
+export interface MetaModelApiModel {
+  id: string;
+  displayName: string;
+}
+
+export const META_MODEL_API_CONTEXT_WINDOW = 1_048_576;
+
+export const META_MODEL_API_MODELS: readonly MetaModelApiModel[] = [
+  { id: 'muse-spark-1.2', displayName: 'Muse Spark 1.2' },
+  {
+    id: 'muse-spark-1.2-contributor',
+    displayName: 'Muse Spark 1.2 Contributor (inputs and outputs may train Meta)',
+  },
+  { id: 'muse-spark-1.1', displayName: 'Muse Spark 1.1' },
+];
+
+export const META_MODEL_API_MODEL_BY_ID: ReadonlyMap<string, MetaModelApiModel> = new Map(
+  META_MODEL_API_MODELS.map((model) => [model.id, model]),
+);
+
 export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
   {
     id: 'qwen',
@@ -257,6 +277,18 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     keyPrefix: 'sk-',
     minKeyLength: 30,
     keyPlaceholder: 'sk-...',
+  },
+  {
+    id: 'meta',
+    displayName: 'Meta',
+    aliases: [],
+    openRouterPrefixes: ['meta'],
+    requiresApiKey: true,
+    localOnly: false,
+    color: '#0668E1',
+    keyPrefix: 'LLM_',
+    minKeyLength: 20,
+    keyPlaceholder: 'LLM_...',
   },
   {
     id: 'xiaomi',


### PR DESCRIPTION
### ✨ What changed
- Add Meta Model API discovery and proxy routing.
- Support Muse Spark 1.1, 1.2, and Contributor from one catalog.
- Validate `LLM_` keys and show the Contributor data-use warning.

### 💭 Why
Manifest did not expose the current Meta Model API models.

### 👤 For users
All three Muse Spark routes work with a direct Meta API key.

### 📝 Notes
Native catalog and completion smokes passed on 2026-08-13.
Local validation and GitHub checks pass.
https://dev.meta.ai/docs/protocols/chat-completions