### PR TITLE
fix: declare tool support for OpenRouter models

### DIFF
--- a/.changeset/openrouter-tool-capabilities.md
+++ b/.changeset/openrouter-tool-capabilities.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Report tool support and modalities for OpenRouter models. OpenRouter reached neither models.dev provider map, so all 323 published models declared only `stream` and never `tools`, and anything reasoning about capability — the dashboard picker, `/v1/models?capabilities=true`, agents choosing a remap target — treated every one of them as tool-incapable. OpenRouter now sits in the capability-only map, so its rates stay with its own live `/models` feed while models.dev supplies the modalities and tool-call flags that feed omits. Routing variants (`:free`, `:nitro`, `:batch`) resolve to their base model's capabilities.

--- a/.changeset/unmapped-provider-capabilities.md
+++ b/.changeset/unmapped-provider-capabilities.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Report modalities and capability flags for Kilo, Pioneer, Cline Pass and Xiaomi models. These providers publish no modality data on their own `/models` endpoints, and models.dev may not price them: they list resold vendor models under the vendor's own ID, so their rates would overwrite the real vendor price in the shared cache. A new capability-only provider map carries them, separate from the map that grants pricing authority.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -270,6 +270,35 @@ const MOCK_API_RESPONSE = {
       },
     },
   },
