### PR TITLE
feat: sync manifest subscription model lists (2026-08-20)

### DIFF
--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -219,6 +219,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionAuthMode: 'token' as const,
     subscriptionKeyPlaceholder: 'Paste your Z.ai API key',
     knownModels: Object.freeze([
+      'glm-5.3',
       'glm-5.2',
       'glm-5.1',
       'glm-5-turbo',


### PR DESCRIPTION
### ✨ What changed
- Adds `glm-5.3` to subscription `knownModels` in configs.ts.

### 💭 Why
Discovery found these subscription models served by the provider but missing from the curated `knownModels` list.

### 📝 Notes
- Smoke could not verify (zai): `glm-5.3` (HTTP 429: {"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}). Ids unverified by a live request.
- 168 new api_key models auto-discover at runtime, not listed here.
- Pricing (models.dev) and params (modelparams.dev) out of scope.
- Draft PR, auto-generated by the modelparams agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `glm-5.3` to the Z.ai subscription `knownModels` so it appears in model pickers and passes validation. Previously `glm-5.3` was not curated and relied on runtime discovery or manual entry.

- Single-line change in `packages/shared/src/subscription/configs.ts`; no pricing or parameter updates.
- Live verification is currently blocked by provider (HTTP 429: insufficient balance). Requests may fail on accounts without access; no migrations required.

<sup>Written for commit 48e20722853f5de143b0de83e679c469fc7c9cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

