### PR TITLE
fix: show Meta provider logo

### DIFF
--- a/.changeset/meta-provider-logo.md
+++ b/.changeset/meta-provider-logo.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show the Meta logo anywhere the dashboard renders provider icons.

--- a/packages/frontend/src/components/ProviderIcon.tsx
+++ b/packages/frontend/src/components/ProviderIcon.tsx
@@ -15,6 +15,19 @@ export function providerIcon(id: string, size: number = 20): JSX.Element | null 
         <img src="/icons/manifest.svg" alt="Manifest" style={{ ...s, 'border-radius': '3px' }} />
       );
 
+    /* ── Meta ────────────────────────────────────── */
+    case 'meta':
+      return (
+        <img
+          src="/icons/providers/meta.svg"
+          alt=""
+          width={size}
+          height={size}
+          style={{ ...s, display: 'block', 'object-fit': 'contain' }}
+          aria-hidden="true"
+        />
+      );
+
     /* ── OpenAI ───────────────────────────────────── */
     case 'openai':
       return (

--- a/packages/frontend/tests/components/ProviderIcon.test.tsx
+++ b/packages/frontend/tests/components/ProviderIcon.test.tsx
@@ -48,6 +48,15 @@ describe('providerIcon', () => {
     expect(img?.getAttribute('alt')).toBe('Manifest');
   });
 
+  it('returns the Meta logo image for "meta"', () => {
+    const { container } = render(() => <div>{providerIcon('meta', 24)}</div>);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('/icons/providers/meta.svg');
+    expect(img?.getAttribute('width')).toBe('24');
+    expect(img?.getAttribute('height')).toBe('24');
+  });
+
   it('returns an SVG for "llamacpp"', () => {
     const { container } = render(() => <div>{providerIcon('llamacpp')}</div>);
     const svg = container.querySelector('svg');


### PR DESCRIPTION
### ✨ What changed\n- Map the Meta provider to its existing branded SVG.\n- Add a regression test for the icon path and dimensions.\n\n### 💭 Why\nMeta provider cards fell back to a letter because the icon resolver returned null.\n\n### 👤 For users\nMeta now shows its logo across provider cards and model views.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Meta logo instead of a letter fallback by mapping the Meta provider to its branded SVG. Previously, Meta resolved to null and rendered a letter.

- Maps provider id "meta" to /icons/providers/meta.svg in packages/frontend/src/components/ProviderIcon.tsx; decorative image with empty alt and aria-hidden="true" that respects the size prop.
- Adds a regression test asserting the image path and dimensions.
- Adds a patch changeset for `manifest`.

<sup>Written for commit 9a128b89104f488f32bc134d33926602002b68f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

