### PR TITLE
fix: enrich Ollama Cloud models from models.dev

### DIFF
--- a/.changeset/ollama-cloud-capabilities.md
+++ b/.changeset/ollama-cloud-capabilities.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Report modalities and capability flags for Ollama Cloud models. `ollama-cloud` was missing from the models.dev provider map, so every lookup missed and `GET /v1/models?capabilities=true` returned no `input_modalities`, `output_modalities`, or `features` for those models. Release tags that models.dev omits from its key (`:preview`, `:0813`) now fall back to the base model.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -313,6 +313,33 @@ const MOCK_API_RESPONSE = {
       },
     },
   },
+  'ollama-cloud': {
+    id: 'ollama-cloud',
+    name: 'Ollama Cloud',
+    models: {
+      'kimi-k3': {
+        id: 'kimi-k3',
+        name: 'kimi-k3',
+        reasoning: true,
+        tool_call: true,
+        modalities: { input: ['text', 'image'], output: ['text'] },
+      },
+      'deepseek-v4-pro': {
+        id: 'deepseek-v4-pro',
+        name: 'deepseek-v4-pro',
+        reasoning: true,
+        tool_call: true,
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'gpt-oss:120b': {
+        id: 'gpt-oss:120b',
+        name: 'gpt-oss:120b',
+        reasoning: true,
+        tool_call: true,
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
   'unknown-provider': {
     id: 'unknown-provider',
     name: 'Unknown',
@@ -348,8 +375,9 @@ describe('ModelsDevSyncService', () => {
       );
       // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 1,
       // fireworks: 1, mistral: 6, xai: 3, bedrock: 8, groq: 2,
-      // nvidia: 1, opencode-go: 1, opencode: 1, cerebras: 1 = 29
-      expect(count).toBe(29);
+      // nvidia: 1, opencode-go: 1, opencode: 1, cerebras: 1,
+      // ollama-cloud: 3 = 32
+      expect(count).toBe(32);
     });
 
     it('should filter out non-text-output models', async () => {
@@ -699,6 +727,7 @@ describe('ModelsDevSyncService', () => {
       expect(service.isProviderSupported('fireworks')).toBe(true);
       expect(service.isProviderSupported('bedrock')).toBe(true);
       expect(service.isProviderSupported('cerebras')).toBe(true);
+      expect(service.isProviderSupported('ollama-cloud')).toBe(true);
     });
 
     it('should return false for unmapped providers', () => {
@@ -1404,6 +1433,55 @@ describe('ModelsDevSyncService', () => {
       const upper = service.getModelsForProvider('ANTHROPIC');
       expect(lower).toEqual(upper);
       expect(lower.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ollama-cloud', () => {
+    beforeEach(async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+    });
+
+    it('should expose modalities and capability flags for cloud models', () => {
+      const model = service.lookupModel('ollama-cloud', 'kimi-k3');
+      expect(model).not.toBeNull();
+      expect(model!.inputModalities).toEqual(['text', 'image']);
+      expect(model!.outputModalities).toEqual(['text']);
+      expect(model!.reasoning).toBe(true);
+      expect(model!.toolCall).toBe(true);
+    });
+
+    it('should leave pricing null when models.dev lists no cost', () => {
+      const model = service.lookupModel('ollama-cloud', 'deepseek-v4-pro');
+      expect(model).not.toBeNull();
+      expect(model!.inputPricePerToken).toBeNull();
+      expect(model!.outputPricePerToken).toBeNull();
+    });
+
+    it('should strip Ollama release tags absent from the models.dev key', () => {
+      expect(service.lookupModel('ollama-cloud', 'deepseek-v4-pro:preview')?.id).toBe(
+        'deepseek-v4-pro',
+      );
+      expect(service.lookupModel('ollama-cloud', 'deepseek-v4-pro:0813')?.id).toBe(
+        'deepseek-v4-pro',
+      );
+    });
+
+    it('should not strip parameter-size tags that are part of the model ID', () => {
+      expect(service.lookupModel('ollama-cloud', 'gpt-oss:120b')?.id).toBe('gpt-oss:120b');
+      expect(service.lookupModel('ollama-cloud', 'gpt-oss:20b')).toBeNull();
+    });
+
+    it('should not apply the tag strip to other providers', () => {
+      expect(service.lookupModel('bedrock', 'qwen.qwen3-32b:preview')).toBeNull();
+    });
+
+    it('should leave local ollama unsupported', () => {
+      expect(service.isProviderSupported('ollama')).toBe(false);
+      expect(service.lookupModel('ollama', 'kimi-k3')).toBeNull();
     });
   });
 

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -31,6 +31,7 @@ const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   groq: 'groq',
   'opencode-go': 'opencode-go',
   'opencode-zen': 'opencode',
+  'ollama-cloud': 'ollama-cloud',
 };
 
 const SUPPORTED_PROVIDERS = new Set(Object.keys(PROVIDER_ID_MAP));
@@ -184,6 +185,13 @@ const MODEL_ID_PREFIX_ALIASES: ReadonlyMap<string, string> = new Map([
 ]);
 /** Matches instruction-tuned suffixes that models.dev sometimes omits on Bedrock keys. */
 const INSTRUCT_SUFFIX_RE = /-instruct$/;
+/**
+ * Matches Ollama release tags that models.dev omits from its base model key
+ * (e.g. `deepseek-v4-pro:preview` → `deepseek-v4-pro`). Deliberately narrow:
+ * parameter-size tags (`:120b`, `:397b`) and Bedrock-style `-v1:0` versions
+ * must not match, since those are part of the canonical model ID.
+ */
+const OLLAMA_TAG_SUFFIX_RE = /:(?:preview|\d{4})$/;
 
 @Injectable()
 export class ModelsDevSyncService implements OnModuleInit {
@@ -404,6 +412,16 @@ export class ModelsDevSyncService implements OnModuleInit {
     if (noReasoning !== modelId) {
       const found = providerModels.get(noReasoning);
       if (found) return found;
+    }
+
+    if (providerId === 'ollama-cloud') {
+      // 7a. Strip Ollama release tags absent from the models.dev key
+      //     (e.g. deepseek-v4-pro:preview → deepseek-v4-pro).
+      const noTag = modelId.replace(OLLAMA_TAG_SUFFIX_RE, '');
+      if (noTag !== modelId) {
+        const found = providerModels.get(noTag);
+        if (found) return found;
+      }
     }
 
     if (providerId === 'bedrock') {


### PR DESCRIPTION
### ✨ What changed

`ollama-cloud` is now in `PROVIDER_ID_MAP`, so models.dev entries are looked up for it. Ollama Cloud release tags that models.dev leaves off its keys (`:preview`, `:0813`) fall back to the base model.

### 💭 Why

`GET /v1/models?capabilities=true` returned no `input_modalities`, `output_modalities`, or `features` for Ollama Cloud models. models.dev has the data for all 20 of them, but the provider was missing from the map, so `lookupModel('ollama-cloud', …)` always returned null and discovery had nothing to merge. `parseOllama` reads `/api/tags`, which carries no capability data of its own, so nothing filled the gap.

### 👤 For users

Ollama Cloud models now report their modalities and capabilities. `kimi-k3` and `gemma4:31b` show image input, `minimax-m3` shows video, and reasoning and tool-call flags feed quality scoring and tier auto-assignment.

### 🔧 For operators

No pricing change. models.dev publishes no `cost` for `ollama-cloud`, so the `mdEntry.inputPricePerToken !== null` guard keeps the pricing branch inert and the 0/0 prices from the tags API stand. Local `ollama` stays unmapped, since models.dev has no entry for it.

### 📝 Notes

The tag regex is `/:(?:preview|\d{4})$/` and is gated on `providerId === 'ollama-cloud'`. Parameter-size tags (`:120b`, `:397b`) and Bedrock `-v1:0` versions do not match it, and exact match still runs first, so `deepseek-v4-flash:0731` resolves to its own models.dev key rather than the base name.

Verified against the live catalogs: 17 of 20 IDs match models.dev exactly, and the tag strip covers 2 of the remaining 3. `deepseek-v4-pro:0813` is not on models.dev yet and now resolves to `deepseek-v4-pro`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate capabilities for Ollama Cloud by mapping `ollama-cloud` to `models.dev` and normalizing release-tagged IDs. Previously, `GET /v1/models?capabilities=true` omitted `input_modalities`, `output_modalities`, and `features` for these models; now they are filled.

- Only for `ollama-cloud`, strip `:preview` and `:MMDD` suffixes when resolving to a `models.dev` key; size tags like `:120b` and Bedrock-style versions still match exactly.
- Pricing is unchanged; `models.dev` lists no cost for `ollama-cloud`, so prices remain unset from this source.
- Local `ollama` stays unsupported/unmapped.
- Tests updated: provider marked supported, tag handling verified, capabilities exposed, pricing stays null, and expected model count increases to 32.

<sup>Written for commit 54f3e6e0cbcce0c4d4b8dcd67268f9a126a10137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

