### PR TITLE
fix(limits): restore the email provider form for self-hosted installs

### DIFF
--- a/packages/frontend/src/components/EmailProviderSection.tsx
+++ b/packages/frontend/src/components/EmailProviderSection.tsx
@@ -1,0 +1,80 @@
+import { For, Show, type Component } from 'solid-js';
+import ProviderBanner from './ProviderBanner.js';
+import EmailProviderSetup from './EmailProviderSetup.js';
+import type { EmailProviderConfig } from '../services/api.js';
+
+interface EmailProviderSectionProps {
+  emailProvider: EmailProviderConfig | null | undefined;
+  loading: boolean;
+  onConfigured: () => void;
+  onEdit: () => void;
+  onRemove: () => void;
+}
+
+const EmailProviderSection: Component<EmailProviderSectionProps> = (props) => (
+  <div style="margin-bottom: var(--gap-lg);">
+    <Show
+      when={!props.loading}
+      fallback={
+        <Show
+          when={!!props.emailProvider}
+          fallback={
+            <div class="panel">
+              <div class="skeleton skeleton--text" style="width: 180px; height: 16px;" />
+              <div
+                class="skeleton skeleton--text"
+                style="width: 280px; height: 13px; margin-top: 6px;"
+              />
+              <div style="display: flex; gap: var(--gap-md); margin-top: var(--gap-lg);">
+                <For each={[1, 2, 3]}>
+                  {() => (
+                    <div
+                      class="skeleton skeleton--rect"
+                      style="flex: 1; height: 64px; border-radius: var(--radius);"
+                    />
+                  )}
+                </For>
+              </div>
+            </div>
+          }
+        >
+          <div class="provider-card">
+            <div class="provider-card__header">
+              <span class="provider-card__label">Your provider</span>
+              <div
+                class="skeleton skeleton--text"
+                style="width: 16px; height: 16px; border-radius: calc(var(--radius) - 2px);"
+              />
+            </div>
+            <div class="provider-card__body">
+              <div
+                class="skeleton skeleton--rect"
+                style="width: 32px; height: 32px; border-radius: calc(var(--radius) - 2px); flex-shrink: 0;"
+              />
+              <div>
+                <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
+                <div
+                  class="skeleton skeleton--text"
+                  style="width: 160px; height: 12px; margin-top: 6px;"
+                />
+              </div>
+            </div>
+          </div>
+        </Show>
+      }
+    >
+      <Show
+        when={props.emailProvider}
+        fallback={<EmailProviderSetup onConfigured={props.onConfigured} />}
+      >
+        <ProviderBanner
+          config={props.emailProvider!}
+          onEdit={props.onEdit}
+          onRemove={props.onRemove}
+        />
+      </Show>
+    </Show>
+  </div>
+);
+
+export default EmailProviderSection;

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -3,19 +3,24 @@ import { useParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import { authClient } from '../services/auth-client.js';
 import CloudEmailInfo from '../components/CloudEmailInfo.js';
+import EmailProviderModal from '../components/EmailProviderModal.js';
+import EmailProviderSection from '../components/EmailProviderSection.js';
 import LimitRuleModal from '../components/LimitRuleModal.js';
 import type { LimitRuleData } from '../components/LimitRuleModal.js';
 import LimitRuleTable from '../components/LimitRuleTable.js';
 import LimitHistoryTable from '../components/LimitHistoryTable.js';
-import { KebabMenu, DeleteRuleModal } from '../components/LimitModals.js';
+import { KebabMenu, DeleteRuleModal, RemoveProviderModal } from '../components/LimitModals.js';
 import { toast } from '../services/toast-store.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
+import { checkIsSelfHosted, checkEmailConfigured } from '../services/setup-status.js';
 import {
   getNotificationRules,
   getNotificationLogs,
   createNotificationRule,
   updateNotificationRule,
   deleteNotificationRule,
+  getEmailProvider,
+  removeEmailProvider,
   getRoutingStatus,
   type NotificationRule,
 } from '../services/api.js';
@@ -33,8 +38,14 @@ const Limits: Component = () => {
     (name) => getNotificationLogs(name),
   );
   const [routingStatus] = createResource(() => agentName(), getRoutingStatus);
+  const [isSelfHosted] = createResource(checkIsSelfHosted);
+  const [emailConfigured] = createResource(checkEmailConfigured);
+  const [emailProvider, { refetch: refetchProvider }] = createResource(getEmailProvider);
   const session = authClient.useSession();
   const [showModal, setShowModal] = createSignal(false);
+  const [showEditProvider, setShowEditProvider] = createSignal(false);
+  const [showRemoveProvider, setShowRemoveProvider] = createSignal(false);
+  const [removingProvider, setRemovingProvider] = createSignal(false);
   const [editRule, setEditRule] = createSignal<NotificationRule | null>(null);
   const [openMenuId, setOpenMenuId] = createSignal<string | null>(null);
   const [menuPos, setMenuPos] = createSignal<{ top: number; left: number }>({ top: 0, left: 0 });
@@ -43,7 +54,30 @@ const Limits: Component = () => {
   const [deleting, setDeleting] = createSignal(false);
 
   const routingEnabled = () => routingStatus()?.enabled ?? false;
-  const hasProvider = () => true;
+  // Cloud always has a sender. Self-hosted has one when the operator saved a
+  // provider in the dashboard or set the EMAIL_* environment variables.
+  const hasProvider = () =>
+    isSelfHosted() !== true || !!emailProvider() || emailConfigured() === true;
+
+  const hasEmailRules = () => {
+    const r = rules();
+    if (!r) return false;
+    return r.some((rule) => rule.action === 'notify' || rule.action === 'both');
+  };
+
+  const handleRemoveProvider = async () => {
+    setRemovingProvider(true);
+    try {
+      await removeEmailProvider();
+      await refetchProvider();
+      setShowRemoveProvider(false);
+      toast.success('Email provider removed');
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      setRemovingProvider(false);
+    }
+  };
 
   const closeMenu = () => setOpenMenuId(null);
   const handleDocClick = () => closeMenu();
@@ -209,9 +243,22 @@ const Limits: Component = () => {
         </div>
       </Show>
 
-      <div style="margin-bottom: var(--gap-lg);">
-        <CloudEmailInfo email={session().data?.user?.email ?? ''} />
-      </div>
+      <Show
+        when={isSelfHosted() === true}
+        fallback={
+          <div style="margin-bottom: var(--gap-lg);">
+            <CloudEmailInfo email={session().data?.user?.email ?? ''} />
+          </div>
+        }
+      >
+        <EmailProviderSection
+          emailProvider={emailProvider()}
+          loading={emailProvider.loading}
+          onConfigured={refetchProvider}
+          onEdit={() => setShowEditProvider(true)}
+          onRemove={() => setShowRemoveProvider(true)}
+        />
+      </Show>
 
       <LimitRuleTable
         rules={rules()}
@@ -264,6 +311,25 @@ const Limits: Component = () => {
               }
             : null
         }
+      />
+
+      <RemoveProviderModal
+        open={showRemoveProvider()}
+        hasEmailRules={hasEmailRules()}
+        removing={removingProvider()}
+        onCancel={() => setShowRemoveProvider(false)}
+        onRemove={handleRemoveProvider}
+      />
+
+      <EmailProviderModal
+        open={showEditProvider()}
+        initialProvider={emailProvider()?.provider ?? 'resend'}
+        editMode={true}
+        existingKeyPrefix={emailProvider()?.keyPrefix ?? null}
+        existingDomain={emailProvider()?.domain ?? null}
+        existingNotificationEmail={emailProvider()?.notificationEmail ?? null}
+        onClose={() => setShowEditProvider(false)}
+        onSaved={() => refetchProvider()}
       />
     </div>
   );

--- a/packages/frontend/tests/components/EmailProviderSection.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderSection.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+
+// Stub the two heavy children — they have their own tests — so we can assert
+// which mode the section renders in.
+vi.mock('../../src/components/EmailProviderSetup.js', () => ({
+  default: (props: { onConfigured: () => void }) => (
+    <div data-testid="email-setup">
+      <button onClick={props.onConfigured}>setup-done</button>
+    </div>
+  ),
+}));
+vi.mock('../../src/components/ProviderBanner.js', () => ({
+  default: (props: { onEdit: () => void; onRemove: () => void }) => (
+    <div data-testid="provider-banner">
+      <button onClick={props.onEdit}>edit</button>
+      <button onClick={props.onRemove}>remove</button>
+    </div>
+  ),
+}));
+
+import EmailProviderSection from '../../src/components/EmailProviderSection';
+
+describe('EmailProviderSection', () => {
+  it('shows the setup form when not loading and no provider is configured', () => {
+    const onConfigured = vi.fn();
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={null}
+        loading={false}
+        onConfigured={onConfigured}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    ));
+    expect(container.querySelector('[data-testid="email-setup"]')).not.toBeNull();
+    fireEvent.click(container.querySelector('[data-testid="email-setup"] button') as HTMLElement);
+    expect(onConfigured).toHaveBeenCalled();
+  });
+
+  it('shows the provider banner when a provider is configured', () => {
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={{ provider: 'mailgun', from_email: 'a@b' } as never}
+        loading={false}
+        onConfigured={vi.fn()}
+        onEdit={onEdit}
+        onRemove={onRemove}
+      />
+    ));
+    const banner = container.querySelector('[data-testid="provider-banner"]');
+    expect(banner).not.toBeNull();
+    const buttons = banner!.querySelectorAll('button');
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+    expect(onEdit).toHaveBeenCalled();
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('renders the setup-choice skeleton when loading with no configured provider', () => {
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={null}
+        loading={true}
+        onConfigured={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    ));
+    // Setup skeleton: a .panel wrapping a row of three skeleton rects.
+    expect(container.querySelector('.panel')).not.toBeNull();
+    expect(container.querySelectorAll('.skeleton--rect')).toHaveLength(3);
+    expect(container.querySelector('[data-testid="email-setup"]')).toBeNull();
+  });
+
+  it('renders the configured-provider skeleton when loading with a provider known to exist', () => {
+    const { container } = render(() => (
+      <EmailProviderSection
+        emailProvider={{ provider: 'mailgun' } as never}
+        loading={true}
+        onConfigured={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    ));
+    expect(container.querySelector('.provider-card')).not.toBeNull();
+    expect(container.querySelector('.provider-card__label')?.textContent).toBe('Your provider');
+    expect(container.querySelector('[data-testid="provider-banner"]')).toBeNull();
+  });
+});

