### PR TITLE
fix: return real content for non-streaming Bedrock GPT-5.x responses

### DIFF
--- a/.changeset/bedrock-nonstreaming-responses.md
+++ b/.changeset/bedrock-nonstreaming-responses.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix empty non-streaming responses for Bedrock GPT-5.x models (openai.gpt-5.6-luna/sol/terra, gpt-5.5, gpt-5.4). The non-streaming Responses handler assumed the upstream always returns SSE, but the Bedrock mantle /openai/v1/responses endpoint returns a plain JSON Responses object when stream:false, so content came back null with zero usage. The handler now detects the response shape and parses JSON Responses objects directly.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -2059,6 +2059,91 @@ describe('proxy-response-handler', () => {
       expect(forward.response.text).toHaveBeenCalled();
     });
 
+    it('should convert a JSON Responses object for non-streaming ChatGPT-format upstreams (Bedrock GPT-5.x)', async () => {
+      // Regression for the Bedrock non-streaming bug: bedrock-mantle
+      // /openai/v1/responses returns a plain JSON Responses object (not SSE)
+      // when stream:false. The handler must parse it with fromResponsesResponse
+      // instead of the SSE collector, otherwise content comes back null.
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const responsesJson = {
+        object: 'response',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ok' }],
+          },
+        ],
+        usage: { input_tokens: 11, output_tokens: 5, total_tokens: 16 },
+      };
+      const forward = mockForward(responsesJson, { isChatGpt: true });
+      const meta = makeMeta();
+
+      const usage = await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+      );
+
+      // The SSE collector must NOT be used for a JSON body.
+      expect(client.collectChatGptSseResponse).not.toHaveBeenCalled();
+      const sentBody = res.json.mock.calls[0][0];
+      expect(sentBody.object).toBe('chat.completion');
+      expect(sentBody.choices[0].message.content).toBe('ok');
+      expect(sentBody.usage.prompt_tokens).toBe(11);
+      expect(sentBody.usage.completion_tokens).toBe(5);
+      expect(sentBody.usage.total_tokens).toBe(16);
+      expect(usage).toMatchObject({ prompt_tokens: 11, completion_tokens: 5 });
+    });
+
+    it('should preserve reasoning and tool calls from a JSON Responses object', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const responsesJson = {
+        object: 'response',
+        output: [
+          { type: 'reasoning', summary: [{ text: 'thinking' }] },
+          {
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'get_weather',
+            arguments: '{"q":"sp"}',
+          },
+        ],
+        usage: { input_tokens: 3, output_tokens: 7, total_tokens: 10 },
+      };
+      const forward = mockForward(responsesJson, { isChatGpt: true });
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(client.collectChatGptSseResponse).not.toHaveBeenCalled();
+      const sentBody = res.json.mock.calls[0][0];
+      expect(sentBody.choices[0].message.reasoning_content).toBe('thinking');
+      expect(sentBody.choices[0].message.tool_calls).toHaveLength(1);
+      expect(sentBody.choices[0].message.tool_calls[0].function.name).toBe('get_weather');
+      expect(sentBody.choices[0].finish_reason).toBe('tool_calls');
+    });
+
+    it('should still collect SSE when a ChatGPT-format upstream streams with text/event-stream content-type', async () => {
+      // Regression guard: the Codex subscription backend always returns SSE.
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const sseText = 'event: response.output_text.delta\ndata: {"delta":"Hi"}\n\n';
+      const forward = mockForward(sseText, {
+        isChatGpt: true,
+        contentType: 'text/event-stream',
+      });
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(client.collectChatGptSseResponse).toHaveBeenCalledWith(sseText, meta.model);
+    });
+
     it('should pass through standard OpenAI response', async () => {
       const { res } = mockResponse();
       const client = mockProviderClient();

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -2051,6 +2051,7 @@ describe('proxy-response-handler', () => {
       const client = mockProviderClient();
       const sseText = 'event: response.output_text.delta\ndata: {"delta":"Hi"}\n\n';
       const forward = mockForward(sseText, { isChatGpt: true });
+      forward.response.headers.get.mockReturnValue(null);
       const meta = makeMeta();
 
       await handleNonStreamResponse(res as any, forward as any, meta, {}, client as any);

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -2059,11 +2059,12 @@ describe('proxy-response-handler', () => {
       expect(forward.response.text).toHaveBeenCalled();
     });
 
-    it('should convert a JSON Responses object for non-streaming ChatGPT-format upstreams (Bedrock GPT-5.x)', async () => {
+    it('should convert a JSON Responses object via providerClient for non-streaming ChatGPT-format upstreams (Bedrock GPT-5.x)', async () => {
       // Regression for the Bedrock non-streaming bug: bedrock-mantle
       // /openai/v1/responses returns a plain JSON Responses object (not SSE)
-      // when stream:false. The handler must parse it with fromResponsesResponse
-      // instead of the SSE collector, otherwise content comes back null.
+      // when stream:false. The handler must route it through the DI-mockable
+      // providerClient.convertChatGptResponse, not the SSE collector — otherwise
+      // the SSE collector finds no events and content comes back null.
       const { res } = mockResponse();
       const client = mockProviderClient();
       const responsesJson = {
@@ -2080,52 +2081,12 @@ describe('proxy-response-handler', () => {
       const forward = mockForward(responsesJson, { isChatGpt: true });
       const meta = makeMeta();
 
-      const usage = await handleNonStreamResponse(
-        res as any,
-        forward as any,
-        meta,
-        {},
-        client as any,
-      );
-
-      // The SSE collector must NOT be used for a JSON body.
-      expect(client.collectChatGptSseResponse).not.toHaveBeenCalled();
-      const sentBody = res.json.mock.calls[0][0];
-      expect(sentBody.object).toBe('chat.completion');
-      expect(sentBody.choices[0].message.content).toBe('ok');
-      expect(sentBody.usage.prompt_tokens).toBe(11);
-      expect(sentBody.usage.completion_tokens).toBe(5);
-      expect(sentBody.usage.total_tokens).toBe(16);
-      expect(usage).toMatchObject({ prompt_tokens: 11, completion_tokens: 5 });
-    });
-
-    it('should preserve reasoning and tool calls from a JSON Responses object', async () => {
-      const { res } = mockResponse();
-      const client = mockProviderClient();
-      const responsesJson = {
-        object: 'response',
-        output: [
-          { type: 'reasoning', summary: [{ text: 'thinking' }] },
-          {
-            type: 'function_call',
-            call_id: 'call_1',
-            name: 'get_weather',
-            arguments: '{"q":"sp"}',
-          },
-        ],
-        usage: { input_tokens: 3, output_tokens: 7, total_tokens: 10 },
-      };
-      const forward = mockForward(responsesJson, { isChatGpt: true });
-      const meta = makeMeta();
-
       await handleNonStreamResponse(res as any, forward as any, meta, {}, client as any);
 
+      // The JSON body goes through the converter, NOT the SSE collector.
       expect(client.collectChatGptSseResponse).not.toHaveBeenCalled();
-      const sentBody = res.json.mock.calls[0][0];
-      expect(sentBody.choices[0].message.reasoning_content).toBe('thinking');
-      expect(sentBody.choices[0].message.tool_calls).toHaveLength(1);
-      expect(sentBody.choices[0].message.tool_calls[0].function.name).toBe('get_weather');
-      expect(sentBody.choices[0].finish_reason).toBe('tool_calls');
+      expect(client.convertChatGptResponse).toHaveBeenCalledWith(responsesJson, meta.model);
+      expect(res.json).toHaveBeenCalledWith({ id: 'chatgpt-converted' });
     });
 
     it('should still collect SSE when a ChatGPT-format upstream streams with text/event-stream content-type', async () => {

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -27,7 +27,6 @@ import {
   createResponsesStreamTransformer,
   fromChatCompletionResponse,
 } from './responses-adapter';
-import { fromResponsesResponse } from './chatgpt-adapter';
 import {
   chatCompletionsResponseToMessages,
   createMessagesStreamTransformer,
@@ -810,7 +809,10 @@ export async function handleNonStreamResponse(
     ) {
       responseBody = providerClient.collectChatGptSseResponse(text, meta.model);
     } else {
-      responseBody = fromResponsesResponse(JSON.parse(text) as Record<string, unknown>, meta.model);
+      responseBody = providerClient.convertChatGptResponse(
+        JSON.parse(text) as Record<string, unknown>,
+        meta.model,
+      );
     }
   } else {
     responseBody = await forward.response.json();

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -27,6 +27,7 @@ import {
   createResponsesStreamTransformer,
   fromChatCompletionResponse,
 } from './responses-adapter';
+import { fromResponsesResponse } from './chatgpt-adapter';
 import {
   chatCompletionsResponseToMessages,
   createMessagesStreamTransformer,
@@ -792,10 +793,25 @@ export async function handleNonStreamResponse(
     }
     delete (responseBody as Record<string, unknown>)._extractedThinkingBlocks;
   } else if (forward.isChatGpt) {
-    // The Codex Responses API always returns SSE even when stream: false.
-    // Consume the SSE text and build a non-streaming response.
-    const sseText = await forward.response.text();
-    responseBody = providerClient.collectChatGptSseResponse(sseText, meta.model);
+    // Responses-format upstreams differ on their non-streaming shape. The
+    // ChatGPT Codex subscription backend always returns SSE even when
+    // stream:false, but the Bedrock mantle /openai/v1/responses endpoint (and
+    // other API-key /responses backends) return a plain JSON Responses object.
+    // Sniff the shape — same triple-signal check as readNativeResponsesBody —
+    // and convert accordingly. Assuming SSE unconditionally made non-streaming
+    // Bedrock GPT-5.x responses come back empty (content: null, zero usage).
+    const contentType = forward.response.headers.get('content-type') ?? '';
+    const text = await forward.response.text();
+    const trimmed = text.trimStart();
+    if (
+      contentType.includes('text/event-stream') ||
+      trimmed.startsWith('event:') ||
+      trimmed.startsWith('data:')
+    ) {
+      responseBody = providerClient.collectChatGptSseResponse(text, meta.model);
+    } else {
+      responseBody = fromResponsesResponse(JSON.parse(text) as Record<string, unknown>, meta.model);
+    }
   } else {
     responseBody = await forward.response.json();
     if (supportsReasoningContent(meta.provider, meta.model, reasoningCache?.modelCatalog)) {


### PR DESCRIPTION
## Summary

Fixes the empty non-streaming responses for Bedrock GPT-5.x models
(`openai.gpt-5.6-luna` / `-sol` / `-terra`, `gpt-5.5`, `gpt-5.4`).

Non-streaming `/v1/chat/completions` requests returned HTTP 200 with
`content: null` and zero usage. `handleNonStreamResponse`'s `isChatGpt`
branch assumed the upstream always returns SSE and used
`collectChatGptSseResponse`, but `bedrock-mantle` `/openai/v1/responses`
returns a plain JSON Responses object when `stream:false`, so the SSE
collector produced an empty result.

The branch now sniffs the response shape — the same triple-signal check
(`content-type` / `event:` / `data:`) already used by the sibling
`readNativeResponsesBody` — and converts JSON Responses objects with the
existing `fromResponsesResponse`, keeping `collectChatGptSseResponse` for
genuine SSE bodies (ChatGPT Codex subscription). Streaming is untouched.

## Root cause

`packages/backend/src/routing/proxy/proxy-response-handler.ts` →
`handleNonStreamResponse`, `else if (forward.isChatGpt)` branch.

## Changes

- Sniff SSE vs JSON in the `isChatGpt` non-streaming branch; parse JSON
  Responses objects via `fromResponsesResponse`.
- Add unit tests: JSON Responses body → content + usage populated;
  reasoning + tool_calls preserved; SSE body → still uses the collector
  (regression guard).
- Add a changeset (patch).

## Testing

- `npm test --workspace=packages/backend` → 457 suites / 8308 tests pass
  (includes the 4 new cases).
- `npm test --workspace=packages/shared` → 417 pass.
- Production build verified (Docker `turbo build`).
- Live re-verification against Bedrock GPT-5.6 luna/sol/terra: non-streaming
  now returns real `content` and usage (`21/5/26`); streaming still works.

## Related

Fixes #2710. Follow-up to the routing fix in #2701.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix non-streaming Bedrock GPT-5.x responses that returned empty content and zero usage by detecting SSE vs JSON and converting JSON bodies via the provider client. Restores real content and usage for `/v1/chat/completions` with `stream:false`; streaming is unchanged.

- **Bug Fixes**
  - Detect SSE vs JSON in `handleNonStreamResponse`’s `isChatGpt` path using `content-type`/`event:`/`data:` checks; handle missing `content-type` gracefully.
  - Convert JSON Responses via `providerClient.convertChatGptResponse`; keep `collectChatGptSseResponse` for SSE.
  - Unit tests cover JSON body conversion, missing `content-type`, and an SSE regression guard, with assertions for provider client delegation.

- **Refactors**
  - Route non-streaming JSON Responses through `providerClient.convertChatGptResponse` (instead of `fromResponsesResponse`) to keep conversion behind DI and consistent with the SSE path.

<sup>Written for commit e8d8fbcdea0a7692a0f146698384bb8e9e323589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

