### PR TITLE
test: extend gateway API contracts

### DIFF
--- a/contracts/gateway/tests/routes.test.mjs
+++ b/contracts/gateway/tests/routes.test.mjs
@@ -7,11 +7,15 @@ if (!baseUrl) {
   throw new Error('MANIFEST_BASE_URL is required');
 }
 
-async function post(path, body) {
+async function request(path, { method = 'GET', body } = {}) {
   const response = await fetch(new URL(path, baseUrl), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    method,
+    ...(body === undefined
+      ? {}
+      : {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
     signal: AbortSignal.timeout(10_000),
   });
   const text = await response.text();
@@ -37,22 +41,56 @@ function assertAuthenticationRequired(path, result) {
     'auth_error',
     `${path} did not return the gateway authentication error: ${result.text}`,
   );
+  assert.equal(
+    typeof result.body?.error?.message,
+    'string',
+    `${path} did not return an authentication error message: ${result.text}`,
+  );
+  assert.ok(
+    result.body.error.message.trim().length > 0,
+    `${path} returned an empty authentication error message: ${result.text}`,
+  );
 }
 
+test('GET /v1/models remains available', async () => {
+  const result = await request('/v1/models');
+
+  assertAuthenticationRequired('/v1/models', result);
+});
+
 test('POST /v1/chat/completions remains available', async () => {
-  const result = await post('/v1/chat/completions', {
-    model: 'auto',
-    messages: [{ role: 'user', content: 'hello' }],
+  const result = await request('/v1/chat/completions', {
+    method: 'POST',
+    body: {
+      model: 'auto',
+      messages: [{ role: 'user', content: 'hello' }],
+    },
   });
 
   assertAuthenticationRequired('/v1/chat/completions', result);
 });
 
 test('POST /v1/responses remains available', async () => {
-  const result = await post('/v1/responses', {
-    model: 'auto',
-    input: 'hello',
+  const result = await request('/v1/responses', {
+    method: 'POST',
+    body: {
+      model: 'auto',
+      input: 'hello',
+    },
   });
 
   assertAuthenticationRequired('/v1/responses', result);
+});
+
+test('POST /v1/messages remains available', async () => {
+  const result = await request('/v1/messages', {
+    method: 'POST',
+    body: {
+      model: 'auto',
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'hello' }],
+    },
+  });
+
+  assertAuthenticationRequired('/v1/messages', result);
 });


### PR DESCRIPTION
### ✨ What changed
- Protect Models and Anthropic Messages gateway routes.
- Require a non-empty authentication message on all four route contracts.

### 💭 Why
Stable public gateway routes should not disappear or lose their authentication envelope without an explicit contract change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend gateway API contract tests to ensure authentication is required and includes a non-empty error message. Adds coverage for GET /v1/models and POST /v1/messages (Anthropic), and refactors the test helper to a generic request() supporting both GET and POST.

<sup>Written for commit 3113d242822d29aac72157a34ba609c8d9b46af3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