--- a/packages/frontend/tests/components/EmailProviderSection.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderSection.test.tsx
@@ -11,8 +11,8 @@ vi.mock('../../src/components/EmailProviderSetup.js', () => ({
   ),
 }));
 vi.mock('../../src/components/ProviderBanner.js', () => ({
-  default: (props: { onEdit: () => void; onRemove: () => void }) => (
-    <div data-testid="provider-banner">
+  default: (props: { config: { provider: string }; onEdit: () => void; onRemove: () => void }) => (
+    <div data-testid="provider-banner" data-provider={props.config?.provider}>
       <button onClick={props.onEdit}>edit</button>
       <button onClick={props.onRemove}>remove</button>
     </div>

--- a/packages/frontend/tests/pages/Limits-interactions.test.tsx
+++ b/packages/frontend/tests/pages/Limits-interactions.test.tsx
@@ -20,7 +20,14 @@ vi.mock("../../src/services/api.js", () => ({
   createNotificationRule: vi.fn(() => Promise.resolve({})),
   updateNotificationRule: vi.fn(() => Promise.resolve({})),
   deleteNotificationRule: vi.fn(() => Promise.resolve({})),
+  getEmailProvider: vi.fn(() => Promise.resolve(null)),
+  removeEmailProvider: vi.fn(() => Promise.resolve({})),
   getRoutingStatus: vi.fn(() => Promise.resolve(mockRoutingStatus)),
+}));
+
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkIsSelfHosted: vi.fn(() => Promise.resolve(false)),
+  checkEmailConfigured: vi.fn(() => Promise.resolve(true)),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -15,6 +15,7 @@ let mockRules: any[] = [];
 let mockRoutingStatus = { enabled: false };
 let mockIsSelfHosted = false;
 let mockEmailProvider: any = null;
+let mockRemoveFails = false;
 
 vi.mock("../../src/services/api.js", () => ({
   getNotificationRules: vi.fn(() => Promise.resolve(mockRules)),
@@ -23,7 +24,7 @@ vi.mock("../../src/services/api.js", () => ({
   updateNotificationRule: vi.fn(() => Promise.resolve({})),
   deleteNotificationRule: vi.fn(() => Promise.resolve({})),
   getEmailProvider: vi.fn(() => Promise.resolve(mockEmailProvider)),
-  removeEmailProvider: vi.fn(() => Promise.resolve({})),
+  removeEmailProvider: vi.fn(() => (mockRemoveFails ? Promise.reject(new Error("boom")) : Promise.resolve({}))),
   getRoutingStatus: vi.fn(() => Promise.resolve(mockRoutingStatus)),
 }));
 
@@ -34,15 +35,28 @@ vi.mock("../../src/services/setup-status.js", () => ({
 
 vi.mock("../../src/components/EmailProviderSection.js", () => ({
   default: (props: any) => (
-    <div data-testid="email-provider-section" data-has-provider={String(!!props.emailProvider)}>
-      EmailProviderSection
+    <div data-testid="email-provider-section" data-has-provider={String(!!props.emailProvider)} data-loading={String(props.loading)}>
+      <button data-testid="section-configured" onClick={() => props.onConfigured()}>configured</button>
+      <button data-testid="section-edit" onClick={() => props.onEdit()}>edit</button>
+      <button data-testid="section-remove" onClick={() => props.onRemove()}>remove</button>
     </div>
   ),
 }));
 
 vi.mock("../../src/components/EmailProviderModal.js", () => ({
   default: (props: any) => (
-    <div data-testid="email-provider-modal" data-open={String(props.open)}>EmailProviderModal</div>
+    <div
+      data-testid="email-provider-modal"
+      data-open={String(props.open)}
+      data-edit-mode={String(props.editMode)}
+      data-initial={props.initialProvider}
+      data-key-prefix={String(props.existingKeyPrefix)}
+      data-domain={String(props.existingDomain)}
+      data-notification-email={String(props.existingNotificationEmail)}
+    >
+      <button data-testid="modal-close" onClick={() => props.onClose()}>close</button>
+      <button data-testid="modal-saved" onClick={() => props.onSaved()}>saved</button>
+    </div>
   ),
 }));
 
@@ -84,6 +98,7 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
     mockIsSelfHosted = false;
     mockEmailProvider = null;
+    mockRemoveFails = false;
   });
 
   it("does not render a duplicate page heading", () => {
@@ -572,5 +587,97 @@ describe("Limits page", () => {
       expect(screen.getByTestId("cloud-email-info")).toBeDefined();
     });
     expect(screen.queryByTestId("email-provider-section")).toBeNull();
+  });
+
+  it("opens the edit modal with the saved provider's details and closes it", async () => {
+    mockIsSelfHosted = true;
+    mockEmailProvider = { provider: "mailgun", keyPrefix: "key-", domain: "mg.example.com", notificationEmail: "ops@example.com" };
+    render(() => <Limits />);
+    await waitFor(() => {
+      expect(screen.getByTestId("email-provider-section").getAttribute("data-has-provider")).toBe("true");
+    });
+    fireEvent.click(screen.getByTestId("section-edit"));
+    const modal = screen.getByTestId("email-provider-modal");
+    expect(modal.getAttribute("data-open")).toBe("true");
+    expect(modal.getAttribute("data-edit-mode")).toBe("true");
+    expect(modal.getAttribute("data-initial")).toBe("mailgun");
+    expect(modal.getAttribute("data-key-prefix")).toBe("key-");
+    expect(modal.getAttribute("data-domain")).toBe("mg.example.com");
+    expect(modal.getAttribute("data-notification-email")).toBe("ops@example.com");
+    fireEvent.click(screen.getByTestId("modal-close"));
+    expect(modal.getAttribute("data-open")).toBe("false");
+  });
+
+  it("refetches the provider after the modal saves or the setup completes", async () => {
+    mockIsSelfHosted = true;
+    render(() => <Limits />);
+    await waitFor(() => {
+      expect(screen.getByTestId("email-provider-section")).toBeDefined();
+    });
+    const api = await import("../../src/services/api.js");
+    const before = (api.getEmailProvider as any).mock.calls.length;
+    fireEvent.click(screen.getByTestId("section-configured"));
+    await waitFor(() => {
+      expect((api.getEmailProvider as any).mock.calls.length).toBeGreaterThanOrEqual(before + 1);
+    });
+    const afterConfigured = (api.getEmailProvider as any).mock.calls.length;
+    fireEvent.click(screen.getByTestId("modal-saved"));
+    await waitFor(() => {
+      expect((api.getEmailProvider as any).mock.calls.length).toBeGreaterThanOrEqual(afterConfigured + 1);
+    });
+  });
+
+  it("removes the provider, warns about email rules, and closes the confirm dialog", async () => {
+    mockIsSelfHosted = true;
+    mockEmailProvider = { provider: "resend" };
+    mockRules = [{ id: "r1", metric_type: "tokens", threshold: 100, period: "day", action: "notify", is_active: true, trigger_count: 0 }];
+    render(() => <Limits />);
+    await waitFor(() => {
+      expect(screen.getByTestId("email-provider-section")).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId("section-remove"));
+    await waitFor(() => {
+      expect(screen.getByText("Remove provider")).toBeDefined();
+    });
+    expect(document.body.textContent).toContain("Email alerts won't be sent until you set up a new one.");
+    fireEvent.click(screen.getByText("Remove"));
+    const api = await import("../../src/services/api.js");
+    await waitFor(() => {
+      expect(api.removeEmailProvider).toHaveBeenCalled();
+    });
+    const { toast } = await import("../../src/services/toast-store.js");
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Email provider removed");
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Remove provider")).toBeNull();
+    });
+  });
+
+  it("keeps the confirm dialog open and recovers when the removal fails", async () => {
+    mockIsSelfHosted = true;
+    mockEmailProvider = { provider: "resend" };
+    mockRemoveFails = true;
+    render(() => <Limits />);
+    await waitFor(() => {
+      expect(screen.getByTestId("email-provider-section")).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId("section-remove"));
+    await waitFor(() => {
+      expect(screen.getByText("Remove provider")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("Remove"));
+    const api = await import("../../src/services/api.js");
+    await waitFor(() => {
+      expect(api.removeEmailProvider).toHaveBeenCalled();
+    });
+    expect(screen.getByText("Remove provider")).toBeDefined();
+    await waitFor(() => {
+      expect((screen.getByText("Remove") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByText("Cancel"));
+    await waitFor(() => {
+      expect(screen.queryByText("Remove provider")).toBeNull();
+    });
   });
 });

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -13,6 +13,8 @@ vi.mock("@solidjs/meta", () => ({
 
 let mockRules: any[] = [];
 let mockRoutingStatus = { enabled: false };
+let mockIsSelfHosted = false;
+let mockEmailProvider: any = null;
 
 vi.mock("../../src/services/api.js", () => ({
   getNotificationRules: vi.fn(() => Promise.resolve(mockRules)),
@@ -20,7 +22,28 @@ vi.mock("../../src/services/api.js", () => ({
   createNotificationRule: vi.fn(() => Promise.resolve({})),
   updateNotificationRule: vi.fn(() => Promise.resolve({})),
   deleteNotificationRule: vi.fn(() => Promise.resolve({})),
+  getEmailProvider: vi.fn(() => Promise.resolve(mockEmailProvider)),
+  removeEmailProvider: vi.fn(() => Promise.resolve({})),
   getRoutingStatus: vi.fn(() => Promise.resolve(mockRoutingStatus)),
+}));
+
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkIsSelfHosted: vi.fn(() => Promise.resolve(mockIsSelfHosted)),
+  checkEmailConfigured: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("../../src/components/EmailProviderSection.js", () => ({
+  default: (props: any) => (
+    <div data-testid="email-provider-section" data-has-provider={String(!!props.emailProvider)}>
+      EmailProviderSection
+    </div>
+  ),
+}));
+
+vi.mock("../../src/components/EmailProviderModal.js", () => ({
+  default: (props: any) => (
+    <div data-testid="email-provider-modal" data-open={String(props.open)}>EmailProviderModal</div>
+  ),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({
@@ -59,6 +82,8 @@ describe("Limits page", () => {
   beforeEach(() => {
     mockRules = [];
     mockRoutingStatus = { enabled: false };
+    mockIsSelfHosted = false;
+    mockEmailProvider = null;
   });
 
   it("does not render a duplicate page heading", () => {
@@ -530,4 +555,22 @@ describe("Limits page", () => {
     });
   });
 
+
+  it("shows the email provider section instead of the cloud card on self-hosted", async () => {
+    mockIsSelfHosted = true;
+    render(() => <Limits />);
+    await waitFor(() => {
+      expect(screen.getByTestId("email-provider-section")).toBeDefined();
+    });
+    expect(screen.queryByTestId("cloud-email-info")).toBeNull();
+  });
+
+  it("keeps the cloud email card on cloud", async () => {
+    mockIsSelfHosted = false;
+    render(() => <Limits />);
+    await waitFor(() => {
+      expect(screen.getByTestId("cloud-email-info")).toBeDefined();
+    });
+    expect(screen.queryByTestId("email-provider-section")).toBeNull();
+  });
 });


### PR DESCRIPTION
Self-hosted installs lost the email provider form on the Limits page by accident. The picker (Resend/Mailgun/SendGrid) was mounted on the old local mode; #1539 removed that mode and silently unmounted the form with it, then #2207 deleted the orphaned `EmailProviderSection` as component cleanup. Nobody decided self-hosters shouldn't have it: the backend endpoints (`/notifications/email-provider` CRUD + test), the API client functions, the `email_provider_configs` table, and the base components all survived. Even `docker/.env.example` still promises "per-user providers configured in the dashboard always take precedence".

This restores the form:

- `EmailProviderSection` recovered from git history, unchanged (80 lines).
- `Limits.tsx` gates on the self-hosted status the setup endpoint already exposes: self-hosted shows the picker, or the provider card with edit/remove once configured; cloud keeps the read-only card exactly as today.
- A dashboard-saved provider or the `EMAIL_*` env vars both count as a configured sender for the rule-table hints.
- Tests: the section's 92-line test restored, the Limits page test extended with the cloud/self-hosted split (35 pass).

Verified live on a self-hosted instance: the Limits page shows "Configure email provider" with the three tiles again (screenshot below), and cloud mode is untouched.

Once merged and released, I'll update the docs (observability page) to document the form alongside the `EMAIL_*` variables.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the email provider configuration UI on the Limits page for self-hosted installs. Previously, self-hosted showed a read-only cloud card with no way to configure email; now it shows the provider picker or a provider card with edit/remove. Cloud behavior is unchanged.

- Gating/behavior: uses `checkIsSelfHosted` and `checkEmailConfigured`; a provider is configured if `getEmailProvider` returns a config or `EMAIL_*` env vars are set. Drives rule-table hints via a `hasProvider` check.
- UI: restores `EmailProviderSection`; wires `EmailProviderModal` (edit) and `RemoveProviderModal` (remove). Calls `removeEmailProvider`, refetches the provider on configure/save/remove, shows skeletons, and warns when removing with active email rules; success toast on removal; failed removal keeps the dialog open and re-enables the button.
- Tests: adds `EmailProviderSection` test; updates Limits page tests to split cloud/self-hosted and to exercise edit modal details, refetch after setup/save, and removal success/failure. Interactions suite mocks `getEmailProvider`/`removeEmailProvider` and setup-status. Changed test files cover new lines fully.
- No backend changes or migrations.

<sup>Written for commit 75878db728ddc70215cc708b2c01fb386c2893ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

