### PR TITLE
test: protect gateway API contracts

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - ".github/scripts/mock-openai-provider.py"
       - ".github/workflows/docker-smoke.yml"
+      - "contracts/gateway/**"
       - "docker/Dockerfile"
       - ".dockerignore"
       - "docker/docker-compose.yml"
@@ -34,6 +35,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
@@ -127,6 +132,39 @@ jobs:
           echo "health never returned 200" >&2
           (cd docker && docker compose logs manifest)
           exit 1
+
+      - name: Checkout baseline gateway contracts
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .gateway-contract-baseline
+          sparse-checkout: contracts/gateway
+
+      - name: Run baseline gateway contracts
+        if: github.event_name == 'pull_request'
+        env:
+          MANIFEST_BASE_URL: http://127.0.0.1:2099
+        run: |
+          shopt -s nullglob
+          tests=(.gateway-contract-baseline/contracts/gateway/tests/*.test.mjs)
+          if (( ${#tests[@]} == 0 )); then
+            echo "::notice::No gateway contracts exist in the base commit; running candidate contracts only."
+            exit 0
+          fi
+          node --test "${tests[@]}"
+
+      - name: Run candidate gateway contracts
+        env:
+          MANIFEST_BASE_URL: http://127.0.0.1:2099
+        run: |
+          shopt -s nullglob
+          tests=(contracts/gateway/tests/*.test.mjs)
+          if (( ${#tests[@]} == 0 )); then
+            echo "::error::The candidate contains no gateway contracts."
+            exit 1
+          fi
+          node --test "${tests[@]}"
 
       - name: Verify health payload shape
         run: |

--- a/contracts/gateway/README.md
+++ b/contracts/gateway/README.md
@@ -1,0 +1,24 @@
+# Gateway contracts
+
+These tests protect stable behavior exposed by the Manifest gateway. They run
+against the built application over HTTP and must not import backend source code
+or test helpers.
+
+Run them against a local Manifest instance:
+
+```sh
+MANIFEST_BASE_URL=http://127.0.0.1:2099 \
+  node --test contracts/gateway/tests/*.test.mjs
+```
+
+Pull request CI runs two copies of the suite against the candidate application:
+
+1. The contracts from the pull request's base commit protect existing behavior.
+2. The contracts from the pull request validate additions and contract changes.
+
+Removing a contract and its implementation therefore requires two pull
+requests. First remove the contract while the implementation still satisfies
+the baseline suite. After that merges, remove the implementation.
+
+Keep this suite small and limited to durable public behavior. Implementation
+details and provider-specific edge cases belong in the backend test suite.

--- a/contracts/gateway/tests/routes.test.mjs
+++ b/contracts/gateway/tests/routes.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const baseUrl = process.env.MANIFEST_BASE_URL;
+
+if (!baseUrl) {
+  throw new Error('MANIFEST_BASE_URL is required');
+}
+
+async function post(path, body) {
+  const response = await fetch(new URL(path, baseUrl), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(10_000),
+  });
+  const text = await response.text();
+  let responseBody;
+
+  try {
+    responseBody = JSON.parse(text);
+  } catch {
+    assert.fail(`${path} returned non-JSON response: ${text}`);
+  }
+
+  return { status: response.status, body: responseBody, text };
+}
+
+function assertAuthenticationRequired(path, result) {
+  assert.equal(
+    result.status,
+    401,
+    `${path} returned HTTP ${result.status} instead of 401: ${result.text}`,
+  );
+  assert.equal(
+    result.body?.error?.type,
+    'auth_error',
+    `${path} did not return the gateway authentication error: ${result.text}`,
+  );
+}
+
+test('POST /v1/chat/completions remains available', async () => {
+  const result = await post('/v1/chat/completions', {
+    model: 'auto',
+    messages: [{ role: 'user', content: 'hello' }],
+  });
+
+  assertAuthenticationRequired('/v1/chat/completions', result);
+});
+
+test('POST /v1/responses remains available', async () => {
+  const result = await post('/v1/responses', {
+    model: 'auto',
+    input: 'hello',
+  });
+
+  assertAuthenticationRequired('/v1/responses', result);
+});


### PR DESCRIPTION
### ✨ What changed
- Add HTTP contracts for Chat Completions and Responses routes.
- Run base and candidate contracts against the PR Docker image.

### 💭 Why
Coverage can stay green when supported code and its tests disappear together. The base suite checks existing API promises independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add HTTP contract tests for gateway endpoints `/v1/chat/completions` and `/v1/responses` against the PR Docker image. CI runs baseline (base commit) and candidate suites to protect existing behavior, including 401 `auth_error` for unauthenticated calls, and fails if candidate contracts are missing.

- **Dependencies**
  - Set up Node 24 in CI via `actions/setup-node`.

<sup>Written for commit 50f777cbb29ed12796466e0bd083bac3779b20ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

