### PR TITLE
docs(docker): fix the LAN instructions and auto-sync the Hub description

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,27 @@
+name: Docker Hub description
+
+# Keeps the Docker Hub repository page in sync with docker/DOCKER_README.md.
+# The page used to be pasted by hand and drifted for months behind the file
+# (dead LAN instructions, stale tag examples, missing recordings volume).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docker/DOCKER_README.md
+      - .github/workflows/dockerhub-description.yml
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4.0.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: manifestdotbuild/manifest
+          readme-filepath: docker/DOCKER_README.md

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -271,7 +271,7 @@ both. A mismatch fails the login with "Invalid origin".
 
 By default the compose file binds port `2099` to `127.0.0.1` only. The dashboard is reachable from the host but not from other machines on the network. To expose it on the LAN:
 
-1. Edit `docker-compose.yml` and change the `ports` line from `"127.0.0.1:2099:2099"` to `"2099:2099"`.
+1. In `.env`, set `HOST_BIND_ADDRESS=0.0.0.0`. Editing `docker-compose.yml` by hand does not survive an upgrade; `.env` does.
 2. In `.env`, set `BETTER_AUTH_URL` to the host you'll reach the dashboard on, e.g. `http://192.168.1.20:2099` or `https://manifest.mydomain.com`. This MUST match the URL in the browser or Better Auth will reject the login with "Invalid origin".
 3. `docker compose up -d` to apply.
 


### PR DESCRIPTION
The Docker Hub page (hub.docker.com/r/manifestdotbuild/manifest) drifted months behind `docker/DOCKER_README.md`: it still tells users to edit a compose `ports` line that no longer exists (wiped on upgrade anyway), shows 5.x tag examples, and claims "nothing else in the Manifest container is stateful" while the recordings volume exists. The repo file had already fixed all of that except the LAN section.

Two changes:

1. `docker/DOCKER_README.md`: the LAN section now sets `HOST_BIND_ADDRESS=0.0.0.0` in `.env` (matching the docs fix in mnfst/docs#65), instead of the dead compose edit.
2. `.github/workflows/dockerhub-description.yml`: republishes the file to Docker Hub whenever it changes on main, with the `DOCKERHUB_*` secrets the image publish job already uses — the page can't drift again.

Note: if `DOCKERHUB_TOKEN` is a limited-scope access token, the description API may reject it; in that case the fix is a read-write PAT in that secret, and the first run will tell us.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LAN setup instructions and keeps the Docker Hub page in sync with `docker/DOCKER_README.md`. Previously the Hub page drifted and told users to edit a compose ports line; now LAN access is configured via `.env`, and a workflow auto-publishes README changes to Docker Hub.

- Docs: LAN step now sets `HOST_BIND_ADDRESS=0.0.0.0` in `.env` instead of editing `docker-compose.yml`.
- CI: adds a workflow that syncs `docker/DOCKER_README.md` to `manifestdotbuild/manifest` using `peter-evans/dockerhub-description` on pushes to `main`.
- Required action: ensure `DOCKERHUB_TOKEN` is a read–write PAT; limited-scope tokens may fail to update the description.

<sup>Written for commit 8f26b712d6225dd597d6372c12a6ab5c7a92b8a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

