### PR TITLE
docs: fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Manifest is an open-source LLM gateway for AI agents and apps. Connect your API 
 - 🔀 Custom Routing: API keys, Subscriptions, Local models, Custom providers
 - 💾 Full Body Logs for Success and Error Messages
 - 📊 Track every single dollar, setup notifications and limits
-- 🚑 Fallback on different models when queries fails, Self-heals your bad requests
+- 🚑 Fallback on different models when queries fail, Self-heals your bad requests
 
 ## Quick start
 


### PR DESCRIPTION
## What changed

Fixed grammar/typo issues in the README.

## Why

Minor documentation cleanup.

## How verified

Visual inspection of the diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a grammar error in the README feature list: "queries fails" → "queries fail." Improves clarity and professionalism; no code or behavior changes.

<sup>Written for commit 9b81d5e5ffa949a216b44e315722f8f8dc602d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

