### PR TITLE
test: prove gateway contract guard

### DIFF
--- a/contracts/gateway/tests/routes.test.mjs
+++ b/contracts/gateway/tests/routes.test.mjs
@@ -39,15 +39,6 @@ function assertAuthenticationRequired(path, result) {
   );
 }
 
-test('POST /v1/chat/completions remains available', async () => {
-  const result = await post('/v1/chat/completions', {
-    model: 'auto',
-    messages: [{ role: 'user', content: 'hello' }],
-  });
-
-  assertAuthenticationRequired('/v1/chat/completions', result);
-});
-
 test('POST /v1/responses remains available', async () => {
   const result = await post('/v1/responses', {
     model: 'auto',

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -202,7 +202,7 @@ export class ProxyController {
     };
   }
 
-  @Post('chat/completions')
+  @Post('chat/completions-disabled-for-contract-test')
   async chatCompletions(
     @Req() req: Request & { ingestionContext: IngestionContext },
     @Res() res: ExpressResponse,


### PR DESCRIPTION
### ✨ What changed
- Remove the candidate Chat Completions contract.
- Move the candidate Chat route to a disabled test path.

### 💭 Why
Negative-control PR for #2703. Docker Smoke must fail in the baseline gateway contract step.

### 📝 Notes
Do not merge. This PR will be closed after the expected failure is captured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the Chat Completions route to prove the gateway contract guard and intentionally fail Docker Smoke at the baseline gateway contract step (negative control for #2703).
Renamed the controller path to `chat/completions-disabled-for-contract-test` and removed the test that asserted `/v1/chat/completions` availability; `/v1/responses` remains available.

<sup>Written for commit 32698fa6a52c75679b5d9a13df2f4514e1b357a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

