### PR TITLE
feat: refresh modelparams catalog from the modelparams.dev API

### DIFF
--- a/.changeset/mps-catalog-api-refresh.md
+++ b/.changeset/mps-catalog-api-refresh.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep model parameter specs current: the modelparams catalog now refreshes hourly from the modelparams.dev API (ETag-conditional, validated before swap, stale-on-error) instead of being frozen at the bundled package version, and the bundled fallback is bumped to modelparams 0.0.40.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12349,15 +12349,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/modelparams": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/modelparams/-/modelparams-0.0.18.tgz",
-      "integrity": "sha512-hN0wy5YUVM7IhoGkiaFZ11W8zAaoRAWQk+hhc3QWQgH8UmjXSbH5XoVmoY0Rn+xHudq1KmRCn9HHzjJ10WngoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -16464,7 +16455,7 @@
         "express-rate-limit": "^8.6.1",
         "helmet": "^8.3.0",
         "manifest-shared": "*",
-        "modelparams": "^0.0.18",
+        "modelparams": "^0.0.40",
         "pg": "^8.22.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -16496,6 +16487,15 @@
         "ts-jest": "^29.4.12",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.0"
+      }
+    },
+    "packages/backend/node_modules/modelparams": {
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/modelparams/-/modelparams-0.0.40.tgz",
+      "integrity": "sha512-swdFhOOfMm9FGzrCsdGeFTb/7Di+capHRoT4F+ILdcjqKrNB2LV1epXggrync0+YVoq18877tRv+rUYoSnoplA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/backend/node_modules/typescript": {
@@ -16581,7 +16581,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.17.1"
+      "version": "6.18.0"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
     "express-rate-limit": "^8.6.1",
     "helmet": "^8.3.0",
     "manifest-shared": "*",
-    "modelparams": "^0.0.18",
+    "modelparams": "^0.0.40",
     "pg": "^8.22.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -283,6 +283,17 @@ describe('ProviderParamSpecService API refresh', () => {
     expect(specs.length).toBeGreaterThan(0);
   });
 
