### PR TITLE
fix(test): stop the message-log e2e counting rows before they land

### DIFF
--- a/packages/backend/test/message-log-completeness.e2e-spec.ts
+++ b/packages/backend/test/message-log-completeness.e2e-spec.ts
@@ -158,13 +158,20 @@ async function pendingRequestCount(): Promise<number> {
   return row.c;
 }
 
-/** Poll until the async recorders settle (streaming rows finish off-request). */
+/**
+ * Poll until the async recorders settle. Both writers run off-request:
+ * `recordSuccessMessage` is fired through `recordSafely()` without an await,
+ * so the HTTP response can land before its `agent_messages` row commits.
+ * Waits on `agent_messages` as well as `requests`, otherwise a slow runner
+ * counts one row short. Returns on timeout so the caller's assertions, not
+ * this helper, report the failure.
+ */
 async function settle(expected: number, timeoutMs = 15000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const c = await counts();
     const pending = await pendingRequestCount();
-    if (c.requests >= expected && pending === 0) return;
+    if (c.requests >= expected && c.messages >= expected && pending === 0) return;
     if (Date.now() > deadline) return;
     await new Promise((r) => setTimeout(r, 250));
   }
@@ -284,6 +291,7 @@ describe('Message log completeness — #2513 regression', () => {
     const statuses: number[] = [];
     for (let i = 0; i < N; i++) statuses.push(await fire());
     expect(statuses.every((s) => s === 200)).toBe(true);
+    await settle(N);
 
     const c = await counts();
     expect(c.requests).toBe(N);
@@ -298,6 +306,7 @@ describe('Message log completeness — #2513 regression', () => {
     const statuses: number[] = [];
     for (let i = 0; i < N; i++) statuses.push(await fire());
     expect(statuses.every((s) => s === 200)).toBe(true);
+    await settle(N);
 
     const c = await counts();
     expect(c.requests).toBe(N);
@@ -314,6 +323,7 @@ describe('Message log completeness — #2513 regression', () => {
     const statuses: number[] = [];
     for (let i = 0; i < N; i++) statuses.push(await fire({ traceparent }));
     expect(statuses.every((s) => s === 200)).toBe(true);
+    await settle(N);
 
     const c = await counts();
     expect(c.requests).toBe(N);


### PR DESCRIPTION
### ✨ What changed

`settle()` in `message-log-completeness.e2e-spec.ts` now polls `agent_messages` alongside `requests`, and the three non-streaming cases call it before counting.

### 💭 Why

`recordSuccessMessage` is fired through `recordSafely()` with no await (`proxy-response-handler.ts:858`), so a proxied request returns 200 before its `agent_messages` row commits. The non-streaming cases counted rows straight after the last request resolved, which is a race. The two streaming cases already called `settle()`.

It bit #2740, a frontend-only PR: `requests` was 12, `messages` was 11.
https://github.com/mnfst/manifest/actions/runs/32293147065/job/96198344308

### 📝 Notes

`settle()` still returns on timeout, so a genuine dedup regression fails on the assertion instead of hanging in the helper. Verified with tsc and prettier only, since the e2e suite needs Postgres and CI is the real check here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the message-log e2e from counting rows before async message writes land. Previously the tests asserted after the 200 responses, but `recordSuccessMessage` commits to `agent_messages` off-request, so counts could run one short on slow runners; now we wait for both tables before asserting.

- Update settle(...) to poll `agent_messages` and `requests` and return when both reach the expected count and there are no pending requests; still returns on timeout so failures surface in assertions.
- Call settle(N) in the three non-streaming cases before reading counts; streaming cases are unchanged.
- Scope: test-only change in `packages/backend/test/message-log-completeness.e2e-spec.ts`; slight test time increase possible on slow CI.

<sup>Written for commit 549c671b0ff1312ca9c79737ff0be760612bed60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

