### PR TITLE
feat: bill DeepSeek V4 at real peak/off-peak rates via time-of-day pricing tiers

### DIFF
--- a/.changeset/deepseek-peak-pricing.md
+++ b/.changeset/deepseek-peak-pricing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bill DeepSeek V4 at its real peak/off-peak rates. Pricing entries can now carry time-of-day tiers (the models.dev `cost.tiers` time variant), cost calculation resolves them against the attempt timestamp, and a built-in seed supplies DeepSeek's schedule until the catalog carries it.

--- a/packages/backend/src/common/utils/cost-calculator.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.spec.ts
@@ -434,6 +434,27 @@ describe('computeTokenCost', () => {
       ).toBeCloseTo(0.22 + 0.66, 10);
     });
 
+    it('never matches a zero-length window (start === end)', () => {
+      const degenerate: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [
+          {
+            windows: ['12:00-12:00'],
+            input_price_per_token: 0.44e-6,
+            output_price_per_token: 1.32e-6,
+          },
+        ],
+      };
+      // Equal endpoints must not fall into the midnight-wrap branch and
+      // become a full-day peak band — base rates apply at any hour.
+      for (const at of ['2026-08-17T12:00:00Z', '2026-08-17T00:00:00Z', '2026-08-17T18:30:00Z']) {
+        expect(computeTokenCost({ ...base, pricing: degenerate, at: new Date(at) })).toBeCloseTo(
+          0.22 + 0.66,
+          10,
+        );
+      }
+    });
+
     it('defaults the billing timestamp to now', () => {
       jest.useFakeTimers().setSystemTime(new Date('2026-08-17T02:00:00Z'));
       try {

--- a/packages/backend/src/common/utils/cost-calculator.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.spec.ts
@@ -348,6 +348,141 @@ describe('computeTokenCost', () => {
     expect(result).toBeCloseTo(0.0075, 10);
   });
 
+  describe('time-of-day pricing tiers', () => {
+    // DeepSeek V4 Flash shape: off-peak base, peak windows at double.
+    const peakPricing: PricingEntry = {
+      model_name: 'deepseek-v4-flash',
+      provider: 'DeepSeek',
+      input_price_per_token: 0.22e-6,
+      output_price_per_token: 0.66e-6,
+      cache_read_price_per_token: 0.007e-6,
+      time_tiers: [
+        {
+          windows: ['01:00-04:00', '06:00-10:00'],
+          input_price_per_token: 0.44e-6,
+          output_price_per_token: 1.32e-6,
+          cache_read_price_per_token: 0.014e-6,
+        },
+      ],
+      display_name: 'DeepSeek V4 Flash',
+    };
+    const base = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      model: 'deepseek-v4-flash',
+      pricing: peakPricing,
+    };
+
+    it('bills the base rate outside every peak window', () => {
+      const cost = computeTokenCost({ ...base, at: new Date('2026-08-17T12:00:00Z') });
+      expect(cost).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('bills the tier rate inside a peak window', () => {
+      const cost = computeTokenCost({ ...base, at: new Date('2026-08-17T02:30:00Z') });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('treats window starts as inclusive and ends as exclusive', () => {
+      expect(computeTokenCost({ ...base, at: new Date('2026-08-17T06:00:00Z') })).toBeCloseTo(
+        0.44 + 1.32,
+        10,
+      );
+      expect(computeTokenCost({ ...base, at: new Date('2026-08-17T10:00:00Z') })).toBeCloseTo(
+        0.22 + 0.66,
+        10,
+      );
+    });
+
+    it('uses the tier cache-read price for cache hits inside a window', () => {
+      const cost = computeTokenCost({
+        ...base,
+        cacheReadTokens: 1_000_000,
+        at: new Date('2026-08-17T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.014 + 1.32, 10);
+    });
+
+    it('falls back to the tier input price for cache writes the tier does not price', () => {
+      const cost = computeTokenCost({
+        ...base,
+        cacheCreationTokens: 1_000_000,
+        at: new Date('2026-08-17T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('matches windows that wrap past midnight', () => {
+      const wrapped: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [
+          {
+            windows: ['22:00-02:00'],
+            input_price_per_token: 0.44e-6,
+            output_price_per_token: 1.32e-6,
+          },
+        ],
+      };
+      expect(
+        computeTokenCost({ ...base, pricing: wrapped, at: new Date('2026-08-17T23:00:00Z') }),
+      ).toBeCloseTo(0.44 + 1.32, 10);
+      expect(
+        computeTokenCost({ ...base, pricing: wrapped, at: new Date('2026-08-17T01:30:00Z') }),
+      ).toBeCloseTo(0.44 + 1.32, 10);
+      expect(
+        computeTokenCost({ ...base, pricing: wrapped, at: new Date('2026-08-17T12:00:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('defaults the billing timestamp to now', () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-17T02:00:00Z'));
+      try {
+        expect(computeTokenCost({ ...base })).toBeCloseTo(0.44 + 1.32, 10);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('ignores a matching tier that lacks its own input/output prices', () => {
+      const incomplete: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [
+          {
+            windows: ['01:00-04:00'],
+            input_price_per_token: null,
+            output_price_per_token: 1.32e-6,
+          },
+        ],
+      };
+      expect(
+        computeTokenCost({ ...base, pricing: incomplete, at: new Date('2026-08-17T02:00:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('ignores malformed windows instead of matching them', () => {
+      const malformed: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [
+          {
+            windows: ['nonsense', '01:00-'],
+            input_price_per_token: 0.44e-6,
+            output_price_per_token: 1.32e-6,
+          },
+        ],
+      };
+      expect(
+        computeTokenCost({ ...base, pricing: malformed, at: new Date('2026-08-17T02:00:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('ignores an empty tier list', () => {
+      const empty: PricingEntry = { ...peakPricing, time_tiers: [] };
+      expect(
+        computeTokenCost({ ...base, pricing: empty, at: new Date('2026-08-17T02:00:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+  });
+
   it('subscription check takes priority over negative pricing guard', () => {
     const negativePricing: PricingEntry = {
       model_name: 'bad-model',

--- a/packages/backend/src/common/utils/cost-calculator.ts
+++ b/packages/backend/src/common/utils/cost-calculator.ts
@@ -1,4 +1,4 @@
-import { PricingEntry } from '../../model-prices/model-pricing-cache.service';
+import { PricingEntry, PricingTimeTier } from '../../model-prices/model-pricing-cache.service';
 
 export interface CostInput {
   inputTokens: number;
@@ -27,6 +27,42 @@ export interface CostInput {
    * (for example NousResearch Portal) instead of being flat-fee unlimited.
    */
   reportedCostUsd?: number | null;
+  /**
+   * Billing timestamp used to resolve time-of-day pricing tiers (peak/off-peak
+   * providers like DeepSeek V4). Pass the request start when available;
+   * defaults to the moment of computation, which for proxy traffic is within
+   * seconds of the response.
+   */
+  at?: Date;
+}
+
+/**
+ * Minutes since UTC midnight for a "HH:MM" string, or null when malformed.
+ * Tier windows are validated upstream, so null only guards corrupted data.
+ */
+function toUtcMinutes(time: string | undefined): number | null {
+  if (!time) return null;
+  const [hours, minutes] = time.split(':').map(Number);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null;
+  return hours * 60 + minutes;
+}
+
+/** True when `minutes` falls inside a "HH:MM-HH:MM" window (end exclusive, wraps midnight). */
+function windowMatches(window: string, minutes: number): boolean {
+  const [start, end] = window.split('-').map(toUtcMinutes);
+  if (start == null || end == null) return false;
+  return start < end ? minutes >= start && minutes < end : minutes >= start || minutes < end;
+}
+
+/**
+ * The time tier whose windows contain `at`, if any. A matching tier replaces
+ * the base prices outright (tiers never compose with the base cost).
+ */
+function resolveTimeTier(pricing: PricingEntry, at: Date): PricingTimeTier | undefined {
+  const tiers = pricing.time_tiers;
+  if (!tiers || tiers.length === 0) return undefined;
+  const minutes = at.getUTCHours() * 60 + at.getUTCMinutes();
+  return tiers.find((tier) => tier.windows.some((window) => windowMatches(window, minutes)));
 }
 
 /**
@@ -60,8 +96,19 @@ export function computeTokenCost(input: CostInput): number | null {
     return null;
   }
 
-  const inputPrice = Number(pricing.input_price_per_token);
-  const outputPrice = Number(pricing.output_price_per_token);
+  // A time tier that matches the billing timestamp replaces the base prices
+  // (peak-hour billing); a tier missing its own input/output prices is
+  // ignored rather than half-applied.
+  const timeTier = resolveTimeTier(pricing, input.at ?? new Date());
+  const effective =
+    timeTier != null &&
+    timeTier.input_price_per_token != null &&
+    timeTier.output_price_per_token != null
+      ? timeTier
+      : pricing;
+
+  const inputPrice = Number(effective.input_price_per_token);
+  const outputPrice = Number(effective.output_price_per_token);
   const cacheReadTokens = Math.min(input.inputTokens, Math.max(0, input.cacheReadTokens ?? 0));
   const cacheCreationTokens = Math.min(
     input.inputTokens - cacheReadTokens,
@@ -72,12 +119,12 @@ export function computeTokenCost(input: CostInput): number | null {
     input.inputTokens - cacheReadTokens - cacheCreationTokens,
   );
   const cacheReadPrice =
-    pricing.cache_read_price_per_token != null
-      ? Number(pricing.cache_read_price_per_token)
+    effective.cache_read_price_per_token != null
+      ? Number(effective.cache_read_price_per_token)
       : inputPrice;
   const cacheWritePrice =
-    pricing.cache_write_price_per_token != null
-      ? Number(pricing.cache_write_price_per_token)
+    effective.cache_write_price_per_token != null
+      ? Number(effective.cache_write_price_per_token)
       : inputPrice;
 
   const cost =

--- a/packages/backend/src/common/utils/cost-calculator.ts
+++ b/packages/backend/src/common/utils/cost-calculator.ts
@@ -51,6 +51,10 @@ function toUtcMinutes(time: string | undefined): number | null {
 function windowMatches(window: string, minutes: number): boolean {
   const [start, end] = window.split('-').map(toUtcMinutes);
   if (start == null || end == null) return false;
+  // A zero-length window matches nothing. Without this, start === end falls
+  // into the wrap branch and matches the whole day, letting a malformed
+  // upstream band override the base rate around the clock.
+  if (start === end) return false;
   return start < end ? minutes >= start && minutes < end : minutes >= start || minutes < end;
 }
 

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1014,6 +1014,204 @@ describe('ModelsDevSyncService', () => {
     });
   });
 
+  describe('time-of-day pricing tiers', () => {
+    it('parses time tiers from cost.tiers and ignores context tiers', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'tiered-model': {
+              id: 'tiered-model',
+              name: 'Tiered',
+              cost: {
+                input: 1.0,
+                output: 2.0,
+                tiers: [
+                  { tier: { type: 'context', size: 200_000 }, input: 2.0, output: 4.0 },
+                  {
+                    tier: { type: 'time', windows: ['01:00-04:00', '06:00-10:00'] },
+                    input: 2.0,
+                    output: 4.0,
+                    cache_read: 0.2,
+                  },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const model = service.lookupModel('openai', 'tiered-model');
+      expect(model!.timeTiers).toEqual([
+        {
+          windows: ['01:00-04:00', '06:00-10:00'],
+          inputPricePerToken: 2.0 / 1_000_000,
+          outputPricePerToken: 4.0 / 1_000_000,
+          cacheReadPricePerToken: 0.2 / 1_000_000,
+          cacheWritePricePerToken: null,
+        },
+      ]);
+    });
+
+    it('drops time tiers with malformed or missing windows', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'bad-tiers': {
+              id: 'bad-tiers',
+              name: 'Bad Tiers',
+              cost: {
+                input: 1.0,
+                output: 2.0,
+                tiers: [
+                  {
+                    tier: { type: 'time', windows: ['25:00-99:00', 'later'] },
+                    input: 2.0,
+                    output: 4.0,
+                  },
+                  { tier: { type: 'time' }, input: 2.0, output: 4.0 },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'bad-tiers')!.timeTiers).toBeNull();
+    });
+
+    it('keeps only valid windows within a mixed tier and nulls unpriced fields', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'mixed-windows': {
+              id: 'mixed-windows',
+              name: 'Mixed Windows',
+              cost: {
+                input: 1.0,
+                output: 2.0,
+                tiers: [
+                  { tier: { type: 'time', windows: ['01:00-04:00', 'garbage'] }, input: 2.0 },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'mixed-windows')!.timeTiers).toEqual([
+        {
+          windows: ['01:00-04:00'],
+          inputPricePerToken: 2.0 / 1_000_000,
+          outputPricePerToken: null,
+          cacheReadPricePerToken: null,
+          cacheWritePricePerToken: null,
+        },
+      ]);
+    });
+
+    it('seeds DeepSeek V4 peak pricing when the catalog carries no time tiers', async () => {
+      const response = {
+        deepseek: {
+          id: 'deepseek',
+          name: 'DeepSeek',
+          models: {
+            'deepseek-v4-flash': {
+              id: 'deepseek-v4-flash',
+              name: 'DeepSeek V4 Flash',
+              cost: { input: 0.14, output: 0.28, cache_read: 0.0028 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+            'deepseek-chat': {
+              id: 'deepseek-chat',
+              name: 'DeepSeek Chat',
+              cost: { input: 0.14, output: 0.28 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const flash = service.lookupModel('deepseek', 'deepseek-v4-flash');
+      // Stale catalog rates are replaced by the real off-peak base…
+      expect(flash!.inputPricePerToken).toBe(0.22 / 1_000_000);
+      expect(flash!.outputPricePerToken).toBe(0.66 / 1_000_000);
+      expect(flash!.cacheReadPricePerToken).toBe(0.007 / 1_000_000);
+      // …plus the peak windows at double.
+      expect(flash!.timeTiers).toEqual([
+        {
+          windows: ['01:00-04:00', '06:00-10:00'],
+          inputPricePerToken: 0.44 / 1_000_000,
+          outputPricePerToken: 1.32 / 1_000_000,
+          cacheReadPricePerToken: 0.014 / 1_000_000,
+          cacheWritePricePerToken: null,
+        },
+      ]);
+      // Models outside the seed (legacy aliases) are untouched.
+      const chat = service.lookupModel('deepseek', 'deepseek-chat');
+      expect(chat!.inputPricePerToken).toBe(0.14 / 1_000_000);
+      expect(chat!.timeTiers).toBeNull();
+    });
+
+    it('prefers catalog time tiers over the DeepSeek seed once models.dev has them', async () => {
+      const response = {
+        deepseek: {
+          id: 'deepseek',
+          name: 'DeepSeek',
+          models: {
+            'deepseek-v4-flash': {
+              id: 'deepseek-v4-flash',
+              name: 'DeepSeek V4 Flash',
+              cost: {
+                input: 0.25,
+                output: 0.7,
+                tiers: [
+                  { tier: { type: 'time', windows: ['02:00-05:00'] }, input: 0.5, output: 1.4 },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const flash = service.lookupModel('deepseek', 'deepseek-v4-flash');
+      expect(flash!.inputPricePerToken).toBe(0.25 / 1_000_000);
+      expect(flash!.timeTiers).toEqual([
+        {
+          windows: ['02:00-05:00'],
+          inputPricePerToken: 0.5 / 1_000_000,
+          outputPricePerToken: 1.4 / 1_000_000,
+          cacheReadPricePerToken: null,
+          cacheWritePricePerToken: null,
+        },
+      ]);
+    });
+  });
+
   describe('refreshCache edge cases', () => {
     it('should skip providers with no models key', async () => {
       const response = {

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1104,7 +1104,10 @@ describe('ModelsDevSyncService', () => {
                 input: 1.0,
                 output: 2.0,
                 tiers: [
-                  { tier: { type: 'time', windows: ['01:00-04:00', 'garbage'] }, input: 2.0 },
+                  {
+                    tier: { type: 'time', windows: ['01:00-04:00', 'garbage', '06:00-06:00'] },
+                    input: 2.0,
+                  },
                 ],
               },
               modalities: { input: ['text'], output: ['text'] },
@@ -1136,7 +1139,7 @@ describe('ModelsDevSyncService', () => {
             'deepseek-v4-flash': {
               id: 'deepseek-v4-flash',
               name: 'DeepSeek V4 Flash',
-              cost: { input: 0.14, output: 0.28, cache_read: 0.0028 },
+              cost: { input: 0.14, output: 0.28, cache_read: 0.0028, cache_write: 0.35 },
               modalities: { input: ['text'], output: ['text'] },
             },
             'deepseek-chat': {
@@ -1157,6 +1160,9 @@ describe('ModelsDevSyncService', () => {
       expect(flash!.inputPricePerToken).toBe(0.22 / 1_000_000);
       expect(flash!.outputPricePerToken).toBe(0.66 / 1_000_000);
       expect(flash!.cacheReadPricePerToken).toBe(0.007 / 1_000_000);
+      // The stale catalog cache-write rate must not survive either: DeepSeek
+      // bills cache writes at the input rate, which null falls back to.
+      expect(flash!.cacheWritePricePerToken).toBeNull();
       // …plus the peak windows at double.
       expect(flash!.timeTiers).toEqual([
         {

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -43,6 +43,20 @@ function resolveProviderId(providerId: string): string {
   return entry?.id ?? lower;
 }
 
+/**
+ * Time-of-day pricing band: the tier's rates replace the model's base rates
+ * inside `windows` (UTC "HH:MM-HH:MM", start inclusive / end exclusive, an end
+ * before its start wraps past midnight). Mirrors the models.dev
+ * `cost.tiers[].tier.type = "time"` schema (anomalyco/models.dev#4892).
+ */
+export interface ModelsDevTimeTier {
+  windows: readonly string[];
+  inputPricePerToken: number | null;
+  outputPricePerToken: number | null;
+  cacheReadPricePerToken: number | null;
+  cacheWritePricePerToken: number | null;
+}
+
 export interface ModelsDevModelEntry {
   id: string;
   name: string;
@@ -56,9 +70,18 @@ export interface ModelsDevModelEntry {
   outputPricePerToken: number | null;
   cacheReadPricePerToken?: number | null;
   cacheWritePricePerToken?: number | null;
+  timeTiers?: readonly ModelsDevTimeTier[] | null;
   capabilities: readonly ModelCapability[];
   inputModalities: readonly ModelModality[];
   outputModalities: readonly ModelModality[];
+}
+
+interface RawModelsDevCostTier {
+  tier?: { type?: string; size?: number; windows?: string[] };
+  input?: number;
+  output?: number;
+  cache_read?: number;
+  cache_write?: number;
 }
 
 interface RawModelsDevModel {
@@ -68,7 +91,13 @@ interface RawModelsDevModel {
   reasoning?: boolean;
   tool_call?: boolean;
   structured_output?: boolean;
-  cost?: { input?: number; output?: number; cache_read?: number; cache_write?: number };
+  cost?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+    tiers?: RawModelsDevCostTier[];
+  };
   limit?: { context?: number; output?: number };
   modalities?: { input?: string[]; output?: string[] };
 }
@@ -83,6 +112,53 @@ type RawModelsDevResponse = Record<string, RawModelsDevProvider>;
 
 const MODELS_DEV_API = 'https://models.dev/api.json';
 const FETCH_TIMEOUT_MS = 10000;
+
+/** UTC "HH:MM-HH:MM" range, as validated by the models.dev schema. */
+const TIME_WINDOW_RE = /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * DeepSeek V4 moved to peak/off-peak billing on 2026-08-16: peak hours are
+ * 01:00-04:00 and 06:00-10:00 UTC, every other hour is off-peak at half the
+ * peak rate. models.dev cannot express time-of-day pricing yet
+ * (anomalyco/models.dev#4892 adds `cost.tiers[].tier.type = "time"`; #4891
+ * corrects the flat numbers in the meantime), so until the catalog carries a
+ * time tier for these models this seed replaces whatever flat rate the sync
+ * returns with the real off-peak base plus a peak-window tier.
+ *
+ * DELETE once models.dev serves time tiers for DeepSeek — the seed only
+ * applies when `parseTimeTiers` finds nothing, so it retires itself, but the
+ * dead constant should not outlive that. Prices are USD per 1M tokens from
+ * https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17).
+ */
+const DEEPSEEK_PEAK_WINDOWS: readonly string[] = ['01:00-04:00', '06:00-10:00'];
+const DEEPSEEK_V4_PEAK_SEED: ReadonlyMap<
+  string,
+  {
+    input: number;
+    output: number;
+    cacheRead: number;
+    peak: { input: number; output: number; cacheRead: number };
+  }
+> = new Map([
+  [
+    'deepseek-v4-flash',
+    {
+      input: 0.22,
+      output: 0.66,
+      cacheRead: 0.007,
+      peak: { input: 0.44, output: 1.32, cacheRead: 0.014 },
+    },
+  ],
+  [
+    'deepseek-v4-pro',
+    {
+      input: 0.66,
+      output: 1.98,
+      cacheRead: 0.022,
+      peak: { input: 1.32, output: 3.96, cacheRead: 0.044 },
+    },
+  ],
+]);
 /** Matches trailing version suffixes like -001, -002 (Google API convention). */
 const VERSION_SUFFIX_RE = /-\d{3}$/;
 /** Matches trailing date suffixes like -20250514, -2025-04-14. */
@@ -453,15 +529,65 @@ export class ModelsDevSyncService implements OnModuleInit {
     if (!index.has(normalized)) index.set(normalized, modelsDevId);
   }
 
+  /**
+   * Extract time-of-day pricing tiers from a raw models.dev cost block.
+   * Context-size tiers (`tier.type = "context"`) are ignored — Manifest does
+   * not price by context band. Returns null when no valid time tier exists.
+   */
+  private parseTimeTiers(raw: RawModelsDevModel): ModelsDevTimeTier[] | null {
+    const tiers = raw.cost?.tiers;
+    if (!Array.isArray(tiers)) return null;
+
+    const parsed: ModelsDevTimeTier[] = [];
+    for (const tier of tiers) {
+      if (tier?.tier?.type !== 'time') continue;
+      const windows = (tier.tier.windows ?? []).filter(
+        (window) => typeof window === 'string' && TIME_WINDOW_RE.test(window),
+      );
+      if (windows.length === 0) continue;
+      parsed.push({
+        windows,
+        inputPricePerToken: tier.input != null ? tier.input / 1_000_000 : null,
+        outputPricePerToken: tier.output != null ? tier.output / 1_000_000 : null,
+        cacheReadPricePerToken: tier.cache_read != null ? tier.cache_read / 1_000_000 : null,
+        cacheWritePricePerToken: tier.cache_write != null ? tier.cache_write / 1_000_000 : null,
+      });
+    }
+    return parsed.length > 0 ? parsed : null;
+  }
+
   private parseModel(
     providerId: string,
     modelId: string,
     raw: RawModelsDevModel,
   ): ModelsDevModelEntry {
-    const inputPerMillion = raw.cost?.input ?? null;
-    const outputPerMillion = raw.cost?.output ?? null;
-    const cacheReadPerMillion = raw.cost?.cache_read ?? null;
+    let inputPerMillion = raw.cost?.input ?? null;
+    let outputPerMillion = raw.cost?.output ?? null;
+    let cacheReadPerMillion = raw.cost?.cache_read ?? null;
     const cacheWritePerMillion = raw.cost?.cache_write ?? null;
+    let timeTiers = this.parseTimeTiers(raw);
+
+    // Peak/off-peak seed for DeepSeek's own API until models.dev can carry
+    // the schedule itself (see DEEPSEEK_V4_PEAK_SEED). Catalog data wins the
+    // moment it exists.
+    if (providerId === 'deepseek' && !timeTiers) {
+      const seed = DEEPSEEK_V4_PEAK_SEED.get(modelId);
+      if (seed) {
+        inputPerMillion = seed.input;
+        outputPerMillion = seed.output;
+        cacheReadPerMillion = seed.cacheRead;
+        timeTiers = [
+          {
+            windows: DEEPSEEK_PEAK_WINDOWS,
+            inputPricePerToken: seed.peak.input / 1_000_000,
+            outputPricePerToken: seed.peak.output / 1_000_000,
+            cacheReadPricePerToken: seed.peak.cacheRead / 1_000_000,
+            cacheWritePricePerToken: null,
+          },
+        ];
+      }
+    }
+
     const modalities = modelModalitiesFromModelsDev(raw.modalities);
 
     return {
@@ -481,6 +607,7 @@ export class ModelsDevSyncService implements OnModuleInit {
       cacheReadPricePerToken: cacheReadPerMillion !== null ? cacheReadPerMillion / 1_000_000 : null,
       cacheWritePricePerToken:
         cacheWritePerMillion !== null ? cacheWritePerMillion / 1_000_000 : null,
+      timeTiers,
     };
   }
 

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -541,8 +541,14 @@ export class ModelsDevSyncService implements OnModuleInit {
     const parsed: ModelsDevTimeTier[] = [];
     for (const tier of tiers) {
       if (tier?.tier?.type !== 'time') continue;
+      // Zero-length windows (e.g. "06:00-06:00") are rejected: only an end
+      // before the start wraps midnight, so equal endpoints would read as a
+      // full-day band and override the base rate around the clock.
       const windows = (tier.tier.windows ?? []).filter(
-        (window) => typeof window === 'string' && TIME_WINDOW_RE.test(window),
+        (window) =>
+          typeof window === 'string' &&
+          TIME_WINDOW_RE.test(window) &&
+          window.slice(0, 5) !== window.slice(6),
       );
       if (windows.length === 0) continue;
       parsed.push({
@@ -564,7 +570,7 @@ export class ModelsDevSyncService implements OnModuleInit {
     let inputPerMillion = raw.cost?.input ?? null;
     let outputPerMillion = raw.cost?.output ?? null;
     let cacheReadPerMillion = raw.cost?.cache_read ?? null;
-    const cacheWritePerMillion = raw.cost?.cache_write ?? null;
+    let cacheWritePerMillion = raw.cost?.cache_write ?? null;
     let timeTiers = this.parseTimeTiers(raw);
 
     // Peak/off-peak seed for DeepSeek's own API until models.dev can carry
@@ -576,6 +582,10 @@ export class ModelsDevSyncService implements OnModuleInit {
         inputPerMillion = seed.input;
         outputPerMillion = seed.output;
         cacheReadPerMillion = seed.cacheRead;
+        // DeepSeek bills cache writes at the plain input rate (no premium), so
+        // clear any stale catalog value; the cost calculator falls back to the
+        // effective input price when cache-write pricing is null.
+        cacheWritePerMillion = null;
         timeTiers = [
           {
             windows: DEEPSEEK_PEAK_WINDOWS,

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -243,18 +243,15 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
         if (!hasRealPricing || !isZeroPricing) {
           this.cache.set(model.id, pricingEntry);
         }
-        // Also update the OpenRouter-prefixed key if it exists. Time tiers
-        // are dropped here: the prefixed key means the request rode through
-        // OpenRouter, which bills its own flat rate regardless of the lab's
-        // peak-hour schedule.
+        // The OpenRouter-prefixed key keeps OpenRouter's own entry: pricing
+        // follows transport, and OpenRouter bills its flat rate regardless of
+        // the lab's peak-hour schedule — so only make sure no time tiers ride
+        // along, never overwrite the OR prices with the lab's.
         for (const prefix of registryEntry.openRouterPrefixes) {
           const prefixedKey = `${prefix}/${model.id}`;
-          if (this.cache.has(prefixedKey)) {
-            this.cache.set(prefixedKey, {
-              ...pricingEntry,
-              model_name: prefixedKey,
-              time_tiers: null,
-            });
+          const orEntry = this.cache.get(prefixedKey);
+          if (orEntry) {
+            this.cache.set(prefixedKey, { ...orEntry, time_tiers: null });
           }
         }
         count++;

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -20,6 +20,20 @@ const CUSTOM_PROVIDER_LABEL = 'Custom';
  * Reads from models.dev (preferred), OpenRouter cache (fallback), and the
  * `custom_providers` table (user-defined OpenAI-compatible endpoints).
  */
+/**
+ * Time-of-day pricing band. The tier's rates replace the base rates for
+ * requests whose billing time falls inside `windows` (UTC "HH:MM-HH:MM",
+ * start inclusive / end exclusive, an end before its start wraps past
+ * midnight). Mirrors models.dev `cost.tiers[].tier.type = "time"`.
+ */
+export interface PricingTimeTier {
+  windows: readonly string[];
+  input_price_per_token: number | null;
+  output_price_per_token: number | null;
+  cache_read_price_per_token?: number | null;
+  cache_write_price_per_token?: number | null;
+}
+
 export interface PricingEntry {
   model_name: string;
   provider: string;
@@ -27,6 +41,8 @@ export interface PricingEntry {
   output_price_per_token: number | null;
   cache_read_price_per_token?: number | null;
   cache_write_price_per_token?: number | null;
+  /** Peak-hour price bands (e.g. DeepSeek V4); base prices apply outside them. */
+  time_tiers?: readonly PricingTimeTier[] | null;
   display_name: string | null;
   /** True if confirmed via provider-native API, false if unverified, undefined if no data. */
   validated?: boolean;
@@ -204,6 +220,13 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
           output_price_per_token: model.outputPricePerToken,
           cache_read_price_per_token: model.cacheReadPricePerToken ?? null,
           cache_write_price_per_token: model.cacheWritePricePerToken ?? null,
+          time_tiers: model.timeTiers?.map((tier) => ({
+            windows: tier.windows,
+            input_price_per_token: tier.inputPricePerToken,
+            output_price_per_token: tier.outputPricePerToken,
+            cache_read_price_per_token: tier.cacheReadPricePerToken,
+            cache_write_price_per_token: tier.cacheWritePricePerToken,
+          })),
           display_name: model.name || null,
           validated: this.resolveValidatedForModelsDev(providerId, model.id),
           source: 'models.dev',
@@ -220,11 +243,18 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
         if (!hasRealPricing || !isZeroPricing) {
           this.cache.set(model.id, pricingEntry);
         }
-        // Also update the OpenRouter-prefixed key if it exists
+        // Also update the OpenRouter-prefixed key if it exists. Time tiers
+        // are dropped here: the prefixed key means the request rode through
+        // OpenRouter, which bills its own flat rate regardless of the lab's
+        // peak-hour schedule.
         for (const prefix of registryEntry.openRouterPrefixes) {
           const prefixedKey = `${prefix}/${model.id}`;
           if (this.cache.has(prefixedKey)) {
-            this.cache.set(prefixedKey, { ...pricingEntry, model_name: prefixedKey });
+            this.cache.set(prefixedKey, {
+              ...pricingEntry,
+              model_name: prefixedKey,
+              time_tiers: null,
+            });
           }
         }
         count++;

--- a/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
@@ -95,9 +95,10 @@ describe('ModelPricingCacheService — time-of-day pricing tiers', () => {
     expect(service.getByModel('deepseek-chat')!.time_tiers).toBeUndefined();
   });
 
-  it('strips time tiers from the OpenRouter-prefixed copy of the entry', async () => {
-    // OpenRouter also lists the model, so the prefixed key pre-exists and the
-    // models.dev overlay rewrites it.
+  it('keeps the OpenRouter entry on the prefixed key and only drops the tiers', async () => {
+    // OpenRouter also lists the model, so the prefixed key pre-exists. Pricing
+    // follows transport: the OR entry keeps OR's own flat rate — the overlay
+    // must not replace it with the lab's prices, only guarantee no tiers.
     mockGetAll.mockReturnValue(
       new Map<string, OpenRouterPricingEntry>([
         ['deepseek/deepseek-v4-flash', { input: 0.3 / 1_000_000, output: 0.9 / 1_000_000 }],
@@ -109,6 +110,9 @@ describe('ModelPricingCacheService — time-of-day pricing tiers', () => {
     const prefixed = service.getByModel('deepseek/deepseek-v4-flash');
     expect(prefixed).toBeDefined();
     expect(prefixed!.time_tiers).toBeNull();
+    // OpenRouter's flat rate survives the models.dev overlay.
+    expect(prefixed!.input_price_per_token).toBe(0.3 / 1_000_000);
+    expect(prefixed!.output_price_per_token).toBe(0.9 / 1_000_000);
     // The bare key still carries the schedule for direct-API traffic.
     expect(service.getByModel('deepseek-v4-flash')!.time_tiers).toHaveLength(1);
   });

--- a/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
@@ -1,0 +1,115 @@
+import { ModelPricingCacheService } from './model-pricing-cache.service';
+import { PricingSyncService, OpenRouterPricingEntry } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
+import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
+
+/**
+ * Tests for time-of-day pricing tiers flowing from the models.dev sync into
+ * `PricingEntry.time_tiers` (peak/off-peak providers like DeepSeek V4).
+ *
+ * The transport rule is pinned here too: the OpenRouter-prefixed key means
+ * the request rode through OpenRouter, which bills its own flat rate, so the
+ * prefixed copy of the entry must NOT carry the lab's peak-hour schedule.
+ */
+
+const DEEPSEEK_TIME_TIER = {
+  windows: ['01:00-04:00', '06:00-10:00'],
+  inputPricePerToken: 0.44 / 1_000_000,
+  outputPricePerToken: 1.32 / 1_000_000,
+  cacheReadPricePerToken: 0.014 / 1_000_000,
+  cacheWritePricePerToken: null,
+};
+
+describe('ModelPricingCacheService — time-of-day pricing tiers', () => {
+  let service: ModelPricingCacheService;
+  let mockGetAll: jest.Mock;
+  let mockModelsDevSync: {
+    lookupModel: jest.Mock;
+    getModelsForProvider: jest.Mock;
+    isProviderSupported: jest.Mock;
+    whenInitialized: jest.Mock;
+  };
+
+  beforeEach(() => {
+    mockGetAll = jest.fn().mockReturnValue(new Map<string, OpenRouterPricingEntry>());
+    const mockPricingSync = {
+      getAll: mockGetAll,
+      whenInitialized: jest.fn().mockResolvedValue(undefined),
+    };
+    mockModelsDevSync = {
+      lookupModel: jest.fn().mockReturnValue(null),
+      getModelsForProvider: jest.fn().mockImplementation((providerId: string) => {
+        if (providerId !== 'deepseek') return [];
+        return [
+          {
+            id: 'deepseek-v4-flash',
+            name: 'DeepSeek V4 Flash',
+            inputPricePerToken: 0.22 / 1_000_000,
+            outputPricePerToken: 0.66 / 1_000_000,
+            cacheReadPricePerToken: 0.007 / 1_000_000,
+            timeTiers: [DEEPSEEK_TIME_TIER],
+          },
+          {
+            id: 'deepseek-chat',
+            name: 'DeepSeek Chat',
+            inputPricePerToken: 0.14 / 1_000_000,
+            outputPricePerToken: 0.28 / 1_000_000,
+          },
+        ];
+      }),
+      isProviderSupported: jest.fn().mockReturnValue(false),
+      whenInitialized: jest.fn().mockResolvedValue(undefined),
+    };
+    const mockRegistry = {
+      isModelConfirmed: jest.fn().mockReturnValue(null),
+      getConfirmedModels: jest.fn().mockReturnValue(null),
+      registerModels: jest.fn(),
+    };
+    service = new ModelPricingCacheService(
+      mockPricingSync as unknown as PricingSyncService,
+      mockModelsDevSync as unknown as ModelsDevSyncService,
+      mockRegistry as unknown as ProviderModelRegistryService,
+    );
+  });
+
+  it('maps models.dev time tiers onto the bare-key pricing entry', async () => {
+    await service.reload();
+
+    const entry = service.getByModel('deepseek-v4-flash');
+    expect(entry).toBeDefined();
+    expect(entry!.time_tiers).toEqual([
+      {
+        windows: ['01:00-04:00', '06:00-10:00'],
+        input_price_per_token: 0.44 / 1_000_000,
+        output_price_per_token: 1.32 / 1_000_000,
+        cache_read_price_per_token: 0.014 / 1_000_000,
+        cache_write_price_per_token: null,
+      },
+    ]);
+    expect(entry!.input_price_per_token).toBe(0.22 / 1_000_000);
+  });
+
+  it('leaves time_tiers undefined for models without a schedule', async () => {
+    await service.reload();
+
+    expect(service.getByModel('deepseek-chat')!.time_tiers).toBeUndefined();
+  });
+
+  it('strips time tiers from the OpenRouter-prefixed copy of the entry', async () => {
+    // OpenRouter also lists the model, so the prefixed key pre-exists and the
+    // models.dev overlay rewrites it.
+    mockGetAll.mockReturnValue(
+      new Map<string, OpenRouterPricingEntry>([
+        ['deepseek/deepseek-v4-flash', { input: 0.3 / 1_000_000, output: 0.9 / 1_000_000 }],
+      ]),
+    );
+
+    await service.reload();
+
+    const prefixed = service.getByModel('deepseek/deepseek-v4-flash');
+    expect(prefixed).toBeDefined();
+    expect(prefixed!.time_tiers).toBeNull();
+    // The bare key still carries the schedule for direct-API traffic.
+    expect(service.getByModel('deepseek-v4-flash')!.time_tiers).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -394,6 +394,39 @@ describe('ProxyMessageRecorder', () => {
       expect(inserted.cost_usd).toBeCloseTo(0.0075, 10);
     });
 
+    it('bills peak-window pricing from the attempt timestamp, not the wall clock', async () => {
+      getByModelMock.mockReturnValue({
+        model_name: 'deepseek-v4-flash',
+        provider: 'DeepSeek',
+        input_price_per_token: 0.22 / 1_000_000,
+        output_price_per_token: 0.66 / 1_000_000,
+        time_tiers: [
+          {
+            windows: ['01:00-04:00', '06:00-10:00'],
+            input_price_per_token: 0.44 / 1_000_000,
+            output_price_per_token: 1.32 / 1_000_000,
+          },
+        ],
+        display_name: 'DeepSeek V4 Flash',
+      });
+
+      // Attempt started inside a peak window.
+      await recorder.recordFallbackSuccess(ctx, 'deepseek-v4-flash', 'standard', {
+        authType: 'api_key',
+        timestamp: '2026-08-17T02:30:00.000Z',
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 },
+      });
+      expect(insertMock.mock.calls[0][0].cost_usd).toBeCloseTo(0.44 + 1.32, 10);
+
+      // Same usage off-peak bills the base rate.
+      await recorder.recordFallbackSuccess(ctx, 'deepseek-v4-flash', 'standard', {
+        authType: 'api_key',
+        timestamp: '2026-08-17T12:00:00.000Z',
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 },
+      });
+      expect(insertMock.mock.calls[1][0].cost_usd).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
     it('computes cost_usd with cache-read pricing when usage has cached tokens', async () => {
       getByModelMock.mockReturnValue({
         model_name: 'deepseek-v4-pro',

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -425,6 +425,27 @@ describe('ProxyMessageRecorder', () => {
         usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 },
       });
       expect(insertMock.mock.calls[1][0].cost_usd).toBeCloseTo(0.22 + 0.66, 10);
+
+      // The provider attempt start wins over the synthetic fallback timestamp:
+      // the attempt ran in-peak even though the delayed write stamps off-peak.
+      const attempt: ProviderAttemptRef = {
+        id: 'attempt-peak',
+        attemptNumber: 1,
+        startedAtMs: Date.parse('2026-08-17T02:30:00.000Z'),
+        startedAt: '2026-08-17T02:30:00.000Z',
+        pendingWrite: Promise.resolve(true),
+      };
+      await recorder.recordFallbackSuccess(ctx, 'deepseek-v4-flash', 'standard', {
+        authType: 'api_key',
+        attempt,
+        timestamp: '2026-08-17T12:00:00.000Z',
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 },
+      });
+      // The resolved pendingWrite routes this through the update path.
+      expect(updateMock).toHaveBeenCalledWith(
+        { id: 'attempt-peak' },
+        expect.objectContaining({ cost_usd: expect.closeTo(0.44 + 1.32, 10) }),
+      );
     });
 
     it('computes cost_usd with cache-read pricing when usage has cached tokens', async () => {

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -1070,6 +1070,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       isSubscription: authType === 'subscription',
       perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
       reportedCostUsd: usage?.reported_cost_usd,
+      at: timestamp ? new Date(timestamp) : undefined,
     });
 
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -1070,7 +1070,10 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       isSubscription: authType === 'subscription',
       perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
       reportedCostUsd: usage?.reported_cost_usd,
-      at: timestamp ? new Date(timestamp) : undefined,
+      // Bill the hour the provider attempt actually ran: `timestamp` is the
+      // synthetic ordering stamp from recordFallbackFailures, not the attempt
+      // start, so it can cross a peak boundary on delayed writes.
+      at: attempt ? new Date(attempt.startedAt) : timestamp ? new Date(timestamp) : undefined,
     });
 
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(


### PR DESCRIPTION
### ✨ What changed
- `PricingEntry` gains optional `time_tiers` — peak-hour price bands with UTC `HH:MM-HH:MM` windows (start inclusive, end exclusive, midnight wrap supported), mirroring the models.dev `cost.tiers[].tier.type = "time"` schema ([anomalyco/models.dev#4892](https://github.com/anomalyco/models.dev/pull/4892)).
- `computeTokenCost` accepts a billing timestamp (`at`) and swaps in the matching tier's prices; a matching tier replaces the base rates outright (tiers never compose). Defaults to now; the fallback-success recorder passes the attempt timestamp so replayed/delayed writes bill the hour the attempt actually ran.
- The models.dev sync parses time tiers from `cost.tiers` (context-size tiers are ignored) and carries them into the pricing cache.
- A built-in seed supplies DeepSeek V4's schedule until models.dev can express it: off-peak base (flash `$0.22/$0.66`, pro `$0.66/$1.98` per 1M) plus peak windows `01:00–04:00` and `06:00–10:00` UTC at exactly double. The seed only applies when the catalog returns no time tiers, so it retires itself once [#4892](https://github.com/anomalyco/models.dev/pull/4892) + a data PR land upstream ([#4891](https://github.com/anomalyco/models.dev/pull/4891) corrects the flat numbers in the meantime).
- OpenRouter-prefixed cache keys drop the tiers: pricing follows transport, and OpenRouter bills its own flat rate regardless of the lab's peak schedule.

### 💭 Why
DeepSeek moved V4 to peak/off-peak billing on 2026-08-16 (peak = double, 7 hours a day) and publishes no pricing API and no per-request tier marker — the hour must be derived client-side. Manifest's pricing model was flat-per-model, so DeepSeek costs recorded since then are wrong under any single number: the stale catalog rate under-reports by up to 4.7× on peak output. `deepseek-chat` / `deepseek-reasoner` legacy aliases are deliberately untouched — DeepSeek's table only covers the V4 models, and upstream is deprecating the aliases.

### 👤 For users
DeepSeek V4 requests are now costed at the rate DeepSeek actually charges for the hour they ran, instead of a stale flat price that could be off by 2–5×.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bills DeepSeek V4 at real peak/off‑peak rates by resolving UTC time‑of‑day tiers at billing time. Previously we recorded a flat per‑model cost; now a matching time tier replaces base prices so recorded costs match DeepSeek’s 2026‑08‑16 schedule.

- Adds `time_tiers` to `PricingEntry` and updates `computeTokenCost` to accept an optional `at` timestamp. Windows use UTC "HH:MM‑HH:MM" (start inclusive, end exclusive, midnight wrap supported); malformed or zero‑length windows are ignored. A matching tier applies only if it supplies both input and output prices; missing cache prices fall back to the tier’s input price for writes and honor the tier cache‑read price when present.
- The `models.dev` sync parses `cost.tiers` with `tier.type = "time"` and ignores context‑size tiers. A built‑in DeepSeek V4 seed sets off‑peak base rates and peak windows `01:00–04:00` and `06:00–10:00` UTC at exactly 2× until the catalog publishes them; catalog data takes precedence. The seed clears cache‑write pricing to follow DeepSeek’s “write at input rate” policy. Legacy `deepseek-chat`/`deepseek-reasoner` aliases are unchanged.
- `ModelPricingCacheService` carries time tiers on bare model keys. OpenRouter‑prefixed keys preserve OpenRouter’s own flat pricing and only drop `time_tiers` because OpenRouter does not follow lab peak windows.
- `proxy-message-recorder` bills from the provider attempt start when available (falls back to the event timestamp). This ensures delayed/replayed writes bill the hour the attempt ran.
- Migration: If you call `computeTokenCost` directly, pass the request start as `at` to ensure correct peak/off‑peak resolution (otherwise it defaults to now).

<sup>Written for commit 50ba9e13ffef6458699027158f69d5a48502eed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

