### PR TITLE
fix: keep subscription requests streaming upstream

### DIFF
--- a/.changeset/bright-bats-stream.md
+++ b/.changeset/bright-bats-stream.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep OpenAI subscription requests streaming upstream when clients request buffered responses.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1605,6 +1605,22 @@ describe('ProviderClient', () => {
       expect(sentBody.store).toBe(false);
     });
 
+    it('forces upstream streaming when the caller sends stream:false (#2706)', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'oauth-token',
+        model: 'gpt-5.6-sol',
+        body: { ...body, stream: false },
+        stream: false,
+        authType: 'subscription',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.stream).toBe(true);
+    });
+
     it('sends default instructions when no system or developer prompt is present', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -645,12 +645,16 @@ export class ProviderClient {
               stripCodexUnsupported: endpointKey === 'openai-subscription',
             })
           : toResponsesRequest(requestSource, bareModel, {
+              // The subscription backend only serves SSE. Manifest buffers it
+              // for non-streaming callers in handleNonStreamResponse.
               stream:
-                endpointKey === 'openai-responses' ||
-                endpointKey === 'xai-responses' ||
-                endpoint.forwardResponsesStream
-                  ? ctx.stream
-                  : undefined,
+                endpointKey === 'openai-subscription'
+                  ? true
+                  : endpointKey === 'openai-responses' ||
+                      endpointKey === 'xai-responses' ||
+                      endpoint.forwardResponsesStream
+                    ? ctx.stream
+                    : undefined,
               // The ChatGPT subscription backend rejects max_output_tokens with
               // unsupported_parameter; only opt in for the API-key paths.
               mapMaxOutputTokens:


### PR DESCRIPTION
### ✨ What changed
- Force OpenAI subscription requests to stream on the upstream leg.
- Cover explicit stream: false with a ProviderClient regression test.

### 💭 Why
The subscription backend serves SSE even when Manifest returns buffered JSON. Forwarding stream: false caused a provider 400 and an unnecessary fallback Provider Attempt.

### 👤 For users
Buffered OpenAI subscription requests now return from the selected model instead of failing or falling back.

### 📝 Notes
Closes https://github.com/mnfst/manifest/issues/2706

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force OpenAI subscription requests to stream upstream even when callers send stream: false. This prevents provider 400s and avoids fallback attempts, so buffered callers still get responses from the selected model. Fixes #2706.

- **Bug Fixes**
  - Always set `stream: true` for the `openai-subscription` endpoint; Manifest buffers SSE for non-streaming callers.
  - Added a regression test to ensure upstream streaming when `stream: false` is requested by the caller.

<sup>Written for commit dc74ab22a53c1f6599c7441b6ce698f7892feb53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

