### PR TITLE
fix: fall back after empty chat completions

### DIFF
--- a/.changeset/fallback-empty-chat-completions.md
+++ b/.changeset/fallback-empty-chat-completions.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Continue fallback routing when a non-streaming Chat Completions provider returns no output.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -123,6 +123,85 @@ describe('ProviderClient', () => {
       });
     });
 
+    it('turns an empty choices list into a provider failure', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ choices: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        apiMode: 'chat_completions',
+      });
+
+      expect(result.response.status).toBe(502);
+      await expect(result.response.json()).resolves.toMatchObject({
+        error: { code: 'empty_response' },
+      });
+    });
+
+    it('records an empty retry response against the retry attempt', async () => {
+      const retryBody = { choices: [] };
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              choices: [
+                {
+                  index: 0,
+                  message: { role: 'assistant', content: 'Initial response' },
+                  finish_reason: 'stop',
+                },
+              ],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(retryBody), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      const originalFinishRecording = jest.fn().mockResolvedValue(undefined);
+      const retryFinishRecording = jest.fn().mockResolvedValue(undefined);
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        apiMode: 'chat_completions',
+        attempt: {
+          id: 'attempt-original',
+          attemptNumber: 1,
+          startedAtMs: 0,
+          startedAt: new Date(0).toISOString(),
+          pendingWrite: Promise.resolve(true),
+          finishRecording: originalFinishRecording,
+        },
+      });
+      const retry = await result.retryWireBody!(body, {
+        id: 'attempt-retry',
+        attemptNumber: 2,
+        startedAtMs: 1,
+        startedAt: new Date(1).toISOString(),
+        pendingWrite: Promise.resolve(true),
+        finishRecording: retryFinishRecording,
+      });
+
+      expect(retry.response.status).toBe(502);
+      expect(originalFinishRecording).not.toHaveBeenCalled();
+      expect(retryFinishRecording).toHaveBeenCalledWith({ type: 'json', body: retryBody });
+    });
+
     it.each([
       ['content', { role: 'assistant', content: 'Hello' }],
       [

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -76,6 +76,156 @@ describe('ProviderClient', () => {
       expect(result.isAnthropic).toBe(false);
     });
 
+    it('turns an empty non-streaming Chat Completions response into a provider failure', async () => {
+      const upstreamBody = {
+        id: 'chatcmpl-empty',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: '', tool_calls: [] },
+            finish_reason: 'stop',
+          },
+        ],
+      };
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(upstreamBody), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      const finishRecording = jest.fn().mockResolvedValue(undefined);
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        apiMode: 'chat_completions',
+        attempt: {
+          id: 'attempt-empty',
+          attemptNumber: 1,
+          startedAtMs: 0,
+          startedAt: new Date(0).toISOString(),
+          pendingWrite: Promise.resolve(true),
+          finishRecording,
+        },
+      });
+
+      expect(result.response.status).toBe(502);
+      expect(finishRecording).toHaveBeenCalledWith({ type: 'json', body: upstreamBody });
+      await expect(result.response.json()).resolves.toEqual({
+        error: {
+          message: 'Upstream provider returned an empty Chat Completions response',
+          type: 'server_error',
+          code: 'empty_response',
+        },
+      });
+    });
+
+    it.each([
+      ['content', { role: 'assistant', content: 'Hello' }],
+      [
+        'tool call',
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'call-1',
+              type: 'function',
+              function: { name: 'get_weather', arguments: '{}' },
+            },
+          ],
+        },
+      ],
+      [
+        'provider output extension',
+        { role: 'assistant', content: null, reasoning_content: 'Done' },
+      ],
+      ['audio output', { role: 'assistant', content: null, audio: { id: 'audio-1' } }],
+    ])('keeps a Chat Completions response with %s', async (_label, message) => {
+      const upstream = new Response(
+        JSON.stringify({ choices: [{ index: 0, message, finish_reason: 'stop' }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+      mockFetch.mockResolvedValue(upstream);
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        apiMode: 'chat_completions',
+      });
+
+      expect(result.response).toBe(upstream);
+      expect(result.response.status).toBe(200);
+    });
+
+    it('leaves a malformed successful response unchanged', async () => {
+      const upstream = new Response('not-json', { status: 200 });
+      mockFetch.mockResolvedValue(upstream);
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        apiMode: 'chat_completions',
+      });
+
+      expect(result.response).toBe(upstream);
+    });
+
+    it('keeps an empty completion stopped by a content filter', async () => {
+      const upstream = new Response(
+        JSON.stringify({
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: null },
+              finish_reason: 'content_filter',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+      mockFetch.mockResolvedValue(upstream);
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        apiMode: 'chat_completions',
+      });
+
+      expect(result.response).toBe(upstream);
+    });
+
+    it('does not inspect streaming Chat Completions responses', async () => {
+      const upstream = new Response(
+        'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\ndata: [DONE]\n\n',
+        { status: 200, headers: { 'content-type': 'text/event-stream' } },
+      );
+      mockFetch.mockResolvedValue(upstream);
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: true,
+        apiMode: 'chat_completions',
+      });
+
+      expect(result.response).toBe(upstream);
+    });
+
     it('adds scoped prompt cache affinity for OpenAI without exposing the session', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -43,7 +43,12 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
 
   // Helper: invoke tryFallbacks with the 16-arg signature. Trailing args we
   // don't care about are passed as undefined.
-  const runFallbacks = (models: string[], routes: ModelRoute[] | null, primaryModel = 'gpt-4o') =>
+  const runFallbacks = (
+    models: string[],
+    routes: ModelRoute[] | null,
+    primaryModel = 'gpt-4o',
+    apiMode?: 'chat_completions' | 'responses' | 'messages',
+  ) =>
     service.tryFallbacks(
       'agent-1',
       'user-1',
@@ -57,7 +62,7 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
       undefined,
       undefined,
       undefined,
-      undefined,
+      apiMode,
       undefined,
       routes,
     );
@@ -188,6 +193,76 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
     expect(result.failures).toHaveLength(2);
     expect(result.failures.map((f) => f.status)).toEqual([429, 429]);
     expect(result.failures.map((f) => f.provider)).toEqual(['openai', 'anthropic']);
+  });
+
+  it('advances after a fallback returns HTTP 200 with an empty completion', async () => {
+    const realClient = new ProviderClient();
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const hostname = new URL(url).hostname;
+      if (hostname === 'api.openai.com') {
+        return new Response(
+          JSON.stringify({
+            id: 'chatcmpl-empty',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: null },
+                finish_reason: 'stop',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          id: 'chatcmpl-success',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Recovered' },
+              finish_reason: 'stop',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    global.fetch = fetchMock as typeof fetch;
+    providerClient.forward.mockImplementation((options) => realClient.forward(options));
+
+    try {
+      const routes: ModelRoute[] = [
+        route('openai', 'gpt-4o-mini'),
+        route('deepseek', 'deepseek-chat'),
+      ];
+      const result = await runFallbacks(
+        ['gpt-4o-mini', 'deepseek-chat'],
+        routes,
+        'primary-model',
+        'chat_completions',
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.success).toMatchObject({
+        fallbackIndex: 1,
+        provider: 'deepseek',
+        model: 'deepseek-chat',
+      });
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toMatchObject({
+        fallbackIndex: 0,
+        provider: 'openai',
+        status: 502,
+      });
+      expect(JSON.parse(result.failures[0].errorBody)).toMatchObject({
+        error: { code: 'empty_response' },
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 
   it('cooldowns repeated 429 attempts for the same provider key and model', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -216,6 +216,9 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
+      if (hostname !== 'api.deepseek.com') {
+        throw new Error(`Unexpected fallback hostname: ${hostname}`);
+      }
       return new Response(
         JSON.stringify({
           id: 'chatcmpl-success',

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -133,6 +133,52 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function hasChatCompletionOutput(message: Record<string, unknown>): boolean {
+  return Object.entries(message).some(([key, value]) => {
+    if (key === 'role' || value == null) return false;
+    if (typeof value === 'string' || Array.isArray(value)) return value.length > 0;
+    return true;
+  });
+}
+
+function isEmptyChatCompletion(body: unknown): boolean {
+  if (!isRecord(body) || !Array.isArray(body.choices) || body.choices.length === 0) return false;
+  return body.choices.every(
+    (choice) =>
+      isRecord(choice) &&
+      choice.finish_reason === 'stop' &&
+      isRecord(choice.message) &&
+      !hasChatCompletionOutput(choice.message),
+  );
+}
+
+async function qualifyEmptyChatCompletion(
+  response: Response,
+  attempt?: ProviderAttemptRef,
+): Promise<Response> {
+  if (response.status !== HttpStatus.OK) return response;
+
+  let body: unknown;
+  try {
+    body = await response.clone().json();
+  } catch {
+    return response;
+  }
+  if (!isEmptyChatCompletion(body)) return response;
+  await attempt?.finishRecording?.({ type: 'json', body });
+
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: 'Upstream provider returned an empty Chat Completions response',
+        type: 'server_error',
+        code: 'empty_response',
+      },
+    }),
+    { status: HttpStatus.BAD_GATEWAY, headers: { 'content-type': 'application/json' } },
+  );
+}
+
 function responsesTextFormat(
   body: Record<string, unknown>,
   apiMode: ForwardOptions['apiMode'],
@@ -373,15 +419,21 @@ export class ProviderClient {
         structuredOutputToolName,
         responsesTextFormat: textFormat,
       });
+      const response =
+        !stream &&
+        endpoint.format === 'openai' &&
+        (opts.apiMode === undefined || opts.apiMode === 'chat_completions')
+          ? await qualifyEmptyChatCompletion(result.response, opts.attempt)
+          : result.response;
       const qualifiedResult =
         endpointKey === 'openai-subscription'
           ? {
               ...result,
-              response: await qualifyChatGptResponse(result.response, {
+              response: await qualifyChatGptResponse(response, {
                 downstreamFormat: isResponses ? 'responses' : 'chat-completions',
               }),
             }
-          : result;
+          : { ...result, response };
       if (affinity) this.codexAffinity.capture(affinity.storeKey, qualifiedResult.response);
       return {
         ...qualifiedResult,

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -142,7 +142,7 @@ function hasChatCompletionOutput(message: Record<string, unknown>): boolean {
 }
 
 function isEmptyChatCompletion(body: unknown): boolean {
-  if (!isRecord(body) || !Array.isArray(body.choices) || body.choices.length === 0) return false;
+  if (!isRecord(body) || !Array.isArray(body.choices)) return false;
   return body.choices.every(
     (choice) =>
       isRecord(choice) &&
@@ -423,7 +423,7 @@ export class ProviderClient {
         !stream &&
         endpoint.format === 'openai' &&
         (opts.apiMode === undefined || opts.apiMode === 'chat_completions')
-          ? await qualifyEmptyChatCompletion(result.response, opts.attempt)
+          ? await qualifyEmptyChatCompletion(result.response, attempt)
           : result.response;
       const qualifiedResult =
         endpointKey === 'openai-subscription'


### PR DESCRIPTION
### ✨ What changed
- Treat empty non-streaming Chat Completions as provider failures.
- Preserve content, tool calls, policy stops, and streaming responses.
- Cover fallback advancement through the real provider client.

### 💭 Why
An HTTP 200 with no assistant output stopped the fallback chain.

### 👤 For users
Manifest now tries the next fallback after an empty completion.

### 📝 Notes
Closes #2709.

Supersedes #2716.

Credit to @RubenDarioGuerreroNeira for the original investigation and first implementation.
