### PR TITLE
feat: per-route "skip on quota exhaustion" toggle for subscription providers

### DIFF
--- a/.changeset/quota-aware-routing-skip.md
+++ b/.changeset/quota-aware-routing-skip.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add per-route "skip on quota exhaustion" toggle for Anthropic, Kimi, OpenAI, MiniMax, and xAI subscription providers

--- a/docs/providers/subscription-based-providers.md
+++ b/docs/providers/subscription-based-providers.md
@@ -33,6 +33,10 @@ If you already pay for one of the plans below, Manifest can route through that s
 
 Providers that support both API keys and subscriptions show both tabs. Subscription-only providers show only the subscription flow. In routing pickers, subscription rows appear only after a usable subscription credential is saved (`has_api_key=true`).
 
+## Skip on quota exhaustion
+
+For providers with a usage endpoint — Anthropic (Claude), Moonshot (Kimi Coding Plan), OpenAI (ChatGPT), MiniMax, and xAI (Grok) — each route in a tier's primary slot or fallback chain offers a "Skip on quota exhaustion" toggle (the gauge icon). When enabled, Manifest polls the provider's quota state and skips that route while the subscription is exhausted, falling through to the next route instead of burning a failed attempt. Off by default; the poll interval defaults to 60s (`SUBSCRIPTION_QUOTA_POLL_INTERVAL_MS`, minimum 30s).
+
 ## How auth works per provider
 
 ### OpenAI

--- a/packages/backend/src/routing/__tests__/specificity.controller.spec.ts
+++ b/packages/backend/src/routing/__tests__/specificity.controller.spec.ts
@@ -72,8 +72,35 @@ describe('SpecificityController', () => {
         'openai',
         'api_key',
         undefined,
+        undefined,
       );
       expect(result).toBe(override);
+    });
+
+    it('should forward skipWhenQuotaExhausted from the structured route', async () => {
+      const body = {
+        model: 'claude',
+        route: {
+          provider: 'anthropic',
+          authType: 'subscription' as const,
+          model: 'claude',
+          skipWhenQuotaExhausted: true,
+        },
+      };
+      mockSpecificityService.setOverride.mockResolvedValue({ id: 'sa-1' });
+
+      await controller.setOverride(ctx, 'test-agent', 'coding', body);
+
+      expect(mockSpecificityService.setOverride).toHaveBeenCalledWith(
+        'agent-1',
+        'tenant-1',
+        'coding',
+        'claude',
+        'anthropic',
+        'subscription',
+        undefined,
+        true,
+      );
     });
 
     it('should throw BadRequestException for invalid category', async () => {

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -39,6 +39,13 @@ export class ModelRouteDto {
   @MaxLength(MAX_PROVIDER_KEY_LABEL_LENGTH)
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   keyLabel?: string;
+
+  // Opt-in per-route flag: the router skips this route while the backing
+  // subscription connection's quota is exhausted. Must be declared explicitly
+  // or the whitelist ValidationPipe strips it.
+  @IsOptional()
+  @IsBoolean()
+  skipWhenQuotaExhausted?: boolean;
 }
 
 export class AgentNameParamDto {

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -422,6 +422,74 @@ describe('HeaderTierService', () => {
       });
     });
 
+    describe('skipWhenQuotaExhausted', () => {
+      const flaggedRow = () =>
+        ({
+          id: 'h1',
+          agent_id: 'agent-1',
+          override_route: {
+            ...route('anthropic', 'subscription', 'claude-opus'),
+            skipWhenQuotaExhausted: true,
+          },
+        }) as unknown as HeaderTier;
+
+      it('sets the flag when true is passed', async () => {
+        repo.findOne.mockResolvedValue({ id: 'h1', agent_id: 'agent-1', override_route: null });
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'h1',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          true,
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBe(true);
+      });
+
+      it('preserves the stored flag when the argument is omitted', async () => {
+        repo.findOne.mockResolvedValue(flaggedRow());
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'h1',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBe(true);
+      });
+
+      it('clears the stored flag when explicit false is passed', async () => {
+        repo.findOne.mockResolvedValue(flaggedRow());
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'h1',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          false,
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBeUndefined();
+      });
+
+      it('leaves the route without the flag when omitted and none is stored', async () => {
+        repo.findOne.mockResolvedValue({ id: 'h1', agent_id: 'agent-1', override_route: null });
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'h1',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBeUndefined();
+      });
+    });
+
     it('resolves via discovery when only the model is given', async () => {
       const row = { id: 'h1', agent_id: 'agent-1', override_route: null } as HeaderTier;
       repo.findOne.mockResolvedValue(row);

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
@@ -141,6 +141,7 @@ describe('HeaderTierController', () => {
       'OpenAI',
       'api_key',
       undefined,
+      undefined,
     );
   });
 
@@ -165,6 +166,32 @@ describe('HeaderTierController', () => {
       'openai',
       'api_key',
       'Personal',
+      undefined,
+    );
+  });
+
+  it('setOverride forwards route skipWhenQuotaExhausted when present', async () => {
+    const { controller, service } = makeController();
+    await controller.setOverride(ctx, 'my-agent', 'ht-1', {
+      model: 'claude',
+      provider: 'anthropic',
+      authType: 'subscription',
+      route: {
+        model: 'claude',
+        provider: 'anthropic',
+        authType: 'subscription',
+        skipWhenQuotaExhausted: true,
+      },
+    });
+    expect(service.setOverride).toHaveBeenCalledWith(
+      'agent-1',
+      'tenant-1',
+      'ht-1',
+      'claude',
+      'anthropic',
+      'subscription',
+      undefined,
+      true,
     );
   });
 

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.ts
@@ -194,6 +194,7 @@ export class HeaderTierController {
       provider,
       authType,
       providerKeyLabel,
+      body.route?.skipWhenQuotaExhausted,
     );
   }
 

