### PR TITLE
fix: read capabilities for providers models.dev does not map

### DIFF
--- a/.changeset/unmapped-provider-capabilities.md
+++ b/.changeset/unmapped-provider-capabilities.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Report modalities and capability flags for Kilo, Pioneer, Cline Pass and Xiaomi models. These providers publish no modality data on their own `/models` endpoints and are not mapped in `PROVIDER_ID_MAP`, so `GET /v1/models?capabilities=true` returned nothing for them. Capability lookups now fall back to the models.dev provider catalog. Pricing is unaffected: it still comes from the connection's own provider.
+Report modalities and capability flags for Kilo, Pioneer, Cline Pass and Xiaomi models. These providers publish no modality data on their own `/models` endpoints, and models.dev may not price them: they list resold vendor models under the vendor's own ID, so their rates would overwrite the real vendor price in the shared cache. A new capability-only provider map carries them, separate from the map that grants pricing authority.

--- a/.changeset/unmapped-provider-capabilities.md
+++ b/.changeset/unmapped-provider-capabilities.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Report modalities and capability flags for Kilo, Pioneer, Cline Pass and Xiaomi models. These providers publish no modality data on their own `/models` endpoints and are not mapped in `PROVIDER_ID_MAP`, so `GET /v1/models?capabilities=true` returned nothing for them. Capability lookups now fall back to the models.dev provider catalog. Pricing is unaffected: it still comes from the connection's own provider.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1520,6 +1520,39 @@ describe('ModelsDevSyncService', () => {
     });
   });
 
