### PR TITLE
feat(proxy): make the gateway rate caps configurable via env

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -146,6 +146,13 @@ BETTER_AUTH_SECRET=
 # THROTTLE_LIMIT=100
 # THROTTLE_TTL=60000
 
+# Gateway guardrails on /v1 proxy traffic. Defaults: 200 requests/minute per
+# user (M201), 500 requests/minute per IP (M202), 10 in-flight requests per
+# workspace (M203). An invalid value falls back to the default.
+# RATE_MAX_REQUESTS=200
+# IP_RATE_MAX_REQUESTS=500
+# CONCURRENCY_MAX=10
+
 # PostgreSQL pool sizes. DB_POOL_MAX is the app's pool; Better Auth opens a
 # second, smaller one of its own.
 # DB_POOL_MAX=10

--- a/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
@@ -382,4 +382,57 @@ describe('ProxyRateLimiter', () => {
       clearIntervalSpy.mockRestore();
     });
   });
+
+  describe('env-configurable caps', () => {
+    const withEnv = (env: Record<string, string>, fn: (l: ProxyRateLimiter) => void) => {
+      const saved: Record<string, string | undefined> = {};
+      for (const [k, v] of Object.entries(env)) {
+        saved[k] = process.env[k];
+        process.env[k] = v;
+      }
+      const l = new ProxyRateLimiter();
+      try {
+        fn(l);
+      } finally {
+        l.onModuleDestroy();
+        for (const [k, v] of Object.entries(saved)) {
+          if (v === undefined) delete process.env[k];
+          else process.env[k] = v;
+        }
+      }
+    };
+
+    it('honors RATE_MAX_REQUESTS', () => {
+      withEnv({ RATE_MAX_REQUESTS: '3' }, (l) => {
+        l.checkLimit('user-env');
+        l.checkLimit('user-env');
+        l.checkLimit('user-env');
+        expect(() => l.checkLimit('user-env')).toThrow(HttpException);
+      });
+    });
+
+    it('honors IP_RATE_MAX_REQUESTS', () => {
+      withEnv({ IP_RATE_MAX_REQUESTS: '2' }, (l) => {
+        l.checkIpLimit('10.0.0.9');
+        l.checkIpLimit('10.0.0.9');
+        expect(() => l.checkIpLimit('10.0.0.9')).toThrow(HttpException);
+      });
+    });
+
+    it('honors CONCURRENCY_MAX', () => {
+      withEnv({ CONCURRENCY_MAX: '1' }, (l) => {
+        l.acquireSlot('tenant-env');
+        expect(() => l.acquireSlot('tenant-env')).toThrow(HttpException);
+      });
+    });
+
+    it('keeps the default when the override is not a positive integer', () => {
+      for (const bad of ['0', '-5', 'abc', '2.5', '']) {
+        withEnv({ CONCURRENCY_MAX: bad }, (l) => {
+          for (let i = 0; i < 10; i++) l.acquireSlot('tenant-bad');
+          expect(() => l.acquireSlot('tenant-bad')).toThrow(HttpException);
+        });
+      }
+    });
+  });
 });

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -2,11 +2,21 @@ import { Injectable, OnModuleDestroy, HttpStatus } from '@nestjs/common';
 import { ManifestError } from '../../common/errors/manifest-error';
 
 const RATE_WINDOW_MS = 60_000;
-const RATE_MAX_REQUESTS = 200;
-const IP_RATE_MAX_REQUESTS = 500;
+const DEFAULT_RATE_MAX_REQUESTS = 200;
+const DEFAULT_IP_RATE_MAX_REQUESTS = 500;
 const MAX_RATE_ENTRIES = 50_000;
-const CONCURRENCY_MAX = 10;
+const DEFAULT_CONCURRENCY_MAX = 10;
 const CLEANUP_INTERVAL_MS = 60_000;
