### PR TITLE
fix: drop non-message Responses input items in chat-completions conversion

### DIFF
--- a/.changeset/responses-drop-non-message-items.md
+++ b/.changeset/responses-drop-non-message-items.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix Responses→chat-completions conversion emitting content-less `{"role":"user"}` messages for `reasoning`, `item_reference`, and other non-message input items, which strict OpenAI-compatible providers rejected with 400/422.

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -195,6 +195,47 @@ describe('Responses adapter', () => {
       expect(result.tool_choice).toBe('auto');
     });
 
+    it('drops non-message input items that have no chat-completions equivalent', () => {
+      const result = toChatCompletionsRequest({
+        instructions: 'You are a helpful assistant.',
+        input: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'total?' }] },
+          {
+            type: 'reasoning',
+            id: 'rs_1',
+            encrypted_content: 'gAAAAA',
+            summary: [{ type: 'summary_text', text: 'thinking about the totals' }],
+          },
+          { type: 'item_reference', id: 'msg_1' },
+          { type: 'web_search_call', id: 'ws_1', status: 'completed' },
+          { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'total?' },
+        { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      ]);
+    });
+
+    it('never emits a message without content for reasoning items', () => {
+      const result = toChatCompletionsRequest({
+        input: [
+          { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+          { type: 'reasoning', id: 'rs_1', encrypted_content: 'gAAAAA' },
+        ],
+      });
+      const messages = result.messages as Record<string, unknown>[];
+
+      expect(messages).toHaveLength(1);
+      for (const message of messages) {
+        expect(Object.prototype.hasOwnProperty.call(message, 'content')).toBe(true);
+        expect(message.content).not.toBeUndefined();
+      }
+      expect(JSON.stringify(messages)).not.toContain('{"role":"user"}');
+    });
+
     it('uses safe defaults for malformed input items', () => {
       const result = toChatCompletionsRequest({
         input: [

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -236,6 +236,18 @@ describe('Responses adapter', () => {
       expect(JSON.stringify(messages)).not.toContain('{"role":"user"}');
     });
 
+    it('drops message items that carry no content at all', () => {
+      const result = toChatCompletionsRequest({
+        input: [
+          { type: 'message', role: 'user' },
+          { role: 'assistant' },
+          { role: 'user', content: [{ type: 'input_text', text: 'still here' }] },
+        ],
+      });
+
+      expect(result.messages).toEqual([{ role: 'user', content: 'still here' }]);
+    });
+
     it('uses safe defaults for malformed input items', () => {
       const result = toChatCompletionsRequest({
         input: [

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -84,7 +84,12 @@ function responseInputItemToMessage(item: JsonRecord): OpenAIMessage[] {
   if (!isNativeResponsesMessageItem(item)) return [];
 
   const role = typeof item.role === 'string' ? item.role : 'user';
-  return [{ role, content: toChatContent(item.content, role) }];
+  const content = toChatContent(item.content, role);
+  // A message item carrying no content at all is the same wire hazard: the
+  // key is omitted on serialization and `{ role: 'user' }` goes out again.
+  if (content === undefined) return [];
+
+  return [{ role, content }];
 }
 
 export function toChatCompletionsRequest(body: JsonRecord): JsonRecord {

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -76,6 +76,13 @@ function responseInputItemToMessage(item: JsonRecord): OpenAIMessage[] {
     ];
   }
 
+  // Typed items with no chat-completions equivalent — `reasoning` (whose
+  // `encrypted_content` is opaque outside OpenAI), `item_reference`,
+  // `web_search_call`, and friends. Dropping them is the only safe mapping:
+  // falling through would emit `{ role: 'user' }` with no `content`, which
+  // strictly-validating providers reject with 400/422.
+  if (!isNativeResponsesMessageItem(item)) return [];
+
   const role = typeof item.role === 'string' ? item.role : 'user';
   return [{ role, content: toChatContent(item.content, role) }];
 }


### PR DESCRIPTION
Fixes #2721.

## The bug

`toChatCompletionsRequest` (`packages/backend/src/routing/proxy/responses-adapter.ts`) ends in a catch-all that maps any input item it doesn't recognise to a chat message:

```ts
const role = typeof item.role === 'string' ? item.role : 'user';
return [{ role, content: toChatContent(item.content, role) }];
```

A Responses `reasoning` item carries `encrypted_content`, not `content`. `toChatContent(undefined, 'user')` returns `undefined`, `JSON.stringify` drops the key, and the wire body carries `{"role":"user"}` with no content. Providers that validate messages strictly reject the whole request:

| Provider | Model | Status | Upstream error |
|---|---|---|---|
| groq | `groq/openai/gpt-oss-120b` | 400 | `'messages.2' : for 'role:user' ... property 'content' is missing` |
| nvidia | `nvidia/nemotron-3-super-120b-a12b` | 400 | `missing field 'content'` |
| ollama-cloud | `gpt-oss:120b` | 400 | `invalid message content type: <nil>` |
| mistral | `codestral-2508` | 422 | `user content missing: Field required` |

One `reasoning` item is enough to fail the request. Any Responses client that echoes reasoning back — the default once `include: ["reasoning.encrypted_content"]` is set — hard-fails on every non-OpenAI transport.

It isn't only `reasoning`. Every typed item that isn't `function_call` / `function_call_output` hits the same fallback, so `item_reference`, `web_search_call` and friends produce the same content-less message. The issue assumed `item_reference` was already dropped; it wasn't.

Blast radius is `proxy.service.ts:700` — every `/v1/responses` request routed to a chat-completions transport.

The native Responses→Responses path was already fixed in aad3033 via `isNativeResponsesMessageItem`; `toChatCompletionsRequest` never got that guard.

## The fix

Reuse the same guard, and drop typed items with no chat-completions equivalent:

```ts
if (!isNativeResponsesMessageItem(item)) return [];
```

Dropping is the correct mapping rather than a lossy one — `encrypted_content` is opaque outside OpenAI, and `item_reference` points at history the surrounding messages already carry. Mapping reasoning summaries onto `reasoning_content` would need the per-endpoint allow-list and is a separate change.

## Verification

- Repro confirmed against `origin/main` before the change: `[message, reasoning, item_reference]` produced `[{"role":"system",...},{"role":"user","content":"..."},{"role":"user"},{"role":"user"}]`.
- Two regression tests added: one asserting the non-message items are dropped and the surrounding messages survive in order, one asserting no emitted message can ever lack `content`.
- `npx jest src/routing/proxy` — 63 suites, 2251 tests, all passing.
- Backend build, eslint and prettier clean on the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents content-less chat messages in Responses→chat-completions conversion by dropping non-message items and message items with no content. Previously, unrecognized items and empty messages serialized as {"role":"user"} and strict providers rejected the request; now such items are omitted.

- Gates the fallback on `isNativeResponsesMessageItem` and drops `reasoning` (with `encrypted_content`), `item_reference`, `web_search_call`, etc.; preserves surrounding message order and ensures every emitted message has content.
- Also drops `message`/untyped items that convert to no content.
- Adds tests and updates the adapter; affects `/v1/responses` routed to chat-completions only; no client changes required.

<sup>Written for commit ec2b587aabc0941971638d2f7c38fa3d055994f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