+  describe('lookupModelCapabilities', () => {
+    beforeEach(async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+    });
+
+    it('should prefer the native catalog', () => {
+      const model = service.lookupModelCapabilities('anthropic', 'claude-opus-4-6');
+      expect(model).not.toBeNull();
+      expect(model!.inputModalities).toEqual(['text', 'image']);
+    });
+
+    it('should fall back to providers absent from PROVIDER_ID_MAP', () => {
+      // `kilo` is a first-class Manifest provider but is not mapped, so
+      // lookupModel misses and only the custom-provider catalog resolves it.
+      expect(service.lookupModel('kilo', 'openai/gpt-4o-mini')).toBeNull();
+      const model = service.lookupModelCapabilities('kilo', 'openai/gpt-4o-mini');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('GPT-4o mini');
+    });
+
+    it('should not resolve local Ollama against the Ollama Cloud catalog', () => {
+      expect(service.lookupModelCapabilities('ollama', 'kimi-k3')).toBeNull();
+    });
+
+    it('should return null for providers models.dev does not list', () => {
+      expect(service.lookupModelCapabilities('nous', 'some-model')).toBeNull();
+    });
+  });
+
   describe('lookupModelAcrossProviders', () => {
     beforeEach(async () => {
       fetchSpy.mockResolvedValue({

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1535,21 +1535,37 @@ describe('ModelsDevSyncService', () => {
       expect(model!.inputModalities).toEqual(['text', 'image']);
     });
 
-    it('should fall back to providers absent from PROVIDER_ID_MAP', () => {
-      // `kilo` is a first-class Manifest provider but is not mapped, so
-      // lookupModel misses and only the custom-provider catalog resolves it.
+    it('should resolve capability-only providers', () => {
+      // `kilo` is a first-class Manifest provider that models.dev may not
+      // price, so only the capability catalog resolves it.
       expect(service.lookupModel('kilo', 'openai/gpt-4o-mini')).toBeNull();
       const model = service.lookupModelCapabilities('kilo', 'openai/gpt-4o-mini');
       expect(model).not.toBeNull();
       expect(model!.name).toBe('GPT-4o mini');
     });
 
+    it('should keep capability-only providers out of every pricing consumer', () => {
+      // getModelsForProvider feeds the shared pricing cache and the discovery
+      // fallback catalog. Kilo lists resold vendor models under the vendor's
+      // own ID, so its rates must not reach either.
+      expect(service.getModelsForProvider('kilo')).toEqual([]);
+      expect(service.isProviderSupported('kilo')).toBe(false);
+    });
+
+    it('should not count capability-only models as priced coverage', async () => {
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => MOCK_API_RESPONSE });
+      // Same total as refreshCache asserts: the kilo model is cached for
+      // capabilities but never counted or priced.
+      expect(await service.refreshCache()).toBe(32);
+    });
+
     it('should not resolve local Ollama against the Ollama Cloud catalog', () => {
       expect(service.lookupModelCapabilities('ollama', 'kimi-k3')).toBeNull();
     });
 
-    it('should return null for providers models.dev does not list', () => {
+    it('should return null for providers on neither map', () => {
       expect(service.lookupModelCapabilities('nous', 'some-model')).toBeNull();
+      expect(service.lookupModelCapabilities('kilo', 'missing-model')).toBeNull();
     });
   });
 

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -9,8 +9,18 @@ import {
 import { GOOGLE_VARIANT_RE } from '../model-prices/model-name-normalizer';
 
 /**
- * Mapping from our internal provider IDs to models.dev provider directory names.
- * models.dev uses its own naming convention for provider directories.
+ * Providers whose models.dev catalog is authoritative for **pricing as well as
+ * capabilities**. models.dev uses its own naming convention for provider
+ * directories, so this maps our internal ID to theirs.
+ *
+ * An entry here does more than name a directory. It also decides that
+ * models.dev may price the provider (`loadModelsDevEntries` overlays these
+ * rates onto the shared pricing cache, keyed by bare model ID), that
+ * `buildModelsDevFallback` may synthesize the provider's whole catalog when its
+ * API is unreachable, and that a lookup miss is authoritative
+ * (`isProviderSupported`). Add a provider here only when its models.dev rates
+ * are the rates its connections actually pay. For a provider that only needs
+ * modalities and capability flags, use CAPABILITY_ONLY_PROVIDER_ID_MAP.
  */
 const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   anthropic: 'anthropic',
@@ -32,6 +42,24 @@ const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   'opencode-go': 'opencode-go',
   'opencode-zen': 'opencode',
   'ollama-cloud': 'ollama-cloud',
+};
+
+/**
+ * Providers whose models.dev catalog is authoritative for **capabilities only**.
+ *
+ * These publish no modality data on their own `/models` endpoint, so models.dev
+ * is the only source of their modalities and capability flags. They are kept
+ * out of PROVIDER_ID_MAP because their models.dev prices must not reach the
+ * shared pricing cache: they list resold vendor models under the vendor's own
+ * ID (`kilo/openai/gpt-4o-mini`, `pioneer/gpt-4o`), so overlaying them would
+ * overwrite the real vendor rate for every client of that model ID. Their
+ * connections are priced from their own API instead.
+ */
+const CAPABILITY_ONLY_PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
+  kilo: 'kilo',
+  pioneer: 'pioneer',
+  'cline-pass': 'cline-pass',
+  xiaomi: 'xiaomi',
 };
 
 const SUPPORTED_PROVIDERS = new Set(Object.keys(PROVIDER_ID_MAP));
@@ -198,6 +226,8 @@ export class ModelsDevSyncService implements OnModuleInit {
   private readonly logger = new Logger(ModelsDevSyncService.name);
   /** Map: our provider ID → Map<model ID (native), entry> */
   private cache = new Map<string, Map<string, ModelsDevModelEntry>>();
+  /** Map: our provider ID → Map<model ID, entry>, for capability-only providers. */
+  private capabilityCache = new Map<string, Map<string, ModelsDevModelEntry>>();
   /** Map: models.dev provider ID → Map<model ID, entry>. Includes providers Manifest does not natively know. */
   private customProviderCache = new Map<string, Map<string, ModelsDevModelEntry>>();
   /** Map: provider id/display-name aliases → models.dev provider ID. */
@@ -264,7 +294,26 @@ export class ModelsDevSyncService implements OnModuleInit {
       }
     }
 
+    // Capability-only providers stay out of `cache`, so no pricing or fallback
+    // consumer can reach them. `totalModels` counts priced coverage only.
+    const newCapabilityCache = new Map<string, Map<string, ModelsDevModelEntry>>();
+    for (const [ourId, modelsDevId] of Object.entries(CAPABILITY_ONLY_PROVIDER_ID_MAP)) {
+      const provider = raw[modelsDevId];
+      if (!provider?.models) continue;
+
+      const modelMap = new Map<string, ModelsDevModelEntry>();
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        if (!this.isChatCompatible(model)) continue;
+        modelMap.set(modelId, this.parseModel(ourId, modelId, model));
+      }
+
+      if (modelMap.size > 0) {
+        newCapabilityCache.set(ourId, modelMap);
+      }
+    }
+
     this.cache = newCache;
+    this.capabilityCache = newCapabilityCache;
     this.customProviderCache = newCustomProviderCache;
     this.customProviderIndex = newCustomProviderIndex;
     this.lastFetchedAt = new Date();
@@ -305,20 +354,21 @@ export class ModelsDevSyncService implements OnModuleInit {
   }
 
   /**
-   * Capability-only lookup: the native catalog first, then the models.dev
-   * provider catalog for providers Manifest knows but `PROVIDER_ID_MAP` does
-   * not map (Kilo, Pioneer, Cline Pass, Xiaomi, OpenRouter, HuggingFace).
+   * Look up a model for its modalities and capability flags: the priced catalog
+   * first, then CAPABILITY_ONLY_PROVIDER_ID_MAP.
    *
-   * **Never read pricing from the result.** Those catalogs are keyed by an
-   * aggregator's own rates, and a connection has to be billed at the price its
-   * own provider charges. Mapping them in `PROVIDER_ID_MAP` instead would push
-   * those rates into the shared pricing cache and the discovery fallback
-   * catalogs; this stays scoped to modalities and capability flags.
+   * **Never read pricing from the result.** A capability-only entry carries a
+   * reseller's rate for a vendor's model ID, which is not what the connection
+   * pays. Callers that need a price must use `lookupModel`.
    */
   lookupModelCapabilities(providerId: string, modelId: string): ModelsDevModelEntry | null {
-    return (
-      this.lookupModel(providerId, modelId) ?? this.lookupCustomProviderModel(providerId, modelId)
-    );
+    const native = this.lookupModel(providerId, modelId);
+    if (native) return native;
+
+    const resolvedProviderId = resolveProviderId(providerId);
+    const providerModels = this.capabilityCache.get(resolvedProviderId);
+    if (!providerModels) return null;
+    return this.lookupModelInProvider(providerModels, modelId, resolvedProviderId);
   }
 
   /**

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -305,6 +305,23 @@ export class ModelsDevSyncService implements OnModuleInit {
   }
 
   /**
+   * Capability-only lookup: the native catalog first, then the models.dev
+   * provider catalog for providers Manifest knows but `PROVIDER_ID_MAP` does
+   * not map (Kilo, Pioneer, Cline Pass, Xiaomi, OpenRouter, HuggingFace).
+   *
+   * **Never read pricing from the result.** Those catalogs are keyed by an
+   * aggregator's own rates, and a connection has to be billed at the price its
+   * own provider charges. Mapping them in `PROVIDER_ID_MAP` instead would push
+   * those rates into the shared pricing cache and the discovery fallback
+   * catalogs; this stays scoped to modalities and capability flags.
+   */
+  lookupModelCapabilities(providerId: string, modelId: string): ModelsDevModelEntry | null {
+    return (
+      this.lookupModel(providerId, modelId) ?? this.lookupCustomProviderModel(providerId, modelId)
+    );
+  }
+
+  /**
    * Conservative model-only fallback for custom providers that are not listed
    * on models.dev. Prefer official provider catalogs, then exact IDs from
    * aggregator catalogs. This is intentionally not fuzzy.

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -144,6 +144,9 @@ describe('resolveModelCapabilityMetadata', () => {
       modelsDevSync,
     );
 
-    expect(modelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('anthropic', 'claude-sonnet-5-v1:0');
+    expect(modelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
+      'anthropic',
+      'claude-sonnet-5-v1:0',
+    );
   });
 });

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -53,16 +53,16 @@ describe('inputModalitiesFromCapabilities', () => {
 
 describe('resolveModelCapabilityMetadata', () => {
   const paramSpecs = { getCapabilities: jest.fn() };
-  const modelsDevSync = { lookupModel: jest.fn() };
+  const modelsDevSync = { lookupModelCapabilities: jest.fn() };
 
   beforeEach(() => {
     paramSpecs.getCapabilities.mockReset().mockResolvedValue(null);
-    modelsDevSync.lookupModel.mockReset().mockReturnValue(null);
+    modelsDevSync.lookupModelCapabilities.mockReset().mockReturnValue(null);
   });
 
   it('merges discovery, models.dev, param-spec, and streaming-heuristic capabilities', async () => {
     paramSpecs.getCapabilities.mockResolvedValue(['tools']);
-    modelsDevSync.lookupModel.mockReturnValue(makeModelsDevEntry());
+    modelsDevSync.lookupModelCapabilities.mockReturnValue(makeModelsDevEntry());
 
     const resolved = await resolveModelCapabilityMetadata(
       makeModel({ capabilities: ['audio'], authType: 'subscription' }),
@@ -144,6 +144,6 @@ describe('resolveModelCapabilityMetadata', () => {
       modelsDevSync,
     );
 
-    expect(modelsDevSync.lookupModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-5-v1:0');
+    expect(modelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('anthropic', 'claude-sonnet-5-v1:0');
   });
 });

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -122,7 +122,9 @@ export async function resolveModelCapabilityMetadata(
       model: string | undefined,
     ): Promise<readonly ModelCapability[] | null>;
   },
-  modelsDevSync: { lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null },
+  modelsDevSync: {
+    lookupModelCapabilities(providerId: string, modelId: string): ModelsDevModelEntry | null;
+  },
 ): Promise<ResolvedCapabilityMetadata> {
   const specCapabilities = await paramSpecs.getCapabilities(
     model.provider,
@@ -133,7 +135,10 @@ export async function resolveModelCapabilityMetadata(
   // Bedrock vendor-prefixed ids). Resolve that provenance for metadata only.
   const metadata = resolveProviderMetadataIdentity(model.provider, model.id);
   const metadataProvider = metadata.provider ?? model.provider;
-  const modelsDevEntry = modelsDevSync.lookupModel(metadataProvider, metadata.model);
+  // Capability-only providers (Kilo, Pioneer, Cline Pass, Xiaomi) resolve here
+  // too; every field read off this entry is capability metadata or a display
+  // name, never a price.
+  const modelsDevEntry = modelsDevSync.lookupModelCapabilities(metadataProvider, metadata.model);
   // Curated facts are the last resort, and applying them here (not only at
   // discovery time) means stale cached_models still resolve correctly.
   const known = lookupKnownModalities(metadataProvider, metadata.model);

--- a/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
@@ -86,6 +86,8 @@ describe('ModelDiscoveryService — boundary conditions', () => {
   let mockModelRegistry: { registerModels: jest.Mock; getConfirmedModels: jest.Mock };
   let mockModelsDevSync: {
     lookupModel: jest.Mock;
+    lookupModelCapabilities: jest.Mock;
+    lookupCustomProviderModel: jest.Mock;
     getModelsForProvider: jest.Mock;
     refreshCache: jest.Mock;
   };
@@ -99,8 +101,16 @@ describe('ModelDiscoveryService — boundary conditions', () => {
       lookupPricing: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue(new Map()),
     };
+    const lookupModel = jest.fn().mockReturnValue(null);
+    const lookupCustomProviderModel = jest.fn().mockReturnValue(null);
     mockModelsDevSync = {
-      lookupModel: jest.fn().mockReturnValue(null),
+      lookupModel,
+      lookupCustomProviderModel,
+      // Mirrors the real service: native catalog first, custom catalog second.
+      lookupModelCapabilities: jest.fn(
+        (providerId: string, modelId: string) =>
+          lookupModel(providerId, modelId) ?? lookupCustomProviderModel(providerId, modelId),
+      ),
       getModelsForProvider: jest.fn().mockReturnValue([]),
       refreshCache: jest.fn().mockResolvedValue(0),
     };

--- a/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
@@ -87,7 +87,6 @@ describe('ModelDiscoveryService — boundary conditions', () => {
   let mockModelsDevSync: {
     lookupModel: jest.Mock;
     lookupModelCapabilities: jest.Mock;
-    lookupCustomProviderModel: jest.Mock;
     getModelsForProvider: jest.Mock;
     refreshCache: jest.Mock;
   };
@@ -102,14 +101,12 @@ describe('ModelDiscoveryService — boundary conditions', () => {
       getAll: jest.fn().mockReturnValue(new Map()),
     };
     const lookupModel = jest.fn().mockReturnValue(null);
-    const lookupCustomProviderModel = jest.fn().mockReturnValue(null);
     mockModelsDevSync = {
       lookupModel,
-      lookupCustomProviderModel,
-      // Mirrors the real service: native catalog first, custom catalog second.
-      lookupModelCapabilities: jest.fn(
-        (providerId: string, modelId: string) =>
-          lookupModel(providerId, modelId) ?? lookupCustomProviderModel(providerId, modelId),
+      // The real service tries the priced catalog first. Tests that exercise
+      // the capability-only catalog override this directly.
+      lookupModelCapabilities: jest.fn((providerId: string, modelId: string) =>
+        lookupModel(providerId, modelId),
       ),
       getModelsForProvider: jest.fn().mockReturnValue([]),
       refreshCache: jest.fn().mockResolvedValue(0),

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1277,6 +1277,37 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].outputPricePerToken).toBeNull();
     });
 
+    it('should filter tool-less models of capability-only providers', async () => {
+      // The tool-support filter reads the same capability catalog as
+      // enrichment, so a Kilo model models.dev marks toolCall=false is
+      // dropped while an unknown one is kept.
+      mockModelsDevSync.lookupModelCapabilities.mockImplementation(
+        (providerId: string, modelId: string) =>
+          providerId === 'kilo' && modelId === 'vendor/no-tools'
+            ? { id: 'vendor/no-tools', name: 'No Tools', toolCall: false }
+            : null,
+      );
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'vendor/no-tools',
+          provider: 'kilo',
+          inputPricePerToken: 0.000001,
+          outputPricePerToken: 0.000002,
+        }),
+        makeModel({
+          id: 'vendor/unknown',
+          provider: 'kilo',
+          inputPricePerToken: 0.000001,
+          outputPricePerToken: 0.000002,
+        }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider({ provider: 'kilo' }));
+
+      expect(result.map((m) => m.id)).toEqual(['vendor/unknown']);
+    });
+
     it('should route capability lookups through lookupModelCapabilities', async () => {
       // enrichModel must not call lookupModel for capabilities: that path is
       // reserved for pricing, and a capability-only entry carries a reseller's

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -99,7 +99,6 @@ describe('ModelDiscoveryService', () => {
   let mockModelsDevSync: {
     lookupModel: jest.Mock;
     lookupModelCapabilities: jest.Mock;
-    lookupCustomProviderModel: jest.Mock;
     getModelsForProvider: jest.Mock;
     refreshCache: jest.Mock;
   };
@@ -115,14 +114,12 @@ describe('ModelDiscoveryService', () => {
       getAll: jest.fn().mockReturnValue(new Map()),
     };
     const lookupModel = jest.fn().mockReturnValue(null);
-    const lookupCustomProviderModel = jest.fn().mockReturnValue(null);
     mockModelsDevSync = {
       lookupModel,
-      lookupCustomProviderModel,
-      // Mirrors the real service: native catalog first, custom catalog second.
-      lookupModelCapabilities: jest.fn(
-        (providerId: string, modelId: string) =>
-          lookupModel(providerId, modelId) ?? lookupCustomProviderModel(providerId, modelId),
+      // The real service tries the priced catalog first. Tests that exercise
+      // the capability-only catalog override this directly.
+      lookupModelCapabilities: jest.fn((providerId: string, modelId: string) =>
+        lookupModel(providerId, modelId),
       ),
       getModelsForProvider: jest.fn().mockReturnValue([]),
       refreshCache: jest.fn().mockResolvedValue(0),
@@ -1212,7 +1209,7 @@ describe('ModelDiscoveryService', () => {
       // Kilo prices its own catalog, so enrichment takes the price-already-set
       // path. models.dev does not map `kilo`, so only the custom-provider
       // catalog carries its modalities.
-      mockModelsDevSync.lookupCustomProviderModel.mockImplementation(
+      mockModelsDevSync.lookupModelCapabilities.mockImplementation(
         (providerId: string, modelId: string) =>
           providerId === 'kilo' && modelId === 'openai/gpt-4o-mini'
             ? {
@@ -1251,7 +1248,7 @@ describe('ModelDiscoveryService', () => {
     it('should apply capabilities from an unmapped models.dev provider (unpriced model)', async () => {
       // Xiaomi's /models publishes no pricing, so enrichment falls through
       // every pricing source before capabilities are applied.
-      mockModelsDevSync.lookupCustomProviderModel.mockImplementation(
+      mockModelsDevSync.lookupModelCapabilities.mockImplementation(
         (providerId: string, modelId: string) =>
           providerId === 'xiaomi' && modelId === 'mimo-v2.5'
             ? {
@@ -1280,32 +1277,20 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].outputPricePerToken).toBeNull();
     });
 
-    it('should keep the native catalog ahead of the custom-provider fallback', async () => {
-      mockModelsDevSync.lookupModel.mockReturnValue({
-        id: 'test-model',
-        name: 'Native',
-        inputPricePerToken: null,
-        outputPricePerToken: null,
-        inputModalities: ['text'],
-        outputModalities: ['text'],
-      });
-      mockModelsDevSync.lookupCustomProviderModel.mockReturnValue({
-        id: 'test-model',
-        name: 'Fallback',
-        inputPricePerToken: null,
-        outputPricePerToken: null,
-        inputModalities: ['text', 'image'],
-        outputModalities: ['text'],
-      });
-
+    it('should route capability lookups through lookupModelCapabilities', async () => {
+      // enrichModel must not call lookupModel for capabilities: that path is
+      // reserved for pricing, and a capability-only entry carries a reseller's
+      // rate for a vendor's model ID.
       fetcher.fetch.mockResolvedValue([
         makeModel({ inputPricePerToken: 0, outputPricePerToken: 0 }),
       ]);
 
-      const result = await service.discoverModels(makeProvider());
+      await service.discoverModels(makeProvider());
 
-      expect(result[0].inputModalities).toEqual(['text']);
-      expect(mockModelsDevSync.lookupCustomProviderModel).not.toHaveBeenCalled();
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
+        'openai',
+        'test-model',
+      );
     });
 
     it('should fall back to exact model ID lookup when prefix lookup misses', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -98,6 +98,8 @@ describe('ModelDiscoveryService', () => {
   };
   let mockModelsDevSync: {
     lookupModel: jest.Mock;
+    lookupModelCapabilities: jest.Mock;
+    lookupCustomProviderModel: jest.Mock;
     getModelsForProvider: jest.Mock;
     refreshCache: jest.Mock;
   };
@@ -112,8 +114,16 @@ describe('ModelDiscoveryService', () => {
       lookupPricing: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue(new Map()),
     };
+    const lookupModel = jest.fn().mockReturnValue(null);
+    const lookupCustomProviderModel = jest.fn().mockReturnValue(null);
     mockModelsDevSync = {
-      lookupModel: jest.fn().mockReturnValue(null),
+      lookupModel,
+      lookupCustomProviderModel,
+      // Mirrors the real service: native catalog first, custom catalog second.
+      lookupModelCapabilities: jest.fn(
+        (providerId: string, modelId: string) =>
+          lookupModel(providerId, modelId) ?? lookupCustomProviderModel(providerId, modelId),
+      ),
       getModelsForProvider: jest.fn().mockReturnValue([]),
       refreshCache: jest.fn().mockResolvedValue(0),
     };
@@ -1196,6 +1206,106 @@ describe('ModelDiscoveryService', () => {
       // Capabilities applied from models.dev
       expect(result[0].capabilityReasoning).toBe(true);
       expect(result[0].capabilityCode).toBe(true);
+    });
+
+    it('should apply capabilities from an unmapped models.dev provider (priced model)', async () => {
+      // Kilo prices its own catalog, so enrichment takes the price-already-set
+      // path. models.dev does not map `kilo`, so only the custom-provider
+      // catalog carries its modalities.
+      mockModelsDevSync.lookupCustomProviderModel.mockImplementation(
+        (providerId: string, modelId: string) =>
+          providerId === 'kilo' && modelId === 'openai/gpt-4o-mini'
+            ? {
+                id: 'openai/gpt-4o-mini',
+                name: 'GPT-4o mini',
+                inputPricePerToken: 0.00000015,
+                outputPricePerToken: 0.0000006,
+                reasoning: true,
+                toolCall: true,
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+                capabilities: ['text', 'image', 'tools'],
+              }
+            : null,
+      );
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'openai/gpt-4o-mini',
+          provider: 'kilo',
+          inputPricePerToken: 0.0000002,
+          outputPricePerToken: 0.0000008,
+        }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider({ provider: 'kilo' }));
+
+      expect(result[0].inputModalities).toEqual(['text', 'image']);
+      expect(result[0].outputModalities).toEqual(['text']);
+      expect(result[0].capabilityReasoning).toBe(true);
+      // The connection's own price wins; models.dev pricing is never read here.
+      expect(result[0].inputPricePerToken).toBe(0.0000002);
+      expect(result[0].outputPricePerToken).toBe(0.0000008);
+    });
+
+    it('should apply capabilities from an unmapped models.dev provider (unpriced model)', async () => {
+      // Xiaomi's /models publishes no pricing, so enrichment falls through
+      // every pricing source before capabilities are applied.
+      mockModelsDevSync.lookupCustomProviderModel.mockImplementation(
+        (providerId: string, modelId: string) =>
+          providerId === 'xiaomi' && modelId === 'mimo-v2.5'
+            ? {
+                id: 'mimo-v2.5',
+                name: 'MiMo V2.5',
+                inputPricePerToken: 0.0000004,
+                outputPricePerToken: 0.0000016,
+                reasoning: true,
+                toolCall: true,
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+                capabilities: ['text', 'image', 'tools'],
+              }
+            : null,
+      );
+
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'mimo-v2.5', provider: 'xiaomi' })]);
+
+      const result = await service.discoverModels(makeProvider({ provider: 'xiaomi' }));
+
+      expect(result[0].inputModalities).toEqual(['text', 'image']);
+      expect(result[0].capabilityReasoning).toBe(true);
+      // No pricing source resolved, so the model stays unpriced rather than
+      // borrowing the aggregator's rate.
+      expect(result[0].inputPricePerToken).toBeNull();
+      expect(result[0].outputPricePerToken).toBeNull();
+    });
+
+    it('should keep the native catalog ahead of the custom-provider fallback', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'test-model',
+        name: 'Native',
+        inputPricePerToken: null,
+        outputPricePerToken: null,
+        inputModalities: ['text'],
+        outputModalities: ['text'],
+      });
+      mockModelsDevSync.lookupCustomProviderModel.mockReturnValue({
+        id: 'test-model',
+        name: 'Fallback',
+        inputPricePerToken: null,
+        outputPricePerToken: null,
+        inputModalities: ['text', 'image'],
+        outputModalities: ['text'],
+      });
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ inputPricePerToken: 0, outputPricePerToken: 0 }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputModalities).toEqual(['text']);
+      expect(mockModelsDevSync.lookupCustomProviderModel).not.toHaveBeenCalled();
     });
 
     it('should fall back to exact model ID lookup when prefix lookup misses', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -326,7 +326,7 @@ export class ModelDiscoveryService {
     const filtered = enriched.filter((model) => {
       const metadata = resolveProviderMetadataIdentity(provider.provider, model.id);
       const metadataProvider = metadata.provider ?? provider.provider;
-      const mdEntry = this.modelsDevSync?.lookupModel(metadataProvider, metadata.model);
+      const mdEntry = this.modelsDevSync?.lookupModelCapabilities(metadataProvider, metadata.model);
       if (mdEntry && mdEntry.toolCall === false) return false;
       return true;
     });

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -731,33 +731,29 @@ export class ModelDiscoveryService {
     }
 
     // Priority 3: OpenRouter cache — broader coverage, needs prefix + variant matching
+    let priced = modelWithMetadataName;
     if (this.pricingSync && !isBedrock) {
       const orPrefix = findOpenRouterPrefix(metadataProvider);
-      if (orPrefix) {
-        const orPricing = lookupWithVariants(this.pricingSync, orPrefix, metadataModel);
-        if (orPricing) {
-          return this.computeScore({
-            ...modelWithMetadataName,
-            inputPricePerToken: orPricing.input,
-            outputPricePerToken: orPricing.output,
-            contextWindow: orPricing.contextWindow ?? modelWithMetadataName.contextWindow,
-            displayName: orPricing.displayName || modelWithMetadataName.displayName,
-          });
-        }
-      }
-      const exactPricing = this.pricingSync.lookupPricing(model.id);
-      if (exactPricing) {
-        return this.computeScore({
+      const orPricing = orPrefix
+        ? lookupWithVariants(this.pricingSync, orPrefix, metadataModel)
+        : null;
+      const pricing = orPricing ?? this.pricingSync.lookupPricing(model.id);
+      if (pricing) {
+        priced = {
           ...modelWithMetadataName,
-          inputPricePerToken: exactPricing.input,
-          outputPricePerToken: exactPricing.output,
-          contextWindow: exactPricing.contextWindow ?? modelWithMetadataName.contextWindow,
-          displayName: exactPricing.displayName || modelWithMetadataName.displayName,
-        });
+          inputPricePerToken: pricing.input,
+          outputPricePerToken: pricing.output,
+          contextWindow: pricing.contextWindow ?? modelWithMetadataName.contextWindow,
+          displayName: pricing.displayName || modelWithMetadataName.displayName,
+        };
       }
     }
 
-    return this.computeScore(modelWithMetadataName);
+    // Capabilities are independent of which catalog priced the model: a miss on
+    // every pricing source still leaves modalities and capability flags to
+    // apply. Providers whose own /models endpoint publishes no modality data
+    // (Kilo, Pioneer, Cline Pass, Xiaomi) reach models.dev only here.
+    return this.computeScore(this.applyCapabilities(priced, providerId));
   }
 
   /** Merge capability flags from models.dev without touching pricing or display name. */
@@ -765,7 +761,7 @@ export class ModelDiscoveryService {
     if (!this.modelsDevSync) return model;
     const metadata = resolveProviderMetadataIdentity(providerId, model.id);
     const metadataProvider = metadata.provider ?? providerId;
-    const mdEntry = this.modelsDevSync.lookupModel(metadataProvider, metadata.model);
+    const mdEntry = this.modelsDevSync.lookupModelCapabilities(metadataProvider, metadata.model);
     if (!mdEntry) return model;
     return {
       ...model,

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -77,7 +77,7 @@ describe('ModelController', () => {
       getCapabilities: jest.fn().mockResolvedValue(null),
     };
     mockModelsDevSync = {
-      lookupModel: jest.fn().mockReturnValue(null),
+      lookupModelCapabilities: jest.fn().mockReturnValue(null),
     };
     mockOpencodeGoCatalog = {
       resolveCostPerRequest: jest.fn().mockResolvedValue(null),
@@ -384,7 +384,7 @@ describe('ModelController', () => {
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([
         makeDiscovered({ id: 'gpt-4o', provider: 'openai' }),
       ]);
-      mockModelsDevSync.lookupModel.mockReturnValue({
+      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({
         capabilities: ['text', 'image', 'tools', 'stream'],
         inputModalities: ['text', 'image'],
         outputModalities: ['text', 'image'],
@@ -405,7 +405,7 @@ describe('ModelController', () => {
           authType: 'subscription',
         }),
       ]);
-      mockModelsDevSync.lookupModel.mockReturnValue({
+      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({
         capabilities: ['text', 'tools', 'stream'],
       });
 
@@ -413,7 +413,7 @@ describe('ModelController', () => {
 
       // The gateway prefix is stripped and the provider inferred from the
       // underlying id, so models.dev is queried as the real provider.
-      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith('zai', 'glm-5.1');
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('zai', 'glm-5.1');
       expect(result[0].capabilities).toEqual(['text', 'tools', 'stream']);
     });
 
@@ -430,7 +430,7 @@ describe('ModelController', () => {
 
       // Unknown underlying ids keep the gateway provider rather than passing
       // `undefined`.
-      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith(
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
         'opencode-go',
         'unknown-route-model',
       );
@@ -454,13 +454,13 @@ describe('ModelController', () => {
           displayName: 'mistral.magistral-small-2509',
         }),
       ]);
-      mockModelsDevSync.lookupModel.mockReturnValue({
+      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({
         name: 'Magistral Small',
       });
 
       const result = await controller.getAvailableModels(mockCtx, mockAgentName);
 
-      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith('mistral', 'magistral-small-2509');
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('mistral', 'magistral-small-2509');
       expect(result[0].model_name).toBe('mistral.magistral-small-2509');
       expect(result[0].display_name).toBe('Magistral Small');
     });

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -460,7 +460,10 @@ describe('ModelController', () => {
 
       const result = await controller.getAvailableModels(mockCtx, mockAgentName);
 
-      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('mistral', 'magistral-small-2509');
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
+        'mistral',
+        'magistral-small-2509',
+      );
       expect(result[0].model_name).toBe('mistral.magistral-small-2509');
       expect(result[0].display_name).toBe('Magistral Small');
     });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -144,7 +144,7 @@ describe('ProxyController', () => {
   let mockPricingCache: { getByModel: jest.Mock };
   let modelDiscovery: { getModelsForAgent: jest.Mock };
   let providerParamSpecs: { getCapabilities: jest.Mock };
-  let modelsDevSync: { lookupModel: jest.Mock };
+  let modelsDevSync: { lookupModelCapabilities: jest.Mock };
   let recorder: ProxyMessageRecorder;
   let planService: { assertWithinRequestLimit: jest.Mock };
   let observationReporter: { report: jest.Mock };
@@ -188,7 +188,7 @@ describe('ProxyController', () => {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
     providerParamSpecs = { getCapabilities: jest.fn().mockResolvedValue(null) };
-    modelsDevSync = { lookupModel: jest.fn().mockReturnValue(null) };
+    modelsDevSync = { lookupModelCapabilities: jest.fn().mockReturnValue(null) };
     observationReporter = { report: jest.fn() };
     recordingCache = { isRecording: jest.fn().mockResolvedValue(false) };
     attemptRecording = {
@@ -476,7 +476,7 @@ describe('ProxyController', () => {
       makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai' }),
     ]);
     providerParamSpecs.getCapabilities.mockResolvedValue(['tools']);
-    modelsDevSync.lookupModel.mockReturnValue({
+    modelsDevSync.lookupModelCapabilities.mockReturnValue({
       id: 'gpt-4o',
       name: 'GPT-4o',
       inputPricePerToken: null,
@@ -504,7 +504,7 @@ describe('ProxyController', () => {
       ],
     });
     expect(providerParamSpecs.getCapabilities).toHaveBeenCalledWith('openai', 'api_key', 'gpt-4o');
-    expect(modelsDevSync.lookupModel).toHaveBeenCalledWith('openai', 'gpt-4o');
+    expect(modelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('openai', 'gpt-4o');
   });
 
   it('should expose capabilities and cost when both query parameters are true', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -132,7 +132,7 @@ describe('ProxyController streaming abort', () => {
       { assertWithinRequestLimit: jest.fn().mockResolvedValue(undefined) } as never,
       { report: jest.fn() } as never,
       { getCapabilities: jest.fn().mockResolvedValue(null) } as never,
-      { lookupModel: jest.fn().mockReturnValue(null) } as never,
+      { lookupModel: jest.fn().mockReturnValue(null), lookupModelCapabilities: jest.fn().mockReturnValue(null) } as never,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -132,7 +132,10 @@ describe('ProxyController streaming abort', () => {
       { assertWithinRequestLimit: jest.fn().mockResolvedValue(undefined) } as never,
       { report: jest.fn() } as never,
       { getCapabilities: jest.fn().mockResolvedValue(null) } as never,
-      { lookupModel: jest.fn().mockReturnValue(null), lookupModelCapabilities: jest.fn().mockReturnValue(null) } as never,
+      {
+        lookupModel: jest.fn().mockReturnValue(null),
+        lookupModelCapabilities: jest.fn().mockReturnValue(null),
+      } as never,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
@@ -13,7 +13,10 @@ describe('reasoning catalog dependency injection', () => {
         ReasoningContentCache,
         ProviderClient,
         ModelsDevReasoningCatalog,
-        { provide: ModelsDevSyncService, useValue: { lookupModel: () => null, lookupModelCapabilities: () => null } },
+        {
+          provide: ModelsDevSyncService,
+          useValue: { lookupModel: () => null, lookupModelCapabilities: () => null },
+        },
       ],
     }).compile();
 

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
@@ -13,7 +13,7 @@ describe('reasoning catalog dependency injection', () => {
         ReasoningContentCache,
         ProviderClient,
         ModelsDevReasoningCatalog,
-        { provide: ModelsDevSyncService, useValue: { lookupModel: () => null } },
+        { provide: ModelsDevSyncService, useValue: { lookupModel: () => null, lookupModelCapabilities: () => null } },
       ],
     }).compile();
 


### PR DESCRIPTION
Stacked on #2733. Merge that one first.

### ✨ What changed

`CAPABILITY_ONLY_PROVIDER_ID_MAP` — a second models.dev provider map that grants capability authority without pricing authority. It builds its own cache, and `lookupModelCapabilities` reads the priced catalog first and it second. `applyCapabilities` uses that lookup, and `enrichModel` now applies capabilities on the OpenRouter and unpriced paths as well, not just when a price is already set.

### 💭 Why

Four first-class providers publish no modality data on their own `/models` endpoint and are absent from `PROVIDER_ID_MAP`, so `lookupModel` always missed and `GET /v1/models?capabilities=true` returned nothing for them.

| Provider | models.dev models | with image input | what the parser gave |
|---|---|---|---|
| kilo | 360 | 196 | nothing; `output_modalities` was read only to filter |
| pioneer | 102 | 56 | `inputModalities` only when `supports_image_input`, never output |
| cline-pass | 11 | 6 | nothing; curated subscription list |
| xiaomi | 6 | 2 | nothing; only `capabilityCode: true` |

They cannot go in `PROVIDER_ID_MAP`. That map also decides who may price, and `loadModelsDevEntries` overlays those rates keyed by bare model ID (`model-pricing-cache.service.ts:235`). Kilo lists `openai/gpt-4o-mini` and Pioneer lists `gpt-4o`, so 462 resold entries would overwrite the real vendor price for every client of those IDs. That is the hazard the Copilot comment above that line already describes. #2733 could use the map because models.dev publishes no `cost` for `ollama-cloud` at all.

### 👤 For users

Kilo, Pioneer, Cline Pass and Xiaomi models now report their modalities and capabilities. Reasoning and tool-call flags also feed quality scoring and tier auto-assignment, which had been reading `false` for all of them.

### 🔧 For operators

No pricing change. Nothing but `lookupModelCapabilities` reads the new cache, so `getModelsForProvider`, `isProviderSupported`, the shared pricing cache and the discovery fallback catalogs are untouched, and the priced-model count is unchanged. Tests assert each of those.

### 📝 Notes

`PROVIDER_ID_MAP` was answering four questions at once: the models.dev directory name, pricing authority, catalog-synthesis authority, and whether a miss is authoritative. Both maps now document which of those they grant, so adding a provider is a deliberate choice rather than an unnoticed pricing change.

The serving-time resolver (`resolveModelCapabilityMetadata`) and the tool-support filter also read the capability catalog now, so stale cached_models resolve without waiting for a discovery refresh, and a capability-only provider model that models.dev marks `toolCall: false` is dropped the same way a mapped provider's would be.

Applying capabilities on the OpenRouter and unpriced paths is a behavior change for every provider, not just these four. Xiaomi's parser emits null prices and Pioneer models missing from the base catalog do too, so those models never reached capability enrichment at all. It only ever adds data models.dev already keys under that provider's own catalog.

Backend suite green: 458 suites, 8386 tests.