+
+// An operator override must be a positive integer; anything else (unset,
+// empty, zero, negative, non-numeric) silently keeps the default so a typo
+// in .env can never disable the guardrail.
+function capFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
 
 interface RateEntry {
   count: number;
@@ -19,8 +29,14 @@ export class ProxyRateLimiter implements OnModuleDestroy {
   private readonly ipRates = new Map<string, RateEntry>();
   private readonly concurrency = new Map<string, number>();
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
+  private readonly rateMaxRequests: number;
+  private readonly ipRateMaxRequests: number;
+  private readonly concurrencyMax: number;
 
   constructor() {
+    this.rateMaxRequests = capFromEnv('RATE_MAX_REQUESTS', DEFAULT_RATE_MAX_REQUESTS);
+    this.ipRateMaxRequests = capFromEnv('IP_RATE_MAX_REQUESTS', DEFAULT_IP_RATE_MAX_REQUESTS);
+    this.concurrencyMax = capFromEnv('CONCURRENCY_MAX', DEFAULT_CONCURRENCY_MAX);
     this.cleanupTimer = setInterval(() => this.evictExpired(), CLEANUP_INTERVAL_MS);
     if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
       this.cleanupTimer.unref();
@@ -43,7 +59,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
       entry = { count: 0, windowStart: now };
     }
 
-    if (entry.count >= RATE_MAX_REQUESTS) {
+    if (entry.count >= this.rateMaxRequests) {
       throw new ManifestError('M201', HttpStatus.TOO_MANY_REQUESTS);
     }
 
@@ -68,7 +84,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
       entry = { count: 0, windowStart: now };
     }
 
-    if (entry.count >= IP_RATE_MAX_REQUESTS) {
+    if (entry.count >= this.ipRateMaxRequests) {
       throw new ManifestError('M202', HttpStatus.TOO_MANY_REQUESTS);
     }
 
@@ -81,7 +97,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
 
   acquireSlot(tenantId: string): void {
     const current = this.concurrency.get(tenantId) ?? 0;
-    if (current >= CONCURRENCY_MAX) {
+    if (current >= this.concurrencyMax) {
       throw new ManifestError('M203', HttpStatus.TOO_MANY_REQUESTS);
     }
     this.concurrency.set(tenantId, current + 1);


### PR DESCRIPTION
The M201/M202/M203 guardrails (200 requests/minute per user, 500 per IP, 10 in-flight per workspace) were hardcoded constants. The docs used to tell self-hosters to raise them by editing `proxy-rate-limiter.ts`, which is impossible on the published Docker image; I removed that dead-end advice from the docs (mnfst/docs#61) and this PR replaces it with a real knob.

- `RATE_MAX_REQUESTS`, `IP_RATE_MAX_REQUESTS`, and `CONCURRENCY_MAX` are now read at startup, with today's values as defaults.
- An override must be a positive integer; anything else (zero, negative, non-numeric, empty) silently keeps the default, so a typo in `.env` can never disable a guardrail.
- `docker/.env.example` documents the three keys, commented out.
- 4 new tests cover the overrides and the invalid-value fallback (32 pass on the suite).

Once released, I'll document the three variables in the docs (error pages M201-M203 and the environment-variables reference).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gateway rate caps for `/v1` proxy traffic are now configurable via environment variables instead of hardcoded constants. Previously: 200/user-minute (M201), 500/IP-minute (M202), 10 in-flight/workspace (M203); now read from `RATE_MAX_REQUESTS`, `IP_RATE_MAX_REQUESTS`, `CONCURRENCY_MAX` at startup, with invalid values falling back to defaults so guardrails cannot be disabled by a typo.

**Review / Rollout**
- Caps require positive integers; unset, blank, non-numeric, zero, or negative values keep defaults.
- Behavior is unchanged if no env vars are set; error codes M201–M203 are thrown as before.
- `docker/.env.example` documents the new keys (commented).
- New tests cover overrides and fallback.

<sup>Written for commit 57ecbbb6f53ca21a08584d5a6dd955802e387b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