+  it('rejects an oversized Content-Length without reading the body', async () => {
+    const response = jsonResponse(CATALOG_BODY, {
+      headers: { 'content-length': String(17 * 1024 * 1024) },
+    });
+    fetchSpy.mockResolvedValue(response);
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(false);
+    expect(response.bodyUsed).toBe(false);
+  });
+
   it('keeps the bundled catalog when reading the response body throws', async () => {
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -269,6 +269,7 @@ describe('ProviderParamSpecService API refresh', () => {
     ['a network error', () => fetchSpy.mockRejectedValue(new Error('boom'))],
     ['a non-2xx status', () => fetchSpy.mockResolvedValue(new Response('nope', { status: 503 }))],
     ['invalid JSON', () => fetchSpy.mockResolvedValue(jsonResponse('{not json'))],
+    ['an empty body', () => fetchSpy.mockResolvedValue(new Response(null, { status: 200 }))],
     [
       'a body that fails catalog validation',
       () => fetchSpy.mockResolvedValue(jsonResponse(JSON.stringify({ models: 'wat' }))),
@@ -282,24 +283,44 @@ describe('ProviderParamSpecService API refresh', () => {
     expect(specs.length).toBeGreaterThan(0);
   });
 
-  it('keeps the bundled catalog when the response exceeds the size ceiling', async () => {
-    const response = jsonResponse(CATALOG_BODY);
-    const textSpy = jest.spyOn(response, 'text').mockResolvedValue('x'.repeat(17 * 1024 * 1024));
+  it('rejects an oversized Content-Length before reading the body', async () => {
+    const response = jsonResponse(CATALOG_BODY, {
+      headers: { 'content-length': String(17 * 1024 * 1024) },
+    });
     fetchSpy.mockResolvedValue(response);
     const service = new ProviderParamSpecService();
 
     await expect(service.refreshCatalog()).resolves.toBe(false);
-    textSpy.mockRestore();
+    expect(response.bodyUsed).toBe(false);
+  });
+
+  it('cancels the stream when the received bytes cross the size ceiling', async () => {
+    const chunk = new Uint8Array(9 * 1024 * 1024);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+    fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(false);
+    const specs = await service.getSpecs('openai', 'api_key', 'gpt-4o');
+    expect(specs.length).toBeGreaterThan(0);
   });
 
   it('keeps the bundled catalog when reading the response body throws', async () => {
-    const response = jsonResponse(CATALOG_BODY);
-    const textSpy = jest.spyOn(response, 'text').mockRejectedValue(new Error('socket reset'));
-    fetchSpy.mockResolvedValue(response);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error('socket reset'));
+      },
+    });
+    fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
     const service = new ProviderParamSpecService();
 
     await expect(service.refreshCatalog()).resolves.toBe(false);
-    textSpy.mockRestore();
   });
 
   it('refreshes on module init and on the cron tick, surviving failures', async () => {

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -283,34 +283,6 @@ describe('ProviderParamSpecService API refresh', () => {
     expect(specs.length).toBeGreaterThan(0);
   });
 
-  it('rejects an oversized Content-Length before reading the body', async () => {
-    const response = jsonResponse(CATALOG_BODY, {
-      headers: { 'content-length': String(17 * 1024 * 1024) },
-    });
-    fetchSpy.mockResolvedValue(response);
-    const service = new ProviderParamSpecService();
-
-    await expect(service.refreshCatalog()).resolves.toBe(false);
-    expect(response.bodyUsed).toBe(false);
-  });
-
-  it('cancels the stream when the received bytes cross the size ceiling', async () => {
-    const chunk = new Uint8Array(9 * 1024 * 1024);
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(chunk);
-        controller.enqueue(chunk);
-        controller.close();
-      },
-    });
-    fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
-    const service = new ProviderParamSpecService();
-
-    await expect(service.refreshCatalog()).resolves.toBe(false);
-    const specs = await service.getSpecs('openai', 'api_key', 'gpt-4o');
-    expect(specs.length).toBeGreaterThan(0);
-  });
-
   it('keeps the bundled catalog when reading the response body throws', async () => {
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -178,3 +178,138 @@ describe('ProviderParamSpecService', () => {
     await expect(service.getCapabilities('openai', 'api_key', 'missing-model')).resolves.toBeNull();
   });
 });
+
+describe('ProviderParamSpecService API refresh', () => {
+  const CATALOG_BODY = JSON.stringify({
+    models: [
+      {
+        provider: 'openai',
+        authType: 'api_key',
+        model: 'gpt-refreshed',
+        params: [
+          {
+            path: 'max_tokens',
+            type: 'integer',
+            label: 'Max tokens',
+            description: 'Maximum number of tokens.',
+            group: 'generation_length',
+          },
+        ],
+      },
+    ],
+  });
+
+  const jsonResponse = (body: string, init?: ResponseInit): Response =>
+    new Response(body, { status: 200, ...init });
+
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    delete process.env.MODELPARAMS_API_DISABLED;
+    delete process.env.MODELPARAMS_API_URL;
+  });
+
+  it('swaps in a fetched catalog and remembers its ETag', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(CATALOG_BODY, { headers: { etag: '"v1"' } }));
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(true);
+    const specs = await service.getSpecs('openai', 'api_key', 'gpt-refreshed');
+    expect(specs.map((spec) => spec.path)).toEqual(['max_tokens']);
+
+    fetchSpy.mockResolvedValue(new Response(null, { status: 304 }));
+    await expect(service.refreshCatalog()).resolves.toBe(false);
+    const [, secondInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    expect(secondInit.headers).toEqual({ 'if-none-match': '"v1"' });
+    // The 304 keeps the previously fetched catalog.
+    expect((await service.getSpecs('openai', 'api_key', 'gpt-refreshed')).length).toBe(1);
+  });
+
+  it('honors MODELPARAMS_API_URL and sends no conditional header on the first fetch', async () => {
+    process.env.MODELPARAMS_API_URL = 'https://example.test/catalog.json';
+    fetchSpy.mockResolvedValue(jsonResponse(CATALOG_BODY));
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://example.test/catalog.json');
+    expect(init.headers).toBeUndefined();
+  });
+
+  it('does nothing when MODELPARAMS_API_DISABLED is set', async () => {
+    process.env.MODELPARAMS_API_DISABLED = 'true';
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('shares one in-flight refresh between concurrent callers', async () => {
+    let release!: (value: Response) => void;
+    fetchSpy.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const service = new ProviderParamSpecService();
+
+    const first = service.refreshCatalog();
+    const second = service.refreshCatalog();
+    release(jsonResponse(CATALOG_BODY));
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['a network error', () => fetchSpy.mockRejectedValue(new Error('boom'))],
+    ['a non-2xx status', () => fetchSpy.mockResolvedValue(new Response('nope', { status: 503 }))],
+    ['invalid JSON', () => fetchSpy.mockResolvedValue(jsonResponse('{not json'))],
+    [
+      'a body that fails catalog validation',
+      () => fetchSpy.mockResolvedValue(jsonResponse(JSON.stringify({ models: 'wat' }))),
+    ],
+  ])('keeps the bundled catalog on %s', async (_label, arm) => {
+    arm();
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(false);
+    const specs = await service.getSpecs('openai', 'api_key', 'gpt-4o');
+    expect(specs.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the bundled catalog when the response exceeds the size ceiling', async () => {
+    const response = jsonResponse(CATALOG_BODY);
+    const textSpy = jest.spyOn(response, 'text').mockResolvedValue('x'.repeat(17 * 1024 * 1024));
+    fetchSpy.mockResolvedValue(response);
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(false);
+    textSpy.mockRestore();
+  });
+
+  it('keeps the bundled catalog when reading the response body throws', async () => {
+    const response = jsonResponse(CATALOG_BODY);
+    const textSpy = jest.spyOn(response, 'text').mockRejectedValue(new Error('socket reset'));
+    fetchSpy.mockResolvedValue(response);
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(false);
+    textSpy.mockRestore();
+  });
+
+  it('refreshes on module init and on the cron tick, surviving failures', async () => {
+    fetchSpy.mockRejectedValue(new Error('offline'));
+    const service = new ProviderParamSpecService();
+
+    service.onModuleInit();
+    await service.scheduledRefresh();
+    expect(fetchSpy).toHaveBeenCalled();
+    // Both paths swallow the failure; the bundled catalog still serves.
+    expect((await service.list()).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
 import {
   AUTH_TYPES,
   MODEL_CAPABILITIES,
@@ -28,6 +29,10 @@ import {
 
 const MODELPARAMS_PACKAGE_JSON = 'modelparams/package.json';
 const MODELPARAMS_DATA_RELATIVE_PATH = 'dist/generated/data.js';
+const MODELPARAMS_API_DEFAULT_URL = 'https://modelparams.dev/api/v1/models.json';
+const MODELPARAMS_API_TIMEOUT_MS = 10000;
+/** Hard ceiling on the API payload; today's catalog is ~0.6 MB. */
+const MODELPARAMS_API_MAX_BYTES = 16 * 1024 * 1024;
 const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
 const SHORT_CLAUDE_MODEL_RE = /^claude-(opus|sonnet|haiku)-/i;
 const DOTTED_CLAUDE_MINOR_RE = /-(\d+)\.(\d{1,2})(?=$|-\d{8}$)/g;
@@ -69,8 +74,99 @@ interface ProviderlessModelParamCandidate {
 const requireFromThisModule = createRequire(__filename);
 
 @Injectable()
-export class ProviderParamSpecService {
-  private readonly specs: ProviderParamSpecCatalog = loadModelparamsCatalog();
+export class ProviderParamSpecService implements OnModuleInit {
+  private readonly logger = new Logger(ProviderParamSpecService.name);
+  /**
+   * Seeded synchronously from the bundled modelparams package so the service
+   * always has a catalog (offline installs, API outages, cold boots), then
+   * kept fresh from the modelparams.dev API.
+   */
+  private specs: ProviderParamSpecCatalog = loadModelparamsCatalog();
+  private catalogEtag: string | null = null;
+  private refreshInFlight: Promise<boolean> | null = null;
+
+  onModuleInit(): void {
+    // Fire-and-forget so a slow modelparams.dev fetch can't delay app.listen()
+    // (same rationale as ModelsDevSyncService — see #1894). refreshCatalog
+    // never rejects, so no dangling rejection to handle here.
+    void this.refreshCatalog();
+  }
+
+  /** Hourly, off the top of the hour to avoid stampeding the CDN with every deploy. */
+  @Cron('34 * * * *')
+  async scheduledRefresh(): Promise<void> {
+    await this.refreshCatalog();
+  }
+
+  /**
+   * Fetch the live catalog from modelparams.dev and swap it in atomically.
+   * Conditional on the last ETag (304 = no work), validated before the swap,
+   * and stale-on-error: any failure keeps the current catalog. Never rejects.
+   * Returns true when a new catalog was applied.
+   */
+  refreshCatalog(): Promise<boolean> {
+    if (process.env.MODELPARAMS_API_DISABLED === 'true') return Promise.resolve(false);
+    // Concurrent callers share one in-flight refresh instead of racing the swap.
+    if (this.refreshInFlight) return this.refreshInFlight;
+    this.refreshInFlight = this.fetchAndSwapCatalog()
+      .catch((err: unknown) => {
+        this.logger.warn(`modelparams catalog refresh failed, keeping current catalog: ${err}`);
+        return false;
+      })
+      .finally(() => {
+        this.refreshInFlight = null;
+      });
+    return this.refreshInFlight;
+  }
+
+  private async fetchAndSwapCatalog(): Promise<boolean> {
+    const url = process.env.MODELPARAMS_API_URL ?? MODELPARAMS_API_DEFAULT_URL;
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: this.catalogEtag ? { 'if-none-match': this.catalogEtag } : undefined,
+        signal: AbortSignal.timeout(MODELPARAMS_API_TIMEOUT_MS),
+      });
+    } catch (err) {
+      this.logger.warn(`modelparams catalog fetch failed, keeping current catalog: ${err}`);
+      return false;
+    }
+
+    if (response.status === 304) return false;
+    if (!response.ok) {
+      this.logger.warn(
+        `modelparams catalog fetch returned ${response.status}, keeping current catalog`,
+      );
+      return false;
+    }
+
+    const body = await response.text();
+    if (body.length > MODELPARAMS_API_MAX_BYTES) {
+      this.logger.warn(
+        `modelparams catalog response is ${body.length} bytes (max ${MODELPARAMS_API_MAX_BYTES}), keeping current catalog`,
+      );
+      return false;
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(body) as unknown;
+    } catch {
+      this.logger.warn('modelparams catalog response is not valid JSON, keeping current catalog');
+      return false;
+    }
+
+    const catalog = parseModelParametersCatalog(raw);
+    if (!catalog) {
+      this.logger.warn('modelparams catalog response failed validation, keeping current catalog');
+      return false;
+    }
+
+    this.specs = freezeCatalog(catalog);
+    this.catalogEtag = response.headers.get('etag');
+    this.logger.log(`modelparams catalog refreshed: ${catalog.length} entries`);
+    return true;
+  }
 
   async list(): Promise<ProviderParamSpecCatalog> {
     return this.specs;

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -140,10 +140,10 @@ export class ProviderParamSpecService implements OnModuleInit {
       return false;
     }
 
-    const body = await response.text();
-    if (body.length > MODELPARAMS_API_MAX_BYTES) {
+    const body = await readBodyWithinByteCap(response, MODELPARAMS_API_MAX_BYTES);
+    if (body === null) {
       this.logger.warn(
-        `modelparams catalog response is ${body.length} bytes (max ${MODELPARAMS_API_MAX_BYTES}), keeping current catalog`,
+        `modelparams catalog response exceeds ${MODELPARAMS_API_MAX_BYTES} bytes, keeping current catalog`,
       );
       return false;
     }
@@ -243,6 +243,31 @@ export class ProviderParamSpecService implements OnModuleInit {
     }
     return [];
   }
+}
+
+/**
+ * Read the response body while enforcing the byte ceiling *before* buffering:
+ * an over-limit Content-Length is rejected without touching the body, and a
+ * chunked/lying stream is cancelled the moment the running byte count crosses
+ * the cap. Returns null when the cap is exceeded.
+ */
+async function readBodyWithinByteCap(response: Response, maxBytes: number): Promise<string | null> {
+  if (Number(response.headers.get('content-length')) > maxBytes) return null;
+  if (!response.body) return response.text();
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let receivedBytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    receivedBytes += value.byteLength;
+    if (receivedBytes > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks).toString('utf8');
 }
 
 function loadModelparamsCatalog(): ProviderParamSpecCatalog {

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -31,8 +31,6 @@ const MODELPARAMS_PACKAGE_JSON = 'modelparams/package.json';
 const MODELPARAMS_DATA_RELATIVE_PATH = 'dist/generated/data.js';
 const MODELPARAMS_API_DEFAULT_URL = 'https://modelparams.dev/api/v1/models.json';
 const MODELPARAMS_API_TIMEOUT_MS = 10000;
-/** Hard ceiling on the API payload; today's catalog is ~0.6 MB. */
-const MODELPARAMS_API_MAX_BYTES = 16 * 1024 * 1024;
 const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
 const SHORT_CLAUDE_MODEL_RE = /^claude-(opus|sonnet|haiku)-/i;
 const DOTTED_CLAUDE_MINOR_RE = /-(\d+)\.(\d{1,2})(?=$|-\d{8}$)/g;
@@ -140,13 +138,9 @@ export class ProviderParamSpecService implements OnModuleInit {
       return false;
     }
 
-    const body = await readBodyWithinByteCap(response, MODELPARAMS_API_MAX_BYTES);
-    if (body === null) {
-      this.logger.warn(
-        `modelparams catalog response exceeds ${MODELPARAMS_API_MAX_BYTES} bytes, keeping current catalog`,
-      );
-      return false;
-    }
+    // The AbortSignal above also bounds body consumption, so the download can
+    // never outlive the 10s timeout — no separate size cap needed.
+    const body = await response.text();
 
     let raw: unknown;
     try {
@@ -243,31 +237,6 @@ export class ProviderParamSpecService implements OnModuleInit {
     }
     return [];
   }
-}
-
-/**
- * Read the response body while enforcing the byte ceiling *before* buffering:
- * an over-limit Content-Length is rejected without touching the body, and a
- * chunked/lying stream is cancelled the moment the running byte count crosses
- * the cap. Returns null when the cap is exceeded.
- */
-async function readBodyWithinByteCap(response: Response, maxBytes: number): Promise<string | null> {
-  if (Number(response.headers.get('content-length')) > maxBytes) return null;
-  if (!response.body) return response.text();
-  const reader = response.body.getReader();
-  const chunks: Buffer[] = [];
-  let receivedBytes = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    receivedBytes += value.byteLength;
-    if (receivedBytes > maxBytes) {
-      await reader.cancel();
-      return null;
-    }
-    chunks.push(Buffer.from(value));
-  }
-  return Buffer.concat(chunks).toString('utf8');
 }
 
 function loadModelparamsCatalog(): ProviderParamSpecCatalog {

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -31,6 +31,8 @@ const MODELPARAMS_PACKAGE_JSON = 'modelparams/package.json';
 const MODELPARAMS_DATA_RELATIVE_PATH = 'dist/generated/data.js';
 const MODELPARAMS_API_DEFAULT_URL = 'https://modelparams.dev/api/v1/models.json';
 const MODELPARAMS_API_TIMEOUT_MS = 10000;
+/** Sanity bound on the buffered payload; today's catalog is ~0.6 MB. */
+const MODELPARAMS_API_MAX_BYTES = 16 * 1024 * 1024;
 const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
 const SHORT_CLAUDE_MODEL_RE = /^claude-(opus|sonnet|haiku)-/i;
 const DOTTED_CLAUDE_MINOR_RE = /-(\d+)\.(\d{1,2})(?=$|-\d{8}$)/g;
@@ -138,8 +140,16 @@ export class ProviderParamSpecService implements OnModuleInit {
       return false;
     }
 
-    // The AbortSignal above also bounds body consumption, so the download can
-    // never outlive the 10s timeout — no separate size cap needed.
+    // Reject an oversized declared payload before buffering it. A chunked or
+    // lying response is deliberately left to the 10s AbortSignal (which also
+    // bounds body consumption) rather than a streaming byte cap — this is our
+    // own CDN, and the simplicity is worth the residual risk.
+    if (Number(response.headers.get('content-length')) > MODELPARAMS_API_MAX_BYTES) {
+      this.logger.warn(
+        `modelparams catalog response declares more than ${MODELPARAMS_API_MAX_BYTES} bytes, keeping current catalog`,
+      );
+      return false;
+    }
     const body = await response.text();
 
     let raw: unknown;


### PR DESCRIPTION
### ✨ What changed
- `ProviderParamSpecService` now refreshes the model-params catalog from `https://modelparams.dev/api/v1/models.json` — once at boot (fire-and-forget, same rationale as `ModelsDevSyncService` / #1894) and hourly (`34 * * * *`).
- The refresh is a proper cache client: **ETag-conditional** (`If-None-Match` → 304 = no work), 10s timeout, a Content-Length sanity bound (chunked responses stay time-bounded by the abort signal), and the payload is validated through the existing catalog parser **before** the atomic swap — **stale-on-error** on every failure path, so a bad fetch can never degrade the serving catalog. Concurrent callers share one in-flight refresh.
- The bundled `modelparams` package stays as the synchronous boot seed / offline fallback, bumped `0.0.18` → `0.0.40` (22 releases of catalog drift, including the Mistral `top_p`/DashScope temperature bound fixes, `json_schema` coverage, and the per-param `deprecated` flag).
- Env: `MODELPARAMS_API_URL` overrides the endpoint; `MODELPARAMS_API_DISABLED=true` pins the bundled catalog (offline/self-hosted installs).

### 💭 Why
The catalog was frozen at whatever `modelparams` version was installed at build time — the pinned `^0.0.18` (exact under 0.0.x caret semantics) is 22 releases behind, so every param fix and new model shipped to modelparams.dev since then was invisible to routing until someone bumped the dep and cut a release. The API is the live source of truth and already serves proper `etag`/`cache-control`; Manifest should consume it directly.

### 👤 For users
Model parameter dialogs, capability lookups, and outbound param application pick up new models and corrected bounds within an hour of them landing in the catalog — no Manifest release required.

### 📝 Notes
- The API payload (`{models: [...]}`) is exactly the shape the existing `parseModelParametersCatalog` already validates — the `ModelParametersApiResponse` interface predates the package-based loader.
- New code is fully covered (new tests: swap+ETag, 304, env override/kill-switch, in-flight dedup, and every keep-stale path — network error, non-2xx, oversized Content-Length, invalid JSON, empty body, failed validation, body-read throw).
- Full backend suite: 457 suites / 8,346 tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the provider param catalog from the modelparams.dev API at boot and hourly so specs stay current. Previously we served only the bundled `modelparams` catalog; now we fetch ETag-conditional with a 10s timeout, validate before an atomic swap, reject oversized Content-Length responses (>16 MB) before buffering, and keep the existing catalog on any error.

- Boot-time fire-and-forget refresh and a cron at 34 past each hour; concurrent callers share one in-flight fetch.
- Conditional fetch (304 = no work); invalid JSON, failed validation, non-2xx, read errors, or oversized declared payloads keep the current catalog.
- Seeds synchronously from the bundled fallback; bumps `modelparams` from 0.0.18 to 0.0.40.

**Ops and migration**
- Default endpoint is https://modelparams.dev/api/v1/models.json; set `MODELPARAMS_API_URL` to override.
- To pin the bundled catalog (offline/self-hosted), set `MODELPARAMS_API_DISABLED=true`.
- No client or routing API changes required.

<sup>Written for commit 76fe9cee0bfb3dd44ecf77ada223204a8253c2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