--- a/packages/backend/src/routing/header-tiers/header-tier.service.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.service.ts
@@ -205,6 +205,7 @@ export class HeaderTierService {
     provider?: string,
     authType?: AuthType,
     providerKeyLabel?: string | null,
+    skipWhenQuotaExhausted?: boolean,
   ): Promise<HeaderTier> {
     const row = await this.findOrThrow(agentId, id);
     // When the caller passes an explicit (provider, authType) the route is
@@ -217,6 +218,7 @@ export class HeaderTierService {
         await this.discoveryService.getModelsForAgent(tenantId, row.agent_id),
         providerKeyLabel,
       );
+    if (route && skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
     assertStreamableResponseMode(
       row.response_mode,
       `custom tier "${row.name}"`,

--- a/packages/backend/src/routing/header-tiers/header-tier.service.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.service.ts
@@ -218,7 +218,13 @@ export class HeaderTierService {
         await this.discoveryService.getModelsForAgent(tenantId, row.agent_id),
         providerKeyLabel,
       );
-    if (route && skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
+    // skipWhenQuotaExhausted: true sets the flag, explicit false clears it,
+    // and omitted (undefined) preserves the stored route's value.
+    const preserved =
+      skipWhenQuotaExhausted === undefined && row.override_route?.skipWhenQuotaExhausted === true;
+    if (route && (skipWhenQuotaExhausted === true || preserved)) {
+      route.skipWhenQuotaExhausted = true;
+    }
     assertStreamableResponseMode(
       row.response_mode,
       `custom tier "${row.name}"`,

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
@@ -11,6 +11,7 @@ import type { RoutingCacheService } from '../../routing-core/routing-cache.servi
 import type { SpecificityService } from '../../routing-core/specificity.service';
 import type { SpecificityPenaltyService } from '../../routing-core/specificity-penalty.service';
 import type { HeaderTierService } from '../../header-tiers/header-tier.service';
+import type { SubscriptionQuotaService } from '../../subscription-quota.service';
 import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import type { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 
@@ -86,6 +87,7 @@ describe('ResolveService — edge cases', () => {
       | 'getAuthType'
       | 'getDefaultKeyLabel'
       | 'hasRouteCredentials'
+      | 'getProviderKeyId'
     >
   >;
   let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
@@ -108,6 +110,7 @@ describe('ResolveService — edge cases', () => {
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
       hasRouteCredentials: jest.fn().mockResolvedValue(true),
+      getProviderKeyId: jest.fn().mockResolvedValue(null),
     };
     specificityService = { getActiveAssignments: jest.fn().mockResolvedValue([]) };
     pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
@@ -136,6 +139,7 @@ describe('ResolveService — edge cases', () => {
       discoveryService as unknown as ModelDiscoveryService,
       penaltyService as unknown as SpecificityPenaltyService,
       headerTierService as unknown as HeaderTierService,
+      { isQuotaExhausted: jest.fn().mockReturnValue(false) } as unknown as SubscriptionQuotaService,
       agentRepo as unknown as Repository<Agent>,
       { addInvalidationListener: jest.fn() } as unknown as RoutingCacheService,
     );

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -11,6 +11,7 @@ import type { RoutingCacheService } from '../../routing-core/routing-cache.servi
 import type { SpecificityService } from '../../routing-core/specificity.service';
 import type { SpecificityPenaltyService } from '../../routing-core/specificity-penalty.service';
 import type { HeaderTierService } from '../../header-tiers/header-tier.service';
+import type { SubscriptionQuotaService } from '../../subscription-quota.service';
 import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import type { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 
@@ -55,6 +56,7 @@ describe('ResolveService', () => {
       | 'getAuthType'
       | 'getDefaultKeyLabel'
       | 'hasRouteCredentials'
+      | 'getProviderKeyId'
     >
   >;
   let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
@@ -64,6 +66,7 @@ describe('ResolveService', () => {
   >;
   let penaltyService: jest.Mocked<Pick<SpecificityPenaltyService, 'getPenaltiesForAgent'>>;
   let headerTierService: jest.Mocked<Pick<HeaderTierService, 'list'>>;
+  let subscriptionQuota: jest.Mocked<Pick<SubscriptionQuotaService, 'isQuotaExhausted'>>;
   let agentRepo: { findOne: jest.Mock };
   let routingCache: { addInvalidationListener: jest.Mock };
   let svc: ResolveService;
@@ -81,6 +84,9 @@ describe('ResolveService', () => {
       // (no keyLabel) passing.
       getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
       hasRouteCredentials: jest.fn().mockResolvedValue(true),
+      // Default: no quota-backed connection resolves, so quota filtering is a
+      // no-op unless a test wires specific ids.
+      getProviderKeyId: jest.fn().mockResolvedValue(null),
     };
     specificityService = { getActiveAssignments: jest.fn().mockResolvedValue([]) };
     pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
@@ -91,6 +97,7 @@ describe('ResolveService', () => {
     };
     penaltyService = { getPenaltiesForAgent: jest.fn().mockResolvedValue(new Map()) };
     headerTierService = { list: jest.fn().mockResolvedValue([]) };
+    subscriptionQuota = { isQuotaExhausted: jest.fn().mockReturnValue(false) };
     agentRepo = {
       findOne: jest.fn().mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: true }),
     };
@@ -114,6 +121,7 @@ describe('ResolveService', () => {
       discoveryService as unknown as ModelDiscoveryService,
       penaltyService as unknown as SpecificityPenaltyService,
       headerTierService as unknown as HeaderTierService,
+      subscriptionQuota as unknown as SubscriptionQuotaService,
       agentRepo as unknown as Repository<Agent>,
       routingCache as unknown as RoutingCacheService,
     );
@@ -655,6 +663,342 @@ describe('ResolveService', () => {
 
       const result = await svc.resolve('agent-1', 'user-1', messages);
       expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o-mini'));
+      expect(result.fallback_routes).toBeNull();
+    });
+  });
+
+  describe('resolve — quota-aware route skipping', () => {
+    const flagged = (
+      provider: string,
+      authType: ModelRoute['authType'],
+      model: string,
+    ): ModelRoute => ({ ...route(provider, authType, model), skipWhenQuotaExhausted: true });
+
+    beforeEach(() => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: false });
+      // Map each route's provider to a distinct tenant_providers row id.
+      providerKeyService.getProviderKeyId.mockImplementation(
+        async (_tenant: string, provider: string) => `tp-${provider}`,
+      );
+      // The anthropic connection is quota-exhausted; everything else is fine.
+      subscriptionQuota.isQuotaExhausted.mockImplementation((id: string) => id === 'tp-anthropic');
+    });
+
+    it('skips a flagged fallback whose connection is quota-exhausted during primary promotion', async () => {
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: null,
+          fallback_routes: [
+            flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+            route('openai', 'api_key', 'gpt-4o-mini'),
+          ],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o-mini'));
+      expect(result.fallback_routes).toBeNull();
+    });
+
+    it('keeps an unflagged route even when its connection is quota-exhausted', async () => {
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: null,
+          fallback_routes: [route('anthropic', 'subscription', 'claude-opus-4-8')],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual(route('anthropic', 'subscription', 'claude-opus-4-8'));
+      // No flag anywhere — the quota lookup is never consulted.
+      expect(providerKeyService.getProviderKeyId).not.toHaveBeenCalled();
+    });
+
+    it('keeps a flagged route whose connection is not exhausted', async () => {
+      subscriptionQuota.isQuotaExhausted.mockReturnValue(false);
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: null,
+          fallback_routes: [flagged('anthropic', 'subscription', 'claude-opus-4-8')],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual({
+        ...route('anthropic', 'subscription', 'claude-opus-4-8'),
+        skipWhenQuotaExhausted: true,
+      });
+    });
+
+    it('keeps the original chain when quota filtering would remove every candidate', async () => {
+      subscriptionQuota.isQuotaExhausted.mockReturnValue(true);
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: null,
+          fallback_routes: [
+            flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+            flagged('moonshot', 'subscription', 'k3'),
+          ],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      // Never-empty rule: the unfiltered chain is used, first candidate wins.
+      expect(result.route).toEqual({
+        ...route('anthropic', 'subscription', 'claude-opus-4-8'),
+        skipWhenQuotaExhausted: true,
+      });
+      expect(result.fallback_routes).toEqual([
+        { ...route('moonshot', 'subscription', 'k3'), skipWhenQuotaExhausted: true },
+      ]);
+    });
+
+    it('drops quota-exhausted fallbacks when the override survives', async () => {
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: route('openai', 'api_key', 'gpt-4o'),
+          auto_assigned_route: null,
+          fallback_routes: [
+            flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+            route('deepseek', 'api_key', 'deepseek-chat'),
+          ],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o'));
+      expect(result.fallback_routes).toEqual([route('deepseek', 'api_key', 'deepseek-chat')]);
+    });
+
+    it('skips a flagged exhausted fallback when promoting a header-tier fallback', async () => {
+      const tier = {
+        id: 'h1',
+        name: 'Premium',
+        header_key: 'x-tier',
+        header_value: 'gold',
+        enabled: true,
+        badge_color: 'red',
+        override_route: route('openai', 'subscription', 'gpt-5.5'),
+        fallback_routes: [
+          flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+          route('deepseek', 'api_key', 'deepseek-chat'),
+        ],
+      } as unknown as HeaderTier;
+      headerTierService.list.mockResolvedValue([tier]);
+      // The override is unavailable, so the tier promotes from its fallbacks.
+      providerKeyService.isRouteAvailable.mockImplementation(
+        async (_tenant: string, r: ModelRoute) => r.model !== 'gpt-5.5',
+      );
+
+      const result = await svc.resolve(
+        'agent-1',
+        'user-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+
+      expect(result.reason).toBe('header-match');
+      expect(result.route).toEqual(route('deepseek', 'api_key', 'deepseek-chat'));
+      expect(result.fallback_routes).toBeNull();
+    });
+
+    it('drops quota-exhausted header-tier fallbacks when the override survives', async () => {
+      const tier = {
+        id: 'h1',
+        name: 'Premium',
+        header_key: 'x-tier',
+        header_value: 'gold',
+        enabled: true,
+        badge_color: 'red',
+        override_route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: [flagged('anthropic', 'subscription', 'claude-opus-4-8')],
+      } as unknown as HeaderTier;
+      headerTierService.list.mockResolvedValue([tier]);
+
+      const result = await svc.resolve(
+        'agent-1',
+        'user-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+
+      expect(result.reason).toBe('header-match');
+      expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o'));
+      // The only fallback was flagged + exhausted; the primary survived, so
+      // the chain legitimately ends with no fallbacks.
+      expect(result.fallback_routes).toBeNull();
+    });
+
+    it('skips a flagged exhausted override and promotes the first available fallback', async () => {
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+          auto_assigned_route: null,
+          fallback_routes: [route('openai', 'api_key', 'gpt-4o-mini')],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o-mini'));
+      expect(result.fallback_routes).toBeNull();
+    });
+
+    it('keeps a flagged exhausted override when the chain has no fallbacks (never-empty)', async () => {
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+          auto_assigned_route: null,
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual({
+        ...route('anthropic', 'subscription', 'claude-opus-4-8'),
+        skipWhenQuotaExhausted: true,
+      });
+      expect(result.fallback_routes).toBeNull();
+    });
+
+    it('keeps the original chain when the override and every fallback are quota-exhausted', async () => {
+      subscriptionQuota.isQuotaExhausted.mockReturnValue(true);
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+          auto_assigned_route: null,
+          fallback_routes: [flagged('moonshot', 'subscription', 'k3')],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      // Never-empty rule: the credential-available override stays primary.
+      expect(result.route).toEqual({
+        ...route('anthropic', 'subscription', 'claude-opus-4-8'),
+        skipWhenQuotaExhausted: true,
+      });
+      expect(result.fallback_routes).toEqual([
+        { ...route('moonshot', 'subscription', 'k3'), skipWhenQuotaExhausted: true },
+      ]);
+    });
+
+    it('keeps a flagged override whose connection is not exhausted', async () => {
+      subscriptionQuota.isQuotaExhausted.mockReturnValue(false);
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+          auto_assigned_route: null,
+          fallback_routes: [route('openai', 'api_key', 'gpt-4o-mini')],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual({
+        ...route('anthropic', 'subscription', 'claude-opus-4-8'),
+        skipWhenQuotaExhausted: true,
+      });
+      expect(result.fallback_routes).toEqual([route('openai', 'api_key', 'gpt-4o-mini')]);
+    });
+
+    it('keeps an unflagged override even when its connection is quota-exhausted', async () => {
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: route('anthropic', 'subscription', 'claude-opus-4-8'),
+          auto_assigned_route: null,
+          fallback_routes: [route('openai', 'api_key', 'gpt-4o-mini')],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual(route('anthropic', 'subscription', 'claude-opus-4-8'));
+      expect(result.fallback_routes).toEqual([route('openai', 'api_key', 'gpt-4o-mini')]);
+    });
+
+    it('skips a flagged exhausted header-tier override and promotes a fallback', async () => {
+      const tier = {
+        id: 'h1',
+        name: 'Premium',
+        header_key: 'x-tier',
+        header_value: 'gold',
+        enabled: true,
+        badge_color: 'red',
+        override_route: flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+        fallback_routes: [route('deepseek', 'api_key', 'deepseek-chat')],
+      } as unknown as HeaderTier;
+      headerTierService.list.mockResolvedValue([tier]);
+
+      const result = await svc.resolve(
+        'agent-1',
+        'user-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+
+      expect(result.reason).toBe('header-match');
+      expect(result.route).toEqual(route('deepseek', 'api_key', 'deepseek-chat'));
+      expect(result.fallback_routes).toBeNull();
+    });
+
+    it('keeps a flagged exhausted header-tier override when the chain has no fallbacks', async () => {
+      const tier = {
+        id: 'h1',
+        name: 'Premium',
+        header_key: 'x-tier',
+        header_value: 'gold',
+        enabled: true,
+        badge_color: 'red',
+        override_route: flagged('anthropic', 'subscription', 'claude-opus-4-8'),
+        fallback_routes: null,
+      } as unknown as HeaderTier;
+      headerTierService.list.mockResolvedValue([tier]);
+
+      const result = await svc.resolve(
+        'agent-1',
+        'user-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+
+      expect(result.reason).toBe('header-match');
+      // Never-empty rule: the credential-available override stays primary.
+      expect(result.route).toEqual(route('anthropic', 'subscription', 'claude-opus-4-8'));
       expect(result.fallback_routes).toBeNull();
     });
   });

--- a/packages/backend/src/routing/resolve/resolve.module.ts
+++ b/packages/backend/src/routing/resolve/resolve.module.ts
@@ -4,6 +4,7 @@ import { RoutingCoreModule } from '../routing-core/routing-core.module';
 import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { ModelDiscoveryModule } from '../../model-discovery/model-discovery.module';
 import { HeaderTiersModule } from '../header-tiers/header-tiers.module';
+import { SubscriptionQuotaModule } from '../subscription-quota.module';
 import { ResolveController } from './resolve.controller';
 import { ResolveService } from './resolve.service';
 
@@ -14,6 +15,7 @@ import { ResolveService } from './resolve.service';
     ModelPricesModule,
     ModelDiscoveryModule,
     forwardRef(() => HeaderTiersModule),
+    SubscriptionQuotaModule,
   ],
   controllers: [ResolveController],
   providers: [ResolveService],

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -8,6 +8,7 @@ import { RoutingCacheService } from '../routing-core/routing-cache.service';
 import { SpecificityService } from '../routing-core/specificity.service';
 import { SpecificityPenaltyService } from '../routing-core/specificity-penalty.service';
 import { HeaderTierService } from '../header-tiers/header-tier.service';
+import { SubscriptionQuotaService } from '../subscription-quota.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import {
@@ -62,6 +63,7 @@ export class ResolveService {
     private readonly discoveryService: ModelDiscoveryService,
     private readonly penaltyService: SpecificityPenaltyService,
     private readonly headerTierService: HeaderTierService,
+    private readonly subscriptionQuota: SubscriptionQuotaService,
     @InjectRepository(Agent)
     private readonly agentRepo: Repository<Agent>,
     private readonly routingCache: RoutingCacheService,
@@ -279,16 +281,47 @@ export class ResolveService {
     const fallbackRoutes = readFallbackRoutes(match);
     let primaryOverride: ModelRoute | null = overrideRoute;
     let remainingFallbacks: ModelRoute[] | null = fallbackRoutes;
-    if (!(await this.providerKeyService.isRouteAvailable(tenantId, overrideRoute, agentId))) {
+    const overrideAvailable = await this.providerKeyService.isRouteAvailable(
+      tenantId,
+      overrideRoute,
+      agentId,
+    );
+    const overrideExhausted =
+      overrideAvailable && (await this.isRouteQuotaExhausted(overrideRoute, agentId, tenantId));
+    if (!overrideAvailable || overrideExhausted) {
       // An explicitly configured tier shouldn't die with its primary: promote
       // the first available fallback instead of abandoning the whole tier.
+      // A flagged override whose quota is exhausted is treated the same way.
       this.logger.warn(
-        `Header tier "${match.name}" override ${overrideRoute.model} is unavailable ` +
-          `for agent=${agentId} — trying the tier's fallbacks`,
+        overrideExhausted
+          ? `Header tier "${match.name}" override ${overrideRoute.model} skipped ` +
+              `for agent=${agentId} — its subscription quota is exhausted`
+          : `Header tier "${match.name}" override ${overrideRoute.model} is unavailable ` +
+              `for agent=${agentId} — trying the tier's fallbacks`,
       );
       primaryOverride = null;
-      const candidates = fallbackRoutes ?? [];
-      for (let i = 0; i < candidates.length; i++) {
+      let candidates = await this.filterQuotaExhaustedRoutes(
+        fallbackRoutes ?? [],
+        agentId,
+        tenantId,
+      );
+      if (candidates.length === 0 && ((fallbackRoutes ?? []).length > 0 || overrideAvailable)) {
+        // Never-empty: quota filtering must not leave the tier with nothing to
+        // try — restore the original chain (the override first when it is
+        // credential-available).
+        this.logger.warn(
+          `Quota filtering would remove every route for header tier "${match.name}" ` +
+            `agent=${agentId} — keeping the original chain`,
+        );
+        if (overrideAvailable) {
+          primaryOverride = overrideRoute;
+          remainingFallbacks = fallbackRoutes;
+          candidates = [];
+        } else {
+          candidates = fallbackRoutes ?? [];
+        }
+      }
+      for (let i = 0; !primaryOverride && i < candidates.length; i++) {
         if (await this.providerKeyService.isRouteAvailable(tenantId, candidates[i], agentId)) {
           primaryOverride = candidates[i];
           const rest = candidates.slice(i + 1);
@@ -303,6 +336,11 @@ export class ResolveService {
         );
         return null;
       }
+    } else {
+      // The primary survived, so quota-filtered fallbacks may empty out — the
+      // chain still has its primary and stays routable.
+      const kept = await this.filterQuotaExhaustedRoutes(fallbackRoutes ?? [], agentId, tenantId);
+      remainingFallbacks = kept.length > 0 ? kept : null;
     }
 
     const provider =
@@ -424,6 +462,12 @@ export class ResolveService {
    * becoming primary without adding a separate model-discovery query to the
    * gateway path. When nothing has usable credentials, the proxy gets a null
    * route and returns the neutral M101 instead of M100 (#2494).
+   *
+   * Quota-aware skip applies to every link in the chain: a flagged override
+   * whose subscription quota is exhausted is treated as unavailable, and
+   * flagged candidates are dropped before credential promotion. The
+   * never-empty rule covers the whole chain — if filtering would leave
+   * nothing to try, the original unfiltered outcome stands.
    */
   private async buildResolvedRouteChain(
     agentId: string,
@@ -437,34 +481,122 @@ export class ResolveService {
     // TierService.hasRoutableTier / effectiveRoute (see route-helpers.ts).
     const autoAssigned = readAutoAssignedRoute(assignment);
 
-    if (override && (await this.providerKeyService.isRouteAvailable(tenantId, override, agentId))) {
-      return {
-        primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, override),
-        fallbackRoutes,
-      };
-    }
+    let overrideAvailable = false;
     if (override) {
+      overrideAvailable = await this.providerKeyService.isRouteAvailable(
+        tenantId,
+        override,
+        agentId,
+      );
+      if (overrideAvailable && !(await this.isRouteQuotaExhausted(override, agentId, tenantId))) {
+        // The primary survived, so quota-filtered fallbacks may empty out.
+        const keptFallbacks = fallbackRoutes
+          ? await this.filterQuotaExhaustedRoutes(fallbackRoutes, agentId, tenantId)
+          : null;
+        return {
+          primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, override),
+          fallbackRoutes: keptFallbacks && keptFallbacks.length > 0 ? keptFallbacks : null,
+        };
+      }
       this.logger.warn(
-        `Override ${override.model} unavailable for agent=${agentId} — ` +
-          `falling back to configured routes`,
+        overrideAvailable
+          ? `Override ${override.model} skipped for agent=${agentId} — ` +
+              `its subscription quota is exhausted`
+          : `Override ${override.model} unavailable for agent=${agentId} — ` +
+              `falling back to configured routes`,
       );
     }
 
-    // An orphaned override walks its fallbacks before the legacy auto-assigned
-    // route; a tier with no override starts from the auto-assigned route.
+    // An orphaned or quota-skipped override walks its fallbacks before the
+    // legacy auto-assigned route; a tier with no override starts from the
+    // auto-assigned route.
     const candidates = override
       ? [...(fallbackRoutes ?? []), ...(autoAssigned ? [autoAssigned] : [])]
       : [...(autoAssigned ? [autoAssigned] : []), ...(fallbackRoutes ?? [])];
-    for (let i = 0; i < candidates.length; i++) {
-      if (await this.providerKeyService.hasRouteCredentials(tenantId, candidates[i], agentId)) {
-        const rest = candidates.slice(i + 1);
+    // Quota-aware skip: drop flagged candidates whose connection is exhausted
+    // before credential promotion.
+    const promotable = await this.filterQuotaExhaustedRoutes(candidates, agentId, tenantId);
+
+    // Never-empty: quota filtering must not leave the chain with nothing to
+    // try. Restore the original unfiltered outcome — the override first when
+    // it is credential-available, otherwise the unfiltered candidates.
+    if (promotable.length === 0 && (candidates.length > 0 || overrideAvailable)) {
+      this.logger.warn(
+        `Quota filtering would remove every route candidate for agent=${agentId} — ` +
+          `keeping the original chain`,
+      );
+      if (overrideAvailable && override) {
         return {
-          primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, candidates[i]),
+          primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, override),
+          fallbackRoutes: fallbackRoutes && fallbackRoutes.length > 0 ? fallbackRoutes : null,
+        };
+      }
+      return this.promoteFirstWithCredentials(candidates, agentId, tenantId);
+    }
+
+    return this.promoteFirstWithCredentials(promotable, agentId, tenantId);
+  }
+
+  /** Promote the first candidate with live credentials to primary. */
+  private async promoteFirstWithCredentials(
+    routes: ModelRoute[],
+    agentId: string,
+    tenantId: string,
+  ): Promise<ResolvedRouteChain> {
+    for (let i = 0; i < routes.length; i++) {
+      if (await this.providerKeyService.hasRouteCredentials(tenantId, routes[i], agentId)) {
+        const rest = routes.slice(i + 1);
+        return {
+          primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, routes[i]),
           fallbackRoutes: rest.length > 0 ? rest : null,
         };
       }
     }
     return { primaryRoute: null, fallbackRoutes: null };
+  }
+
+  /**
+   * True when the route opted into quota-aware skipping
+   * (`skipWhenQuotaExhausted`) AND the subscription connection backing it is
+   * quota-exhausted. The connection is resolved through the same key-row
+   * lookup the credential check uses, so the quota snapshot keyed by
+   * `tenant_providers.id` lines up with the key the proxy would actually
+   * forward. Fail-open: unknown quota state is never exhausted.
+   */
+  private async isRouteQuotaExhausted(
+    route: ModelRoute,
+    agentId: string,
+    tenantId: string,
+  ): Promise<boolean> {
+    if (route.skipWhenQuotaExhausted !== true) return false;
+    const keyId = await this.providerKeyService.getProviderKeyId(
+      tenantId,
+      route.provider,
+      route.authType,
+      route.keyLabel ?? undefined,
+      agentId,
+    );
+    return keyId !== null && this.subscriptionQuota.isQuotaExhausted(keyId);
+  }
+
+  /**
+   * Drop routes that opted into quota-aware skipping while the subscription
+   * connection backing them is quota-exhausted. Callers own the never-empty
+   * rule — this filter may legitimately return an empty list.
+   */
+  private async filterQuotaExhaustedRoutes(
+    routes: ModelRoute[],
+    agentId: string,
+    tenantId: string,
+  ): Promise<ModelRoute[]> {
+    if (routes.length === 0 || !routes.some((r) => r.skipWhenQuotaExhausted === true)) {
+      return routes;
+    }
+    const kept: ModelRoute[] = [];
+    for (const route of routes) {
+      if (!(await this.isRouteQuotaExhausted(route, agentId, tenantId))) kept.push(route);
+    }
+    return kept;
   }
 
   /**

--- a/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
@@ -179,6 +179,74 @@ describe('SpecificityService', () => {
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
     });
 
+    describe('skipWhenQuotaExhausted', () => {
+      const flaggedExisting = () =>
+        ({
+          category: 'coding',
+          is_active: true,
+          override_route: {
+            ...route('anthropic', 'subscription', 'claude-opus'),
+            skipWhenQuotaExhausted: true,
+          },
+        }) as unknown as SpecificityAssignment;
+
+      it('sets the flag when true is passed', async () => {
+        repo.findOne.mockResolvedValue(null);
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'coding',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          true,
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBe(true);
+      });
+
+      it('preserves the stored flag when the argument is omitted', async () => {
+        repo.findOne.mockResolvedValue(flaggedExisting());
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'coding',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBe(true);
+      });
+
+      it('clears the stored flag when explicit false is passed', async () => {
+        repo.findOne.mockResolvedValue(flaggedExisting());
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'coding',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          false,
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBeUndefined();
+      });
+
+      it('creates without the flag when omitted and no row exists yet', async () => {
+        repo.findOne.mockResolvedValue(null);
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'coding',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBeUndefined();
+      });
+    });
+
     it('falls back to discovery resolution when no explicit triple is passed', async () => {
       discoveryService.getModelsForAgent.mockResolvedValue([
         discovered('gpt-4o', 'openai', 'api_key'),

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -335,6 +335,80 @@ describe('TierService', () => {
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
     });
 
+    describe('skipWhenQuotaExhausted', () => {
+      const flaggedExisting = () =>
+        ({
+          agent_id: 'agent-1',
+          tier: 'standard',
+          override_route: {
+            ...route('anthropic', 'subscription', 'claude-opus'),
+            skipWhenQuotaExhausted: true,
+          },
+          fallback_routes: null,
+        }) as unknown as TierAssignment;
+
+      beforeEach(() => {
+        discoveryService.getModelsForAgent.mockResolvedValue([
+          discovered('claude-opus', 'anthropic', 'subscription'),
+        ]);
+      });
+      it('sets the flag when true is passed', async () => {
+        tierRepo.findOne.mockResolvedValue(null);
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'standard',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          true,
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBe(true);
+      });
+
+      it('preserves the stored flag when the argument is omitted', async () => {
+        tierRepo.findOne.mockResolvedValue(flaggedExisting());
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'standard',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBe(true);
+      });
+
+      it('clears the stored flag when explicit false is passed', async () => {
+        tierRepo.findOne.mockResolvedValue(flaggedExisting());
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'standard',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          false,
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBeUndefined();
+      });
+
+      it('creates without the flag when omitted and no row exists yet', async () => {
+        tierRepo.findOne.mockResolvedValue(null);
+        const result = await svc.setOverride(
+          'agent-1',
+          'tenant-1',
+          'standard',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+        );
+        expect(result.override_route?.skipWhenQuotaExhausted).toBeUndefined();
+      });
+    });
+
     it('retries on a unique-index conflict and returns the persisted row', async () => {
       // Conflict path: the concurrent row already exists on re-read, so the
       // service adopts it (recursing into the existing-row branch) and returns

--- a/packages/backend/src/routing/routing-core/specificity.service.ts
+++ b/packages/backend/src/routing/routing-core/specificity.service.ts
@@ -100,8 +100,14 @@ export class SpecificityService {
           `provider + authType so the route is unambiguous.`,
       );
     }
-    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
     const existing = await this.repo.findOne({ where: { agent_id: agentId, category } });
+
+    // skipWhenQuotaExhausted: true sets the flag, explicit false clears it,
+    // and omitted (undefined) preserves the stored route's value.
+    const preserved =
+      skipWhenQuotaExhausted === undefined &&
+      existing?.override_route?.skipWhenQuotaExhausted === true;
+    if (skipWhenQuotaExhausted === true || preserved) route.skipWhenQuotaExhausted = true;
 
     if (existing) {
       assertStreamableResponseMode(

--- a/packages/backend/src/routing/routing-core/specificity.service.ts
+++ b/packages/backend/src/routing/routing-core/specificity.service.ts
@@ -84,6 +84,7 @@ export class SpecificityService {
     provider?: string,
     authType?: AuthType,
     providerKeyLabel?: string,
+    skipWhenQuotaExhausted?: boolean,
   ): Promise<SpecificityAssignment> {
     const explicit = explicitRoute(model, provider, authType, providerKeyLabel);
     const route =
@@ -99,6 +100,7 @@ export class SpecificityService {
           `provider + authType so the route is unambiguous.`,
       );
     }
+    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
     const existing = await this.repo.findOne({ where: { agent_id: agentId, category } });
 
     if (existing) {
@@ -146,6 +148,7 @@ export class SpecificityService {
           provider,
           authType,
           providerKeyLabel,
+          skipWhenQuotaExhausted,
         );
       }
       throw err;

--- a/packages/backend/src/routing/routing-core/tier.service.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.ts
@@ -97,6 +97,7 @@ export class TierService {
     provider?: string,
     authType?: AuthType,
     providerKeyLabel?: string,
+    skipWhenQuotaExhausted?: boolean,
   ): Promise<TierAssignment> {
     const available = await this.discoveryService.getModelsForAgent(tenantId, agentId);
     const matches = available.filter((m) => m.id === model);
@@ -132,6 +133,7 @@ export class TierService {
           `provider + authType so the route is unambiguous.`,
       );
     }
+    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
 
     const existing = await this.tierRepo.findOne({
       where: { agent_id: agentId, tier },
@@ -187,6 +189,7 @@ export class TierService {
           provider,
           authType,
           providerKeyLabel,
+          skipWhenQuotaExhausted,
         );
       }
       throw err;

--- a/packages/backend/src/routing/routing-core/tier.service.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.ts
@@ -133,11 +133,18 @@ export class TierService {
           `provider + authType so the route is unambiguous.`,
       );
     }
-    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
 
     const existing = await this.tierRepo.findOne({
       where: { agent_id: agentId, tier },
     });
+
+    // skipWhenQuotaExhausted: true sets the flag, explicit false clears it,
+    // and omitted (undefined) preserves the stored route's value — a model
+    // change from the picker must not silently wipe the toggle.
+    const preserved =
+      skipWhenQuotaExhausted === undefined &&
+      existing?.override_route?.skipWhenQuotaExhausted === true;
+    if (skipWhenQuotaExhausted === true || preserved) route.skipWhenQuotaExhausted = true;
 
     if (existing) {
       existing.override_route = route;

--- a/packages/backend/src/routing/routing.module.ts
+++ b/packages/backend/src/routing/routing.module.ts
@@ -10,6 +10,7 @@ import { CustomProviderModule } from './custom-provider/custom-provider.module';
 import { ResolveModule } from './resolve/resolve.module';
 import { HeaderTiersModule } from './header-tiers/header-tiers.module';
 import { AutofixModule } from './autofix/autofix.module';
+import { SubscriptionQuotaModule } from './subscription-quota.module';
 import { ProviderController } from './provider.controller';
 import { TierController } from './tier.controller';
 import { ModelController } from './model.controller';
@@ -56,6 +57,7 @@ import { InstallMetadata } from '../entities/install-metadata.entity';
     ResolveModule,
     HeaderTiersModule,
     AutofixModule,
+    SubscriptionQuotaModule,
   ],
   controllers: [
     ProviderController,
@@ -69,6 +71,6 @@ import { InstallMetadata } from '../entities/install-metadata.entity';
     ManagedFreeProviderController,
   ],
   providers: [OllamaSyncService, ManagedFreeProviderService],
-  exports: [RoutingCoreModule, CustomProviderModule, OAuthModule],
+  exports: [RoutingCoreModule, CustomProviderModule, OAuthModule, SubscriptionQuotaModule],
 })
 export class RoutingModule {}

--- a/packages/backend/src/routing/specificity.controller.ts
+++ b/packages/backend/src/routing/specificity.controller.ts
@@ -58,6 +58,7 @@ export class SpecificityController {
       provider,
       authType,
       providerKeyLabel,
+      body.route?.skipWhenQuotaExhausted,
     );
   }
 

--- a/packages/backend/src/routing/subscription-quota.module.ts
+++ b/packages/backend/src/routing/subscription-quota.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TenantProvider } from '../entities/tenant-provider.entity';
+import { OAuthModule } from './oauth/oauth.module';
+import { SubscriptionQuotaService } from './subscription-quota.service';
+
+/**
+ * Owns the subscription-quota poller. A dedicated module (instead of
+ * registering the service directly in RoutingModule) lets ResolveModule
+ * import it without creating a RoutingModule <-> ResolveModule import cycle.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([TenantProvider]), OAuthModule],
+  providers: [SubscriptionQuotaService],
+  exports: [SubscriptionQuotaService],
+})
+export class SubscriptionQuotaModule {}

--- a/packages/backend/src/routing/subscription-quota.service.spec.ts
+++ b/packages/backend/src/routing/subscription-quota.service.spec.ts
@@ -556,11 +556,19 @@ describe('parseXaiUsage', () => {
     const fields = grpcWebTrailerFields(data);
     expect(fields['grpc-status']).toBe('0');
     expect(() => validateGrpcStatusFields(fields)).not.toThrow();
-    // 4% used; the only future in-range reset varint sits at path [1,5,1].
-    expect(parseXaiUsage(data)).toEqual({
-      usedPercent: 4.0,
-      resetsAt: XAI_PROD_RESET_ISO,
-    });
+    // Keep the production capture deterministic: its recorded reset must be
+    // future relative to the parser's clock, not relative to the day this
+    // test happens to run.
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(Date.parse(XAI_PROD_RESET_ISO) - 1_000);
+    try {
+      // 4% used; the only future in-range reset varint sits at path [1,5,1].
+      expect(parseXaiUsage(data)).toEqual({
+        usedPercent: 4.0,
+        resetsAt: XAI_PROD_RESET_ISO,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it.each([

--- a/packages/backend/src/routing/subscription-quota.service.spec.ts
+++ b/packages/backend/src/routing/subscription-quota.service.spec.ts
@@ -185,6 +185,17 @@ describe('parseAnthropicUsage', () => {
 });
 
 describe('parseKimiUsage', () => {
+  it('fails open when quota strings are malformed or partially numeric', () => {
+    const result = parseKimiUsage(
+      kimiUsage({ usage: { used: '0oops', limit: '100', resetTime: FUTURE } }),
+    );
+    expect(result).toEqual({ exhausted: false, resetsAt: null });
+
+    const result2 = parseKimiUsage(
+      kimiUsage({ usage: { used: ' ', limit: '100', resetTime: FUTURE } }),
+    );
+    expect(result2).toEqual({ exhausted: false, resetsAt: null });
+  });
   it('is not exhausted when all windows have headroom', () => {
     expect(parseKimiUsage(kimiUsage())).toEqual({ exhausted: false, resetsAt: null });
   });
@@ -580,6 +591,12 @@ describe('grpc-web framing helpers', () => {
 });
 
 describe('resolveQuotaPollIntervalMs', () => {
+  it('rejects values beyond the maximum timeout limit', () => {
+    expect(resolveQuotaPollIntervalMs('2147483648')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('999999999999999999999999999999')).toBe(
+      DEFAULT_QUOTA_POLL_INTERVAL_MS,
+    );
+  });
   it('defaults to 60s when unset or invalid', () => {
     expect(resolveQuotaPollIntervalMs(undefined)).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
     expect(resolveQuotaPollIntervalMs('')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);

--- a/packages/backend/src/routing/subscription-quota.service.spec.ts
+++ b/packages/backend/src/routing/subscription-quota.service.spec.ts
@@ -1,0 +1,885 @@
+import type { Repository } from 'typeorm';
+import {
+  SubscriptionQuotaService,
+  parseAnthropicUsage,
+  parseKimiUsage,
+  parseOpenAiUsage,
+  parseMinimaxUsage,
+  parseXaiUsage,
+  grpcWebDataFrames,
+  grpcWebTrailerFields,
+  validateGrpcStatusFields,
+  resolveQuotaPollIntervalMs,
+  DEFAULT_QUOTA_POLL_INTERVAL_MS,
+  MIN_QUOTA_POLL_INTERVAL_MS,
+} from './subscription-quota.service';
+import type { TenantProvider } from '../entities/tenant-provider.entity';
+import type { AnthropicOauthService } from './oauth/anthropic/anthropic-oauth.service';
+import type { OpenaiOauthService } from './oauth/openai/openai-oauth.service';
+import type { MinimaxOauthService } from './oauth/minimax/minimax-oauth.service';
+import type { XaiOauthService } from './oauth/xai/xai-oauth.service';
+
+// decrypt is identity in tests — rows carry their "raw" token directly.
+jest.mock('../common/utils/crypto.util', () => ({
+  decrypt: jest.fn((value: string) => value),
+  getEncryptionSecret: jest.fn(() => 'test-secret'),
+}));
+
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const LATER = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+const PAST = new Date(Date.now() - 60 * 1000).toISOString();
+
+// OpenAI windows report reset_at in epoch seconds; MiniMax in epoch ms.
+const FUTURE_SEC = Math.floor(Date.parse(FUTURE) / 1000);
+const LATER_SEC = Math.floor(Date.parse(LATER) / 1000);
+const FUTURE_MS = Date.parse(FUTURE);
+const LATER_MS = Date.parse(LATER);
+
+const anthropicUsage = (utilization: number, resetsAt: string | null = FUTURE) => ({
+  five_hour: { utilization: 12, resets_at: LATER },
+  seven_day: { utilization, resets_at: resetsAt },
+  seven_day_sonnet: { utilization: 5, resets_at: LATER },
+  seven_day_opus: { utilization: 5, resets_at: LATER },
+  seven_day_oauth_apps: { utilization: 5, resets_at: LATER },
+  extra_usage: { is_enabled: false, used: 0, limit: 0 },
+});
+
+const kimiUsage = (overrides: Record<string, unknown> = {}) => ({
+  usage: { used: '10', limit: '100', resetTime: FUTURE },
+  limits: [
+    {
+      window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+      detail: { used: '1', limit: '50', resetTime: FUTURE },
+    },
+  ],
+  totalQuota: { limit: '1000', remaining: '900' },
+  ...overrides,
+});
+
+const row = (overrides: Partial<TenantProvider>): TenantProvider =>
+  ({
+    id: 'tp-1',
+    tenant_id: 'user-1',
+    agent_id: 'agent-1',
+    provider: 'anthropic',
+    api_key_encrypted: 'raw-token',
+    auth_type: 'subscription',
+    label: 'Default',
+    is_active: true,
+    ...overrides,
+  }) as TenantProvider;
+
+const okResponse = (data: unknown) => ({ ok: true, json: async () => data }) as unknown as Response;
+
+/* ── gRPC-web/protobuf fixture helpers (ported from the upstream PR's spec) ── */
+
+const varint = (value: number): number[] => {
+  let remaining = value;
+  const bytes: number[] = [];
+  do {
+    let byte = remaining & 0x7f;
+    remaining = Math.floor(remaining / 128);
+    if (remaining !== 0) byte |= 0x80;
+    bytes.push(byte);
+  } while (remaining !== 0);
+  return bytes;
+};
+
+const floatLE = (value: number): number[] => {
+  const buf = Buffer.alloc(4);
+  buf.writeFloatLE(value, 0);
+  return [...buf];
+};
+
+/** field 1 fixed32 percent + field 2 varint reset, like the PR's helper. */
+const protobufPayload = (usedPercent: number, resetEpoch: number): Uint8Array =>
+  Uint8Array.from([0x0d, ...floatLE(usedPercent), 0x10, ...varint(resetEpoch)]);
+
+const grpcFrame = (payload: Uint8Array, flags = 0): Uint8Array => {
+  const frame = new Uint8Array(5 + payload.length);
+  frame[0] = flags;
+  frame[1] = (payload.length >>> 24) & 0xff;
+  frame[2] = (payload.length >>> 16) & 0xff;
+  frame[3] = (payload.length >>> 8) & 0xff;
+  frame[4] = payload.length & 0xff;
+  frame.set(payload, 5);
+  return frame;
+};
+
+const concatBytes = (...parts: Uint8Array[]): Uint8Array => {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+};
+
+const binaryResponse = (
+  body: Uint8Array,
+  init: { status?: number; headers?: Record<string, string> } = {},
+) => {
+  const status = init.status ?? 200;
+  const headers = init.headers ?? {};
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  } as unknown as Response;
+};
+
+/**
+ * Real production capture (HTTP 200, 115 bytes, trailer grpc-status:0) from a
+ * GetGrokCreditsConfig call where the user had used 4% of their credits. The
+ * weekly reset varint at path [1,5,1] decodes to 1787523556
+ * (2026-08-23T22:19:16.000Z); the other in-range varint (1786918756) is in
+ * the past and must be filtered out.
+ */
+const XAI_PROD_FIXTURE_HEX =
+  '000000005a0a580d0000804012001a00220c08e4ee88d40610e8bd8dc003' +
+  '2a0c08e4e3add40610e8bd8dc0033a07080215000080403a020805' +
+  '421e0802120c08e4ee88d40610e8bd8dc0031a0c08e4e3add40610e8bd8dc003' +
+  '580162006801800000000f677270632d7374617475733a300d0a';
+const XAI_PROD_RESET_ISO = '2026-08-23T22:19:16.000Z';
+
+describe('parseAnthropicUsage', () => {
+  it('is not exhausted when every window is below 100', () => {
+    expect(parseAnthropicUsage(anthropicUsage(99))).toEqual({
+      exhausted: false,
+      resetsAt: null,
+    });
+  });
+
+  it('is exhausted when any window hits 100', () => {
+    const result = parseAnthropicUsage(anthropicUsage(100));
+    expect(result.exhausted).toBe(true);
+    expect(result.resetsAt).toBe(FUTURE);
+  });
+
+  it('picks the earliest resets_at among the exhausted windows', () => {
+    const result = parseAnthropicUsage({
+      five_hour: { utilization: 100, resets_at: LATER },
+      seven_day: { utilization: 100, resets_at: FUTURE },
+      seven_day_sonnet: { utilization: 10, resets_at: PAST },
+    });
+    expect(result).toEqual({ exhausted: true, resetsAt: FUTURE });
+  });
+
+  it('returns resetsAt null when the exhausted window has no reset time', () => {
+    const result = parseAnthropicUsage({
+      five_hour: { utilization: 100, resets_at: null },
+    });
+    expect(result).toEqual({ exhausted: true, resetsAt: null });
+  });
+
+  it('fails open on missing or malformed data', () => {
+    expect(parseAnthropicUsage(null)).toEqual({ exhausted: false, resetsAt: null });
+    expect(parseAnthropicUsage({})).toEqual({ exhausted: false, resetsAt: null });
+    expect(parseAnthropicUsage({ five_hour: { utilization: '100' } })).toEqual({
+      exhausted: false,
+      resetsAt: null,
+    });
+  });
+});
+
+describe('parseKimiUsage', () => {
+  it('is not exhausted when all windows have headroom', () => {
+    expect(parseKimiUsage(kimiUsage())).toEqual({ exhausted: false, resetsAt: null });
+  });
+
+  it('is exhausted when the weekly window is full (string numbers)', () => {
+    const result = parseKimiUsage(
+      kimiUsage({ usage: { used: '100', limit: '100', resetTime: FUTURE } }),
+    );
+    expect(result).toEqual({ exhausted: true, resetsAt: FUTURE });
+  });
+
+  it('is exhausted when the 5h rolling window is full', () => {
+    const result = parseKimiUsage(
+      kimiUsage({
+        limits: [
+          {
+            window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+            detail: { used: '50', limit: '50', resetTime: FUTURE },
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({ exhausted: true, resetsAt: FUTURE });
+  });
+
+  it('selects the 5h window by duration 300 minutes, not by position', () => {
+    const result = parseKimiUsage(
+      kimiUsage({
+        limits: [
+          {
+            window: { duration: 1440, timeUnit: 'TIME_UNIT_MINUTE' },
+            detail: { used: '99', limit: '100', resetTime: LATER },
+          },
+          {
+            window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+            detail: { used: '50', limit: '50', resetTime: FUTURE },
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({ exhausted: true, resetsAt: FUTURE });
+  });
+
+  it('falls back to limits[0] when no 300-minute window exists', () => {
+    const result = parseKimiUsage(
+      kimiUsage({
+        limits: [
+          {
+            window: { duration: 1440, timeUnit: 'TIME_UNIT_MINUTE' },
+            detail: { used: '100', limit: '100', resetTime: LATER },
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({ exhausted: true, resetsAt: LATER });
+  });
+
+  it('is exhausted when the monthly quota has nothing remaining', () => {
+    const result = parseKimiUsage(kimiUsage({ totalQuota: { limit: '1000', remaining: '0' } }));
+    // Monthly carries no reset time.
+    expect(result).toEqual({ exhausted: true, resetsAt: null });
+  });
+
+  it('picks the earliest reset among exhausted windows', () => {
+    const result = parseKimiUsage(
+      kimiUsage({
+        usage: { used: '100', limit: '100', resetTime: LATER },
+        limits: [
+          {
+            window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+            detail: { used: '50', limit: '50', resetTime: FUTURE },
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({ exhausted: true, resetsAt: FUTURE });
+  });
+
+  it('ignores windows with a zero limit', () => {
+    const result = parseKimiUsage(
+      kimiUsage({
+        usage: { used: '0', limit: '0', resetTime: FUTURE },
+        limits: [],
+        totalQuota: { limit: '0', remaining: '0' },
+      }),
+    );
+    expect(result).toEqual({ exhausted: false, resetsAt: null });
+  });
+
+  it('fails open on missing or malformed data', () => {
+    expect(parseKimiUsage(null)).toEqual({ exhausted: false, resetsAt: null });
+    expect(parseKimiUsage({})).toEqual({ exhausted: false, resetsAt: null });
+    expect(parseKimiUsage({ usage: { used: 'abc', limit: 'def' } })).toEqual({
+      exhausted: false,
+      resetsAt: null,
+    });
+  });
+});
+
+describe('parseOpenAiUsage', () => {
+  const openAiUsage = (primaryPercent: number, secondaryPercent = 10) => ({
+    rate_limit: {
+      primary_window: { used_percent: primaryPercent, reset_at: FUTURE_SEC },
+      secondary_window: { used_percent: secondaryPercent, reset_at: LATER_SEC },
+    },
+    credits: { unlimited: false, balance: 5 },
+  });
+
+  it('is not exhausted when every window is below 100', () => {
+    expect(parseOpenAiUsage(openAiUsage(99, 42))).toEqual({ exhausted: false, resetsAt: null });
+  });
+
+  it('is exhausted when any window hits 100, converting epoch seconds to ISO', () => {
+    expect(parseOpenAiUsage(openAiUsage(100))).toEqual({
+      exhausted: true,
+      resetsAt: new Date(FUTURE_SEC * 1000).toISOString(),
+    });
+  });
+
+  it('picks the earliest reset_at among the exhausted windows', () => {
+    const result = parseOpenAiUsage({
+      rate_limit: {
+        primary_window: { used_percent: 100, reset_at: LATER_SEC },
+        secondary_window: { used_percent: 100, reset_at: FUTURE_SEC },
+      },
+    });
+    expect(result).toEqual({
+      exhausted: true,
+      resetsAt: new Date(FUTURE_SEC * 1000).toISOString(),
+    });
+  });
+
+  it('is not exhausted when the windows are missing', () => {
+    expect(parseOpenAiUsage({ rate_limit: {} })).toEqual({ exhausted: false, resetsAt: null });
+    expect(parseOpenAiUsage({})).toEqual({ exhausted: false, resetsAt: null });
+  });
+
+  it('fails open on missing or malformed data', () => {
+    expect(parseOpenAiUsage(null)).toEqual({ exhausted: false, resetsAt: null });
+    expect(
+      parseOpenAiUsage({ rate_limit: { primary_window: { used_percent: '100', reset_at: 1 } } }),
+    ).toEqual({ exhausted: false, resetsAt: null });
+  });
+});
+
+describe('parseMinimaxUsage', () => {
+  const minimaxEntry = (overrides: Record<string, unknown> = {}) => ({
+    model_name: 'general',
+    current_interval_remaining_percent: 99,
+    end_time: FUTURE_MS,
+    current_weekly_remaining_percent: 99,
+    weekly_end_time: LATER_MS,
+    current_interval_total_count: 0,
+    current_interval_usage_count: 0,
+    ...overrides,
+  });
+  const minimaxUsage = (entries: Record<string, unknown>[]) => ({
+    model_remains: entries,
+    base_resp: { status_code: 0, status_msg: 'success' },
+  });
+
+  it('is not exhausted when the remaining percents are above zero', () => {
+    expect(parseMinimaxUsage(minimaxUsage([minimaxEntry()]))).toEqual({
+      exhausted: false,
+      resetsAt: null,
+    });
+  });
+
+  it('is exhausted when the interval remaining percent hits 0', () => {
+    expect(
+      parseMinimaxUsage(minimaxUsage([minimaxEntry({ current_interval_remaining_percent: 0 })])),
+    ).toEqual({ exhausted: true, resetsAt: new Date(FUTURE_MS).toISOString() });
+  });
+
+  it('is exhausted when the weekly remaining percent hits 0', () => {
+    expect(
+      parseMinimaxUsage(minimaxUsage([minimaxEntry({ current_weekly_remaining_percent: 0 })])),
+    ).toEqual({ exhausted: true, resetsAt: new Date(LATER_MS).toISOString() });
+  });
+
+  it('picks the earliest reset when both windows are exhausted', () => {
+    expect(
+      parseMinimaxUsage(
+        minimaxUsage([
+          minimaxEntry({
+            current_interval_remaining_percent: 0,
+            current_weekly_remaining_percent: 0,
+          }),
+        ]),
+      ),
+    ).toEqual({ exhausted: true, resetsAt: new Date(FUTURE_MS).toISOString() });
+  });
+
+  it("selects the 'general' entry over other models", () => {
+    const result = parseMinimaxUsage(
+      minimaxUsage([
+        minimaxEntry({
+          model_name: 'video',
+          current_interval_remaining_percent: 0,
+          current_weekly_remaining_percent: 0,
+        }),
+        minimaxEntry(),
+      ]),
+    );
+    expect(result).toEqual({ exhausted: false, resetsAt: null });
+  });
+
+  it("falls back to the first entry when no 'general' entry exists", () => {
+    const result = parseMinimaxUsage(
+      minimaxUsage([minimaxEntry({ model_name: 'video', current_weekly_remaining_percent: 0 })]),
+    );
+    expect(result).toEqual({ exhausted: true, resetsAt: new Date(LATER_MS).toISOString() });
+  });
+
+  it('throws on a non-zero base_resp.status_code (business error)', () => {
+    expect(() =>
+      parseMinimaxUsage({
+        model_remains: [],
+        base_resp: { status_code: 2062, status_msg: 'no active plan' },
+      }),
+    ).toThrow('2062');
+  });
+
+  it('treats missing percent fields as not exhausted', () => {
+    const entry = minimaxEntry();
+    delete (entry as Record<string, unknown>).current_interval_remaining_percent;
+    delete (entry as Record<string, unknown>).current_weekly_remaining_percent;
+    expect(parseMinimaxUsage(minimaxUsage([entry]))).toEqual({
+      exhausted: false,
+      resetsAt: null,
+    });
+  });
+
+  it('returns resetsAt null when the exhausted window lacks a reset time', () => {
+    expect(
+      parseMinimaxUsage(
+        minimaxUsage([minimaxEntry({ current_interval_remaining_percent: 0, end_time: null })]),
+      ),
+    ).toEqual({ exhausted: true, resetsAt: null });
+  });
+
+  it('fails open on missing or malformed data', () => {
+    expect(parseMinimaxUsage(null)).toEqual({ exhausted: false, resetsAt: null });
+    expect(parseMinimaxUsage({})).toEqual({ exhausted: false, resetsAt: null });
+    expect(parseMinimaxUsage(minimaxUsage([]))).toEqual({ exhausted: false, resetsAt: null });
+  });
+});
+
+describe('parseXaiUsage', () => {
+  it('parses a framed protobuf payload (percent + reset)', () => {
+    expect(parseXaiUsage(grpcFrame(protobufPayload(42.5, FUTURE_SEC)))).toEqual({
+      usedPercent: 42.5,
+      resetsAt: new Date(FUTURE_SEC * 1000).toISOString(),
+    });
+  });
+
+  it('accepts a bare protobuf payload without gRPC-web framing', () => {
+    expect(parseXaiUsage(protobufPayload(25, FUTURE_SEC))).toEqual({
+      usedPercent: 25,
+      resetsAt: new Date(FUTURE_SEC * 1000).toISOString(),
+    });
+  });
+
+  it('throws when the response carries no protobuf payload (trailer-only)', () => {
+    expect(() => parseXaiUsage(grpcFrame(Buffer.from('grpc-status: 0\r\n'), 0x80))).toThrow(
+      'no protobuf payload',
+    );
+  });
+
+  it('throws when neither a percent nor a plausible reset is found', () => {
+    // field 1, length 0 — a valid but empty message.
+    expect(() => parseXaiUsage(grpcFrame(Uint8Array.from([0x0a, 0x00])))).toThrow(
+      'Could not parse Grok web billing usage',
+    );
+  });
+
+  it('prefers the reset at path [1,5,1] over an earlier candidate', () => {
+    const inner = Uint8Array.from([
+      0x0d,
+      ...floatLE(50), // [1,1] percent 50
+      0x48,
+      ...varint(FUTURE_SEC), // [1,9] earlier future reset
+      0x2a,
+      1 + varint(LATER_SEC).length,
+      0x08,
+      ...varint(LATER_SEC), // [1,5,1] later reset
+    ]);
+    const payload = Uint8Array.from([0x0a, inner.length, ...inner]);
+    expect(parseXaiUsage(grpcFrame(payload))).toEqual({
+      usedPercent: 50,
+      resetsAt: new Date(LATER_SEC * 1000).toISOString(),
+    });
+  });
+
+  it('falls back to the earliest future reset when no [1,5,1] candidate exists', () => {
+    const inner = Uint8Array.from([
+      0x0d,
+      ...floatLE(50), // [1,1] percent 50
+      0x48,
+      ...varint(LATER_SEC), // [1,9] later
+      0x50,
+      ...varint(FUTURE_SEC), // [1,10] earlier
+    ]);
+    const payload = Uint8Array.from([0x0a, inner.length, ...inner]);
+    expect(parseXaiUsage(grpcFrame(payload)).resetsAt).toBe(
+      new Date(FUTURE_SEC * 1000).toISOString(),
+    );
+  });
+
+  it('parses the production capture: usedPercent 4.0, weekly reset, grpc-status 0', () => {
+    const data = Uint8Array.from(Buffer.from(XAI_PROD_FIXTURE_HEX, 'hex'));
+    expect(data.length).toBe(115);
+    // Trailer validates cleanly.
+    const fields = grpcWebTrailerFields(data);
+    expect(fields['grpc-status']).toBe('0');
+    expect(() => validateGrpcStatusFields(fields)).not.toThrow();
+    // 4% used; the only future in-range reset varint sits at path [1,5,1].
+    expect(parseXaiUsage(data)).toEqual({
+      usedPercent: 4.0,
+      resetsAt: XAI_PROD_RESET_ISO,
+    });
+  });
+});
+
+describe('grpc-web framing helpers', () => {
+  it('grpcWebDataFrames returns null for malformed input', () => {
+    expect(grpcWebDataFrames(new Uint8Array())).toBeNull();
+    expect(grpcWebDataFrames(Uint8Array.from([0]))).toBeNull();
+    expect(grpcWebDataFrames(Uint8Array.from([0x02, 0, 0, 0, 0]))).toBeNull();
+    expect(grpcWebDataFrames(Uint8Array.from([0, 0, 0, 0, 2, 1]))).toBeNull();
+  });
+
+  it('grpcWebDataFrames returns only data frames, skipping trailers', () => {
+    const data = concatBytes(
+      grpcFrame(protobufPayload(10, FUTURE_SEC)),
+      grpcFrame(Buffer.from('grpc-status:0\r\n'), 0x80),
+    );
+    const frames = grpcWebDataFrames(data);
+    expect(frames).toHaveLength(1);
+    expect(Array.from(frames![0])).toEqual(Array.from(protobufPayload(10, FUTURE_SEC)));
+  });
+
+  it('grpcWebTrailerFields decodes trailer lines and percent-encoding', () => {
+    const trailer = grpcFrame(Buffer.from('grpc-status: 7\r\ngrpc-message: bad%20req\r\n'), 0x80);
+    expect(grpcWebTrailerFields(trailer)).toEqual({
+      'grpc-status': '7',
+      'grpc-message': 'bad req',
+    });
+  });
+
+  it('validateGrpcStatusFields accepts missing or zero status, throws otherwise', () => {
+    expect(() => validateGrpcStatusFields({})).not.toThrow();
+    expect(() => validateGrpcStatusFields({ 'grpc-status': '0' })).not.toThrow();
+    expect(() =>
+      validateGrpcStatusFields({ 'grpc-status': '7', 'grpc-message': 'bad%ZZ' }),
+    ).toThrow('gRPC 7: bad%ZZ');
+    expect(() => validateGrpcStatusFields({ 'grpc-status': '4' })).toThrow('gRPC 4: ');
+  });
+});
+
+describe('resolveQuotaPollIntervalMs', () => {
+  it('defaults to 60s when unset or invalid', () => {
+    expect(resolveQuotaPollIntervalMs(undefined)).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('not-a-number')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('-5000')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+  });
+
+  it('clamps to the 30s minimum', () => {
+    expect(resolveQuotaPollIntervalMs('1000')).toBe(MIN_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('30000')).toBe(MIN_QUOTA_POLL_INTERVAL_MS);
+  });
+
+  it('honors values above the minimum', () => {
+    expect(resolveQuotaPollIntervalMs('120000')).toBe(120_000);
+  });
+});
+
+describe('SubscriptionQuotaService', () => {
+  let providerRepo: { find: jest.Mock };
+  let anthropicOauth: { unwrapToken: jest.Mock };
+  let openaiOauth: { unwrapToken: jest.Mock };
+  let minimaxOauth: { unwrapToken: jest.Mock };
+  let xaiOauth: { unwrapToken: jest.Mock };
+  let svc: SubscriptionQuotaService;
+  let fetchMock: jest.Mock;
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    providerRepo = { find: jest.fn().mockResolvedValue([]) };
+    anthropicOauth = { unwrapToken: jest.fn().mockResolvedValue('anthropic-access-token') };
+    openaiOauth = { unwrapToken: jest.fn().mockResolvedValue('openai-access-token') };
+    minimaxOauth = { unwrapToken: jest.fn().mockResolvedValue({ t: 'minimax-access-token' }) };
+    xaiOauth = { unwrapToken: jest.fn().mockResolvedValue('xai-access-token') };
+    svc = new SubscriptionQuotaService(
+      providerRepo as unknown as Repository<TenantProvider>,
+      anthropicOauth as unknown as AnthropicOauthService,
+      openaiOauth as unknown as OpenaiOauthService,
+      minimaxOauth as unknown as MinimaxOauthService,
+      xaiOauth as unknown as XaiOauthService,
+    );
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    svc.onModuleDestroy();
+  });
+
+  const poll = () => (svc as unknown as { pollSafely(): Promise<void> }).pollSafely();
+
+  it('isQuotaExhausted is false when no data exists for the connection', () => {
+    expect(svc.isQuotaExhausted('tp-unknown')).toBe(false);
+    expect(svc.getQuotaState('tp-unknown')).toBeUndefined();
+  });
+
+  it('polls anthropic subscriptions through the OAuth unwrap path', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    fetchMock.mockResolvedValue(okResponse(anthropicUsage(100)));
+
+    await poll();
+
+    expect(anthropicOauth.unwrapToken).toHaveBeenCalledWith(
+      'raw-token',
+      'agent-1',
+      'user-1',
+      'Default',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.anthropic.com/api/oauth/usage');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer anthropic-access-token',
+      'anthropic-beta': 'oauth-2025-04-20',
+      'User-Agent': 'claude-code/2.1.0',
+    });
+    expect(svc.isQuotaExhausted('tp-1')).toBe(true);
+    expect(svc.getQuotaState('tp-1')).toMatchObject({ exhausted: true, resetsAt: FUTURE });
+  });
+
+  it('polls moonshot subscriptions with the raw token and no unwrap', async () => {
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-kimi', provider: 'moonshot' })]);
+    fetchMock.mockResolvedValue(
+      okResponse(kimiUsage({ usage: { used: '100', limit: '100', resetTime: FUTURE } })),
+    );
+
+    await poll();
+
+    expect(anthropicOauth.unwrapToken).not.toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.kimi.com/coding/v1/usages');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer raw-token' });
+    expect(svc.isQuotaExhausted('tp-kimi')).toBe(true);
+  });
+
+  it('skips providers without a quota endpoint', async () => {
+    providerRepo.find.mockResolvedValue([row({ provider: 'gemini' })]);
+    await poll();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('polls openai subscriptions through the OpenAI unwrap path', async () => {
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-openai', provider: 'openai' })]);
+    fetchMock.mockResolvedValue(
+      okResponse({
+        rate_limit: {
+          primary_window: { used_percent: 100, reset_at: FUTURE_SEC },
+          secondary_window: { used_percent: 10, reset_at: LATER_SEC },
+        },
+      }),
+    );
+
+    await poll();
+
+    expect(openaiOauth.unwrapToken).toHaveBeenCalledWith(
+      'raw-token',
+      'agent-1',
+      'user-1',
+      'Default',
+    );
+    expect(anthropicOauth.unwrapToken).not.toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://chatgpt.com/backend-api/wham/usage');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer openai-access-token',
+      'User-Agent': 'Manifest',
+    });
+    expect(svc.isQuotaExhausted('tp-openai')).toBe(true);
+  });
+
+  it('polls minimax subscriptions against the resource-URL origin', async () => {
+    minimaxOauth.unwrapToken.mockResolvedValue({
+      t: 'minimax-access-token',
+      u: 'https://api.minimaxi.com/anthropic/v1',
+    });
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-minimax', provider: 'minimax' })]);
+    fetchMock.mockResolvedValue(
+      okResponse({
+        model_remains: [
+          {
+            model_name: 'general',
+            current_interval_remaining_percent: 0,
+            end_time: FUTURE_MS,
+            current_weekly_remaining_percent: 50,
+            weekly_end_time: LATER_MS,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: 'success' },
+      }),
+    );
+
+    await poll();
+
+    expect(minimaxOauth.unwrapToken).toHaveBeenCalledWith(
+      'raw-token',
+      'agent-1',
+      'user-1',
+      'Default',
+    );
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.minimaxi.com/v1/token_plan/remains');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer minimax-access-token',
+      'Content-Type': 'application/json',
+    });
+    expect(svc.isQuotaExhausted('tp-minimax')).toBe(true);
+  });
+
+  it('falls back to the default MiniMax base URL when the blob has no resource URL', async () => {
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-minimax', provider: 'minimax' })]);
+    fetchMock.mockResolvedValue(okResponse({ model_remains: [], base_resp: { status_code: 0 } }));
+
+    await poll();
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.minimax.io/v1/token_plan/remains');
+    expect(svc.isQuotaExhausted('tp-minimax')).toBe(false);
+  });
+
+  it('treats a MiniMax business error (non-zero status_code) as a fetch failure', async () => {
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-minimax', provider: 'minimax' })]);
+    fetchMock.mockResolvedValue(
+      okResponse({ model_remains: [], base_resp: { status_code: 2062, status_msg: 'no plan' } }),
+    );
+
+    await poll();
+
+    expect(svc.isQuotaExhausted('tp-minimax')).toBe(false);
+    expect(svc.getQuotaState('tp-minimax')?.error).toContain('2062');
+  });
+
+  it('polls xai subscriptions via gRPC-web and the xAI unwrap path', async () => {
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-xai', provider: 'xai' })]);
+    fetchMock.mockResolvedValue(
+      binaryResponse(
+        concatBytes(
+          grpcFrame(protobufPayload(100, FUTURE_SEC)),
+          grpcFrame(Buffer.from('grpc-status:0\r\n'), 0x80),
+        ),
+      ),
+    );
+
+    await poll();
+
+    expect(xaiOauth.unwrapToken).toHaveBeenCalledWith('raw-token', 'agent-1', 'user-1', 'Default');
+    expect(anthropicOauth.unwrapToken).not.toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer xai-access-token',
+      Origin: 'https://grok.com',
+      Referer: 'https://grok.com/?_s=usage',
+      'Content-Type': 'application/grpc-web+proto',
+      'x-grpc-web': '1',
+      'x-user-agent': 'connect-es/2.1.1',
+      'User-Agent': 'Manifest',
+    });
+    expect(Array.from(init.body as Uint8Array)).toEqual([0, 0, 0, 0, 0]);
+    expect(svc.isQuotaExhausted('tp-xai')).toBe(true);
+    expect(svc.getQuotaState('tp-xai')).toMatchObject({
+      exhausted: true,
+      resetsAt: new Date(FUTURE_SEC * 1000).toISOString(),
+    });
+  });
+
+  it('treats a non-zero grpc-status trailer as a fetch failure (fail-open)', async () => {
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-xai', provider: 'xai' })]);
+    fetchMock.mockResolvedValue(
+      binaryResponse(
+        concatBytes(
+          grpcFrame(protobufPayload(100, FUTURE_SEC)),
+          grpcFrame(Buffer.from('grpc-status:7\r\ngrpc-message:denied\r\n'), 0x80),
+        ),
+      ),
+    );
+
+    await poll();
+
+    expect(svc.isQuotaExhausted('tp-xai')).toBe(false);
+    expect(svc.getQuotaState('tp-xai')?.error).toContain('gRPC 7');
+  });
+
+  it('treats a non-zero grpc-status response header as a fetch failure', async () => {
+    providerRepo.find.mockResolvedValue([row({ id: 'tp-xai', provider: 'xai' })]);
+    fetchMock.mockResolvedValue(
+      binaryResponse(new Uint8Array(), { status: 200, headers: { 'grpc-status': '16' } }),
+    );
+
+    await poll();
+
+    expect(svc.isQuotaExhausted('tp-xai')).toBe(false);
+    expect(svc.getQuotaState('tp-xai')?.error).toContain('gRPC 16');
+  });
+
+  it('fails open when the fetch errors, storing a non-exhausted state', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await poll();
+
+    expect(svc.isQuotaExhausted('tp-1')).toBe(false);
+    expect(svc.getQuotaState('tp-1')).toMatchObject({
+      exhausted: false,
+      error: 'network down',
+    });
+  });
+
+  it('fails open when the endpoint returns a non-OK status', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+    await poll();
+
+    expect(svc.isQuotaExhausted('tp-1')).toBe(false);
+    expect(svc.getQuotaState('tp-1')?.error).toContain('401');
+  });
+
+  it('fails open when the fetch times out (abort)', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    fetchMock.mockRejectedValue(abortError);
+
+    await poll();
+
+    expect(svc.isQuotaExhausted('tp-1')).toBe(false);
+  });
+
+  it('keeps the previous verdict when a later refresh fails', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    fetchMock.mockResolvedValueOnce(okResponse(anthropicUsage(100)));
+    await poll();
+    expect(svc.isQuotaExhausted('tp-1')).toBe(true);
+
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    await poll();
+
+    const state = svc.getQuotaState('tp-1');
+    expect(state).toMatchObject({ exhausted: true, resetsAt: FUTURE, error: 'network down' });
+    expect(svc.isQuotaExhausted('tp-1')).toBe(true);
+  });
+
+  it('treats an unwrap failure as a fetch failure (fail-open)', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    anthropicOauth.unwrapToken.mockResolvedValue(null);
+
+    await poll();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(svc.isQuotaExhausted('tp-1')).toBe(false);
+  });
+
+  it('reads a connection as not exhausted once its resetsAt has passed', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    fetchMock.mockResolvedValue(okResponse(anthropicUsage(100, PAST)));
+
+    await poll();
+
+    expect(svc.getQuotaState('tp-1')).toMatchObject({ exhausted: true, resetsAt: PAST });
+    expect(svc.isQuotaExhausted('tp-1')).toBe(false);
+  });
+
+  it('starts and clears the poll timer with the module lifecycle', () => {
+    jest.useFakeTimers();
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    try {
+      svc.onModuleInit();
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+      svc.onModuleDestroy();
+    } finally {
+      setIntervalSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/backend/src/routing/subscription-quota.service.spec.ts
+++ b/packages/backend/src/routing/subscription-quota.service.spec.ts
@@ -282,6 +282,40 @@ describe('parseKimiUsage', () => {
       resetsAt: null,
     });
   });
+
+  it('never treats missing or corrupt numbers as zero (fail-open)', () => {
+    // A missing/corrupt monthly remaining must NOT read as remaining <= 0.
+    expect(parseKimiUsage(kimiUsage({ totalQuota: { limit: '1000' } }))).toEqual({
+      exhausted: false,
+      resetsAt: null,
+    });
+    expect(parseKimiUsage(kimiUsage({ totalQuota: { limit: '1000', remaining: 'abc' } }))).toEqual({
+      exhausted: false,
+      resetsAt: null,
+    });
+    // Corrupt weekly used / 5h limit likewise cannot exhaust.
+    expect(
+      parseKimiUsage(kimiUsage({ usage: { used: 'abc', limit: '100', resetTime: FUTURE } })),
+    ).toEqual({ exhausted: false, resetsAt: null });
+    expect(
+      parseKimiUsage(
+        kimiUsage({
+          limits: [
+            {
+              window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+              detail: { used: '5', resetTime: FUTURE },
+            },
+          ],
+        }),
+      ),
+    ).toEqual({ exhausted: false, resetsAt: null });
+  });
+
+  it('still parses a legitimate "0" string as zero and can exhaust on it', () => {
+    // remaining "0" with a positive limit is a real exhaustion signal.
+    const result = parseKimiUsage(kimiUsage({ totalQuota: { limit: '1000', remaining: '0' } }));
+    expect(result.exhausted).toBe(true);
+  });
 });
 
 describe('parseOpenAiUsage', () => {
@@ -553,8 +587,18 @@ describe('resolveQuotaPollIntervalMs', () => {
     expect(resolveQuotaPollIntervalMs('-5000')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
   });
 
+  it('rejects numeric prefixes with trailing junk (digits-only)', () => {
+    expect(resolveQuotaPollIntervalMs('60000junk')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('60_000')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('6e4')).toBe(DEFAULT_QUOTA_POLL_INTERVAL_MS);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(resolveQuotaPollIntervalMs(' 45000 ')).toBe(45_000);
+  });
+
   it('clamps to the 30s minimum', () => {
-    expect(resolveQuotaPollIntervalMs('1000')).toBe(MIN_QUOTA_POLL_INTERVAL_MS);
+    expect(resolveQuotaPollIntervalMs('100')).toBe(MIN_QUOTA_POLL_INTERVAL_MS);
     expect(resolveQuotaPollIntervalMs('30000')).toBe(MIN_QUOTA_POLL_INTERVAL_MS);
   });
 
@@ -857,6 +901,19 @@ describe('SubscriptionQuotaService', () => {
     await poll();
 
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(svc.isQuotaExhausted('tp-1')).toBe(false);
+  });
+
+  it('prunes state for connections no longer returned by the poll', async () => {
+    providerRepo.find.mockResolvedValue([row({})]);
+    fetchMock.mockResolvedValue(okResponse(anthropicUsage(100)));
+    await poll();
+    expect(svc.getQuotaState('tp-1')).toBeDefined();
+
+    // The connection is deleted/deactivated before the next poll.
+    providerRepo.find.mockResolvedValue([]);
+    await poll();
+    expect(svc.getQuotaState('tp-1')).toBeUndefined();
     expect(svc.isQuotaExhausted('tp-1')).toBe(false);
   });
 

--- a/packages/backend/src/routing/subscription-quota.service.spec.ts
+++ b/packages/backend/src/routing/subscription-quota.service.spec.ts
@@ -373,6 +373,16 @@ describe('parseOpenAiUsage', () => {
       parseOpenAiUsage({ rate_limit: { primary_window: { used_percent: '100', reset_at: 1 } } }),
     ).toEqual({ exhausted: false, resetsAt: null });
   });
+
+  it('reports exhaustion with no reset when reset_at is missing or invalid', () => {
+    expect(
+      parseOpenAiUsage({
+        rate_limit: {
+          primary_window: { used_percent: 100, reset_at: 'not-an-epoch' },
+        },
+      }),
+    ).toEqual({ exhausted: true, resetsAt: null });
+  });
 });
 
 describe('parseMinimaxUsage', () => {
@@ -552,6 +562,23 @@ describe('parseXaiUsage', () => {
       resetsAt: XAI_PROD_RESET_ISO,
     });
   });
+
+  it.each([
+    ['unterminated varint value', [0x08, ...Array(10).fill(0x80)]],
+    ['truncated fixed64', [0x09]],
+    ['oversized nested message', [0x0a, 0x05, 0x00]],
+    ['truncated fixed32', [0x0d, 0x00]],
+    ['unsupported wire type', [0x0b]],
+  ])('rejects malformed protobuf input: %s', (_label, bytes) => {
+    expect(() => parseXaiUsage(grpcFrame(Uint8Array.from(bytes as number[])))).toThrow();
+  });
+
+  it('skips a zero field key and continues scanning the payload', () => {
+    expect(parseXaiUsage(grpcFrame(Uint8Array.from([0x00, 0x0d, ...floatLE(10)])))).toEqual({
+      usedPercent: 10,
+      resetsAt: null,
+    });
+  });
 });
 
 describe('grpc-web framing helpers', () => {
@@ -578,6 +605,10 @@ describe('grpc-web framing helpers', () => {
       'grpc-status': '7',
       'grpc-message': 'bad req',
     });
+    expect(grpcWebTrailerFields(grpcFrame(Buffer.from('grpc-message: bad%ZZ\r\n'), 0x80))).toEqual({
+      'grpc-message': 'bad%ZZ',
+    });
+    expect(grpcWebTrailerFields(Uint8Array.from([0, 0, 0, 0, 2, 1]))).toEqual({});
   });
 
   it('validateGrpcStatusFields accepts missing or zero status, throws otherwise', () => {
@@ -921,6 +952,69 @@ describe('SubscriptionQuotaService', () => {
     expect(svc.isQuotaExhausted('tp-1')).toBe(false);
   });
 
+  it('fails open when the provider query itself fails', async () => {
+    providerRepo.find.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(poll()).resolves.toBeUndefined();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores an unsupported provider passed directly to refreshOne', async () => {
+    await (svc as unknown as { refreshOne(value: TenantProvider): Promise<void> }).refreshOne(
+      row({ provider: 'unsupported-provider' }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(svc.getQuotaState('tp-1')).toBeUndefined();
+  });
+
+  it('returns no credential when encrypted data is absent', async () => {
+    await expect(
+      (
+        svc as unknown as {
+          resolveCredential(
+            value: TenantProvider,
+            kind: 'anthropic',
+          ): Promise<{ token: string } | null>;
+        }
+      ).resolveCredential(row({ api_key_encrypted: '' }), 'anthropic'),
+    ).resolves.toBeNull();
+  });
+
+  it.each([
+    ['moonshot', 'https://api.kimi.com/coding/v1/usages', 'Kimi'],
+    ['openai', 'https://chatgpt.com/backend-api/wham/usage', 'OpenAI'],
+    ['minimax', 'https://api.minimax.io/v1/token_plan/remains', 'MiniMax'],
+    ['xai', 'https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig', 'xAI'],
+  ])(
+    'fails open when the %s quota endpoint returns a non-OK response',
+    async (provider, url, name) => {
+      providerRepo.find.mockResolvedValue([row({ id: `tp-${provider}`, provider })]);
+      fetchMock.mockResolvedValue(binaryResponse(new Uint8Array(), { status: 503 }));
+
+      await poll();
+
+      expect(fetchMock).toHaveBeenCalledWith(url, expect.any(Object));
+      expect(svc.getQuotaState(`tp-${provider}`)?.error).toContain(`${name} usage fetch failed`);
+    },
+  );
+
+  it.each([
+    ['openai', 'openaiOauth'],
+    ['minimax', 'minimaxOauth'],
+    ['xai', 'xaiOauth'],
+  ])('fails open when %s token unwrapping returns no token', async (provider, oauthName) => {
+    const oauth = { openaiOauth, minimaxOauth, xaiOauth }[oauthName]!;
+    oauth.unwrapToken.mockResolvedValue(null);
+    providerRepo.find.mockResolvedValue([row({ id: `tp-${provider}`, provider, agent_id: null })]);
+
+    await poll();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(svc.getQuotaState(`tp-${provider}`)).toMatchObject({ exhausted: false });
+  });
+
   it('prunes state for connections no longer returned by the poll', async () => {
     providerRepo.find.mockResolvedValue([row({})]);
     fetchMock.mockResolvedValue(okResponse(anthropicUsage(100)));
@@ -944,12 +1038,15 @@ describe('SubscriptionQuotaService', () => {
     expect(svc.isQuotaExhausted('tp-1')).toBe(false);
   });
 
-  it('starts and clears the poll timer with the module lifecycle', () => {
+  it('starts, executes, and clears the poll timer with the module lifecycle', async () => {
     jest.useFakeTimers();
     const setIntervalSpy = jest.spyOn(global, 'setInterval');
     try {
       svc.onModuleInit();
       expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+      expect(providerRepo.find).toHaveBeenCalledTimes(2);
       svc.onModuleDestroy();
     } finally {
       setIntervalSpy.mockRestore();

--- a/packages/backend/src/routing/subscription-quota.service.ts
+++ b/packages/backend/src/routing/subscription-quota.service.ts
@@ -1,0 +1,758 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  normalizeProviderName,
+  SHARED_PROVIDER_BY_ID_OR_ALIAS,
+  supportsQuotaCheck,
+} from 'manifest-shared';
+import { TenantProvider } from '../entities/tenant-provider.entity';
+import { AnthropicOauthService } from './oauth/anthropic/anthropic-oauth.service';
+import { OpenaiOauthService } from './oauth/openai/openai-oauth.service';
+import { MinimaxOauthService } from './oauth/minimax/minimax-oauth.service';
+import { XaiOauthService } from './oauth/xai/xai-oauth.service';
+import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
+
+export interface SubscriptionQuotaState {
+  exhausted: boolean;
+  resetsAt: string | null;
+  checkedAt: number;
+  error?: string;
+}
+
+export const DEFAULT_QUOTA_POLL_INTERVAL_MS = 60_000;
+export const MIN_QUOTA_POLL_INTERVAL_MS = 30_000;
+const QUOTA_FETCH_TIMEOUT_MS = 10_000;
+
+const ANTHROPIC_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const KIMI_USAGE_URL = 'https://api.kimi.com/coding/v1/usages';
+const OPENAI_USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
+const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
+const XAI_USAGE_URL = 'https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig';
+/** Empty protobuf message, gRPC-web framed — the GetGrokCreditsConfig request body. */
+const XAI_USAGE_BODY = new Uint8Array([0, 0, 0, 0, 0]);
+
+/** Canonical ids of the providers with a quota endpoint. */
+type QuotaProviderKind = 'anthropic' | 'moonshot' | 'openai' | 'minimax' | 'xai';
+
+/** Poll cadence from SUBSCRIPTION_QUOTA_POLL_INTERVAL_MS, clamped to >= 30s. */
+export function resolveQuotaPollIntervalMs(raw: string | undefined): number {
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_QUOTA_POLL_INTERVAL_MS;
+  return Math.max(parsed, MIN_QUOTA_POLL_INTERVAL_MS);
+}
+
+/** Canonical id for providers with a quota endpoint, else null. */
+function quotaProviderKind(provider: string): QuotaProviderKind | null {
+  const lower = String(provider || '')
+    .trim()
+    .toLowerCase();
+  const entry =
+    SHARED_PROVIDER_BY_ID_OR_ALIAS.get(lower) ??
+    SHARED_PROVIDER_BY_ID_OR_ALIAS.get(normalizeProviderName(lower));
+  const id = entry?.id ?? lower;
+  return id === 'anthropic' ||
+    id === 'moonshot' ||
+    id === 'openai' ||
+    id === 'minimax' ||
+    id === 'xai'
+    ? id
+    : null;
+}
+
+interface QuotaVerdict {
+  exhausted: boolean;
+  resetsAt: string | null;
+}
+
+/** Earliest parseable timestamp among the candidates, else null. */
+function earliestReset(candidates: (string | null)[]): string | null {
+  let best: string | null = null;
+  let bestMs = Infinity;
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const ms = Date.parse(candidate);
+    if (!Number.isFinite(ms) || ms >= bestMs) continue;
+    best = candidate;
+    bestMs = ms;
+  }
+  return best;
+}
+
+/**
+ * Anthropic OAuth usage: exhausted when ANY window (5h, 7d, or the per-model
+ * 7d windows) reports utilization >= 100. The connection stays exhausted until
+ * the earliest reset among the exhausted windows.
+ */
+export function parseAnthropicUsage(data: unknown): QuotaVerdict {
+  const body = (data ?? {}) as Record<string, unknown>;
+  const windows = [
+    'five_hour',
+    'seven_day',
+    'seven_day_sonnet',
+    'seven_day_opus',
+    'seven_day_oauth_apps',
+  ]
+    .map((key) => body[key])
+    .filter((w): w is Record<string, unknown> => !!w && typeof w === 'object');
+  const exhausted = windows.filter(
+    (w) => typeof w.utilization === 'number' && w.utilization >= 100,
+  );
+  if (exhausted.length === 0) return { exhausted: false, resetsAt: null };
+  return {
+    exhausted: true,
+    resetsAt: earliestReset(
+      exhausted.map((w) => (typeof w.resets_at === 'string' ? w.resets_at : null)),
+    ),
+  };
+}
+
+/** Kimi reports every quota number as a string; parseInt with 0 fallback. */
+function kimiNumber(value: unknown): number {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Kimi Coding Plan usage: weekly + 5h rolling windows exhaust when
+ * used >= limit (limit > 0); the monthly window exhausts when
+ * remaining <= 0. The 5h window is the limits[] entry with a 300-minute
+ * duration (fallback: the first entry). Monthly has no reset time, so a
+ * monthly-only exhaustion yields resetsAt = null.
+ */
+export function parseKimiUsage(data: unknown): QuotaVerdict {
+  const body = (data ?? {}) as Record<string, unknown>;
+  let exhausted = false;
+  const resets: (string | null)[] = [];
+
+  const weekly = body.usage as Record<string, unknown> | undefined;
+  if (weekly && typeof weekly === 'object') {
+    const limit = kimiNumber(weekly.limit);
+    if (limit > 0 && kimiNumber(weekly.used) >= limit) {
+      exhausted = true;
+      resets.push(typeof weekly.resetTime === 'string' ? weekly.resetTime : null);
+    }
+  }
+
+  const limits = Array.isArray(body.limits) ? (body.limits as Record<string, unknown>[]) : [];
+  const rolling =
+    limits.find((entry) => {
+      const window = entry?.window as Record<string, unknown> | undefined;
+      return window?.duration === 300 && window?.timeUnit === 'TIME_UNIT_MINUTE';
+    }) ?? limits[0];
+  const detail = rolling?.detail as Record<string, unknown> | undefined;
+  if (detail && typeof detail === 'object') {
+    const limit = kimiNumber(detail.limit);
+    if (limit > 0 && kimiNumber(detail.used) >= limit) {
+      exhausted = true;
+      resets.push(typeof detail.resetTime === 'string' ? detail.resetTime : null);
+    }
+  }
+
+  const monthly = body.totalQuota as Record<string, unknown> | undefined;
+  if (monthly && typeof monthly === 'object') {
+    const limit = kimiNumber(monthly.limit);
+    if (limit > 0 && kimiNumber(monthly.remaining) <= 0) {
+      exhausted = true;
+    }
+  }
+
+  return exhausted
+    ? { exhausted: true, resetsAt: earliestReset(resets) }
+    : { exhausted: false, resetsAt: null };
+}
+
+/** Epoch milliseconds → ISO string; null for missing/non-numeric input. */
+function epochMsToIso(value: unknown): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return new Date(value).toISOString();
+}
+
+/**
+ * ChatGPT subscription usage: rate_limit carries a primary (5h) and a
+ * secondary (weekly) window, each { used_percent, reset_at } with reset_at in
+ * epoch SECONDS. Exhausted when ANY window hits 100%; resetsAt is the earliest
+ * reset among the exhausted windows. credits/individual_limit/
+ * additional_rate_limits are ignored for now.
+ */
+export function parseOpenAiUsage(data: unknown): QuotaVerdict {
+  const body = (data ?? {}) as Record<string, unknown>;
+  const rateLimit = body.rate_limit as Record<string, unknown> | undefined;
+  if (!rateLimit || typeof rateLimit !== 'object') return { exhausted: false, resetsAt: null };
+  const windows = ['primary_window', 'secondary_window']
+    .map((key) => rateLimit[key])
+    .filter((w): w is Record<string, unknown> => !!w && typeof w === 'object');
+  const exhausted = windows.filter(
+    (w) => typeof w.used_percent === 'number' && w.used_percent >= 100,
+  );
+  if (exhausted.length === 0) return { exhausted: false, resetsAt: null };
+  let resetsAt: string | null = null;
+  let bestMs = Infinity;
+  for (const w of exhausted) {
+    if (typeof w.reset_at !== 'number' || !Number.isFinite(w.reset_at)) continue;
+    const ms = w.reset_at * 1000;
+    if (ms < bestMs) {
+      bestMs = ms;
+      resetsAt = new Date(ms).toISOString();
+    }
+  }
+  return { exhausted: true, resetsAt };
+}
+
+/**
+ * MiniMax Token Plan usage: model_remains[] carries per-model quota windows.
+ * The 'general' entry holds the LLM quota (fallback: the first entry). The
+ * percents are REMAINING percents — a window is exhausted when it drops to 0.
+ * The *_total_count/*_usage_count fields are always 0 on time-based plans and
+ * must not be used. Reset times are epoch MILLISECONDS (end_time for the 5h
+ * interval, weekly_end_time for the weekly window).
+ *
+ * Throws on a non-zero base_resp.status_code (business error, e.g. 2062 "no
+ * active plan") so the caller treats it as a fetch failure and fails open.
+ */
+export function parseMinimaxUsage(data: unknown): QuotaVerdict {
+  const body = (data ?? {}) as Record<string, unknown>;
+  const baseResp = body.base_resp as Record<string, unknown> | undefined;
+  if (baseResp && typeof baseResp.status_code === 'number' && baseResp.status_code !== 0) {
+    throw new Error(`MiniMax usage returned status_code ${baseResp.status_code}`);
+  }
+  const remains = Array.isArray(body.model_remains)
+    ? (body.model_remains as Record<string, unknown>[])
+    : [];
+  if (remains.length === 0) return { exhausted: false, resetsAt: null };
+  const entry = remains.find((e) => e?.model_name === 'general') ?? remains[0];
+
+  let exhausted = false;
+  const resets: (string | null)[] = [];
+  const intervalPct = entry.current_interval_remaining_percent;
+  if (typeof intervalPct === 'number' && intervalPct <= 0) {
+    exhausted = true;
+    resets.push(epochMsToIso(entry.end_time));
+  }
+  const weeklyPct = entry.current_weekly_remaining_percent;
+  if (typeof weeklyPct === 'number' && weeklyPct <= 0) {
+    exhausted = true;
+    resets.push(epochMsToIso(entry.weekly_end_time));
+  }
+  return exhausted
+    ? { exhausted: true, resetsAt: earliestReset(resets) }
+    : { exhausted: false, resetsAt: null };
+}
+
+/* ── xAI (Grok) gRPC-web + protobuf parsing ──────────────────────────────
+ * Ported from the reference implementation in the unmerged upstream
+ * subscription-usage PR, adapted to this service's exported-pure-function
+ * style. The grok.com billing endpoint answers with gRPC-web framed
+ * protobuf, so the parser splits frames, validates the trailer's
+ * grpc-status, then heuristically scans the protobuf payload — no protobuf
+ * library needed. */
+
+interface ProtobufFixed32Field {
+  path: number[];
+  value: number;
+  order: number;
+}
+
+interface ProtobufVarintField {
+  path: number[];
+  value: number;
+}
+
+interface ProtobufScan {
+  fixed32Fields: ProtobufFixed32Field[];
+  varintFields: ProtobufVarintField[];
+  order: number;
+}
+
+function readVarint(data: Uint8Array, start: number): { value: number; index: number } | null {
+  let value = 0;
+  let shift = 0;
+  let index = start;
+  while (index < data.length && shift < 64) {
+    const byte = data[index];
+    index += 1;
+    value += (byte & 0x7f) * 2 ** shift;
+    if ((byte & 0x80) === 0) return { value, index };
+    shift += 7;
+  }
+  return null;
+}
+
+function pathsEqual(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function decodeGrpcValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/** Data (non-trailer) gRPC-web frames, or null when the bytes aren't framed. */
+export function grpcWebDataFrames(data: Uint8Array): Uint8Array[] | null {
+  if (data.length === 0) return null;
+  const frames: Uint8Array[] = [];
+  let index = 0;
+  while (index < data.length) {
+    if (index + 5 > data.length) return null;
+    const flags = data[index];
+    if ((flags & 0x7e) !== 0) return null;
+    const length =
+      data[index + 1] * 2 ** 24 +
+      (data[index + 2] << 16) +
+      (data[index + 3] << 8) +
+      data[index + 4];
+    const start = index + 5;
+    const end = start + length;
+    if (end > data.length) return null;
+    if ((flags & 0x80) === 0) frames.push(data.slice(start, end));
+    index = end;
+  }
+  return frames;
+}
+
+/** Trailer gRPC-web frames decoded into lowercase header fields. */
+export function grpcWebTrailerFields(data: Uint8Array): Record<string, string> {
+  const fields: Record<string, string> = {};
+  let index = 0;
+  while (index + 5 <= data.length) {
+    const flags = data[index];
+    const length =
+      data[index + 1] * 2 ** 24 +
+      (data[index + 2] << 16) +
+      (data[index + 3] << 8) +
+      data[index + 4];
+    const start = index + 5;
+    const end = start + length;
+    if (end > data.length) break;
+    if ((flags & 0x80) !== 0) {
+      const text = Buffer.from(data.slice(start, end)).toString('utf8');
+      for (const line of text.split(/\r?\n/)) {
+        const separator = line.indexOf(':');
+        if (separator === -1) continue;
+        fields[line.slice(0, separator).trim().toLowerCase()] = decodeGrpcValue(
+          line.slice(separator + 1).trim(),
+        );
+      }
+    }
+    index = end;
+  }
+  return fields;
+}
+
+function throwGrpcStatus(status: string, message: string): never {
+  throw new Error(`gRPC ${status}: ${message}`);
+}
+
+/** Throws unless the trailer reports success (grpc-status 0 or absent). */
+export function validateGrpcStatusFields(fields: Record<string, string>): void {
+  const status = fields['grpc-status'];
+  if (!status || status === '0') return;
+  throwGrpcStatus(status, fields['grpc-message'] ?? '');
+}
+
+/** Cheap shape check: could these bytes be a bare protobuf message? */
+function looksLikeProtobufPayload(data: Uint8Array): boolean {
+  const first = data[0];
+  if (first === undefined) return false;
+  const fieldNumber = first >> 3;
+  const wireType = first & 0x07;
+  return fieldNumber > 0 && (wireType === 0 || wireType === 1 || wireType === 2 || wireType === 5);
+}
+
+/**
+ * Dependency-free heuristic protobuf scanner: walks length-delimited messages
+ * up to depth 4 and collects every fixed32 (float) and varint field with its
+ * field-number path. Fixed32 fields carry an `order` so ties between equally
+ * shallow percent candidates resolve to the first occurrence.
+ */
+function scanProtobuf(
+  data: Uint8Array,
+  depth: number,
+  path: number[] = [],
+  order = 0,
+): ProtobufScan {
+  const scan: ProtobufScan = { fixed32Fields: [], varintFields: [], order };
+  let index = 0;
+
+  while (index < data.length) {
+    const fieldStart = index;
+    const key = readVarint(data, index);
+    if (!key || key.value === 0) {
+      index = fieldStart + 1;
+      continue;
+    }
+    index = key.index;
+    const fieldNumber = Math.floor(key.value / 8);
+    const wireType = key.value % 8;
+    const fieldPath = [...path, fieldNumber];
+
+    if (wireType === 0) {
+      const value = readVarint(data, index);
+      if (value) {
+        scan.varintFields.push({ path: fieldPath, value: value.value });
+        index = value.index;
+      } else {
+        index = fieldStart + 1;
+      }
+    } else if (wireType === 1) {
+      if (index + 8 > data.length) return scan;
+      index += 8;
+    } else if (wireType === 2) {
+      const length = readVarint(data, index);
+      if (!length || length.value > data.length - length.index) {
+        index = fieldStart + 1;
+        continue;
+      }
+      index = length.index;
+      const end = index + length.value;
+      if (depth < 4) {
+        const nested = scanProtobuf(data.slice(index, end), depth + 1, fieldPath, scan.order);
+        scan.fixed32Fields.push(...nested.fixed32Fields);
+        scan.varintFields.push(...nested.varintFields);
+        scan.order = nested.order;
+      }
+      index = end;
+    } else if (wireType === 5) {
+      if (index + 4 > data.length) return scan;
+      const view = new DataView(data.buffer, data.byteOffset + index, 4);
+      scan.fixed32Fields.push({
+        path: fieldPath,
+        value: view.getFloat32(0, true),
+        order: scan.order,
+      });
+      scan.order += 1;
+      index += 4;
+    } else {
+      index = fieldStart + 1;
+    }
+  }
+
+  return scan;
+}
+
+export interface XaiUsageSnapshot {
+  usedPercent: number;
+  resetsAt: string | null;
+}
+
+/**
+ * Grok web billing (GetGrokCreditsConfig): the used percent is the
+ * shallowest/first fixed32 field whose path ends in segment 1 with a 0-100
+ * value; reset candidates are future varint fields in the plausible epoch
+ * range [1.7e9, 2.1e9], preferring path [1,5,1] then the earliest. Throws
+ * (fail-open) when the response carries no protobuf payload, or when neither
+ * a percent nor a plausible reset can be found.
+ */
+export function parseXaiUsage(data: Uint8Array): XaiUsageSnapshot {
+  const framedPayloads = grpcWebDataFrames(data);
+  const payloads =
+    framedPayloads === null && looksLikeProtobufPayload(data) ? [data] : (framedPayloads ?? []);
+  if (payloads.length === 0) {
+    throw new Error('Grok web billing returned no protobuf payload');
+  }
+
+  const scan = payloads.reduce<ProtobufScan>(
+    (merged, payload) => {
+      const next = scanProtobuf(payload, 0, [], merged.order);
+      merged.fixed32Fields.push(...next.fixed32Fields);
+      merged.varintFields.push(...next.varintFields);
+      merged.order = next.order;
+      return merged;
+    },
+    { fixed32Fields: [], varintFields: [], order: 0 },
+  );
+
+  const percent = scan.fixed32Fields
+    .filter(
+      (field) =>
+        field.path[field.path.length - 1] === 1 &&
+        Number.isFinite(field.value) &&
+        field.value >= 0 &&
+        field.value <= 100,
+    )
+    .sort((a, b) => a.path.length - b.path.length || a.order - b.order)[0]?.value;
+
+  const nowSeconds = Date.now() / 1000;
+  const resetCandidates = scan.varintFields
+    .filter((field) => field.value >= 1_700_000_000 && field.value <= 2_100_000_000)
+    .filter((field) => field.value > nowSeconds)
+    .sort((a, b) => a.value - b.value);
+  const reset =
+    resetCandidates.find((field) => pathsEqual(field.path, [1, 5, 1])) ?? resetCandidates[0];
+
+  if (percent === undefined && !reset) {
+    throw new Error('Could not parse Grok web billing usage');
+  }
+
+  return {
+    usedPercent: percent ?? 0,
+    resetsAt: reset ? new Date(reset.value * 1000).toISOString() : null,
+  };
+}
+
+/**
+ * Polls the usage endpoints of subscription connections whose providers expose
+ * one (Anthropic Claude, Kimi Coding Plan, ChatGPT, MiniMax Token Plan, Grok)
+ * and keeps an in-memory exhaustion snapshot per `tenant_providers` row.
+ * ResolveService consults the snapshot to skip routes flagged
+ * `skipWhenQuotaExhausted`.
+ *
+ * Fail-open everywhere: fetch errors, unwrap failures, and missing data never
+ * mark a connection exhausted, and a failed refresh keeps the previous state.
+ */
+@Injectable()
+export class SubscriptionQuotaService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(SubscriptionQuotaService.name);
+  private readonly states = new Map<string, SubscriptionQuotaState>();
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(
+    @InjectRepository(TenantProvider)
+    private readonly providerRepo: Repository<TenantProvider>,
+    private readonly anthropicOauth: AnthropicOauthService,
+    private readonly openaiOauth: OpenaiOauthService,
+    private readonly minimaxOauth: MinimaxOauthService,
+    private readonly xaiOauth: XaiOauthService,
+  ) {}
+
+  onModuleInit(): void {
+    const intervalMs = resolveQuotaPollIntervalMs(process.env.SUBSCRIPTION_QUOTA_POLL_INTERVAL_MS);
+    this.timer = setInterval(() => {
+      void this.pollSafely();
+    }, intervalMs);
+    // Don't keep the process alive for the poller (tests, CLI runs).
+    this.timer.unref?.();
+    // Kick one immediate poll without blocking module init.
+    void this.pollSafely();
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * True when the connection is known to be exhausted and its earliest reset
+   * time is still in the future. No data, stale errors, or a reset time that
+   * has already passed all read as NOT exhausted (fail-open).
+   */
+  isQuotaExhausted(tenantProviderId: string): boolean {
+    const state = this.states.get(tenantProviderId);
+    if (!state || !state.exhausted) return false;
+    if (state.resetsAt) {
+      const resetMs = Date.parse(state.resetsAt);
+      if (Number.isFinite(resetMs) && resetMs <= Date.now()) return false;
+    }
+    return true;
+  }
+
+  /** Snapshot for future UI surfaces; undefined when never polled. */
+  getQuotaState(tenantProviderId: string): SubscriptionQuotaState | undefined {
+    const state = this.states.get(tenantProviderId);
+    return state ? { ...state } : undefined;
+  }
+
+  private async pollSafely(): Promise<void> {
+    try {
+      await this.poll();
+    } catch (err) {
+      this.logger.warn(`Subscription quota poll failed: ${err}`);
+    }
+  }
+
+  private async poll(): Promise<void> {
+    const rows = await this.providerRepo.find({
+      where: { auth_type: 'subscription', is_active: true },
+    });
+    const targets = rows.filter((row) => row.api_key_encrypted && supportsQuotaCheck(row.provider));
+    await Promise.all(targets.map((row) => this.refreshOne(row)));
+  }
+
+  private async refreshOne(row: TenantProvider): Promise<void> {
+    try {
+      const kind = quotaProviderKind(row.provider);
+      if (!kind) return;
+      const credential = await this.resolveCredential(row, kind);
+      if (!credential) throw new Error('no usable access token');
+      const verdict = await this.fetchUsage(kind, credential);
+      this.states.set(row.id, { ...verdict, checkedAt: Date.now() });
+    } catch (err) {
+      // Fail-open: keep the previous verdict; with no history store a
+      // non-exhausted state so the route is never skipped on unknown data.
+      const previous = this.states.get(row.id);
+      this.states.set(row.id, {
+        exhausted: previous?.exhausted ?? false,
+        resetsAt: previous?.resetsAt ?? null,
+        checkedAt: Date.now(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      this.logger.debug(
+        `Quota refresh failed for provider=${row.provider} connection=${row.id}: ${err}`,
+      );
+    }
+  }
+
+  /**
+   * Decrypt the stored credential and resolve it to a usable bearer token.
+   * OAuth-blob providers (Anthropic, OpenAI, MiniMax, xAI) reuse the same
+   * unwrap/refresh path the proxy uses at request time so expired tokens
+   * refresh here too; MiniMax additionally yields the resource URL the usage
+   * endpoint's base is derived from. Kimi tokens are raw `sk-kimi-` keys used
+   * as-is.
+   */
+  private async resolveCredential(
+    row: TenantProvider,
+    kind: QuotaProviderKind,
+  ): Promise<{ token: string; resourceUrl?: string } | null> {
+    if (!row.api_key_encrypted) return null;
+    const raw = decrypt(row.api_key_encrypted, getEncryptionSecret());
+    const agentId = row.agent_id ?? '';
+    if (kind === 'anthropic') {
+      const token = await this.anthropicOauth.unwrapToken(raw, agentId, row.tenant_id, row.label);
+      return token ? { token } : null;
+    }
+    if (kind === 'openai') {
+      const token = await this.openaiOauth.unwrapToken(raw, agentId, row.tenant_id, row.label);
+      return token ? { token } : null;
+    }
+    if (kind === 'minimax') {
+      const unwrapped = await this.minimaxOauth.unwrapToken(raw, agentId, row.tenant_id, row.label);
+      return unwrapped?.t ? { token: unwrapped.t, resourceUrl: unwrapped.u } : null;
+    }
+    if (kind === 'xai') {
+      const token = await this.xaiOauth.unwrapToken(raw, agentId, row.tenant_id, row.label);
+      return token ? { token } : null;
+    }
+    return raw ? { token: raw } : null;
+  }
+
+  private fetchUsage(
+    kind: QuotaProviderKind,
+    credential: { token: string; resourceUrl?: string },
+  ): Promise<QuotaVerdict> {
+    switch (kind) {
+      case 'anthropic':
+        return this.fetchAnthropicUsage(credential.token);
+      case 'moonshot':
+        return this.fetchKimiUsage(credential.token);
+      case 'openai':
+        return this.fetchOpenAiUsage(credential.token);
+      case 'minimax':
+        return this.fetchMinimaxUsage(credential.token, credential.resourceUrl);
+      case 'xai':
+        return this.fetchXaiUsage(credential.token);
+    }
+  }
+
+  private async fetchAnthropicUsage(token: string): Promise<QuotaVerdict> {
+    const response = await fetch(ANTHROPIC_USAGE_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'anthropic-beta': 'oauth-2025-04-20',
+        'User-Agent': 'claude-code/2.1.0',
+      },
+      signal: AbortSignal.timeout(QUOTA_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`Anthropic usage fetch failed: HTTP ${response.status}`);
+    }
+    return parseAnthropicUsage(await response.json());
+  }
+
+  private async fetchKimiUsage(token: string): Promise<QuotaVerdict> {
+    const response = await fetch(KIMI_USAGE_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(QUOTA_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`Kimi usage fetch failed: HTTP ${response.status}`);
+    }
+    return parseKimiUsage(await response.json());
+  }
+
+  private async fetchOpenAiUsage(token: string): Promise<QuotaVerdict> {
+    const response = await fetch(OPENAI_USAGE_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'User-Agent': 'Manifest',
+      },
+      signal: AbortSignal.timeout(QUOTA_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`OpenAI usage fetch failed: HTTP ${response.status}`);
+    }
+    return parseOpenAiUsage(await response.json());
+  }
+
+  /**
+   * The usage endpoint lives on the same origin as the provider's resource
+   * URL (stored in the OAuth blob's `u`); fall back to the public api host
+   * when the blob carries no usable URL.
+   */
+  private async fetchMinimaxUsage(token: string, resourceUrl?: string): Promise<QuotaVerdict> {
+    let base = MINIMAX_DEFAULT_BASE_URL;
+    if (resourceUrl) {
+      try {
+        base = new URL(resourceUrl).origin;
+      } catch {
+        // keep the default base
+      }
+    }
+    const response = await fetch(`${base}/v1/token_plan/remains`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      signal: AbortSignal.timeout(QUOTA_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`MiniMax usage fetch failed: HTTP ${response.status}`);
+    }
+    return parseMinimaxUsage(await response.json());
+  }
+
+  /**
+   * Grok's billing endpoint answers gRPC-web: grpc-status may arrive as a
+   * header on error responses, otherwise the trailer frame carries it. Both
+   * are validated before parsing the protobuf payload.
+   */
+  private async fetchXaiUsage(token: string): Promise<QuotaVerdict> {
+    const response = await fetch(XAI_USAGE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Origin: 'https://grok.com',
+        Referer: 'https://grok.com/?_s=usage',
+        Accept: '*/*',
+        'Content-Type': 'application/grpc-web+proto',
+        'x-grpc-web': '1',
+        'x-user-agent': 'connect-es/2.1.1',
+        'User-Agent': 'Manifest',
+      },
+      body: XAI_USAGE_BODY,
+      signal: AbortSignal.timeout(QUOTA_FETCH_TIMEOUT_MS),
+    });
+    const headerStatus = response.headers.get('grpc-status');
+    if (headerStatus && headerStatus !== '0') {
+      throwGrpcStatus(headerStatus, response.headers.get('grpc-message') ?? '');
+    }
+    if (!response.ok) {
+      throw new Error(`xAI usage fetch failed: HTTP ${response.status}`);
+    }
+    const data = new Uint8Array(await response.arrayBuffer());
+    validateGrpcStatusFields(grpcWebTrailerFields(data));
+    const snapshot = parseXaiUsage(data);
+    return { exhausted: snapshot.usedPercent >= 100, resetsAt: snapshot.resetsAt };
+  }
+}

--- a/packages/backend/src/routing/subscription-quota.service.ts
+++ b/packages/backend/src/routing/subscription-quota.service.ts
@@ -37,9 +37,11 @@ type QuotaProviderKind = 'anthropic' | 'moonshot' | 'openai' | 'minimax' | 'xai'
 
 /** Poll cadence from SUBSCRIPTION_QUOTA_POLL_INTERVAL_MS, clamped to >= 30s. */
 export function resolveQuotaPollIntervalMs(raw: string | undefined): number {
-  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_QUOTA_POLL_INTERVAL_MS;
-  return Math.max(parsed, MIN_QUOTA_POLL_INTERVAL_MS);
+  // Digits-only (surrounding whitespace tolerated): parseInt would silently
+  // accept a numeric prefix like '60000junk'.
+  const trimmed = raw?.trim() ?? '';
+  if (!/^\d+$/.test(trimmed)) return DEFAULT_QUOTA_POLL_INTERVAL_MS;
+  return Math.max(Number.parseInt(trimmed, 10), MIN_QUOTA_POLL_INTERVAL_MS);
 }
 
 /** Canonical id for providers with a quota endpoint, else null. */
@@ -107,10 +109,15 @@ export function parseAnthropicUsage(data: unknown): QuotaVerdict {
   };
 }
 
-/** Kimi reports every quota number as a string; parseInt with 0 fallback. */
+/**
+ * Kimi reports every quota number as a string; NaN when missing or corrupt.
+ * Callers must check Number.isFinite before comparing — a missing value must
+ * never read as 0 and trip a `<= 0` / `>= limit` exhaustion check (fail-open).
+ */
 function kimiNumber(value: unknown): number {
-  const parsed = Number.parseInt(String(value ?? ''), 10);
-  return Number.isFinite(parsed) ? parsed : 0;
+  if (value === null || value === undefined) return NaN;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : NaN;
 }
 
 /**
@@ -127,8 +134,9 @@ export function parseKimiUsage(data: unknown): QuotaVerdict {
 
   const weekly = body.usage as Record<string, unknown> | undefined;
   if (weekly && typeof weekly === 'object') {
+    const used = kimiNumber(weekly.used);
     const limit = kimiNumber(weekly.limit);
-    if (limit > 0 && kimiNumber(weekly.used) >= limit) {
+    if (Number.isFinite(used) && Number.isFinite(limit) && limit > 0 && used >= limit) {
       exhausted = true;
       resets.push(typeof weekly.resetTime === 'string' ? weekly.resetTime : null);
     }
@@ -142,8 +150,9 @@ export function parseKimiUsage(data: unknown): QuotaVerdict {
     }) ?? limits[0];
   const detail = rolling?.detail as Record<string, unknown> | undefined;
   if (detail && typeof detail === 'object') {
+    const used = kimiNumber(detail.used);
     const limit = kimiNumber(detail.limit);
-    if (limit > 0 && kimiNumber(detail.used) >= limit) {
+    if (Number.isFinite(used) && Number.isFinite(limit) && limit > 0 && used >= limit) {
       exhausted = true;
       resets.push(typeof detail.resetTime === 'string' ? detail.resetTime : null);
     }
@@ -152,7 +161,8 @@ export function parseKimiUsage(data: unknown): QuotaVerdict {
   const monthly = body.totalQuota as Record<string, unknown> | undefined;
   if (monthly && typeof monthly === 'object') {
     const limit = kimiNumber(monthly.limit);
-    if (limit > 0 && kimiNumber(monthly.remaining) <= 0) {
+    const remaining = kimiNumber(monthly.remaining);
+    if (Number.isFinite(remaining) && Number.isFinite(limit) && limit > 0 && remaining <= 0) {
       exhausted = true;
     }
   }
@@ -570,6 +580,13 @@ export class SubscriptionQuotaService implements OnModuleInit, OnModuleDestroy {
       where: { auth_type: 'subscription', is_active: true },
     });
     const targets = rows.filter((row) => row.api_key_encrypted && supportsQuotaCheck(row.provider));
+    // Prune snapshots for connections that were deleted or deactivated since
+    // the last poll — the map would otherwise grow (and serve stale reads)
+    // forever.
+    const targetIds = new Set(targets.map((row) => row.id));
+    for (const id of this.states.keys()) {
+      if (!targetIds.has(id)) this.states.delete(id);
+    }
     await Promise.all(targets.map((row) => this.refreshOne(row)));
   }
 

--- a/packages/backend/src/routing/subscription-quota.service.ts
+++ b/packages/backend/src/routing/subscription-quota.service.ts
@@ -41,7 +41,9 @@ export function resolveQuotaPollIntervalMs(raw: string | undefined): number {
   // accept a numeric prefix like '60000junk'.
   const trimmed = raw?.trim() ?? '';
   if (!/^\d+$/.test(trimmed)) return DEFAULT_QUOTA_POLL_INTERVAL_MS;
-  return Math.max(Number.parseInt(trimmed, 10), MIN_QUOTA_POLL_INTERVAL_MS);
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed > 2147483647) return DEFAULT_QUOTA_POLL_INTERVAL_MS;
+  return Math.max(parsed, MIN_QUOTA_POLL_INTERVAL_MS);
 }
 
 /** Canonical id for providers with a quota endpoint, else null. */
@@ -116,7 +118,9 @@ export function parseAnthropicUsage(data: unknown): QuotaVerdict {
  */
 function kimiNumber(value: unknown): number {
   if (value === null || value === undefined) return NaN;
-  const parsed = Number.parseInt(String(value), 10);
+  const text = String(value).trim();
+  if (!text) return NaN;
+  const parsed = Number(text);
   return Number.isFinite(parsed) ? parsed : NaN;
 }
 

--- a/packages/backend/src/routing/tier.controller.spec.ts
+++ b/packages/backend/src/routing/tier.controller.spec.ts
@@ -120,6 +120,33 @@ describe('TierController', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
+    );
+  });
+
+  it('PUT /tiers/:tier forwards skipWhenQuotaExhausted from the structured route', async () => {
+    (tierService.setOverride as jest.Mock).mockResolvedValue({
+      tier: 'default',
+      override_model: 'claude',
+    });
+    await controller.setOverride(ctx, 'demo', 'default', {
+      model: 'claude',
+      route: {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude',
+        skipWhenQuotaExhausted: true,
+      },
+    });
+    expect(tierService.setOverride).toHaveBeenCalledWith(
+      'agent-1',
+      'tenant-1',
+      'default',
+      'claude',
+      'anthropic',
+      'subscription',
+      undefined,
+      true,
     );
   });
 

--- a/packages/backend/src/routing/tier.controller.ts
+++ b/packages/backend/src/routing/tier.controller.ts
@@ -79,6 +79,7 @@ export class TierController {
       provider,
       authType,
       providerKeyLabel,
+      body.route?.skipWhenQuotaExhausted,
     );
   }
 

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -100,7 +100,6 @@ const FallbackUndoIcon: Component<{ size: 20 | 16; class?: string }> = (p) => (
 
 const FallbackList: Component<FallbackListProps> = (props) => {
   const [removingIndex, setRemovingIndex] = createSignal<number | null>(null);
-  const [quotaSkipPending, setQuotaSkipPending] = createSignal<number | null>(null);
   const [dragIndex, setDragIndex] = createSignal<number | null>(null);
   const [dropSlot, setDropSlot] = createSignal<number | null>(null);
   const [isMutating, setIsMutating] = createSignal(false);
@@ -212,15 +211,13 @@ const FallbackList: Component<FallbackListProps> = (props) => {
    * stale state or land out of order.
    */
   const setQuotaSkipAt = async (index: number, enabled: boolean) => {
-    if (isMutating()) return;
+    if (isMutating() || !props.fallbackRoutes) return;
     setIsMutating(true);
     const original = [...props.fallbacks];
-    const originalRoutes = props.fallbackRoutes ? [...props.fallbackRoutes] : null;
-    if (!originalRoutes) return;
+    const originalRoutes = [...props.fallbackRoutes];
     const updatedRoutes = originalRoutes.map((r, i) =>
       i === index ? ({ ...r, skipWhenQuotaExhausted: enabled } as ModelRoute) : r,
     );
-    setQuotaSkipPending(index);
     props.onUpdate(original, updatedRoutes);
     try {
       await persistSet(props.agentName, props.tier, original, updatedRoutes);
@@ -228,7 +225,6 @@ const FallbackList: Component<FallbackListProps> = (props) => {
     } catch {
       props.onUpdate(original, originalRoutes);
     } finally {
-      setQuotaSkipPending(null);
       setIsMutating(false);
     }
   };
@@ -353,6 +349,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
     setDragIndex(null);
     setDropSlot(null);
 
+    if (isMutating()) return;
+
     // Primary model dropped into fallback list
     if (props.primaryDragging && fromIndex === null && toSlot !== null) {
       props.onPrimaryDropAtSlot?.(toSlot);
@@ -364,7 +362,6 @@ const FallbackList: Component<FallbackListProps> = (props) => {
     const insertAt = toSlot > fromIndex ? toSlot - 1 : toSlot;
     if (insertAt === fromIndex) return;
 
-    if (isMutating()) return;
     setIsMutating(true);
 
     const original = [...props.fallbacks];

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -103,6 +103,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   const [quotaSkipPending, setQuotaSkipPending] = createSignal<number | null>(null);
   const [dragIndex, setDragIndex] = createSignal<number | null>(null);
   const [dropSlot, setDropSlot] = createSignal<number | null>(null);
+  const [isMutating, setIsMutating] = createSignal(false);
   let listRef: HTMLDivElement | undefined;
 
   const modelLabel = (model: string): string => {
@@ -170,6 +171,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
    * keep optimistic-update parents that still consume `string[]` working.
    */
   const setLabelAt = async (index: number, newLabel: string | null) => {
+    if (isMutating()) return;
+    setIsMutating(true);
     const original = [...props.fallbacks];
     const originalRoutes = props.fallbackRoutes ? [...props.fallbackRoutes] : null;
     const updatedRoutes: ModelRoute[] | null = originalRoutes
@@ -188,6 +191,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
       toast.success(newLabel ? `Fallback pinned to "${newLabel}"` : 'Fallback key pin cleared');
     } catch {
       props.onUpdate(original, originalRoutes);
+    } finally {
+      setIsMutating(false);
     }
   };
 
@@ -207,7 +212,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
    * stale state or land out of order.
    */
   const setQuotaSkipAt = async (index: number, enabled: boolean) => {
-    if (quotaSkipPending() === index) return;
+    if (isMutating()) return;
+    setIsMutating(true);
     const original = [...props.fallbacks];
     const originalRoutes = props.fallbackRoutes ? [...props.fallbackRoutes] : null;
     if (!originalRoutes) return;
@@ -223,6 +229,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
       props.onUpdate(original, originalRoutes);
     } finally {
       setQuotaSkipPending(null);
+      setIsMutating(false);
     }
   };
 
@@ -259,6 +266,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   };
 
   const handleRemove = async (index: number) => {
+    if (isMutating()) return;
+    setIsMutating(true);
     setRemovingIndex(index);
     const original = [...props.fallbacks];
     const originalRoutes = props.fallbackRoutes ? [...props.fallbackRoutes] : null;
@@ -278,6 +287,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
       props.onUpdate(original, originalRoutes);
     } finally {
       setRemovingIndex(null);
+      setIsMutating(false);
     }
   };
 
@@ -354,6 +364,9 @@ const FallbackList: Component<FallbackListProps> = (props) => {
     const insertAt = toSlot > fromIndex ? toSlot - 1 : toSlot;
     if (insertAt === fromIndex) return;
 
+    if (isMutating()) return;
+    setIsMutating(true);
+
     const original = [...props.fallbacks];
     const originalRoutes = props.fallbackRoutes ? [...props.fallbackRoutes] : null;
     const reordered = [...props.fallbacks];
@@ -371,6 +384,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
       toast.success('Fallback order updated');
     } catch {
       props.onUpdate(original, originalRoutes);
+    } finally {
+      setIsMutating(false);
     }
   };
 
@@ -425,7 +440,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                         ? 'Skipped while Stream mode is active'
                         : undefined
                     }
-                    draggable={true}
+                    draggable={!isMutating()}
                     onDragStart={(e) => handleDragStart(i(), e)}
                     // Bind dragend on the draggable row itself rather than
                     // only on the container. When a fallback row is dropped
@@ -518,7 +533,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                       <QuotaSkipToggle
                         route={route()}
                         modelLabel={modelLabel(model())}
-                        disabled={removingIndex() !== null || quotaSkipPending() === i()}
+                        disabled={isMutating()}
                         onToggle={(enabled) => void setQuotaSkipAt(i(), enabled)}
                       />
                       <Show
@@ -546,7 +561,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                         onClick={() => handleRemove(i())}
                         title="Remove fallback"
                         aria-label={`Remove ${modelLabel(model())}`}
-                        disabled={removingIndex() !== null}
+                        disabled={isMutating()}
                       >
                         {removingIndex() === i() ? (
                           <span class="spinner" style="width: 10px; height: 10px;" />
@@ -611,7 +626,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
           <button
             class="btn btn--outline btn--sm fallback-list__add"
             onClick={props.onAddFallback}
-            disabled={props.adding || removingIndex() !== null}
+            disabled={props.adding || isMutating()}
           >
             {props.adding ? (
               <span class="spinner" />

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -100,6 +100,7 @@ const FallbackUndoIcon: Component<{ size: 20 | 16; class?: string }> = (p) => (
 
 const FallbackList: Component<FallbackListProps> = (props) => {
   const [removingIndex, setRemovingIndex] = createSignal<number | null>(null);
+  const [quotaSkipPending, setQuotaSkipPending] = createSignal<number | null>(null);
   const [dragIndex, setDragIndex] = createSignal<number | null>(null);
   const [dropSlot, setDropSlot] = createSignal<number | null>(null);
   let listRef: HTMLDivElement | undefined;
@@ -201,21 +202,27 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   /**
    * Flip the quota-skip flag on a single fallback row. Mirrors setLabelAt:
    * the structured routes are canonical, so the flag rides through the same
-   * persist call with optimistic update + revert on failure.
+   * persist call with optimistic update + revert on failure. A second click
+   * while the save is in flight is ignored so two rapid toggles can't submit
+   * stale state or land out of order.
    */
   const setQuotaSkipAt = async (index: number, enabled: boolean) => {
+    if (quotaSkipPending() === index) return;
     const original = [...props.fallbacks];
     const originalRoutes = props.fallbackRoutes ? [...props.fallbackRoutes] : null;
     if (!originalRoutes) return;
     const updatedRoutes = originalRoutes.map((r, i) =>
       i === index ? ({ ...r, skipWhenQuotaExhausted: enabled } as ModelRoute) : r,
     );
+    setQuotaSkipPending(index);
     props.onUpdate(original, updatedRoutes);
     try {
       await persistSet(props.agentName, props.tier, original, updatedRoutes);
       toast.success(enabled ? 'Route skipped on quota exhaustion' : 'Quota skip disabled');
     } catch {
       props.onUpdate(original, originalRoutes);
+    } finally {
+      setQuotaSkipPending(null);
     }
   };
 
@@ -511,7 +518,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                       <QuotaSkipToggle
                         route={route()}
                         modelLabel={modelLabel(model())}
-                        disabled={removingIndex() !== null}
+                        disabled={removingIndex() !== null || quotaSkipPending() === i()}
                         onToggle={(enabled) => void setQuotaSkipAt(i(), enabled)}
                       />
                       <Show

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -24,6 +24,7 @@ import { authBadgeFor } from './AuthBadge.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
 import ModelParamsAffordance from './ModelParamsAffordance.jsx';
 import RouteKeyChip from './RouteKeyChip.js';
+import QuotaSkipToggle from './QuotaSkipToggle.js';
 import { modelParamsScopeForTier } from 'manifest-shared';
 
 interface FallbackListProps {
@@ -195,6 +196,27 @@ const FallbackList: Component<FallbackListProps> = (props) => {
     const info = props.models.find((m) => m.model_name === model);
     if (info) return resolveProviderId(info.provider);
     return undefined;
+  };
+
+  /**
+   * Flip the quota-skip flag on a single fallback row. Mirrors setLabelAt:
+   * the structured routes are canonical, so the flag rides through the same
+   * persist call with optimistic update + revert on failure.
+   */
+  const setQuotaSkipAt = async (index: number, enabled: boolean) => {
+    const original = [...props.fallbacks];
+    const originalRoutes = props.fallbackRoutes ? [...props.fallbackRoutes] : null;
+    if (!originalRoutes) return;
+    const updatedRoutes = originalRoutes.map((r, i) =>
+      i === index ? ({ ...r, skipWhenQuotaExhausted: enabled } as ModelRoute) : r,
+    );
+    props.onUpdate(original, updatedRoutes);
+    try {
+      await persistSet(props.agentName, props.tier, original, updatedRoutes);
+      toast.success(enabled ? 'Route skipped on quota exhaustion' : 'Quota skip disabled');
+    } catch {
+      props.onUpdate(original, originalRoutes);
+    }
   };
 
   const authTypeFor = (providerId: string | undefined, index: number): string | null => {
@@ -486,6 +508,12 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                           onPick={(label) => setLabelAt(i(), label)}
                         />
                       </Show>
+                      <QuotaSkipToggle
+                        route={route()}
+                        modelLabel={modelLabel(model())}
+                        disabled={removingIndex() !== null}
+                        onToggle={(enabled) => void setQuotaSkipAt(i(), enabled)}
+                      />
                       <Show
                         when={
                           props.getModelParams &&

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -78,6 +78,8 @@ interface Props {
    * When absent, the toggle is not rendered on the primary chip.
    */
   onQuotaSkipToggle?: (enabled: boolean) => void | Promise<void>;
+  /** Disables the quota-skip toggle while its save is in flight. */
+  quotaSkipPending?: boolean;
   onFallbacksUpdate: (fallbacks: string[], routes?: ModelRoute[] | null) => void;
   onEdit?: () => void;
   onDisable?: () => void;
@@ -462,6 +464,7 @@ const HeaderTierCard: Component<Props> = (props) => {
                     <QuotaSkipToggle
                       route={props.tier.override_route}
                       modelLabel={modelLabel() || modelName()}
+                      disabled={props.quotaSkipPending}
                       onToggle={(enabled) => void props.onQuotaSkipToggle?.(enabled)}
                     />
                   </Show>

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -31,6 +31,7 @@ import ModelParamsAffordance from './ModelParamsAffordance.jsx';
 import ModelPickerModal from './ModelPickerModal.js';
 import HeaderTierSnippetModal from './HeaderTierSnippetModal.js';
 import RouteKeyChip from './RouteKeyChip.js';
+import QuotaSkipToggle from './QuotaSkipToggle.js';
 import KeyPickerModal from './KeyPickerModal.js';
 import { toast } from '../services/toast-store.js';
 import { modelParamsScopeForHeaderTier } from 'manifest-shared';
@@ -72,6 +73,11 @@ interface Props {
     authType?: AuthType,
     providerKeyLabel?: string,
   ) => void | Promise<void>;
+  /**
+   * Persist the per-route quota-skip flag on the tier's override route.
+   * When absent, the toggle is not rendered on the primary chip.
+   */
+  onQuotaSkipToggle?: (enabled: boolean) => void | Promise<void>;
   onFallbacksUpdate: (fallbacks: string[], routes?: ModelRoute[] | null) => void;
   onEdit?: () => void;
   onDisable?: () => void;
@@ -450,6 +456,13 @@ const HeaderTierCard: Component<Props> = (props) => {
                       leadingMargin
                       stopPropagation
                       onPick={handlePrimaryKeyPick}
+                    />
+                  </Show>
+                  <Show when={props.onQuotaSkipToggle}>
+                    <QuotaSkipToggle
+                      route={props.tier.override_route}
+                      modelLabel={modelLabel() || modelName()}
+                      onToggle={(enabled) => void props.onQuotaSkipToggle?.(enabled)}
                     />
                   </Show>
                   <Show

--- a/packages/frontend/src/components/QuotaSkipToggle.tsx
+++ b/packages/frontend/src/components/QuotaSkipToggle.tsx
@@ -1,0 +1,63 @@
+import { Show, type Component } from 'solid-js';
+import { supportsQuotaCheck } from 'manifest-shared';
+import type { ModelRoute } from '../services/api.js';
+
+interface QuotaSkipToggleProps {
+  route: ModelRoute | null | undefined;
+  /** Used in the aria-label, mirroring ModelParamsAffordance's slotLabel. */
+  modelLabel: string;
+  disabled?: boolean;
+  onToggle: (enabled: boolean) => void;
+}
+
+/**
+ * Compact per-route "Skip on quota exhaustion" icon-button toggle, styled like
+ * the params affordance (chip-action button + tooltip, success-colored when
+ * active). Renders only for subscription routes whose provider exposes a
+ * usage/quota endpoint — everywhere else the flag would be inert, so the
+ * control stays hidden.
+ */
+const QuotaSkipToggle: Component<QuotaSkipToggleProps> = (props) => {
+  const visible = () =>
+    !!props.route &&
+    props.route.authType === 'subscription' &&
+    supportsQuotaCheck(props.route.provider);
+  const enabled = () => props.route?.skipWhenQuotaExhausted === true;
+  return (
+    <Show when={visible()}>
+      <button
+        type="button"
+        class="routing-card__chip-action"
+        classList={{ 'routing-card__chip-action--configured': enabled() }}
+        onClick={(e) => {
+          // Rows/chips are clickable (model picker) or draggable — never let
+          // the toggle's click bubble up to them.
+          e.stopPropagation();
+          props.onToggle(!enabled());
+        }}
+        disabled={props.disabled}
+        aria-pressed={enabled()}
+        aria-label={`Toggle skip-on-quota-exhaustion for ${props.modelLabel}`}
+      >
+        <span class="routing-tooltip">Skip on quota exhaustion</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="12"
+          height="12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path d="m12 14 4-4" />
+          <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+        </svg>
+      </button>
+    </Show>
+  );
+};
+
+export default QuotaSkipToggle;

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -498,6 +498,36 @@ const Routing: Component = () => {
     }
   };
 
+  /**
+   * Flip the quota-skip flag on a specificity tier's override route. Re-uses
+   * the same PUT endpoint as `handleSpecificityOverride` — the route stays
+   * the same, only skipWhenQuotaExhausted changes (mirrors
+   * handleSpecificityPinKey).
+   */
+  const handleSpecificityQuotaSkipToggle = async (category: string, enabled: boolean) => {
+    const assignment = specificityAssignments()?.find((a) => a.category === category);
+    const route = assignment?.override_route;
+    if (!assignment || !route) return;
+    setChangingSpecificity(category);
+    try {
+      await overrideSpecificity(
+        agentName(),
+        category,
+        route.model,
+        route.provider,
+        route.authType,
+        route.keyLabel ?? undefined,
+        enabled,
+      );
+      await refetchSpecificity();
+      toast.success(enabled ? 'Route skipped on quota exhaustion' : 'Quota skip disabled');
+    } catch {
+      // toast handled upstream
+    } finally {
+      setChangingSpecificity(null);
+    }
+  };
+
   return (
     <div class="container--lg">
       <Title>{agentDisplayName() ?? agentName()} Routing - Manifest</Title>
@@ -617,6 +647,9 @@ const Routing: Component = () => {
                     onDropdownOpen={(tierId) => setDropdownTier(tierId)}
                     onOverride={handleOverride}
                     onPinKey={actions.handlePinKey}
+                    onQuotaSkipToggle={(tierId, enabled) =>
+                      void actions.handleQuotaSkipToggle(tierId, enabled)
+                    }
                     onReset={actions.handleReset}
                     onFallbackUpdate={actions.handleFallbackUpdate}
                     onAddFallback={(tierId) => setFallbackPickerTier(tierId)}
@@ -637,6 +670,29 @@ const Routing: Component = () => {
                           try {
                             await overrideHeaderTier(agentName(), tier.id, m, p, a, label);
                             await refetchHeaderTiers();
+                          } catch (err) {
+                            toast.error(
+                              err instanceof Error ? err.message : 'Failed to update tier',
+                            );
+                          }
+                        }}
+                        onQuotaSkipToggle={async (enabled) => {
+                          const route = tier.override_route;
+                          if (!route) return;
+                          try {
+                            await overrideHeaderTier(
+                              agentName(),
+                              tier.id,
+                              route.model,
+                              route.provider,
+                              route.authType,
+                              route.keyLabel ?? undefined,
+                              enabled,
+                            );
+                            await refetchHeaderTiers();
+                            toast.success(
+                              enabled ? 'Route skipped on quota exhaustion' : 'Quota skip disabled',
+                            );
                           } catch (err) {
                             toast.error(
                               err instanceof Error ? err.message : 'Failed to update tier',
@@ -744,6 +800,9 @@ const Routing: Component = () => {
                     onDropdownOpen={(tierId) => setDropdownTier(tierId)}
                     onOverride={handleOverride}
                     onPinKey={actions.handlePinKey}
+                    onQuotaSkipToggle={(tierId, enabled) =>
+                      void actions.handleQuotaSkipToggle(tierId, enabled)
+                    }
                     onReset={actions.handleReset}
                     onFallbackUpdate={actions.handleFallbackUpdate}
                     onAddFallback={(tierId) => setFallbackPickerTier(tierId)}
@@ -776,6 +835,9 @@ const Routing: Component = () => {
                     onDropdownOpen={(category) => setSpecificityDropdown(category)}
                     onOverride={handleSpecificityOverride}
                     onPinKey={handleSpecificityPinKey}
+                    onQuotaSkipToggle={(category, enabled) =>
+                      void handleSpecificityQuotaSkipToggle(category, enabled)
+                    }
                     onReset={async (category) => {
                       setResettingSpecificity(category);
                       try {

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -452,10 +452,30 @@ const Routing: Component = () => {
     provider: string,
     authType?: 'api_key' | 'subscription' | 'local',
     providerKeyLabel?: string,
+    skipWhenQuotaExhausted?: boolean,
   ) => {
     setChangingSpecificity(category);
     try {
-      await overrideSpecificity(agentName(), category, model, provider, authType, providerKeyLabel);
+      if (skipWhenQuotaExhausted === undefined) {
+        await overrideSpecificity(
+          agentName(),
+          category,
+          model,
+          provider,
+          authType,
+          providerKeyLabel,
+        );
+      } else {
+        await overrideSpecificity(
+          agentName(),
+          category,
+          model,
+          provider,
+          authType,
+          providerKeyLabel,
+          skipWhenQuotaExhausted,
+        );
+      }
       await refetchSpecificity();
     } catch {
       toast.error('Failed to update specificity model');

--- a/packages/frontend/src/pages/RoutingActions.tsx
+++ b/packages/frontend/src/pages/RoutingActions.tsx
@@ -40,17 +40,29 @@ export function createRoutingActions(input: RoutingActionsInput) {
     providerId: string,
     authType?: AuthType,
     providerKeyLabel?: string,
+    skipWhenQuotaExhausted?: boolean,
   ) => {
     setChangingTier(tierId);
     try {
-      const updated = await overrideTier(
-        input.agentName(),
-        tierId,
-        modelName,
-        providerId,
-        authType,
-        providerKeyLabel,
-      );
+      const updated =
+        skipWhenQuotaExhausted === undefined
+          ? await overrideTier(
+              input.agentName(),
+              tierId,
+              modelName,
+              providerId,
+              authType,
+              providerKeyLabel,
+            )
+          : await overrideTier(
+              input.agentName(),
+              tierId,
+              modelName,
+              providerId,
+              authType,
+              providerKeyLabel,
+              skipWhenQuotaExhausted,
+            );
       // Commit the primary update to local state immediately so the UI reflects
       // the new model even if the fallback cleanup below fails.
       input.mutateTiers((prev) => prev?.map((t) => (t.tier === tierId ? updated : t)));

--- a/packages/frontend/src/pages/RoutingActions.tsx
+++ b/packages/frontend/src/pages/RoutingActions.tsx
@@ -131,6 +131,35 @@ export function createRoutingActions(input: RoutingActionsInput) {
     }
   };
 
+  /**
+   * Flip the quota-skip flag on a tier's override route. Re-uses the existing
+   * PUT /tiers/:tier endpoint by re-sending the current route — the only
+   * delta is the new skipWhenQuotaExhausted value (mirrors handlePinKey).
+   */
+  const handleQuotaSkipToggle = async (tierId: string, enabled: boolean) => {
+    const tier = getTier(tierId);
+    const route = tier?.override_route;
+    if (!tier || !route) return;
+    setChangingTier(tierId);
+    try {
+      const updated = await overrideTier(
+        input.agentName(),
+        tierId,
+        route.model,
+        route.provider,
+        route.authType,
+        route.keyLabel ?? undefined,
+        enabled,
+      );
+      input.mutateTiers((prev) => prev?.map((t) => (t.tier === tierId ? updated : t)));
+      toast.success(enabled ? 'Route skipped on quota exhaustion' : 'Quota skip disabled');
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      setChangingTier(null);
+    }
+  };
+
   const handleResetAll = async () => {
     setResettingAll(true);
     try {
@@ -264,6 +293,7 @@ export function createRoutingActions(input: RoutingActionsInput) {
     getFallbacksFor,
     handleOverride,
     handlePinKey,
+    handleQuotaSkipToggle,
     handleResetAll,
     handleReset,
     handleAddFallback,

--- a/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
+++ b/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
@@ -33,6 +33,7 @@ export interface RoutingDefaultTierSectionProps {
     providerKeyLabel: string | null,
     authType?: AuthType,
   ) => void;
+  onQuotaSkipToggle?: (tierId: string, enabled: boolean) => void;
   onReset: (tierId: string) => void;
   onFallbackUpdate: (tierId: string, fallbacks: string[]) => void;
   onAddFallback: (tierId: string) => void;
@@ -101,6 +102,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
         onDropdownOpen={props.onDropdownOpen}
         onOverride={props.onOverride}
         onPinKey={props.onPinKey}
+        onQuotaSkipToggle={props.onQuotaSkipToggle}
         onReset={props.onReset}
         onFallbackUpdate={props.onFallbackUpdate}
         onAddFallback={props.onAddFallback}
@@ -131,6 +133,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
             onDropdownOpen={props.onDropdownOpen}
             onOverride={props.onOverride}
             onPinKey={props.onPinKey}
+            onQuotaSkipToggle={props.onQuotaSkipToggle}
             onReset={props.onReset}
             onFallbackUpdate={props.onFallbackUpdate}
             onAddFallback={props.onAddFallback}

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -145,8 +145,8 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
     }
   };
 
-  // Which tier currently has a quota-skip toggle save in flight.
-  const [quotaToggling, setQuotaToggling] = createSignal<string | null>(null);
+  // Which tiers currently have a quota-skip toggle save in flight.
+  const [quotaToggling, setQuotaToggling] = createSignal<Set<string>>(new Set());
 
   /**
    * Flip the quota-skip flag on a custom tier's override route by re-sending
@@ -156,8 +156,8 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
    */
   const handleQuotaSkipToggle = async (tier: HeaderTier, enabled: boolean): Promise<void> => {
     const route = tier.override_route;
-    if (!route || quotaToggling() === tier.id) return;
-    setQuotaToggling(tier.id);
+    if (!route || quotaToggling().has(tier.id)) return;
+    setQuotaToggling((prev) => new Set(prev).add(tier.id));
     try {
       await overrideHeaderTier(
         props.agentName(),
@@ -173,7 +173,11 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to update tier');
     } finally {
-      setQuotaToggling(null);
+      setQuotaToggling((prev) => {
+        const next = new Set(prev);
+        next.delete(tier.id);
+        return next;
+      });
     }
   };
 
@@ -414,7 +418,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 connectedProviders={props.connectedProviders()}
                 onOverride={(m, p, a, label) => handleOverride(tier.id, m, p, a, label)}
                 onQuotaSkipToggle={(enabled) => void handleQuotaSkipToggle(tier, enabled)}
-                quotaSkipPending={quotaToggling() === tier.id}
+                quotaSkipPending={quotaToggling().has(tier.id)}
                 onFallbacksUpdate={(_fallbacks, updatedRoutes) =>
                   applyFallbackUpdate(tier.id, updatedRoutes)
                 }

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -145,13 +145,19 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
     }
   };
 
+  // Which tier currently has a quota-skip toggle save in flight.
+  const [quotaToggling, setQuotaToggling] = createSignal<string | null>(null);
+
   /**
    * Flip the quota-skip flag on a custom tier's override route by re-sending
-   * the current route with the new skipWhenQuotaExhausted value.
+   * the current route with the new skipWhenQuotaExhausted value. A second
+   * click while the save is in flight is ignored so two rapid toggles can't
+   * submit stale state or land out of order.
    */
   const handleQuotaSkipToggle = async (tier: HeaderTier, enabled: boolean): Promise<void> => {
     const route = tier.override_route;
-    if (!route) return;
+    if (!route || quotaToggling() === tier.id) return;
+    setQuotaToggling(tier.id);
     try {
       await overrideHeaderTier(
         props.agentName(),
@@ -166,6 +172,8 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
       toast.success(enabled ? 'Route skipped on quota exhaustion' : 'Quota skip disabled');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to update tier');
+    } finally {
+      setQuotaToggling(null);
     }
   };
 
@@ -406,6 +414,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 connectedProviders={props.connectedProviders()}
                 onOverride={(m, p, a, label) => handleOverride(tier.id, m, p, a, label)}
                 onQuotaSkipToggle={(enabled) => void handleQuotaSkipToggle(tier, enabled)}
+                quotaSkipPending={quotaToggling() === tier.id}
                 onFallbacksUpdate={(_fallbacks, updatedRoutes) =>
                   applyFallbackUpdate(tier.id, updatedRoutes)
                 }

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -145,6 +145,30 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
     }
   };
 
+  /**
+   * Flip the quota-skip flag on a custom tier's override route by re-sending
+   * the current route with the new skipWhenQuotaExhausted value.
+   */
+  const handleQuotaSkipToggle = async (tier: HeaderTier, enabled: boolean): Promise<void> => {
+    const route = tier.override_route;
+    if (!route) return;
+    try {
+      await overrideHeaderTier(
+        props.agentName(),
+        tier.id,
+        route.model,
+        route.provider,
+        route.authType,
+        route.keyLabel ?? undefined,
+        enabled,
+      );
+      await refetch();
+      toast.success(enabled ? 'Route skipped on quota exhaustion' : 'Quota skip disabled');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update tier');
+    }
+  };
+
   const handleDelete = async (id: string): Promise<void> => {
     try {
       await deleteHeaderTier(props.agentName(), id);
@@ -381,6 +405,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 customProviders={props.customProviders()}
                 connectedProviders={props.connectedProviders()}
                 onOverride={(m, p, a, label) => handleOverride(tier.id, m, p, a, label)}
+                onQuotaSkipToggle={(enabled) => void handleQuotaSkipToggle(tier, enabled)}
                 onFallbacksUpdate={(_fallbacks, updatedRoutes) =>
                   applyFallbackUpdate(tier.id, updatedRoutes)
                 }

--- a/packages/frontend/src/pages/RoutingSpecificitySection.tsx
+++ b/packages/frontend/src/pages/RoutingSpecificitySection.tsx
@@ -156,6 +156,7 @@ export interface RoutingSpecificitySectionProps {
     providerKeyLabel: string | null,
     authType?: AuthType,
   ) => void;
+  onQuotaSkipToggle?: (category: string, enabled: boolean) => void;
   onReset: (category: string) => void;
   onFallbackUpdate: (category: string, fallbacks: string[], routes?: ModelRoute[] | null) => void;
   onAddFallback: (category: string) => void;
@@ -283,6 +284,7 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
                 onDropdownOpen={props.onDropdownOpen}
                 onOverride={props.onOverride}
                 onPinKey={props.onPinKey}
+                onQuotaSkipToggle={props.onQuotaSkipToggle}
                 onReset={props.onReset}
                 onFallbackUpdate={props.onFallbackUpdate}
                 onAddFallback={props.onAddFallback}

--- a/packages/frontend/src/pages/RoutingSpecificitySection.tsx
+++ b/packages/frontend/src/pages/RoutingSpecificitySection.tsx
@@ -149,7 +149,14 @@ export interface RoutingSpecificitySectionProps {
   resettingAll: () => boolean;
   addingFallback: () => string | null;
   onDropdownOpen: (category: string) => void;
-  onOverride: (category: string, model: string, provider: string, authType?: AuthType) => void;
+  onOverride: (
+    category: string,
+    model: string,
+    provider: string,
+    authType?: AuthType,
+    providerKeyLabel?: string,
+    skipWhenQuotaExhausted?: boolean,
+  ) => void;
   onPinKey?: (
     category: string,
     providerId: string,

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -84,6 +84,7 @@ export interface RoutingTierCardProps {
     providerId: string,
     authType?: AuthType,
     providerKeyLabel?: string,
+    skipWhenQuotaExhausted?: boolean,
   ) => void;
   onPinKey?: (
     tierId: string,
@@ -252,13 +253,25 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
     }
     const provId = newPrimaryRoute?.provider ?? providerIdForModel(newPrimary, props.models());
     try {
-      await props.onOverride(
-        props.stage.id,
-        newPrimary,
-        provId ?? '',
-        newPrimaryRoute?.authType,
-        newPrimaryRoute?.keyLabel ?? undefined,
-      );
+      const skipWhenQuotaExhausted = newPrimaryRoute?.skipWhenQuotaExhausted;
+      if (skipWhenQuotaExhausted === undefined) {
+        await props.onOverride(
+          props.stage.id,
+          newPrimary,
+          provId ?? '',
+          newPrimaryRoute?.authType,
+          newPrimaryRoute?.keyLabel ?? undefined,
+        );
+      } else {
+        await props.onOverride(
+          props.stage.id,
+          newPrimary,
+          provId ?? '',
+          newPrimaryRoute?.authType,
+          newPrimaryRoute?.keyLabel ?? undefined,
+          skipWhenQuotaExhausted,
+        );
+      }
     } finally {
       setSwappingFbIndex(null);
     }
@@ -303,13 +316,25 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
     }
     const provId = fbRoute?.provider ?? providerIdForModel(fbModel, props.models());
     try {
-      await props.onOverride(
-        props.stage.id,
-        fbModel,
-        provId ?? '',
-        fbRoute?.authType,
-        fbRoute?.keyLabel ?? undefined,
-      );
+      const skipWhenQuotaExhausted = fbRoute?.skipWhenQuotaExhausted;
+      if (skipWhenQuotaExhausted === undefined) {
+        await props.onOverride(
+          props.stage.id,
+          fbModel,
+          provId ?? '',
+          fbRoute?.authType,
+          fbRoute?.keyLabel ?? undefined,
+        );
+      } else {
+        await props.onOverride(
+          props.stage.id,
+          fbModel,
+          provId ?? '',
+          fbRoute?.authType,
+          fbRoute?.keyLabel ?? undefined,
+          skipWhenQuotaExhausted,
+        );
+      }
     } finally {
       setSwappingFbIndex(null);
     }

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -13,6 +13,7 @@ import {
 import { customProviderColor, formatPerRequestCost } from '../services/formatters.js';
 import FallbackList from '../components/FallbackList.js';
 import ModelParamsAffordance from '../components/ModelParamsAffordance.jsx';
+import QuotaSkipToggle from '../components/QuotaSkipToggle.js';
 import RouteKeyChip from '../components/RouteKeyChip.js';
 import { setFallbacks as setFallbacksApi } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
@@ -91,6 +92,11 @@ export interface RoutingTierCardProps {
     authType?: AuthType,
   ) => void;
   onReset: (tierId: string) => void;
+  /**
+   * Persist the per-route quota-skip flag on the tier's override route.
+   * When absent, the toggle is not rendered on the primary chip.
+   */
+  onQuotaSkipToggle?: (tierId: string, enabled: boolean) => void;
   onFallbackUpdate: (
     tierId: string,
     fallbacks: string[],
@@ -539,6 +545,16 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                             }}
                             disabled={() => props.changingTier() === props.stage.id}
                           />
+                          <Show when={props.onQuotaSkipToggle && isManual()}>
+                            <QuotaSkipToggle
+                              route={props.tier()?.override_route}
+                              modelLabel={labelFor(modelName())}
+                              disabled={props.changingTier() === props.stage.id}
+                              onToggle={(enabled) =>
+                                props.onQuotaSkipToggle?.(props.stage.id, enabled)
+                              }
+                            />
+                          </Show>
                           <Show
                             when={props.setModelParams && props.getModelParams && effectiveAuth()}
                           >

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -545,7 +545,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                             }}
                             disabled={() => props.changingTier() === props.stage.id}
                           />
-                          <Show when={props.onQuotaSkipToggle && isManual()}>
+                          <Show when={props.onQuotaSkipToggle}>
                             <QuotaSkipToggle
                               route={props.tier()?.override_route}
                               modelLabel={labelFor(modelName())}

--- a/packages/frontend/src/services/api/header-tiers.ts
+++ b/packages/frontend/src/services/api/header-tiers.ts
@@ -109,13 +109,16 @@ export function overrideHeaderTier(
   provider: string,
   authType?: AuthType,
   providerKeyLabel?: string,
+  skipWhenQuotaExhausted?: boolean,
 ) {
   const body: Record<string, unknown> = { model, provider };
   if (authType) {
     body.authType = authType;
-    body.route = providerKeyLabel
+    const route: ModelRoute = providerKeyLabel
       ? { provider, authType, model, keyLabel: providerKeyLabel }
       : { provider, authType, model };
+    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
+    body.route = route;
   }
   if (providerKeyLabel) body.providerKeyLabel = providerKeyLabel;
   return fetchMutate<HeaderTier>(

--- a/packages/frontend/src/services/api/header-tiers.ts
+++ b/packages/frontend/src/services/api/header-tiers.ts
@@ -117,7 +117,11 @@ export function overrideHeaderTier(
     const route: ModelRoute = providerKeyLabel
       ? { provider, authType, model, keyLabel: providerKeyLabel }
       : { provider, authType, model };
-    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
+    // Preserve an omitted value, but send explicit false so a toggle can clear
+    // an existing quota-skip flag.
+    if (skipWhenQuotaExhausted !== undefined) {
+      route.skipWhenQuotaExhausted = skipWhenQuotaExhausted;
+    }
     body.route = route;
   }
   if (providerKeyLabel) body.providerKeyLabel = providerKeyLabel;

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -259,7 +259,11 @@ export function overrideTier(
     const route: ModelRoute = providerKeyLabel
       ? { provider, authType, model, keyLabel: providerKeyLabel }
       : { provider, authType, model };
-    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
+    // `false` is meaningful: it explicitly clears a saved quota-skip flag.
+    // Omitting it asks the backend to preserve the current route value.
+    if (skipWhenQuotaExhausted !== undefined) {
+      route.skipWhenQuotaExhausted = skipWhenQuotaExhausted;
+    }
     body.route = route;
   }
   if (providerKeyLabel) body.providerKeyLabel = providerKeyLabel;

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -246,6 +246,7 @@ export function overrideTier(
   provider: string,
   authType?: AuthType,
   providerKeyLabel?: string,
+  skipWhenQuotaExhausted?: boolean,
 ) {
   // The backend requires the structured (provider, authType, model) tuple now
   // that legacy column persistence is gone. authType is optional only for
@@ -258,6 +259,7 @@ export function overrideTier(
     const route: ModelRoute = providerKeyLabel
       ? { provider, authType, model, keyLabel: providerKeyLabel }
       : { provider, authType, model };
+    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
     body.route = route;
   }
   if (providerKeyLabel) body.providerKeyLabel = providerKeyLabel;

--- a/packages/frontend/src/services/api/specificity.ts
+++ b/packages/frontend/src/services/api/specificity.ts
@@ -44,7 +44,11 @@ export function overrideSpecificity(
     const route: ModelRoute = providerKeyLabel
       ? { provider, authType, model, keyLabel: providerKeyLabel }
       : { provider, authType, model };
-    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
+    // Preserve an omitted value, but send explicit false so a toggle can clear
+    // an existing quota-skip flag.
+    if (skipWhenQuotaExhausted !== undefined) {
+      route.skipWhenQuotaExhausted = skipWhenQuotaExhausted;
+    }
     body.route = route;
   }
   if (providerKeyLabel) body.providerKeyLabel = providerKeyLabel;

--- a/packages/frontend/src/services/api/specificity.ts
+++ b/packages/frontend/src/services/api/specificity.ts
@@ -36,6 +36,7 @@ export function overrideSpecificity(
   provider: string,
   authType?: AuthType,
   providerKeyLabel?: string,
+  skipWhenQuotaExhausted?: boolean,
 ) {
   const body: Record<string, unknown> = { model, provider };
   if (authType) {
@@ -43,6 +44,7 @@ export function overrideSpecificity(
     const route: ModelRoute = providerKeyLabel
       ? { provider, authType, model, keyLabel: providerKeyLabel }
       : { provider, authType, model };
+    if (skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
     body.route = route;
   }
   if (providerKeyLabel) body.providerKeyLabel = providerKeyLabel;

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1306,4 +1306,90 @@ describe('FallbackList', () => {
       expect(btn).toBeDefined();
     });
   });
+
+  describe('quota skip toggle', () => {
+    const anthropicSubRoute = {
+      provider: 'anthropic',
+      authType: 'subscription',
+      model: 'model-b',
+    } as any;
+
+    const quotaButton = (container: HTMLElement) =>
+      container.querySelector<HTMLButtonElement>(
+        'button[aria-label^="Toggle skip-on-quota-exhaustion"]',
+      );
+
+    it('renders for subscription routes on quota-capable providers', () => {
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={['model-b']}
+          fallbackRoutes={[anthropicSubRoute]}
+        />
+      ));
+      expect(quotaButton(container)).not.toBeNull();
+    });
+
+    it('renders for moonshot (Kimi) subscription routes', () => {
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={['model-b']}
+          fallbackRoutes={[
+            { provider: 'moonshot', authType: 'subscription', model: 'model-b' } as any,
+          ]}
+        />
+      ));
+      expect(quotaButton(container)).not.toBeNull();
+    });
+
+    it('is hidden for api_key routes', () => {
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={['model-b']}
+          fallbackRoutes={[{ provider: 'anthropic', authType: 'api_key', model: 'model-b' } as any]}
+        />
+      ));
+      expect(quotaButton(container)).toBeNull();
+    });
+
+    it('is hidden for subscription routes on providers without a quota endpoint', () => {
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={['model-a']}
+          fallbackRoutes={[
+            { provider: 'gemini', authType: 'subscription', model: 'model-a' } as any,
+          ]}
+        />
+      ));
+      expect(quotaButton(container)).toBeNull();
+    });
+
+    it('reflects the stored flag via aria-pressed and persists toggles through setFallbacks', async () => {
+      const onUpdate = vi.fn();
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          onUpdate={onUpdate}
+          fallbacks={['model-b']}
+          fallbackRoutes={[{ ...anthropicSubRoute, skipWhenQuotaExhausted: true }]}
+        />
+      ));
+      const button = quotaButton(container)!;
+      expect(button.getAttribute('aria-pressed')).toBe('true');
+      expect(button.classList.contains('routing-card__chip-action--configured')).toBe(true);
+
+      fireEvent.click(button);
+      await waitFor(() => expect(mockSetFallbacks).toHaveBeenCalled());
+      const [, , modelsArg, routesArg] = mockSetFallbacks.mock.calls[0] as any[];
+      expect(modelsArg).toEqual(['model-b']);
+      expect(routesArg).toEqual([{ ...anthropicSubRoute, skipWhenQuotaExhausted: false }]);
+      expect(onUpdate).toHaveBeenCalledWith(
+        ['model-b'],
+        [{ ...anthropicSubRoute, skipWhenQuotaExhausted: false }],
+      );
+    });
+  });
 });

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -996,6 +996,46 @@ describe('FallbackList', () => {
     expect(items).not.toBeNull();
   });
 
+  it('ignores a primary drop while a fallback save is in flight', async () => {
+    let resolveSave: (value: unknown) => void = () => {};
+    mockSetFallbacks.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+    const onPrimaryDropAtSlot = vi.fn();
+    const { container } = render(() => (
+      <FallbackList
+        {...defaultProps}
+        fallbacks={['model-a', 'model-b']}
+        fallbackRoutes={[
+          { provider: 'openai', authType: 'api_key', model: 'model-a' } as any,
+          { provider: 'anthropic', authType: 'subscription', model: 'model-b' } as any,
+        ]}
+        primaryDragging={true}
+        onPrimaryDropAtSlot={onPrimaryDropAtSlot}
+      />
+    ));
+
+    const quotaButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label^="Toggle skip-on-quota-exhaustion"]',
+    )!;
+    fireEvent.click(quotaButton);
+    expect(quotaButton.disabled).toBe(true);
+
+    const list = container.querySelector('.fallback-list__items')!;
+    fireEvent.dragOver(list, {
+      clientY: 100,
+      dataTransfer: { dropEffect: '' },
+      preventDefault: vi.fn(),
+    });
+    fireEvent.drop(list, { preventDefault: vi.fn() });
+
+    expect(onPrimaryDropAtSlot).not.toHaveBeenCalled();
+    resolveSave(undefined);
+    await waitFor(() => expect(quotaButton.disabled).toBe(false));
+  });
+
   it('onFallbackDragStart callback is called', () => {
     const onFallbackDragStart = vi.fn();
     const { container } = render(() => (

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1391,5 +1391,31 @@ describe('FallbackList', () => {
         [{ ...anthropicSubRoute, skipWhenQuotaExhausted: false }],
       );
     });
+
+    it('reverts the optimistic update when persisting the toggle fails', async () => {
+      const onUpdate = vi.fn();
+      mockSetFallbacks.mockRejectedValue(new Error('boom'));
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          onUpdate={onUpdate}
+          fallbacks={['model-b']}
+          fallbackRoutes={[{ ...anthropicSubRoute, skipWhenQuotaExhausted: true }]}
+        />
+      ));
+      fireEvent.click(quotaButton(container)!);
+      await waitFor(() => expect(mockSetFallbacks).toHaveBeenCalled());
+      // Optimistic flip, then revert to the original routes on failure.
+      expect(onUpdate).toHaveBeenNthCalledWith(
+        1,
+        ['model-b'],
+        [{ ...anthropicSubRoute, skipWhenQuotaExhausted: false }],
+      );
+      expect(onUpdate).toHaveBeenNthCalledWith(
+        2,
+        ['model-b'],
+        [{ ...anthropicSubRoute, skipWhenQuotaExhausted: true }],
+      );
+    });
   });
 });

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1417,5 +1417,29 @@ describe('FallbackList', () => {
         [{ ...anthropicSubRoute, skipWhenQuotaExhausted: true }],
       );
     });
+
+    it('ignores a second click while the first save is in flight and disables the toggle', async () => {
+      let resolveSave: (v: unknown) => void = () => {};
+      mockSetFallbacks.mockReturnValue(
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+      );
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={['model-b']}
+          fallbackRoutes={[anthropicSubRoute]}
+        />
+      ));
+      const button = quotaButton(container)!;
+      fireEvent.click(button);
+      expect(button.disabled).toBe(true);
+      // The in-flight save makes the second click a no-op.
+      fireEvent.click(button);
+      expect(mockSetFallbacks).toHaveBeenCalledTimes(1);
+      resolveSave([]);
+      await waitFor(() => expect(button.disabled).toBe(false));
+    });
   });
 });

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -444,6 +444,11 @@ describe('HeaderTierCard', () => {
       const { container } = renderCard({});
       expect(quotaButton(container)).toBeNull();
     });
+
+    it('disables the toggle while a save is in flight', () => {
+      const { container } = renderCard({ onQuotaSkipToggle: vi.fn(), quotaSkipPending: true });
+      expect(quotaButton(container)?.disabled).toBe(true);
+    });
   });
 
   it('shows the primary account chip for multi-account header tier routes', () => {

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -387,6 +387,65 @@ describe('HeaderTierCard', () => {
     expect(container.textContent).toContain('Included in subscription');
   });
 
+  describe('quota skip toggle', () => {
+    const subTier: HeaderTier = {
+      ...baseTier,
+      override_route: {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-opus',
+      },
+    };
+    const renderCard = (props: Partial<Parameters<typeof HeaderTierCard>[0]>, tier = subTier) =>
+      render(() => (
+        <HeaderTierCard
+          agentName="demo"
+          tier={tier}
+          models={models}
+          customProviders={customProviders}
+          connectedProviders={connectedProviders}
+          onOverride={vi.fn()}
+          onFallbacksUpdate={vi.fn()}
+          {...props}
+        />
+      ));
+    const quotaButton = (container: HTMLElement) =>
+      container.querySelector<HTMLButtonElement>(
+        'button[aria-label^="Toggle skip-on-quota-exhaustion"]',
+      );
+
+    it('renders on the primary chip for a quota-capable subscription override and forwards clicks', () => {
+      const onQuotaSkipToggle = vi.fn();
+      const { container } = renderCard({ onQuotaSkipToggle });
+      const button = quotaButton(container);
+      expect(button).not.toBeNull();
+      expect(button!.getAttribute('aria-pressed')).toBe('false');
+      fireEvent.click(button!);
+      expect(onQuotaSkipToggle).toHaveBeenCalledWith(true);
+    });
+
+    it('reflects the stored flag via aria-pressed and the configured class', () => {
+      const flagged: HeaderTier = {
+        ...subTier,
+        override_route: { ...subTier.override_route!, skipWhenQuotaExhausted: true },
+      };
+      const { container } = renderCard({ onQuotaSkipToggle: vi.fn() }, flagged);
+      const button = quotaButton(container);
+      expect(button?.getAttribute('aria-pressed')).toBe('true');
+      expect(button?.classList.contains('routing-card__chip-action--configured')).toBe(true);
+    });
+
+    it('is hidden for api_key overrides', () => {
+      const { container } = renderCard({ onQuotaSkipToggle: vi.fn() }, baseTier);
+      expect(quotaButton(container)).toBeNull();
+    });
+
+    it('is hidden when no toggle handler is provided', () => {
+      const { container } = renderCard({});
+      expect(quotaButton(container)).toBeNull();
+    });
+  });
+
   it('shows the primary account chip for multi-account header tier routes', () => {
     const onOverride = vi.fn();
     const tierSub = {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -326,6 +326,7 @@ vi.mock('../../src/pages/RoutingDefaultTierSection.js', () => ({
       props.addingFallback,
       props.onOverride,
       props.onPinKey,
+      props.onQuotaSkipToggle,
       props.onReset,
       props.onFallbackUpdate,
       props.onAddFallback,
@@ -348,6 +349,14 @@ vi.mock('../../src/pages/RoutingDefaultTierSection.js', () => ({
           onClick={() => (props.onToggleComplexity as () => void)()}
         >
           toggle
+        </button>
+        <button
+          data-testid="default-quota-toggle"
+          onClick={() =>
+            (props.onQuotaSkipToggle as (id: string, enabled: boolean) => void)?.('default', true)
+          }
+        >
+          quota-toggle
         </button>
         <button
           data-testid="open-dropdown"
@@ -424,6 +433,7 @@ vi.mock('../../src/pages/RoutingSpecificitySection.js', () => ({
     changingResponseMode?: () => boolean;
     onResponseModeChange?: (mode: 'stream' | 'buffered') => void;
     onPinKey?: (cat: string, provider: string, label: string | null, authType?: string) => void;
+    onQuotaSkipToggle?: (cat: string, enabled: boolean) => void;
     setModelParams?: (
       scope: string,
       provider: string,
@@ -510,6 +520,24 @@ vi.mock('../../src/pages/RoutingSpecificitySection.js', () => ({
         spec-pin-key-missing-provider
       </button>
       <button
+        data-testid="spec-quota-toggle"
+        onClick={() => props.onQuotaSkipToggle?.('coding', true)}
+      >
+        spec-quota-toggle
+      </button>
+      <button
+        data-testid="spec-quota-toggle-off"
+        onClick={() => props.onQuotaSkipToggle?.('coding', false)}
+      >
+        spec-quota-toggle-off
+      </button>
+      <button
+        data-testid="spec-quota-toggle-missing-cat"
+        onClick={() => props.onQuotaSkipToggle?.('unknown-category', true)}
+      >
+        spec-quota-toggle-missing-cat
+      </button>
+      <button
         data-testid="spec-persist-params"
         onClick={() =>
           props.setModelParams?.('specificity:coding', 'deepseek', 'api_key', 'deepseek-v4', {
@@ -581,6 +609,7 @@ vi.mock('../../src/pages/RoutingTierCard.js', () => ({
       // getters (covers the onPinKey/onReset/onFallbackUpdate prop lines).
       props.onOverride,
       props.onPinKey,
+      props.onQuotaSkipToggle,
       props.onReset,
       props.onFallbackUpdate,
       props.onAddFallback,
@@ -593,6 +622,14 @@ vi.mock('../../src/pages/RoutingTierCard.js', () => ({
           onClick={() => (props.onDropdownOpen as (id: string) => void)('default')}
         >
           open
+        </button>
+        <button
+          data-testid="tier-card-quota-toggle"
+          onClick={() =>
+            (props.onQuotaSkipToggle as (id: string, enabled: boolean) => void)?.('default', true)
+          }
+        >
+          quota-toggle
         </button>
       </div>
     );
@@ -652,6 +689,12 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
           onClick={() => (props.onDisable as () => void)()}
         >
           disable
+        </button>
+        <button
+          data-testid={`clean-quota-${tier.id}`}
+          onClick={() => (props.onQuotaSkipToggle as (enabled: boolean) => void)?.(true)}
+        >
+          quota-toggle
         </button>
       </div>
     );
@@ -725,6 +768,7 @@ vi.mock('../../src/pages/RoutingPanels.js', () => ({
 
 const mockActionGetTier = vi.fn();
 const mockActionHandleOverride = vi.fn();
+const mockActionHandleQuotaSkipToggle = vi.fn();
 const mockActionHandleResetAll = vi.fn();
 const mockActionHandleReset = vi.fn();
 const mockActionHandleAddFallback = vi.fn();
@@ -738,6 +782,7 @@ vi.mock('../../src/pages/RoutingActions.js', () => ({
     getTier: (...args: unknown[]) => mockActionGetTier(...args),
     getFallbacksFor: () => [],
     handleOverride: (...args: unknown[]) => mockActionHandleOverride(...args),
+    handleQuotaSkipToggle: (...args: unknown[]) => mockActionHandleQuotaSkipToggle(...args),
     handleResetAll: (...args: unknown[]) => mockActionHandleResetAll(...args),
     handleReset: (...args: unknown[]) => mockActionHandleReset(...args),
     handleAddFallback: (...args: unknown[]) => mockActionHandleAddFallback(...args),
@@ -816,6 +861,15 @@ describe('Routing page', () => {
       expect(screen.getByTestId('spec-section')).toBeDefined();
       expect(screen.getByTestId('custom-section')).toBeDefined();
     });
+  });
+
+  it('threads the quota-skip toggle through the default section to the actions handler', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('default-quota-toggle')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('default-quota-toggle'));
+    expect(mockActionHandleQuotaSkipToggle).toHaveBeenCalledWith('default', true);
   });
 
   it('passes only enabled providers into the model picker path', async () => {
@@ -1329,6 +1383,110 @@ describe('Routing page', () => {
       });
       // No success toast on rejection
       expect(mockToastSuccess).not.toHaveBeenCalledWith('Pinned to "Work" key');
+    });
+  });
+
+  describe('handleSpecificityQuotaSkipToggle', () => {
+    const codingSubAssignment = {
+      id: 's1',
+      agent_id: 'a',
+      category: 'coding',
+      is_active: true,
+      override_route: {
+        provider: 'anthropic',
+        authType: 'subscription' as const,
+        model: 'claude-opus',
+      },
+      auto_assigned_route: null,
+      fallback_routes: [],
+      updated_at: '2025-01-01',
+    };
+
+    it('re-sends the current override with skipWhenQuotaExhausted=true', async () => {
+      mockGetSpecificityAssignments.mockResolvedValue([codingSubAssignment]);
+      mockOverrideSpecificity.mockResolvedValue(undefined);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('spec-quota-toggle')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('spec-quota-toggle'));
+      await waitFor(() => {
+        expect(mockOverrideSpecificity).toHaveBeenCalledWith(
+          'demo',
+          'coding',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          true,
+        );
+        expect(mockToastSuccess).toHaveBeenCalledWith('Route skipped on quota exhaustion');
+      });
+    });
+
+    it('re-sends the current override with skipWhenQuotaExhausted=false when disabling', async () => {
+      const flaggedAssignment = {
+        ...codingSubAssignment,
+        override_route: { ...codingSubAssignment.override_route, skipWhenQuotaExhausted: true },
+      };
+      mockGetSpecificityAssignments.mockResolvedValue([flaggedAssignment]);
+      mockOverrideSpecificity.mockResolvedValue(undefined);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('spec-quota-toggle-off')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('spec-quota-toggle-off'));
+      await waitFor(() => {
+        expect(mockOverrideSpecificity).toHaveBeenCalledWith(
+          'demo',
+          'coding',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          undefined,
+          false,
+        );
+        expect(mockToastSuccess).toHaveBeenCalledWith('Quota skip disabled');
+      });
+    });
+
+    it('does nothing when the assignment has no override route', async () => {
+      mockGetSpecificityAssignments.mockResolvedValue([
+        { ...codingSubAssignment, override_route: null },
+      ]);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('spec-quota-toggle')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('spec-quota-toggle'));
+      // Wait one tick to make sure no async overrideSpecificity call slips through
+      await new Promise((r) => setTimeout(r, 5));
+      expect(mockOverrideSpecificity).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the category does not match an existing assignment', async () => {
+      mockGetSpecificityAssignments.mockResolvedValue([codingSubAssignment]);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('spec-quota-toggle-missing-cat')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('spec-quota-toggle-missing-cat'));
+      await new Promise((r) => setTimeout(r, 5));
+      expect(mockOverrideSpecificity).not.toHaveBeenCalled();
+    });
+
+    it('swallows errors silently (toast handled upstream by fetchMutate)', async () => {
+      mockGetSpecificityAssignments.mockResolvedValue([codingSubAssignment]);
+      mockOverrideSpecificity.mockRejectedValue(new Error('boom'));
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('spec-quota-toggle')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('spec-quota-toggle'));
+      await waitFor(() => {
+        expect(mockOverrideSpecificity).toHaveBeenCalled();
+      });
+      expect(mockToastSuccess).not.toHaveBeenCalledWith('Route skipped on quota exhaustion');
     });
   });
 
@@ -2159,6 +2317,86 @@ describe('Routing page', () => {
       fireEvent.click(screen.getByTestId('clean-fb-routes-ht-1'));
       await new Promise((r) => setTimeout(r, 10));
       expect(mockListHeaderTiers).not.toHaveBeenCalled();
+    });
+
+    it('re-sends the header tier override with skipWhenQuotaExhausted when the toggle fires', async () => {
+      const subTier = {
+        ...cleanTier,
+        override_route: {
+          provider: 'anthropic',
+          authType: 'subscription' as const,
+          model: 'claude-opus',
+          keyLabel: 'Work',
+        },
+      };
+      mockListHeaderTiers.mockResolvedValue([subTier]);
+      mockOverrideHeaderTier.mockResolvedValue(undefined);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('clean-quota-ht-1')).toBeDefined();
+      });
+      mockListHeaderTiers.mockClear();
+      fireEvent.click(screen.getByTestId('clean-quota-ht-1'));
+      await waitFor(() => {
+        expect(mockOverrideHeaderTier).toHaveBeenCalledWith(
+          'demo',
+          'ht-1',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          'Work',
+          true,
+        );
+      });
+      // Success: refetch + toast.
+      await waitFor(() => {
+        expect(mockListHeaderTiers).toHaveBeenCalled();
+        expect(mockToastSuccess).toHaveBeenCalledWith('Route skipped on quota exhaustion');
+      });
+    });
+
+    it('toasts when the quota-skip toggle update fails', async () => {
+      const subTier = {
+        ...cleanTier,
+        override_route: {
+          provider: 'anthropic',
+          authType: 'subscription' as const,
+          model: 'claude-opus',
+        },
+      };
+      mockListHeaderTiers.mockResolvedValue([subTier]);
+      mockOverrideHeaderTier.mockRejectedValue(new Error('quota boom'));
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('clean-quota-ht-1')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('clean-quota-ht-1'));
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith('quota boom');
+      });
+      expect(mockToastSuccess).not.toHaveBeenCalledWith('Route skipped on quota exhaustion');
+    });
+
+    it('does nothing when the header tier has no override route', async () => {
+      // cleanTier.override_route is null — the handler returns early.
+      mockListHeaderTiers.mockResolvedValue([cleanTier]);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('clean-quota-ht-1')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('clean-quota-ht-1'));
+      await new Promise((r) => setTimeout(r, 5));
+      expect(mockOverrideHeaderTier).not.toHaveBeenCalled();
+    });
+
+    it('threads the quota-skip toggle into the default tier card and forwards to the actions handler', async () => {
+      mockListHeaderTiers.mockResolvedValue([]);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('tier-card-quota-toggle')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('tier-card-quota-toggle'));
+      expect(mockActionHandleQuotaSkipToggle).toHaveBeenCalledWith('default', true);
     });
 
     it('triggers the edit opener from a unified-view card', async () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -434,6 +434,14 @@ vi.mock('../../src/pages/RoutingSpecificitySection.js', () => ({
     onResponseModeChange?: (mode: 'stream' | 'buffered') => void;
     onPinKey?: (cat: string, provider: string, label: string | null, authType?: string) => void;
     onQuotaSkipToggle?: (cat: string, enabled: boolean) => void;
+    onOverride?: (
+      cat: string,
+      model: string,
+      provider: string,
+      authType?: string,
+      keyLabel?: string,
+      skipWhenQuotaExhausted?: boolean,
+    ) => void;
     setModelParams?: (
       scope: string,
       provider: string,
@@ -455,6 +463,14 @@ vi.mock('../../src/pages/RoutingSpecificitySection.js', () => ({
       </button>
       <button data-testid="spec-reset" onClick={() => props.onReset('coding')}>
         spec-reset
+      </button>
+      <button
+        data-testid="spec-override-quota-off"
+        onClick={() =>
+          props.onOverride?.('coding', 'claude', 'anthropic', 'subscription', undefined, false)
+        }
+      >
+        spec-override-quota-off
       </button>
       <button
         data-testid="spec-fb-update-add"
@@ -666,9 +682,10 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
         <button
           data-testid={`clean-fb-routes-${tier.id}`}
           onClick={() =>
-            (props.onFallbacksUpdate as (f: string[], r: unknown) => void)(['fb1'], [
-              { provider: 'openai', authType: 'api_key', model: 'fb1' },
-            ])
+            (props.onFallbacksUpdate as (f: string[], r: unknown) => void)(
+              ['fb1'],
+              [{ provider: 'openai', authType: 'api_key', model: 'fb1' }],
+            )
           }
         >
           fb-routes
@@ -681,7 +698,10 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
         >
           fb-noroutes
         </button>
-        <button data-testid={`clean-edit-${tier.id}`} onClick={() => (props.onEdit as () => void)()}>
+        <button
+          data-testid={`clean-edit-${tier.id}`}
+          onClick={() => (props.onEdit as () => void)()}
+        >
           edit
         </button>
         <button
@@ -704,12 +724,7 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
 vi.mock('../../src/components/ResponseModeModal.js', () => ({
   default: (props: Record<string, unknown>) => {
     // Read every prop so JSX attribute lines 711-723 are covered.
-    const _read = [
-      props.responseMode,
-      props.disabled,
-      props.tiers,
-      props.models,
-    ];
+    const _read = [props.responseMode, props.disabled, props.tiers, props.models];
     void _read;
     return (
       <div data-testid="response-mode-modal">
@@ -891,7 +906,9 @@ describe('Routing page', () => {
       expect(screen.getByTestId('default-section')).toBeDefined();
     });
 
-    const pickerProviders = (lastModalsProps!.connectedProviders as () => (typeof baseProvider)[])();
+    const pickerProviders = (
+      lastModalsProps!.connectedProviders as () => (typeof baseProvider)[]
+    )();
     expect(pickerProviders.map((provider) => provider.id)).toEqual(['p1']);
   });
 
@@ -1181,6 +1198,26 @@ describe('Routing page', () => {
         'anthropic',
         'api_key',
         undefined,
+      );
+    });
+  });
+
+  it('forwards an explicit false quota-skip value from a specificity fallback promotion', async () => {
+    mockOverrideSpecificity.mockResolvedValue(undefined);
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('spec-override-quota-off')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('spec-override-quota-off'));
+    await waitFor(() => {
+      expect(mockOverrideSpecificity).toHaveBeenCalledWith(
+        'demo',
+        'coding',
+        'claude',
+        'anthropic',
+        'subscription',
+        undefined,
+        false,
       );
     });
   });
@@ -1567,15 +1604,13 @@ describe('Routing page', () => {
   });
 
   it('keeps the routing page mounted when model refresh completes after a selection', async () => {
-    let resolveProviderRefresh!: (providers: typeof baseProvider[]) => void;
-    mockGetProviders
-      .mockResolvedValueOnce([baseProvider])
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveProviderRefresh = resolve;
-          }),
-      );
+    let resolveProviderRefresh!: (providers: (typeof baseProvider)[]) => void;
+    mockGetProviders.mockResolvedValueOnce([baseProvider]).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveProviderRefresh = resolve;
+        }),
+    );
 
     render(() => <Routing />);
     await waitFor(() => {
@@ -1870,9 +1905,9 @@ describe('Routing page', () => {
     // actions.getTier was consulted first with the category id.
     expect(mockActionGetTier).toHaveBeenCalledWith('coding');
     // Outer getTier maps the specificity row's category to tier and returns it.
-    const result = (lastModalsProps?.getTier as (id: string) => Record<string, unknown> | undefined)(
-      'coding',
-    );
+    const result = (
+      lastModalsProps?.getTier as (id: string) => Record<string, unknown> | undefined
+    )('coding');
     expect(result).toBeDefined();
     expect(result?.tier).toBe('coding');
     expect(result?.category).toBe('coding');
@@ -2146,7 +2181,7 @@ describe('Routing page', () => {
       fireEvent.click(screen.getByTestId('setup-done'));
       await waitFor(() => {
         expect(localStorage.getItem('setup_completed_demo')).toBe('1');
-        expect((lastSetupModalProps?.open as boolean)).toBe(false);
+        expect(lastSetupModalProps?.open as boolean).toBe(false);
       });
       expect(mockClearSetupPending).toHaveBeenCalledWith('demo');
       expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('false');

--- a/packages/frontend/tests/pages/RoutingActions.test.ts
+++ b/packages/frontend/tests/pages/RoutingActions.test.ts
@@ -482,4 +482,95 @@ describe("createRoutingActions", () => {
       expect(actions.getFallbacksFor("simple")).toEqual(["fb-1", "fb-2"]);
     });
   });
+
+  describe("handleQuotaSkipToggle", () => {
+    const tierWithSubOverride: TierAssignment = {
+      ...baseTier,
+      override_route: {
+        provider: "anthropic",
+        authType: "subscription",
+        model: "claude-opus",
+      },
+    };
+
+    it("re-sends the current override with skipWhenQuotaExhausted=true", async () => {
+      mockOverrideTier.mockResolvedValue({
+        ...tierWithSubOverride,
+        override_route: { ...tierWithSubOverride.override_route!, skipWhenQuotaExhausted: true },
+      });
+      const { actions } = setupActions([tierWithSubOverride]);
+      await actions.handleQuotaSkipToggle("simple", true);
+      expect(mockOverrideTier).toHaveBeenCalledWith(
+        "demo",
+        "simple",
+        "claude-opus",
+        "anthropic",
+        "subscription",
+        undefined,
+        true,
+      );
+      expect(mockToastSuccess).toHaveBeenCalledWith("Route skipped on quota exhaustion");
+      expect(actions.getTier("simple")?.override_route?.skipWhenQuotaExhausted).toBe(true);
+    });
+
+    it("disables the flag with skipWhenQuotaExhausted=false and updates state from the response", async () => {
+      const flagged: TierAssignment = {
+        ...tierWithSubOverride,
+        override_route: { ...tierWithSubOverride.override_route!, skipWhenQuotaExhausted: true },
+      };
+      mockOverrideTier.mockResolvedValue(tierWithSubOverride);
+      const { actions } = setupActions([flagged]);
+      await actions.handleQuotaSkipToggle("simple", false);
+      expect(mockOverrideTier).toHaveBeenCalledWith(
+        "demo",
+        "simple",
+        "claude-opus",
+        "anthropic",
+        "subscription",
+        undefined,
+        false,
+      );
+      expect(mockToastSuccess).toHaveBeenCalledWith("Quota skip disabled");
+      expect(actions.getTier("simple")?.override_route?.skipWhenQuotaExhausted).toBeUndefined();
+    });
+
+    it("threads the keyLabel pin through the re-sent override", async () => {
+      const pinned: TierAssignment = {
+        ...tierWithSubOverride,
+        override_route: { ...tierWithSubOverride.override_route!, keyLabel: "Work" },
+      };
+      mockOverrideTier.mockResolvedValue(pinned);
+      const { actions } = setupActions([pinned]);
+      await actions.handleQuotaSkipToggle("simple", true);
+      expect(mockOverrideTier).toHaveBeenCalledWith(
+        "demo",
+        "simple",
+        "claude-opus",
+        "anthropic",
+        "subscription",
+        "Work",
+        true,
+      );
+    });
+
+    it("returns silently when the tier has no override route", async () => {
+      const { actions } = setupActions();
+      await actions.handleQuotaSkipToggle("simple", true);
+      expect(mockOverrideTier).not.toHaveBeenCalled();
+    });
+
+    it("returns silently for unknown tier ids", async () => {
+      const { actions } = setupActions();
+      await actions.handleQuotaSkipToggle("unknown", true);
+      expect(mockOverrideTier).not.toHaveBeenCalled();
+    });
+
+    it("clears changingTier and skips the success toast when the override call rejects", async () => {
+      mockOverrideTier.mockRejectedValue(new Error("boom"));
+      const { actions } = setupActions([tierWithSubOverride]);
+      await actions.handleQuotaSkipToggle("simple", true);
+      expect(actions.changingTier()).toBeNull();
+      expect(mockToastSuccess).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../../src/pages/RoutingTierCard.js', () => ({
       props.persistParamDefaults,
       props.onParamDefaultsSaved,
       props.onPinKey,
+      props.onQuotaSkipToggle,
       props.getModelParams,
       props.setModelParams,
     ];
@@ -48,6 +49,14 @@ vi.mock('../../src/pages/RoutingTierCard.js', () => ({
           onClick={() => (props.onDropdownOpen as (id: string) => void)(stage.id)}
         >
           open
+        </button>
+        <button
+          data-testid={`quota-toggle-${stage.id}`}
+          onClick={() =>
+            (props.onQuotaSkipToggle as (id: string, enabled: boolean) => void)?.(stage.id, true)
+          }
+        >
+          quota-toggle
         </button>
       </div>
     );
@@ -235,5 +244,23 @@ describe('RoutingDefaultTierSection', () => {
     // No assertion needed beyond the render — the assignment getters are
     // exercised when the mock reads `props.tier` for each card.
     expect(screen.getByTestId('tier-card-simple')).toBeDefined();
+  });
+
+  it('threads onQuotaSkipToggle into the default card when complexity is off', () => {
+    const onQuotaSkipToggle = vi.fn();
+    render(() => <RoutingDefaultTierSection {...makeProps({ onQuotaSkipToggle })} />);
+    fireEvent.click(screen.getByTestId('quota-toggle-default'));
+    expect(onQuotaSkipToggle).toHaveBeenCalledWith('default', true);
+  });
+
+  it('threads onQuotaSkipToggle into the complexity tier cards when complexity is on', () => {
+    const onQuotaSkipToggle = vi.fn();
+    render(() => (
+      <RoutingDefaultTierSection
+        {...makeProps({ complexityEnabled: () => true, onQuotaSkipToggle })}
+      />
+    ));
+    fireEvent.click(screen.getByTestId('quota-toggle-simple'));
+    expect(onQuotaSkipToggle).toHaveBeenCalledWith('simple', true);
   });
 });

--- a/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
@@ -379,6 +379,25 @@ describe('RoutingHeaderTiersSection', () => {
       });
       expect(mockToastSuccess).not.toHaveBeenCalledWith('Route skipped on quota exhaustion');
     });
+
+    it('ignores a second toggle click while the first save is in flight', async () => {
+      let resolveSave: (v: unknown) => void = () => {};
+      mockOverrideHeaderTier.mockReturnValue(
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+      );
+      render(() => (
+        <RoutingHeaderTiersSection
+          {...makeProps({ externalTiers: () => [subTier], externalRefetch: vi.fn() })}
+        />
+      ));
+      fireEvent.click(screen.getByTestId('quota-toggle-ht-1'));
+      fireEvent.click(screen.getByTestId('quota-toggle-ht-1'));
+      expect(mockOverrideHeaderTier).toHaveBeenCalledTimes(1);
+      resolveSave(undefined);
+      await waitFor(() => expect(mockOverrideHeaderTier).toHaveBeenCalledTimes(1));
+    });
   });
 
   it('refetches when a card fires onFallbacksUpdate without routes (e.g. tier reset)', async () => {

--- a/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
@@ -101,6 +101,18 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
         >
           response-buffered
         </button>
+        <button
+          data-testid={`quota-toggle-${tier.id}`}
+          onClick={() => (props.onQuotaSkipToggle as (enabled: boolean) => void)?.(true)}
+        >
+          quota-toggle
+        </button>
+        <button
+          data-testid={`quota-toggle-off-${tier.id}`}
+          onClick={() => (props.onQuotaSkipToggle as (enabled: boolean) => void)?.(false)}
+        >
+          quota-toggle-off
+        </button>
       </div>
     );
   },
@@ -289,6 +301,83 @@ describe('RoutingHeaderTiersSection', () => {
     fireEvent.click(getByTestId('override-ht-1'));
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith('boom');
+    });
+  });
+
+  describe('quota skip toggle', () => {
+    const subTier: HeaderTier = {
+      ...tier1,
+      override_route: {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-opus',
+        keyLabel: 'Work',
+      },
+    };
+
+    it('re-sends the current override with skipWhenQuotaExhausted=true and refetches', async () => {
+      const externalRefetch = vi.fn();
+      render(() => (
+        <RoutingHeaderTiersSection
+          {...makeProps({ externalTiers: () => [subTier], externalRefetch })}
+        />
+      ));
+      fireEvent.click(screen.getByTestId('quota-toggle-ht-1'));
+      await waitFor(() => {
+        expect(mockOverrideHeaderTier).toHaveBeenCalledWith(
+          'demo',
+          'ht-1',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          'Work',
+          true,
+        );
+      });
+      await waitFor(() => {
+        expect(externalRefetch).toHaveBeenCalled();
+        expect(mockToastSuccess).toHaveBeenCalledWith('Route skipped on quota exhaustion');
+      });
+    });
+
+    it('disables the flag with skipWhenQuotaExhausted=false', async () => {
+      render(() => (
+        <RoutingHeaderTiersSection
+          {...makeProps({ externalTiers: () => [subTier], externalRefetch: vi.fn() })}
+        />
+      ));
+      fireEvent.click(screen.getByTestId('quota-toggle-off-ht-1'));
+      await waitFor(() => {
+        expect(mockOverrideHeaderTier).toHaveBeenCalledWith(
+          'demo',
+          'ht-1',
+          'claude-opus',
+          'anthropic',
+          'subscription',
+          'Work',
+          false,
+        );
+        expect(mockToastSuccess).toHaveBeenCalledWith('Quota skip disabled');
+      });
+    });
+
+    it('does nothing when the tier has no override route', async () => {
+      render(() => <RoutingHeaderTiersSection {...makeProps({ externalTiers: () => [tier1] })} />);
+      fireEvent.click(screen.getByTestId('quota-toggle-ht-1'));
+      await new Promise((r) => setTimeout(r, 5));
+      expect(mockOverrideHeaderTier).not.toHaveBeenCalled();
+    });
+
+    it('toasts an error when the quota-skip update fails', async () => {
+      mockOverrideHeaderTier.mockRejectedValue(new Error('boom'));
+      render(() => (
+        <RoutingHeaderTiersSection {...makeProps({ externalTiers: () => [subTier] })} />
+      ));
+      fireEvent.click(screen.getByTestId('quota-toggle-ht-1'));
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith('boom');
+      });
+      expect(mockToastSuccess).not.toHaveBeenCalledWith('Route skipped on quota exhaustion');
     });
   });
 

--- a/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
@@ -170,7 +170,9 @@ describe('RoutingSpecificitySection', () => {
   });
 
   it('renders the task-specific deprecation notice', () => {
-    render(() => <RoutingSpecificitySection {...makeProps({ assignments: () => [codingActive] })} />);
+    render(() => (
+      <RoutingSpecificitySection {...makeProps({ assignments: () => [codingActive] })} />
+    ));
     expect(screen.getByText("We're deprecating rule-based routing.")).toBeDefined();
   });
 
@@ -343,6 +345,35 @@ describe('RoutingSpecificitySection', () => {
     expect(mockClearSpecificityFallbacks).toHaveBeenCalledWith('demo', 'coding');
   });
 
+  it('forwards an explicit quota-skip value from a promoted fallback to the parent', () => {
+    const onOverride = vi.fn();
+    render(() => (
+      <RoutingSpecificitySection
+        {...makeProps({ assignments: () => [codingActive], onOverride })}
+      />
+    ));
+    const cardProps = tierCardCalls[tierCardCalls.length - 1];
+    (
+      cardProps.onOverride as (
+        category: string,
+        model: string,
+        provider: string,
+        authType?: string,
+        keyLabel?: string,
+        skipWhenQuotaExhausted?: boolean,
+      ) => void
+    )('coding', 'claude-opus', 'anthropic', 'subscription', undefined, false);
+
+    expect(onOverride).toHaveBeenCalledWith(
+      'coding',
+      'claude-opus',
+      'anthropic',
+      'subscription',
+      undefined,
+      false,
+    );
+  });
+
   it("getFallbacksFor on the tier card returns the assignment's fallback model names", () => {
     const assignment: SpecificityAssignment = {
       ...codingActive,
@@ -448,8 +479,7 @@ describe('RoutingSpecificitySection', () => {
     ));
     const cardProps = tierCardCalls[tierCardCalls.length - 1];
     const tier = (cardProps.tier as () => unknown)?.() as
-      | { tier: string; category: string }
-      | undefined;
+      { tier: string; category: string } | undefined;
     expect(tier?.tier).toBe('coding');
     expect(tier?.category).toBe('coding');
   });

--- a/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../../src/pages/RoutingTierCard.js', () => ({
       props.onFallbackUpdate,
       props.onAddFallback,
       props.onPinKey,
+      props.onQuotaSkipToggle,
       props.connectedProviders,
       props.persistFallbacks,
       props.persistClearFallbacks,
@@ -64,6 +65,14 @@ vi.mock('../../src/pages/RoutingTierCard.js', () => ({
     return (
       <div data-testid={`tier-card-${stage.id}`}>
         <span>{stage.label}</span>
+        <button
+          data-testid={`quota-toggle-${stage.id}`}
+          onClick={() =>
+            (props.onQuotaSkipToggle as (cat: string, enabled: boolean) => void)?.(stage.id, true)
+          }
+        >
+          quota-toggle
+        </button>
       </div>
     );
   },
@@ -147,6 +156,17 @@ describe('RoutingSpecificitySection', () => {
     ));
     expect(screen.getByTestId('tier-card-coding')).toBeDefined();
     expect(screen.queryByTestId('tier-card-trading')).toBeNull();
+  });
+
+  it('threads onQuotaSkipToggle into the tier cards', () => {
+    const onQuotaSkipToggle = vi.fn();
+    render(() => (
+      <RoutingSpecificitySection
+        {...makeProps({ assignments: () => [codingActiveWithRoute], onQuotaSkipToggle })}
+      />
+    ));
+    fireEvent.click(screen.getByTestId('quota-toggle-coding'));
+    expect(onQuotaSkipToggle).toHaveBeenCalledWith('coding', true);
   });
 
   it('renders the task-specific deprecation notice', () => {

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -501,7 +501,12 @@ describe('RoutingTierCard', () => {
       ...baseTier,
       fallback_routes: [
         { provider: 'anthropic', authType: 'subscription', model: 'claude' },
-        { provider: 'openai', authType: 'api_key', model: 'gpt-4o-mini' },
+        {
+          provider: 'openai',
+          authType: 'api_key',
+          model: 'gpt-4o-mini',
+          skipWhenQuotaExhausted: false,
+        },
       ],
     };
     const { container, getByTestId } = render(() => (
@@ -531,6 +536,7 @@ describe('RoutingTierCard', () => {
         'openai',
         'api_key',
         undefined,
+        false,
       );
     });
   });

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -442,8 +442,22 @@ describe('RoutingTierCard', () => {
   it('inserts the primary at slot 2 on drop, persisting both arrays', async () => {
     const onFallbackUpdate = vi.fn();
     const onOverride = vi.fn();
+    const tier: TierAssignment = {
+      ...baseTier,
+      fallback_routes: [
+        { ...baseTier.fallback_routes![0], skipWhenQuotaExhausted: false },
+        baseTier.fallback_routes![1],
+      ],
+    };
     const { getByTestId } = render(() => (
-      <RoutingTierCard {...makeProps({ onFallbackUpdate, onOverride })} />
+      <RoutingTierCard
+        {...makeProps({
+          tier: () => tier,
+          getFallbacksFor: () => tier.fallback_routes!.map((route) => route.model),
+          onFallbackUpdate,
+          onOverride,
+        })}
+      />
     ));
     // Slot 2 = end of list. The primary "gpt-4o" gets inserted at index 2,
     // then shifted out of position 0 → newFallbacks = ["claude", "gpt-4o"]
@@ -474,6 +488,7 @@ describe('RoutingTierCard', () => {
         'openai',
         'api_key',
         undefined,
+        false,
       );
     });
   });

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1476,4 +1476,73 @@ describe('providerIdForModel route-provider attribution', () => {
       );
     });
   });
+
+  describe('quota skip toggle', () => {
+    const anthropicSubTier: TierAssignment = {
+      ...baseTier,
+      override_route: { provider: 'anthropic', authType: 'subscription', model: 'claude' },
+    };
+
+    const quotaButton = (container: HTMLElement) =>
+      container.querySelector<HTMLButtonElement>(
+        'button[aria-label^="Toggle skip-on-quota-exhaustion"]',
+      );
+
+    it('renders on the primary chip for an anthropic subscription override and forwards toggles', () => {
+      const onQuotaSkipToggle = vi.fn();
+      const { container } = render(() => (
+        <RoutingTierCard {...makeProps({ tier: () => anthropicSubTier, onQuotaSkipToggle })} />
+      ));
+      const button = quotaButton(container);
+      expect(button).not.toBeNull();
+      expect(button!.getAttribute('aria-pressed')).toBe('false');
+      expect(button!.classList.contains('routing-card__chip-action--configured')).toBe(false);
+      fireEvent.click(button!);
+      expect(onQuotaSkipToggle).toHaveBeenCalledWith('simple', true);
+    });
+
+    it('reflects the stored flag on the override route via aria-pressed', () => {
+      const { container } = render(() => (
+        <RoutingTierCard
+          {...makeProps({
+            tier: () => ({
+              ...anthropicSubTier,
+              override_route: { ...anthropicSubTier.override_route!, skipWhenQuotaExhausted: true },
+            }),
+            onQuotaSkipToggle: vi.fn(),
+          })}
+        />
+      ));
+      const button = quotaButton(container);
+      expect(button?.getAttribute('aria-pressed')).toBe('true');
+      expect(button?.classList.contains('routing-card__chip-action--configured')).toBe(true);
+    });
+
+    it('is hidden for api_key overrides', () => {
+      const { container } = render(() => (
+        <RoutingTierCard {...makeProps({ onQuotaSkipToggle: vi.fn() })} />
+      ));
+      expect(quotaButton(container)).toBeNull();
+    });
+
+    it('is hidden for subscription overrides on providers without a quota endpoint', () => {
+      const geminiSubTier: TierAssignment = {
+        ...baseTier,
+        override_route: { provider: 'gemini', authType: 'subscription', model: 'gpt-4o' },
+      };
+      const { container } = render(() => (
+        <RoutingTierCard
+          {...makeProps({ tier: () => geminiSubTier, onQuotaSkipToggle: vi.fn() })}
+        />
+      ));
+      expect(quotaButton(container)).toBeNull();
+    });
+
+    it('is hidden when no toggle handler is provided', () => {
+      const { container } = render(() => (
+        <RoutingTierCard {...makeProps({ tier: () => anthropicSubTier })} />
+      ));
+      expect(quotaButton(container)).toBeNull();
+    });
+  });
 });

--- a/packages/frontend/tests/services/api/routing-routes.test.ts
+++ b/packages/frontend/tests/services/api/routing-routes.test.ts
@@ -53,6 +53,26 @@ describe('routing-routes dual-write API client', () => {
       });
     });
 
+    it('sends an explicit false quota-skip value so an existing flag can be cleared', async () => {
+      const fetchMock = setupFetch({});
+      await routing.overrideTier(
+        'my-agent',
+        'simple',
+        'gpt-4o',
+        'openai',
+        'api_key',
+        undefined,
+        false,
+      );
+
+      expect(lastBody(fetchMock).route).toEqual({
+        provider: 'openai',
+        authType: 'api_key',
+        model: 'gpt-4o',
+        skipWhenQuotaExhausted: false,
+      });
+    });
+
     it('omits the route key entirely when authType is not provided (legacy-only)', async () => {
       const fetchMock = setupFetch({});
       await routing.overrideTier('my-agent', 'simple', 'gpt-4o', 'openai');
@@ -96,9 +116,7 @@ describe('routing-routes dual-write API client', () => {
 
     it('drops `routes` defensively when length drifts from models', async () => {
       const fetchMock = setupFetch([]);
-      const routes: ModelRoute[] = [
-        { provider: 'openai', authType: 'api_key', model: 'm1' },
-      ];
+      const routes: ModelRoute[] = [{ provider: 'openai', authType: 'api_key', model: 'm1' }];
       await routing.setFallbacks('my-agent', 'simple', ['m1', 'm2'], routes);
 
       const body = lastBody(fetchMock);
@@ -138,6 +156,21 @@ describe('routing-routes dual-write API client', () => {
           model: 'claude-opus-4-6',
         },
       });
+    });
+
+    it('sends an explicit false quota-skip value so an existing flag can be cleared', async () => {
+      const fetchMock = setupFetch({});
+      await specificity.overrideSpecificity(
+        'my-agent',
+        'coding',
+        'claude-opus-4-6',
+        'anthropic',
+        'subscription',
+        undefined,
+        false,
+      );
+
+      expect(lastBody(fetchMock).route).toMatchObject({ skipWhenQuotaExhausted: false });
     });
 
     it('omits the route key entirely when authType is not provided', async () => {
@@ -209,6 +242,21 @@ describe('routing-routes dual-write API client', () => {
       });
     });
 
+    it('sends an explicit false quota-skip value so an existing flag can be cleared', async () => {
+      const fetchMock = setupFetch({});
+      await headerTiers.overrideHeaderTier(
+        'my-agent',
+        'ht-1',
+        'gpt-4o',
+        'OpenAI',
+        'api_key',
+        undefined,
+        false,
+      );
+
+      expect(lastBody(fetchMock).route).toMatchObject({ skipWhenQuotaExhausted: false });
+    });
+
     it('omits the route key entirely when authType is not provided', async () => {
       const fetchMock = setupFetch({});
       await headerTiers.overrideHeaderTier('my-agent', 'ht-1', 'gpt-4o', 'OpenAI');
@@ -220,7 +268,13 @@ describe('routing-routes dual-write API client', () => {
 
     it('PUTs to the header-tier override path with the encoded id', async () => {
       const fetchMock = setupFetch({});
-      await headerTiers.overrideHeaderTier('my-agent', 'ht with space', 'gpt-4o', 'OpenAI', 'api_key');
+      await headerTiers.overrideHeaderTier(
+        'my-agent',
+        'ht with space',
+        'gpt-4o',
+        'OpenAI',
+        'api_key',
+      );
       const [url, init] = fetchMock.mock.calls[0];
       // header-tier path uses /override suffix and encodes the id.
       expect(url).toContain('/routing/my-agent/header-tiers/ht%20with%20space/override');
@@ -252,9 +306,7 @@ describe('routing-routes dual-write API client', () => {
 
     it('drops `routes` defensively when lengths drift', async () => {
       const fetchMock = setupFetch([]);
-      const routes: ModelRoute[] = [
-        { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
-      ];
+      const routes: ModelRoute[] = [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o' }];
       await headerTiers.setHeaderTierFallbacks(
         'my-agent',
         'ht-1',

--- a/packages/shared/__tests__/model-route.spec.ts
+++ b/packages/shared/__tests__/model-route.spec.ts
@@ -260,6 +260,18 @@ describe('legacyToRoute / routeToLegacy round-trip', () => {
     expect(legacyToRoute(triple)).toEqual(route);
   });
 
+  it('preserves skipWhenQuotaExhausted: false through the round-trip', () => {
+    const route: ModelRoute = {
+      provider: 'anthropic',
+      authType: 'subscription',
+      model: 'claude-opus',
+      skipWhenQuotaExhausted: false,
+    };
+    const triple = routeToLegacy(route);
+    expect(triple.skipWhenQuotaExhausted).toBe(false);
+    expect(legacyToRoute(triple)).toEqual(route);
+  });
+
   it('preserves skipWhenQuotaExhausted through the round-trip', () => {
     const route: ModelRoute = {
       provider: 'anthropic',

--- a/packages/shared/__tests__/model-route.spec.ts
+++ b/packages/shared/__tests__/model-route.spec.ts
@@ -140,6 +140,44 @@ describe('isModelRoute', () => {
       false,
     );
   });
+
+  it('accepts a boolean skipWhenQuotaExhausted flag', () => {
+    expect(
+      isModelRoute({
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'm',
+        skipWhenQuotaExhausted: true,
+      }),
+    ).toBe(true);
+    expect(
+      isModelRoute({
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'm',
+        skipWhenQuotaExhausted: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a non-boolean skipWhenQuotaExhausted', () => {
+    expect(
+      isModelRoute({
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'm',
+        skipWhenQuotaExhausted: 'yes',
+      }),
+    ).toBe(false);
+    expect(
+      isModelRoute({
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'm',
+        skipWhenQuotaExhausted: 1,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('isModelRouteArray', () => {

--- a/packages/shared/__tests__/model-route.spec.ts
+++ b/packages/shared/__tests__/model-route.spec.ts
@@ -260,6 +260,18 @@ describe('legacyToRoute / routeToLegacy round-trip', () => {
     expect(legacyToRoute(triple)).toEqual(route);
   });
 
+  it('preserves skipWhenQuotaExhausted through the round-trip', () => {
+    const route: ModelRoute = {
+      provider: 'anthropic',
+      authType: 'subscription',
+      model: 'claude-opus',
+      skipWhenQuotaExhausted: true,
+    };
+    const triple = routeToLegacy(route);
+    expect(triple.skipWhenQuotaExhausted).toBe(true);
+    expect(legacyToRoute(triple)).toEqual(route);
+  });
+
   it('round-trips a missing route through null', () => {
     expect(legacyToRoute(routeToLegacy(null))).toBeNull();
   });

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -6,6 +6,7 @@ import {
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
   getSubscriptionCapabilities,
+  supportsQuotaCheck,
 } from '../src/subscription';
 
 describe('SUBSCRIPTION_PROVIDER_CONFIGS', () => {
@@ -648,5 +649,30 @@ describe('getSubscriptionCapabilities', () => {
 
   it('returns null for unsupported providers', () => {
     expect(getSubscriptionCapabilities('unknown')).toBeNull();
+  });
+});
+
+describe('supportsQuotaCheck', () => {
+  it('returns true for providers with a quota endpoint', () => {
+    expect(supportsQuotaCheck('anthropic')).toBe(true);
+    expect(supportsQuotaCheck('moonshot')).toBe(true);
+    expect(supportsQuotaCheck('openai')).toBe(true);
+    expect(supportsQuotaCheck('minimax')).toBe(true);
+    expect(supportsQuotaCheck('xai')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(supportsQuotaCheck('Anthropic')).toBe(true);
+    expect(supportsQuotaCheck('MOONSHOT')).toBe(true);
+  });
+
+  it('returns false for subscription providers without a quota endpoint', () => {
+    expect(supportsQuotaCheck('gemini')).toBe(false);
+    expect(supportsQuotaCheck('zai')).toBe(false);
+  });
+
+  it('returns false for unsupported providers', () => {
+    expect(supportsQuotaCheck('unknown')).toBe(false);
+    expect(supportsQuotaCheck('')).toBe(false);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -152,6 +152,7 @@ export {
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
   getSubscriptionCapabilities,
+  supportsQuotaCheck,
 } from './subscription';
 export type { SubscriptionCapabilities, SubscriptionProviderConfig } from './subscription';
 export type {

--- a/packages/shared/src/model-route.ts
+++ b/packages/shared/src/model-route.ts
@@ -78,7 +78,9 @@ export function legacyToRoute(triple: LegacyOverrideTriple): ModelRoute | null {
     authType: triple.authType,
     model: triple.model,
   };
-  if (triple.skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
+  if (triple.skipWhenQuotaExhausted != null) {
+    route.skipWhenQuotaExhausted = triple.skipWhenQuotaExhausted;
+  }
   return route;
 }
 
@@ -93,6 +95,8 @@ export function routeToLegacy(route: ModelRoute | null): LegacyOverrideTriple {
     provider: route.provider,
     authType: route.authType,
   };
-  if (route.skipWhenQuotaExhausted) triple.skipWhenQuotaExhausted = true;
+  if (route.skipWhenQuotaExhausted != null) {
+    triple.skipWhenQuotaExhausted = route.skipWhenQuotaExhausted;
+  }
   return triple;
 }

--- a/packages/shared/src/model-route.ts
+++ b/packages/shared/src/model-route.ts
@@ -5,6 +5,8 @@ export interface ModelRoute {
   authType: AuthType;
   model: string;
   keyLabel?: string | null;
+  /** Skip this route while the backing subscription connection's quota is exhausted. */
+  skipWhenQuotaExhausted?: boolean;
 }
 
 export function routeEquals(
@@ -40,6 +42,12 @@ export function isModelRoute(value: unknown): value is ModelRoute {
     v.keyLabel !== undefined &&
     v.keyLabel !== null &&
     typeof v.keyLabel !== 'string'
+  )
+    return false;
+  if (
+    'skipWhenQuotaExhausted' in v &&
+    v.skipWhenQuotaExhausted !== undefined &&
+    typeof v.skipWhenQuotaExhausted !== 'boolean'
   )
     return false;
   return true;

--- a/packages/shared/src/model-route.ts
+++ b/packages/shared/src/model-route.ts
@@ -61,6 +61,7 @@ export interface LegacyOverrideTriple {
   model: string | null;
   provider: string | null;
   authType: AuthType | null;
+  skipWhenQuotaExhausted?: boolean | null;
 }
 
 /**
@@ -72,11 +73,13 @@ export interface LegacyOverrideTriple {
 export function legacyToRoute(triple: LegacyOverrideTriple): ModelRoute | null {
   if (!triple.model) return null;
   if (!triple.provider || !triple.authType) return null;
-  return {
+  const route: ModelRoute = {
     provider: triple.provider,
     authType: triple.authType,
     model: triple.model,
   };
+  if (triple.skipWhenQuotaExhausted) route.skipWhenQuotaExhausted = true;
+  return route;
 }
 
 /**
@@ -85,9 +88,11 @@ export function legacyToRoute(triple: LegacyOverrideTriple): ModelRoute | null {
  */
 export function routeToLegacy(route: ModelRoute | null): LegacyOverrideTriple {
   if (!route) return { model: null, provider: null, authType: null };
-  return {
+  const triple: LegacyOverrideTriple = {
     model: route.model,
     provider: route.provider,
     authType: route.authType,
   };
+  if (route.skipWhenQuotaExhausted) triple.skipWhenQuotaExhausted = true;
+  return triple;
 }

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -30,6 +30,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       }),
       supportsPromptCaching: true,
       supportsBatching: false,
+      quotaCheck: true,
     }),
   }),
   byteplus: Object.freeze({
@@ -78,6 +79,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       }),
       supportsPromptCaching: true,
       supportsBatching: false,
+      quotaCheck: true,
     }),
   }),
   minimax: Object.freeze({
@@ -100,6 +102,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       maxContextWindow: 1000000,
       supportsPromptCaching: true,
       supportsBatching: false,
+      quotaCheck: true,
     }),
   }),
   mistral: Object.freeze({
@@ -166,6 +169,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       }),
       supportsPromptCaching: true,
       supportsBatching: false,
+      quotaCheck: true,
     }),
   }),
   nous: Object.freeze({
@@ -286,6 +290,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       maxContextWindow: 128000,
       supportsPromptCaching: true,
       supportsBatching: false,
+      quotaCheck: true,
     }),
   }),
   copilot: Object.freeze({

--- a/packages/shared/src/subscription/helpers.ts
+++ b/packages/shared/src/subscription/helpers.ts
@@ -42,3 +42,13 @@ export function getSubscriptionCapabilities(
   const config = getSubscriptionProviderConfig(providerId);
   return config?.subscriptionCapabilities ?? null;
 }
+
+/**
+ * Whether the provider exposes a usage/quota endpoint the backend can poll,
+ * so routes on its subscription connections can opt into being skipped while
+ * the quota is exhausted. Today: Anthropic, Moonshot (Kimi), OpenAI, MiniMax,
+ * and xAI (Grok).
+ */
+export function supportsQuotaCheck(providerId: string): boolean {
+  return getSubscriptionCapabilities(providerId)?.quotaCheck === true;
+}

--- a/packages/shared/src/subscription/index.ts
+++ b/packages/shared/src/subscription/index.ts
@@ -6,4 +6,5 @@ export {
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
   getSubscriptionCapabilities,
+  supportsQuotaCheck,
 } from './helpers';

--- a/packages/shared/src/subscription/types.ts
+++ b/packages/shared/src/subscription/types.ts
@@ -3,6 +3,8 @@ export interface SubscriptionCapabilities {
   modelContextWindows?: Readonly<Record<string, number>>;
   supportsPromptCaching: boolean;
   supportsBatching: boolean;
+  /** Provider exposes a usage/quota endpoint the router can poll. */
+  quotaCheck?: boolean;
 }
 
 export interface SubscriptionProviderConfig {


### PR DESCRIPTION
## Summary

Subscription providers with usage windows (Anthropic, Kimi, OpenAI, MiniMax, xAI) currently keep getting attempted on every request even when their quota is exhausted — each attempt fails with a quota/rate-limit error before the fallback chain engages, adding avoidable latency to every routed request.

This PR adds an opt-in **per-route "Skip on quota exhaustion"** flag: a new backend service polls each subscription connection's usage endpoint on an interval, and the router skips flagged routes while their connection is known to be exhausted.

### What changed

- **`ModelRoute` gains `skipWhenQuotaExhausted?: boolean`** (shared type; stored in the existing jsonb route columns — **no migration**). A `quotaCheck` capability on the shared subscription configs marks which providers expose a usable usage endpoint.
- **New `SubscriptionQuotaService`** (`routing/subscription-quota.service.ts`): polls every 60s (`SUBSCRIPTION_QUOTA_POLL_INTERVAL_MS`, clamped to ≥30s), in-memory state only, **fail-open everywhere** — fetch errors, unwrap failures, or missing data never skip a route, and a failed refresh keeps the previous state. Per provider:
  - Anthropic: `GET api.anthropic.com/api/oauth/usage` (5h/weekly/per-model windows, `utilization >= 100`)
  - Kimi: `GET api.kimi.com/coding/v1/usages` (5h/weekly/monthly, `used >= limit`)
  - OpenAI: `GET chatgpt.com/backend-api/wham/usage` (`used_percent >= 100`)
  - MiniMax: `GET <resource-origin>/v1/token_plan/remains` (remaining-percent `<= 0`)
  - xAI: `POST grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig` (gRPC-web + dependency-free protobuf scan)
  - OAuth tokens reuse the same unwrap/refresh path the proxy uses at request time.
- **`ResolveService`** skips flagged routes backed by an exhausted connection in both promotion paths (tier chain and header tiers), for **primaries and fallbacks alike**. A **never-empty safeguard** keeps the original chain when every candidate is exhausted, so a harness is never left unroutable.
- **Routing UI**: a compact gauge-icon toggle (matching the existing Parameters affordance) on quota-capable subscription routes — tier overrides, fallback rows, specificity and header-tier cards. Default off.

### For users

New "Skip on quota exhaustion" toggle on subscription routes in a harness's routing. When enabled, an exhausted connection's models are bypassed until the quota window resets, so requests reach a working fallback immediately.

### For operators

- No migration, no new dependencies, in-memory state only (re-polls from scratch at boot).
- Optional env knob `SUBSCRIPTION_QUOTA_POLL_INTERVAL_MS` (default 60000, min 30000).

### Notes

- **Kimi's `/coding/v1/usages` is undocumented** (reverse-engineered, used by several community tools); the parser is deliberately defensive (string numbers, window fallbacks).
- **The xAI parser relies on protobuf field heuristics** over gRPC-web (grok.com has no public usage API). It fails open if the schema changes. A regression fixture captured from a real live response is included in the spec.
- **Relation to #2378**: that PR adds a display-only usage endpoint; this one feeds routing decisions. Intentionally a standalone service (`subscription-quota.*`, not `subscription-usage.*`) to avoid conflicting with the unmerged PR — the fetchers could be unified later.
- `supportsQuotaCheck` (shared configs, drives UI visibility) and the backend service's provider list are two sources of truth to keep in sync when adding providers.

### Validation

- `npm test --workspace=packages/shared` — 429/429
- `npm test --workspace=packages/backend` — full suite 458/458 suites, 8413 tests
- Frontend: all touched/neighboring suites green (Routing, FallbackList, tier cards, header tiers)
- `npm run build` — clean; eslint clean on all changed files
- Live-verified all five providers' usage endpoints against real subscription connections on a self-hosted install, including the skip behavior end to end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips exhausted subscription routes during routing so requests hit working fallbacks faster. Previously every candidate was attempted even when its subscription was exhausted; now quota-capable routes can opt in to be skipped, with a safeguard that keeps chains non-empty.

- Adds skipWhenQuotaExhausted?: boolean to ModelRoute (stored in existing jsonb; no migration). PUT omitting the field preserves the stored flag; explicit false clears it; specificity swaps and fallback promotion retain it. DTOs whitelist the flag; tier, specificity, and header-tier controllers forward it.
- Introduces a quota poller service (`SubscriptionQuotaService` via `SubscriptionQuotaModule`) that polls Anthropic, Moonshot (Kimi), OpenAI, MiniMax, and xAI every 60s (`SUBSCRIPTION_QUOTA_POLL_INTERVAL_MS`, min 30s; digits-only). In-memory, fail-open; failed refresh keeps prior state; prunes deleted/disabled connections; reuses existing OAuth refresh.
- Router consults quota state for primaries and fallbacks across default tiers, specificity overrides, and header tiers; if all candidates are exhausted it keeps the original chain.
- UI adds a compact gauge-icon toggle on quota-capable subscription routes (primaries and fallbacks, including header tiers). Default off. Guards double-click races and in-flight saves.
- `manifest-shared` exposes `supportsQuotaCheck` and marks provider coverage. Docs and tests updated; no new runtime dependencies.

<sup>Written for commit ec6f4efa62c76120124e113fc468a1e9dd8b7676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