+  openrouter: {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    models: {
+      'qwen/qwen3-coder': {
+        id: 'qwen/qwen3-coder',
+        name: 'Qwen3 Coder',
+        tool_call: true,
+        cost: { input: 0.3, output: 1 },
+        limit: { context: 262144 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'google/gemini-3.5-flash': {
+        id: 'google/gemini-3.5-flash',
+        name: 'Gemini 3.5 Flash',
+        tool_call: true,
+        cost: { input: 0.3, output: 2.5 },
+        limit: { context: 1000000 },
+        modalities: { input: ['text', 'image'], output: ['text'] },
+      },
+      'google/gemma-3-4b-it': {
+        id: 'google/gemma-3-4b-it',
+        name: 'Gemma 3 4B',
+        tool_call: false,
+        cost: { input: 0.02, output: 0.04 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
   nvidia: {
     id: 'nvidia',
     name: 'NVIDIA',
@@ -1557,6 +1586,41 @@ describe('ModelsDevSyncService', () => {
       // Same total as refreshCache asserts: the kilo model is cached for
       // capabilities but never counted or priced.
       expect(await service.refreshCache()).toBe(32);
+    });
+
+    it('should declare tool support for OpenRouter models', () => {
+      // #2737: every OpenRouter model looked tool-incapable because OpenRouter
+      // reached neither map, so `tools` was never added.
+      expect(service.lookupModel('openrouter', 'qwen/qwen3-coder')).toBeNull();
+      const model = service.lookupModelCapabilities('openrouter', 'qwen/qwen3-coder');
+      expect(model).not.toBeNull();
+      expect(model!.capabilities).toContain('tools');
+      expect(
+        service.lookupModelCapabilities('openrouter', 'google/gemini-3.5-flash')!.inputModalities,
+      ).toEqual(['text', 'image']);
+    });
+
+    it('should keep OpenRouter models.dev rates out of the pricing cache', () => {
+      // OpenRouter's own /models feed prices its connections, including the
+      // `:free` and `:nitro` variants models.dev does not carry.
+      expect(service.getModelsForProvider('openrouter')).toEqual([]);
+      expect(service.isProviderSupported('openrouter')).toBe(false);
+    });
+
+    it('should resolve an OpenRouter variant suffix to its base model', () => {
+      // OpenRouter sells routing variants (`:batch`, `:free`, `:nitro`) that
+      // models.dev lists only under the base ID. Capabilities are the base
+      // model's either way.
+      const batch = service.lookupModelCapabilities('openrouter', 'qwen/qwen3-coder:batch');
+      expect(batch?.id).toBe('qwen/qwen3-coder');
+      expect(service.lookupModelCapabilities('openrouter', 'qwen/unknown-model:batch')).toBeNull();
+    });
+
+    it('should not strip a colon suffix for providers that use one in model IDs', () => {
+      // Ollama tags (`gpt-oss:120b`) and Bedrock versions (`-v1:0`) are part of
+      // the model ID, not a routing variant.
+      expect(service.lookupModelCapabilities('ollama-cloud', 'gpt-oss:120b')).not.toBeNull();
+      expect(service.lookupModelCapabilities('ollama-cloud', 'kimi-k3:8b')).toBeNull();
     });
 
     it('should not resolve local Ollama against the Ollama Cloud catalog', () => {

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1520,6 +1520,55 @@ describe('ModelsDevSyncService', () => {
     });
   });
 
+  describe('lookupModelCapabilities', () => {
+    beforeEach(async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+    });
+
+    it('should prefer the native catalog', () => {
+      const model = service.lookupModelCapabilities('anthropic', 'claude-opus-4-6');
+      expect(model).not.toBeNull();
+      expect(model!.inputModalities).toEqual(['text', 'image']);
+    });
+
+    it('should resolve capability-only providers', () => {
+      // `kilo` is a first-class Manifest provider that models.dev may not
+      // price, so only the capability catalog resolves it.
+      expect(service.lookupModel('kilo', 'openai/gpt-4o-mini')).toBeNull();
+      const model = service.lookupModelCapabilities('kilo', 'openai/gpt-4o-mini');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('GPT-4o mini');
+    });
+
+    it('should keep capability-only providers out of every pricing consumer', () => {
+      // getModelsForProvider feeds the shared pricing cache and the discovery
+      // fallback catalog. Kilo lists resold vendor models under the vendor's
+      // own ID, so its rates must not reach either.
+      expect(service.getModelsForProvider('kilo')).toEqual([]);
+      expect(service.isProviderSupported('kilo')).toBe(false);
+    });
+
+    it('should not count capability-only models as priced coverage', async () => {
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => MOCK_API_RESPONSE });
+      // Same total as refreshCache asserts: the kilo model is cached for
+      // capabilities but never counted or priced.
+      expect(await service.refreshCache()).toBe(32);
+    });
+
+    it('should not resolve local Ollama against the Ollama Cloud catalog', () => {
+      expect(service.lookupModelCapabilities('ollama', 'kimi-k3')).toBeNull();
+    });
+
+    it('should return null for providers on neither map', () => {
+      expect(service.lookupModelCapabilities('nous', 'some-model')).toBeNull();
+      expect(service.lookupModelCapabilities('kilo', 'missing-model')).toBeNull();
+    });
+  });
+
   describe('lookupModelAcrossProviders', () => {
     beforeEach(async () => {
       fetchSpy.mockResolvedValue({

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -9,8 +9,18 @@ import {
 import { GOOGLE_VARIANT_RE } from '../model-prices/model-name-normalizer';
 
 /**
- * Mapping from our internal provider IDs to models.dev provider directory names.
- * models.dev uses its own naming convention for provider directories.
+ * Providers whose models.dev catalog is authoritative for **pricing as well as
+ * capabilities**. models.dev uses its own naming convention for provider
+ * directories, so this maps our internal ID to theirs.
+ *
+ * An entry here does more than name a directory. It also decides that
+ * models.dev may price the provider (`loadModelsDevEntries` overlays these
+ * rates onto the shared pricing cache, keyed by bare model ID), that
+ * `buildModelsDevFallback` may synthesize the provider's whole catalog when its
+ * API is unreachable, and that a lookup miss is authoritative
+ * (`isProviderSupported`). Add a provider here only when its models.dev rates
+ * are the rates its connections actually pay. For a provider that only needs
+ * modalities and capability flags, use CAPABILITY_ONLY_PROVIDER_ID_MAP.
  */
 const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   anthropic: 'anthropic',
@@ -32,6 +42,24 @@ const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   'opencode-go': 'opencode-go',
   'opencode-zen': 'opencode',
   'ollama-cloud': 'ollama-cloud',
+};
+
+/**
+ * Providers whose models.dev catalog is authoritative for **capabilities only**.
+ *
+ * These publish no modality data on their own `/models` endpoint, so models.dev
+ * is the only source of their modalities and capability flags. They are kept
+ * out of PROVIDER_ID_MAP because their models.dev prices must not reach the
+ * shared pricing cache: they list resold vendor models under the vendor's own
+ * ID (`kilo/openai/gpt-4o-mini`, `pioneer/gpt-4o`), so overlaying them would
+ * overwrite the real vendor rate for every client of that model ID. Their
+ * connections are priced from their own API instead.
+ */
+const CAPABILITY_ONLY_PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
+  kilo: 'kilo',
+  pioneer: 'pioneer',
+  'cline-pass': 'cline-pass',
+  xiaomi: 'xiaomi',
 };
 
 const SUPPORTED_PROVIDERS = new Set(Object.keys(PROVIDER_ID_MAP));
@@ -198,6 +226,8 @@ export class ModelsDevSyncService implements OnModuleInit {
   private readonly logger = new Logger(ModelsDevSyncService.name);
   /** Map: our provider ID → Map<model ID (native), entry> */
   private cache = new Map<string, Map<string, ModelsDevModelEntry>>();
+  /** Map: our provider ID → Map<model ID, entry>, for capability-only providers. */
+  private capabilityCache = new Map<string, Map<string, ModelsDevModelEntry>>();
   /** Map: models.dev provider ID → Map<model ID, entry>. Includes providers Manifest does not natively know. */
   private customProviderCache = new Map<string, Map<string, ModelsDevModelEntry>>();
   /** Map: provider id/display-name aliases → models.dev provider ID. */
@@ -264,7 +294,26 @@ export class ModelsDevSyncService implements OnModuleInit {
       }
     }
 
+    // Capability-only providers stay out of `cache`, so no pricing or fallback
+    // consumer can reach them. `totalModels` counts priced coverage only.
+    const newCapabilityCache = new Map<string, Map<string, ModelsDevModelEntry>>();
+    for (const [ourId, modelsDevId] of Object.entries(CAPABILITY_ONLY_PROVIDER_ID_MAP)) {
+      const provider = raw[modelsDevId];
+      if (!provider?.models) continue;
+
+      const modelMap = new Map<string, ModelsDevModelEntry>();
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        if (!this.isChatCompatible(model)) continue;
+        modelMap.set(modelId, this.parseModel(ourId, modelId, model));
+      }
+
+      if (modelMap.size > 0) {
+        newCapabilityCache.set(ourId, modelMap);
+      }
+    }
+
     this.cache = newCache;
+    this.capabilityCache = newCapabilityCache;
     this.customProviderCache = newCustomProviderCache;
     this.customProviderIndex = newCustomProviderIndex;
     this.lastFetchedAt = new Date();
@@ -302,6 +351,24 @@ export class ModelsDevSyncService implements OnModuleInit {
     const providerModels = this.customProviderCache.get(providerKey);
     if (!providerModels) return null;
     return this.lookupModelInProvider(providerModels, modelId);
+  }
+
+  /**
+   * Look up a model for its modalities and capability flags: the priced catalog
+   * first, then CAPABILITY_ONLY_PROVIDER_ID_MAP.
+   *
+   * **Never read pricing from the result.** A capability-only entry carries a
+   * reseller's rate for a vendor's model ID, which is not what the connection
+   * pays. Callers that need a price must use `lookupModel`.
+   */
+  lookupModelCapabilities(providerId: string, modelId: string): ModelsDevModelEntry | null {
+    const native = this.lookupModel(providerId, modelId);
+    if (native) return native;
+
+    const resolvedProviderId = resolveProviderId(providerId);
+    const providerModels = this.capabilityCache.get(resolvedProviderId);
+    if (!providerModels) return null;
+    return this.lookupModelInProvider(providerModels, modelId, resolvedProviderId);
   }
 
   /**

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -60,6 +60,11 @@ const CAPABILITY_ONLY_PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   pioneer: 'pioneer',
   'cline-pass': 'cline-pass',
   xiaomi: 'xiaomi',
+  // OpenRouter's own /models feed already prices every connection, down to the
+  // routing variants (`:free`, `:nitro`, `:batch`) models.dev does not carry,
+  // and PricingSyncService keeps it fresh. models.dev is read here only for the
+  // modalities and tool-call flags that feed does not publish (#2737).
+  openrouter: 'openrouter',
 };
 
 const SUPPORTED_PROVIDERS = new Set(Object.keys(PROVIDER_ID_MAP));
@@ -213,6 +218,13 @@ const MODEL_ID_PREFIX_ALIASES: ReadonlyMap<string, string> = new Map([
 ]);
 /** Matches instruction-tuned suffixes that models.dev sometimes omits on Bedrock keys. */
 const INSTRUCT_SUFFIX_RE = /-instruct$/;
+/**
+ * Matches an OpenRouter routing variant (`:free`, `:nitro`, `:batch`, ...).
+ * The variant selects how a request is routed, not which model answers, so the
+ * base entry carries its capabilities. Only applied to OpenRouter: elsewhere a
+ * colon is part of the model ID itself (Ollama tags, Bedrock `-v1:0`).
+ */
+const OPENROUTER_VARIANT_SUFFIX_RE = /:[a-z0-9-]+$/;
 /**
  * Matches Ollama release tags that models.dev omits from its base model key
  * (e.g. `deepseek-v4-pro:preview` → `deepseek-v4-pro`). Deliberately narrow:
@@ -487,6 +499,15 @@ export class ModelsDevSyncService implements OnModuleInit {
       const noTag = modelId.replace(OLLAMA_TAG_SUFFIX_RE, '');
       if (noTag !== modelId) {
         const found = providerModels.get(noTag);
+        if (found) return found;
+      }
+    }
+
+    if (providerId === 'openrouter') {
+      // 7a. Strip the routing variant (qwen/qwen3-coder:batch → qwen/qwen3-coder)
+      const noVariant = modelId.replace(OPENROUTER_VARIANT_SUFFIX_RE, '');
+      if (noVariant !== modelId) {
+        const found = providerModels.get(noVariant);
         if (found) return found;
       }
     }

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -53,16 +53,16 @@ describe('inputModalitiesFromCapabilities', () => {
 
 describe('resolveModelCapabilityMetadata', () => {
   const paramSpecs = { getCapabilities: jest.fn() };
-  const modelsDevSync = { lookupModel: jest.fn() };
+  const modelsDevSync = { lookupModelCapabilities: jest.fn() };
 
   beforeEach(() => {
     paramSpecs.getCapabilities.mockReset().mockResolvedValue(null);
-    modelsDevSync.lookupModel.mockReset().mockReturnValue(null);
+    modelsDevSync.lookupModelCapabilities.mockReset().mockReturnValue(null);
   });
 
   it('merges discovery, models.dev, param-spec, and streaming-heuristic capabilities', async () => {
     paramSpecs.getCapabilities.mockResolvedValue(['tools']);
-    modelsDevSync.lookupModel.mockReturnValue(makeModelsDevEntry());
+    modelsDevSync.lookupModelCapabilities.mockReturnValue(makeModelsDevEntry());
 
     const resolved = await resolveModelCapabilityMetadata(
       makeModel({ capabilities: ['audio'], authType: 'subscription' }),
@@ -144,6 +144,9 @@ describe('resolveModelCapabilityMetadata', () => {
       modelsDevSync,
     );
 
-    expect(modelsDevSync.lookupModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-5-v1:0');
+    expect(modelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
+      'anthropic',
+      'claude-sonnet-5-v1:0',
+    );
   });
 });

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -137,6 +137,22 @@ describe('resolveModelCapabilityMetadata', () => {
     expect(resolved.outputModalities).toEqual(['text']);
   });
 
+  it('keeps the vendor prefix on OpenRouter ids so the OpenRouter catalog answers', async () => {
+    // OpenRouter is not a transparent gateway: it resells a vendor's model
+    // under its own catalog entry, so `openai/gpt-4o-mini` must be looked up
+    // whole rather than split into ('openai', 'gpt-4o-mini') (#2737).
+    await resolveModelCapabilityMetadata(
+      makeModel({ id: 'openai/gpt-4o-mini', provider: 'openrouter' }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(modelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
+      'openrouter',
+      'openai/gpt-4o-mini',
+    );
+  });
+
   it('looks up metadata under the underlying provider for vendor-prefixed ids', async () => {
     await resolveModelCapabilityMetadata(
       makeModel({ id: 'anthropic.claude-sonnet-5-v1:0', provider: 'bedrock' }),

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -122,7 +122,9 @@ export async function resolveModelCapabilityMetadata(
       model: string | undefined,
     ): Promise<readonly ModelCapability[] | null>;
   },
-  modelsDevSync: { lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null },
+  modelsDevSync: {
+    lookupModelCapabilities(providerId: string, modelId: string): ModelsDevModelEntry | null;
+  },
 ): Promise<ResolvedCapabilityMetadata> {
   const specCapabilities = await paramSpecs.getCapabilities(
     model.provider,
@@ -133,7 +135,10 @@ export async function resolveModelCapabilityMetadata(
   // Bedrock vendor-prefixed ids). Resolve that provenance for metadata only.
   const metadata = resolveProviderMetadataIdentity(model.provider, model.id);
   const metadataProvider = metadata.provider ?? model.provider;
-  const modelsDevEntry = modelsDevSync.lookupModel(metadataProvider, metadata.model);
+  // Capability-only providers (Kilo, Pioneer, Cline Pass, Xiaomi) resolve here
+  // too; every field read off this entry is capability metadata or a display
+  // name, never a price.
+  const modelsDevEntry = modelsDevSync.lookupModelCapabilities(metadataProvider, metadata.model);
   // Curated facts are the last resort, and applying them here (not only at
   // discovery time) means stale cached_models still resolve correctly.
   const known = lookupKnownModalities(metadataProvider, metadata.model);

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -135,9 +135,9 @@ export async function resolveModelCapabilityMetadata(
   // Bedrock vendor-prefixed ids). Resolve that provenance for metadata only.
   const metadata = resolveProviderMetadataIdentity(model.provider, model.id);
   const metadataProvider = metadata.provider ?? model.provider;
-  // Capability-only providers (Kilo, Pioneer, Cline Pass, Xiaomi) resolve here
-  // too; every field read off this entry is capability metadata or a display
-  // name, never a price.
+  // Capability-only providers (Kilo, Pioneer, Cline Pass, Xiaomi, OpenRouter)
+  // resolve here too; every field read off this entry is capability metadata or
+  // a display name, never a price.
   const modelsDevEntry = modelsDevSync.lookupModelCapabilities(metadataProvider, metadata.model);
   // Curated facts are the last resort, and applying them here (not only at
   // discovery time) means stale cached_models still resolve correctly.

--- a/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
@@ -86,6 +86,7 @@ describe('ModelDiscoveryService — boundary conditions', () => {
   let mockModelRegistry: { registerModels: jest.Mock; getConfirmedModels: jest.Mock };
   let mockModelsDevSync: {
     lookupModel: jest.Mock;
+    lookupModelCapabilities: jest.Mock;
     getModelsForProvider: jest.Mock;
     refreshCache: jest.Mock;
   };
@@ -99,8 +100,14 @@ describe('ModelDiscoveryService — boundary conditions', () => {
       lookupPricing: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue(new Map()),
     };
+    const lookupModel = jest.fn().mockReturnValue(null);
     mockModelsDevSync = {
-      lookupModel: jest.fn().mockReturnValue(null),
+      lookupModel,
+      // The real service tries the priced catalog first. Tests that exercise
+      // the capability-only catalog override this directly.
+      lookupModelCapabilities: jest.fn((providerId: string, modelId: string) =>
+        lookupModel(providerId, modelId),
+      ),
       getModelsForProvider: jest.fn().mockReturnValue([]),
       refreshCache: jest.fn().mockResolvedValue(0),
     };

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1309,19 +1309,37 @@ describe('ModelDiscoveryService', () => {
     });
 
     it('should route capability lookups through lookupModelCapabilities', async () => {
-      // enrichModel must not call lookupModel for capabilities: that path is
+      // enrichModel must not read capabilities from lookupModel: that path is
       // reserved for pricing, and a capability-only entry carries a reseller's
-      // rate for a vendor's model ID.
+      // rate for a vendor's model ID. Only the capability catalog answers here,
+      // so reverting enrichModel to lookupModel leaves the flags unset.
+      mockModelsDevSync.lookupModel.mockReturnValue(null);
+      mockModelsDevSync.lookupModelCapabilities.mockImplementation(
+        (providerId: string, modelId: string) =>
+          providerId === 'openai' && modelId === 'test-model'
+            ? {
+                id: 'test-model',
+                name: 'Test Model',
+                reasoning: true,
+                toolCall: true,
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+                capabilities: ['text', 'image', 'tools'],
+              }
+            : null,
+      );
       fetcher.fetch.mockResolvedValue([
         makeModel({ inputPricePerToken: 0, outputPricePerToken: 0 }),
       ]);
 
-      await service.discoverModels(makeProvider());
+      const result = await service.discoverModels(makeProvider());
 
       expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
         'openai',
         'test-model',
       );
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].inputModalities).toEqual(['text', 'image']);
     });
 
     it('should fall back to exact model ID lookup when prefix lookup misses', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -98,6 +98,7 @@ describe('ModelDiscoveryService', () => {
   };
   let mockModelsDevSync: {
     lookupModel: jest.Mock;
+    lookupModelCapabilities: jest.Mock;
     getModelsForProvider: jest.Mock;
     refreshCache: jest.Mock;
   };
@@ -112,8 +113,14 @@ describe('ModelDiscoveryService', () => {
       lookupPricing: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue(new Map()),
     };
+    const lookupModel = jest.fn().mockReturnValue(null);
     mockModelsDevSync = {
-      lookupModel: jest.fn().mockReturnValue(null),
+      lookupModel,
+      // The real service tries the priced catalog first. Tests that exercise
+      // the capability-only catalog override this directly.
+      lookupModelCapabilities: jest.fn((providerId: string, modelId: string) =>
+        lookupModel(providerId, modelId),
+      ),
       getModelsForProvider: jest.fn().mockReturnValue([]),
       refreshCache: jest.fn().mockResolvedValue(0),
     };
@@ -1196,6 +1203,125 @@ describe('ModelDiscoveryService', () => {
       // Capabilities applied from models.dev
       expect(result[0].capabilityReasoning).toBe(true);
       expect(result[0].capabilityCode).toBe(true);
+    });
+
+    it('should apply capabilities from an unmapped models.dev provider (priced model)', async () => {
+      // Kilo prices its own catalog, so enrichment takes the price-already-set
+      // path. models.dev does not map `kilo`, so only the custom-provider
+      // catalog carries its modalities.
+      mockModelsDevSync.lookupModelCapabilities.mockImplementation(
+        (providerId: string, modelId: string) =>
+          providerId === 'kilo' && modelId === 'openai/gpt-4o-mini'
+            ? {
+                id: 'openai/gpt-4o-mini',
+                name: 'GPT-4o mini',
+                inputPricePerToken: 0.00000015,
+                outputPricePerToken: 0.0000006,
+                reasoning: true,
+                toolCall: true,
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+                capabilities: ['text', 'image', 'tools'],
+              }
+            : null,
+      );
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'openai/gpt-4o-mini',
+          provider: 'kilo',
+          inputPricePerToken: 0.0000002,
+          outputPricePerToken: 0.0000008,
+        }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider({ provider: 'kilo' }));
+
+      expect(result[0].inputModalities).toEqual(['text', 'image']);
+      expect(result[0].outputModalities).toEqual(['text']);
+      expect(result[0].capabilityReasoning).toBe(true);
+      // The connection's own price wins; models.dev pricing is never read here.
+      expect(result[0].inputPricePerToken).toBe(0.0000002);
+      expect(result[0].outputPricePerToken).toBe(0.0000008);
+    });
+
+    it('should apply capabilities from an unmapped models.dev provider (unpriced model)', async () => {
+      // Xiaomi's /models publishes no pricing, so enrichment falls through
+      // every pricing source before capabilities are applied.
+      mockModelsDevSync.lookupModelCapabilities.mockImplementation(
+        (providerId: string, modelId: string) =>
+          providerId === 'xiaomi' && modelId === 'mimo-v2.5'
+            ? {
+                id: 'mimo-v2.5',
+                name: 'MiMo V2.5',
+                inputPricePerToken: 0.0000004,
+                outputPricePerToken: 0.0000016,
+                reasoning: true,
+                toolCall: true,
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+                capabilities: ['text', 'image', 'tools'],
+              }
+            : null,
+      );
+
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'mimo-v2.5', provider: 'xiaomi' })]);
+
+      const result = await service.discoverModels(makeProvider({ provider: 'xiaomi' }));
+
+      expect(result[0].inputModalities).toEqual(['text', 'image']);
+      expect(result[0].capabilityReasoning).toBe(true);
+      // No pricing source resolved, so the model stays unpriced rather than
+      // borrowing the aggregator's rate.
+      expect(result[0].inputPricePerToken).toBeNull();
+      expect(result[0].outputPricePerToken).toBeNull();
+    });
+
+    it('should filter tool-less models of capability-only providers', async () => {
+      // The tool-support filter reads the same capability catalog as
+      // enrichment, so a Kilo model models.dev marks toolCall=false is
+      // dropped while an unknown one is kept.
+      mockModelsDevSync.lookupModelCapabilities.mockImplementation(
+        (providerId: string, modelId: string) =>
+          providerId === 'kilo' && modelId === 'vendor/no-tools'
+            ? { id: 'vendor/no-tools', name: 'No Tools', toolCall: false }
+            : null,
+      );
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'vendor/no-tools',
+          provider: 'kilo',
+          inputPricePerToken: 0.000001,
+          outputPricePerToken: 0.000002,
+        }),
+        makeModel({
+          id: 'vendor/unknown',
+          provider: 'kilo',
+          inputPricePerToken: 0.000001,
+          outputPricePerToken: 0.000002,
+        }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider({ provider: 'kilo' }));
+
+      expect(result.map((m) => m.id)).toEqual(['vendor/unknown']);
+    });
+
+    it('should route capability lookups through lookupModelCapabilities', async () => {
+      // enrichModel must not call lookupModel for capabilities: that path is
+      // reserved for pricing, and a capability-only entry carries a reseller's
+      // rate for a vendor's model ID.
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ inputPricePerToken: 0, outputPricePerToken: 0 }),
+      ]);
+
+      await service.discoverModels(makeProvider());
+
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
+        'openai',
+        'test-model',
+      );
     });
 
     it('should fall back to exact model ID lookup when prefix lookup misses', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -326,7 +326,7 @@ export class ModelDiscoveryService {
     const filtered = enriched.filter((model) => {
       const metadata = resolveProviderMetadataIdentity(provider.provider, model.id);
       const metadataProvider = metadata.provider ?? provider.provider;
-      const mdEntry = this.modelsDevSync?.lookupModel(metadataProvider, metadata.model);
+      const mdEntry = this.modelsDevSync?.lookupModelCapabilities(metadataProvider, metadata.model);
       if (mdEntry && mdEntry.toolCall === false) return false;
       return true;
     });
@@ -731,33 +731,29 @@ export class ModelDiscoveryService {
     }
 
     // Priority 3: OpenRouter cache — broader coverage, needs prefix + variant matching
+    let priced = modelWithMetadataName;
     if (this.pricingSync && !isBedrock) {
       const orPrefix = findOpenRouterPrefix(metadataProvider);
-      if (orPrefix) {
-        const orPricing = lookupWithVariants(this.pricingSync, orPrefix, metadataModel);
-        if (orPricing) {
-          return this.computeScore({
-            ...modelWithMetadataName,
-            inputPricePerToken: orPricing.input,
-            outputPricePerToken: orPricing.output,
-            contextWindow: orPricing.contextWindow ?? modelWithMetadataName.contextWindow,
-            displayName: orPricing.displayName || modelWithMetadataName.displayName,
-          });
-        }
-      }
-      const exactPricing = this.pricingSync.lookupPricing(model.id);
-      if (exactPricing) {
-        return this.computeScore({
+      const orPricing = orPrefix
+        ? lookupWithVariants(this.pricingSync, orPrefix, metadataModel)
+        : null;
+      const pricing = orPricing ?? this.pricingSync.lookupPricing(model.id);
+      if (pricing) {
+        priced = {
           ...modelWithMetadataName,
-          inputPricePerToken: exactPricing.input,
-          outputPricePerToken: exactPricing.output,
-          contextWindow: exactPricing.contextWindow ?? modelWithMetadataName.contextWindow,
-          displayName: exactPricing.displayName || modelWithMetadataName.displayName,
-        });
+          inputPricePerToken: pricing.input,
+          outputPricePerToken: pricing.output,
+          contextWindow: pricing.contextWindow ?? modelWithMetadataName.contextWindow,
+          displayName: pricing.displayName || modelWithMetadataName.displayName,
+        };
       }
     }
 
-    return this.computeScore(modelWithMetadataName);
+    // Capabilities are independent of which catalog priced the model: a miss on
+    // every pricing source still leaves modalities and capability flags to
+    // apply. Providers whose own /models endpoint publishes no modality data
+    // (Kilo, Pioneer, Cline Pass, Xiaomi) reach models.dev only here.
+    return this.computeScore(this.applyCapabilities(priced, providerId));
   }
 
   /** Merge capability flags from models.dev without touching pricing or display name. */
@@ -765,7 +761,7 @@ export class ModelDiscoveryService {
     if (!this.modelsDevSync) return model;
     const metadata = resolveProviderMetadataIdentity(providerId, model.id);
     const metadataProvider = metadata.provider ?? providerId;
-    const mdEntry = this.modelsDevSync.lookupModel(metadataProvider, metadata.model);
+    const mdEntry = this.modelsDevSync.lookupModelCapabilities(metadataProvider, metadata.model);
     if (!mdEntry) return model;
     return {
       ...model,

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -77,7 +77,7 @@ describe('ModelController', () => {
       getCapabilities: jest.fn().mockResolvedValue(null),
     };
     mockModelsDevSync = {
-      lookupModel: jest.fn().mockReturnValue(null),
+      lookupModelCapabilities: jest.fn().mockReturnValue(null),
     };
     mockOpencodeGoCatalog = {
       resolveCostPerRequest: jest.fn().mockResolvedValue(null),
@@ -384,7 +384,7 @@ describe('ModelController', () => {
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([
         makeDiscovered({ id: 'gpt-4o', provider: 'openai' }),
       ]);
-      mockModelsDevSync.lookupModel.mockReturnValue({
+      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({
         capabilities: ['text', 'image', 'tools', 'stream'],
         inputModalities: ['text', 'image'],
         outputModalities: ['text', 'image'],
@@ -405,7 +405,7 @@ describe('ModelController', () => {
           authType: 'subscription',
         }),
       ]);
-      mockModelsDevSync.lookupModel.mockReturnValue({
+      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({
         capabilities: ['text', 'tools', 'stream'],
       });
 
@@ -413,7 +413,7 @@ describe('ModelController', () => {
 
       // The gateway prefix is stripped and the provider inferred from the
       // underlying id, so models.dev is queried as the real provider.
-      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith('zai', 'glm-5.1');
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('zai', 'glm-5.1');
       expect(result[0].capabilities).toEqual(['text', 'tools', 'stream']);
     });
 
@@ -430,7 +430,7 @@ describe('ModelController', () => {
 
       // Unknown underlying ids keep the gateway provider rather than passing
       // `undefined`.
-      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith(
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
         'opencode-go',
         'unknown-route-model',
       );
@@ -454,13 +454,16 @@ describe('ModelController', () => {
           displayName: 'mistral.magistral-small-2509',
         }),
       ]);
-      mockModelsDevSync.lookupModel.mockReturnValue({
+      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({
         name: 'Magistral Small',
       });
 
       const result = await controller.getAvailableModels(mockCtx, mockAgentName);
 
-      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith('mistral', 'magistral-small-2509');
+      expect(mockModelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith(
+        'mistral',
+        'magistral-small-2509',
+      );
       expect(result[0].model_name).toBe('mistral.magistral-small-2509');
       expect(result[0].display_name).toBe('Magistral Small');
     });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -144,7 +144,7 @@ describe('ProxyController', () => {
   let mockPricingCache: { getByModel: jest.Mock };
   let modelDiscovery: { getModelsForAgent: jest.Mock };
   let providerParamSpecs: { getCapabilities: jest.Mock };
-  let modelsDevSync: { lookupModel: jest.Mock };
+  let modelsDevSync: { lookupModelCapabilities: jest.Mock };
   let recorder: ProxyMessageRecorder;
   let planService: { assertWithinRequestLimit: jest.Mock };
   let observationReporter: { report: jest.Mock };
@@ -188,7 +188,7 @@ describe('ProxyController', () => {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
     providerParamSpecs = { getCapabilities: jest.fn().mockResolvedValue(null) };
-    modelsDevSync = { lookupModel: jest.fn().mockReturnValue(null) };
+    modelsDevSync = { lookupModelCapabilities: jest.fn().mockReturnValue(null) };
     observationReporter = { report: jest.fn() };
     recordingCache = { isRecording: jest.fn().mockResolvedValue(false) };
     attemptRecording = {
@@ -476,7 +476,7 @@ describe('ProxyController', () => {
       makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai' }),
     ]);
     providerParamSpecs.getCapabilities.mockResolvedValue(['tools']);
-    modelsDevSync.lookupModel.mockReturnValue({
+    modelsDevSync.lookupModelCapabilities.mockReturnValue({
       id: 'gpt-4o',
       name: 'GPT-4o',
       inputPricePerToken: null,
@@ -504,7 +504,7 @@ describe('ProxyController', () => {
       ],
     });
     expect(providerParamSpecs.getCapabilities).toHaveBeenCalledWith('openai', 'api_key', 'gpt-4o');
-    expect(modelsDevSync.lookupModel).toHaveBeenCalledWith('openai', 'gpt-4o');
+    expect(modelsDevSync.lookupModelCapabilities).toHaveBeenCalledWith('openai', 'gpt-4o');
   });
 
   it('should expose capabilities and cost when both query parameters are true', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -132,7 +132,10 @@ describe('ProxyController streaming abort', () => {
       { assertWithinRequestLimit: jest.fn().mockResolvedValue(undefined) } as never,
       { report: jest.fn() } as never,
       { getCapabilities: jest.fn().mockResolvedValue(null) } as never,
-      { lookupModel: jest.fn().mockReturnValue(null) } as never,
+      {
+        lookupModel: jest.fn().mockReturnValue(null),
+        lookupModelCapabilities: jest.fn().mockReturnValue(null),
+      } as never,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
@@ -13,7 +13,10 @@ describe('reasoning catalog dependency injection', () => {
         ReasoningContentCache,
         ProviderClient,
         ModelsDevReasoningCatalog,
-        { provide: ModelsDevSyncService, useValue: { lookupModel: () => null } },
+        {
+          provide: ModelsDevSyncService,
+          useValue: { lookupModel: () => null, lookupModelCapabilities: () => null },
+        },
       ],
     }).compile();
 


### PR DESCRIPTION
### ✨ What changed
- `openrouter` joins `CAPABILITY_ONLY_PROVIDER_ID_MAP`, so models.dev supplies its modalities and tool-call flags.
- Routing variants (`:free`, `:nitro`, `:batch`) resolve to their base model's capabilities.
- Re-lands #2734, which merged into an already-merged branch and never reached `main` (first commit here).

### 💭 Why
All 323 OpenRouter models published `features: ["stream"]` and never `tools`, because OpenRouter was in neither models.dev provider map. Its prices stay with its own `/models` feed, so the capability-only map is the right one: `PROVIDER_ID_MAP` would let models.dev overwrite live OpenRouter rates.

### 👤 For users
OpenRouter models now report tool support and image input in the model picker and on `/v1/models?capabilities=true`. Discovery also drops the 66 models models.dev marks `tool_call: false`, matching what every other provider already does. OpenRouter's own catalog lists no `tools` parameter for any of those 66.

### 📝 Notes
- Closes #2737.
- Measured against the live catalogs: 412 of 414 OpenRouter models resolve, 345 declare tools, and every resolved flag agrees with OpenRouter's own `supported_parameters`. The 2 misses (`openrouter/auto-beta`, `openai/gpt-5-codex:batch`) keep today's behaviour.
- The 12 files in the first commit are #2734 unchanged, not new work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare tool and modality support for OpenRouter models by sourcing capabilities from models.dev without affecting pricing. Previously, all OpenRouter models exposed only streaming; now they report tools and image input in the picker and `/v1/models?capabilities=true`, and routing variants resolve to their base model’s capabilities.

- Add `openrouter` to `CAPABILITY_ONLY_PROVIDER_ID_MAP` (also `kilo`, `pioneer`, `cline-pass`, `xiaomi`) with a separate capability cache that never feeds pricing or fallback catalogs.
- Introduce `lookupModelCapabilities` and use it in discovery, serving-time capability metadata, and controller filters; read only modalities/capability flags, never models.dev prices. Tests pin this path to prevent regressions.
- Map OpenRouter variant suffixes (`:free`, `:nitro`, `:batch`) to the base model; preserve vendor prefixes for OpenRouter IDs (e.g., `openai/gpt-4o-mini`), and do not strip colons for providers where colons are part of the model ID (e.g., `ollama-cloud`, Bedrock).
- Apply tool-support filtering to capability-only providers; unknown models remain unchanged.
- Pricing behavior is unchanged: OpenRouter pricing comes from its own `/models`; aggregator rates for resellers do not overwrite vendor rates.

<sup>Written for commit ba5066ce473ec5444f82830bacf15b9a1bdffe61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

