### PR TITLE
feat(admin): scoped AI-admin API surface (mnfst_admin_ai_*) for self-hosted management

### DIFF
--- a/.changeset/agent-admin-api.md
+++ b/.changeset/agent-admin-api.md
@@ -1,0 +1,12 @@
+---
+'manifest': minor
+---
+
+Add a scoped AI-admin API surface (`/api/v1/admin`) for agent-native administration of a self-hosted Manifest install.
+
+- New `scope` column on `api_keys` (defaults to `owner`, additive — existing keys unchanged).
+- New `mnfst_admin_ai_*` key type minted as `api_keys` rows with `scope = 'ai_admin'`.
+- `AdminAiGuard` restricts the admin surface to those keys; the global `ApiKeyGuard` now stashes the resolved scope on the request.
+- `AdminController` manages admin keys (create/list/revoke) and a health endpoint, reusing existing `ApiKey`/`Tenant` services.
+
+This is the foundation for agents to administer agents, providers, and routing via API (a wanted capability for the "AI Agents that don't break" mission). Subsequent milestones (M2–M4) layer agent CRUD, provider-key attach + match-verify, and routing/usage read over the existing services.

--- a/.changeset/agent-admin-api.md
+++ b/.changeset/agent-admin-api.md
@@ -4,9 +4,13 @@
 
 Add a scoped AI-admin API surface (`/api/v1/admin`) for agent-native administration of a self-hosted Manifest install.
 
-- New `scope` column on `api_keys` (defaults to `owner`, additive — existing keys unchanged).
+- New `scope` column on `api_keys` (defaults to `owner`, additive — existing owner keys unchanged) and a `key_hash` column on `tenant_providers` (one-way hash of the stored provider key, for match-verify without ever returning the raw secret).
 - New `mnfst_admin_ai_*` key type minted as `api_keys` rows with `scope = 'ai_admin'`.
 - `AdminAiGuard` restricts the admin surface to those keys; the global `ApiKeyGuard` now stashes the resolved scope on the request.
-- `AdminController` manages admin keys (create/list/revoke) and a health endpoint, reusing existing `ApiKey`/`Tenant` services.
+- Controllers under `/api/v1/admin`:
+  - `AdminController` — admin key create/list/revoke + health.
+  - `AdminAgentController` — full agent CRUD (create, get, rename, rotate-key, duplicate, delete) over the existing lifecycle services.
+  - `AdminProviderController` — attach/update a provider key (custom + standard) and **match-verify** a posted key against the stored one-way hash (no raw secret returned).
+  - `AdminObservabilityController` — read-only per-agent/per-provider usage and agent routing visibility.
 
-This is the foundation for agents to administer agents, providers, and routing via API (a wanted capability for the "AI Agents that don't break" mission). Subsequent milestones (M2–M4) layer agent CRUD, provider-key attach + match-verify, and routing/usage read over the existing services.
+This is the foundation for agents to administer agents, providers, and routing via API (a wanted capability for the "AI Agents that don't break" mission). Provider-key writes now also persist `key_hash` so match-verify works.

--- a/packages/backend/src/admin/admin.module.ts
+++ b/packages/backend/src/admin/admin.module.ts
@@ -2,21 +2,56 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ApiKey } from '../entities/api-key.entity';
 import { Tenant } from '../entities/tenant.entity';
+import { Agent } from '../entities/agent.entity';
+import { AgentApiKey } from '../entities/agent-api-key.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { AdminController } from './controllers/admin.controller';
+import { AdminAgentController } from './controllers/admin-agent.controller';
+import { AdminProviderController } from './controllers/admin-provider.controller';
+import { AdminObservabilityController } from './controllers/admin-observability.controller';
 import { AdminKeyService } from './services/admin-key.service';
 import { AdminAiGuard } from './guards/admin-ai.guard';
+import { AgentLifecycleService } from '../analytics/services/agent-lifecycle.service';
+import { ApiKeyGeneratorService } from '../otlp/services/api-key.service';
+import { AgentDuplicationService } from '../analytics/services/agent-duplication.service';
+import { ProviderService } from '../routing/routing-core/provider.service';
+import { ProviderKeyService } from '../routing/routing-core/provider-key.service';
+import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
+import { TimeseriesQueriesService } from '../analytics/services/timeseries-queries.service';
+import { RoutingCacheService } from '../routing/routing-core/routing-cache.service';
+import { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
+import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
+import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
 
 /**
- * Scoped AI-administration surface. Mounts the AdminController (gated by
- * AdminAiGuard) and the AdminKeyService (mints/resolves `mnfst_admin_ai_*`
- * keys as `api_keys` rows with `scope = 'ai_admin'`). Depends only on the
- * ApiKey and Tenant entities, both already managed by the global TypeORM
- * feature list.
+ * Scoped AI-administration surface. Mounts the AdminController (key
+ * self-management) and AdminAgentController (agent CRUD over existing
+ * services), both gated by AdminAiGuard. Depends only on entities already
+ * managed by the global TypeORM feature list and services that are already
+ * singletons in the app — no new provider wiring beyond what those services
+ * themselves require.
  */
 @Module({
-  imports: [TypeOrmModule.forFeature([ApiKey, Tenant])],
-  controllers: [AdminController],
-  providers: [AdminKeyService, AdminAiGuard],
+  imports: [TypeOrmModule.forFeature([ApiKey, Tenant, Agent, AgentApiKey, AgentEnabledProvider])],
+  controllers: [AdminController, AdminAgentController, AdminProviderController, AdminObservabilityController],
+  providers: [
+    AdminKeyService,
+    AdminAiGuard,
+    AgentLifecycleService,
+    ApiKeyGeneratorService,
+    AgentDuplicationService,
+    ProviderService,
+    ProviderKeyService,
+    CustomProviderService,
+    TimeseriesQueriesService,
+    AdminObservabilityController,
+    RoutingCacheService,
+    ResolveAgentService,
+    ModelPricingCacheService,
+    ModelDiscoveryService,
+    IngestEventBusService,
+  ],
   exports: [AdminKeyService],
 })
 export class AdminModule {}

--- a/packages/backend/src/admin/admin.module.ts
+++ b/packages/backend/src/admin/admin.module.ts
@@ -2,56 +2,41 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ApiKey } from '../entities/api-key.entity';
 import { Tenant } from '../entities/tenant.entity';
-import { Agent } from '../entities/agent.entity';
-import { AgentApiKey } from '../entities/agent-api-key.entity';
-import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { AdminController } from './controllers/admin.controller';
 import { AdminAgentController } from './controllers/admin-agent.controller';
 import { AdminProviderController } from './controllers/admin-provider.controller';
 import { AdminObservabilityController } from './controllers/admin-observability.controller';
 import { AdminKeyService } from './services/admin-key.service';
 import { AdminAiGuard } from './guards/admin-ai.guard';
-import { AgentLifecycleService } from '../analytics/services/agent-lifecycle.service';
-import { ApiKeyGeneratorService } from '../otlp/services/api-key.service';
-import { AgentDuplicationService } from '../analytics/services/agent-duplication.service';
-import { ProviderService } from '../routing/routing-core/provider.service';
-import { ProviderKeyService } from '../routing/routing-core/provider-key.service';
-import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
-import { TimeseriesQueriesService } from '../analytics/services/timeseries-queries.service';
-import { RoutingCacheService } from '../routing/routing-core/routing-cache.service';
-import { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
-import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
-import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
-import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
+import { AnalyticsModule } from '../analytics/analytics.module';
+import { RoutingCoreModule } from '../routing/routing-core/routing-core.module';
+import { CustomProviderModule } from '../routing/custom-provider/custom-provider.module';
+import { OtlpModule } from '../otlp/otlp.module';
 
 /**
- * Scoped AI-administration surface. Mounts the AdminController (key
- * self-management) and AdminAgentController (agent CRUD over existing
- * services), both gated by AdminAiGuard. Depends only on entities already
- * managed by the global TypeORM feature list and services that are already
- * singletons in the app — no new provider wiring beyond what those services
- * themselves require.
+ * Admin API surface (`/api/v1/admin`). Thin layer over the existing
+ * analytics / routing-core / otlp services — those modules own the real
+ * business logic and are imported (not re-provided) so DI resolves cleanly.
+ *
+ * Only the admin-specific pieces are provided here:
+ *  - AdminKeyService mints `mnfst_admin_ai_*` keys (api_keys rows, scope=ai_admin).
+ *  - AdminAiGuard restricts the whole surface to that scope.
  */
 @Module({
-  imports: [TypeOrmModule.forFeature([ApiKey, Tenant, Agent, AgentApiKey, AgentEnabledProvider])],
-  controllers: [AdminController, AdminAgentController, AdminProviderController, AdminObservabilityController],
-  providers: [
-    AdminKeyService,
-    AdminAiGuard,
-    AgentLifecycleService,
-    ApiKeyGeneratorService,
-    AgentDuplicationService,
-    ProviderService,
-    ProviderKeyService,
-    CustomProviderService,
-    TimeseriesQueriesService,
-    AdminObservabilityController,
-    RoutingCacheService,
-    ResolveAgentService,
-    ModelPricingCacheService,
-    ModelDiscoveryService,
-    IngestEventBusService,
+  imports: [
+    TypeOrmModule.forFeature([ApiKey, Tenant]),
+    AnalyticsModule,
+    RoutingCoreModule,
+    CustomProviderModule,
+    OtlpModule,
   ],
+  controllers: [
+    AdminController,
+    AdminAgentController,
+    AdminProviderController,
+    AdminObservabilityController,
+  ],
+  providers: [AdminKeyService, AdminAiGuard],
   exports: [AdminKeyService],
 })
 export class AdminModule {}

--- a/packages/backend/src/admin/admin.module.ts
+++ b/packages/backend/src/admin/admin.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ApiKey } from '../entities/api-key.entity';
+import { Tenant } from '../entities/tenant.entity';
+import { AdminController } from './controllers/admin.controller';
+import { AdminKeyService } from './services/admin-key.service';
+import { AdminAiGuard } from './guards/admin-ai.guard';
+
+/**
+ * Scoped AI-administration surface. Mounts the AdminController (gated by
+ * AdminAiGuard) and the AdminKeyService (mints/resolves `mnfst_admin_ai_*`
+ * keys as `api_keys` rows with `scope = 'ai_admin'`). Depends only on the
+ * ApiKey and Tenant entities, both already managed by the global TypeORM
+ * feature list.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([ApiKey, Tenant])],
+  controllers: [AdminController],
+  providers: [AdminKeyService, AdminAiGuard],
+  exports: [AdminKeyService],
+})
+export class AdminModule {}

--- a/packages/backend/src/admin/controllers/admin-agent.controller.ts
+++ b/packages/backend/src/admin/controllers/admin-agent.controller.ts
@@ -1,0 +1,169 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
+import { AdminAiGuard } from '../guards/admin-ai.guard';
+import { AgentLifecycleService } from '../../analytics/services/agent-lifecycle.service';
+import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
+import { AgentDuplicationService } from '../../analytics/services/agent-duplication.service';
+import { ProviderService } from '../../routing/routing-core/provider.service';
+import { TimeseriesQueriesService } from '../../analytics/services/timeseries-queries.service';
+import { slugify } from '../../common/utils/slugify';
+import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
+import { CreateAgentDto } from '../../common/dto/create-agent.dto';
+import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
+import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
+
+/**
+ * Agent CRUD over the existing services, mounted under the admin surface.
+ * Reuses AgentLifecycleService / ApiKeyGeneratorService / AgentDuplicationService
+ * / ProviderService / TimeseriesQueriesService — no logic duplicated. The
+ * dashboard's AgentsController is the user-facing twin; this is the AI-admin
+ * twin, gated by AdminAiGuard.
+ *
+ * No handler returns a stored provider/harness secret. Agent ingest keys are
+ * only returned at creation/rotation/duplicate time (same as the dashboard).
+ */
+@Controller('api/v1/admin/agents')
+@UseGuards(AdminAiGuard)
+export class AdminAgentController {
+  constructor(
+    private readonly lifecycle: AgentLifecycleService,
+    private readonly apiKeyGenerator: ApiKeyGeneratorService,
+    private readonly duplication: AgentDuplicationService,
+    private readonly providerService: ProviderService,
+    private readonly timeseries: TimeseriesQueriesService,
+  ) {}
+
+  @Get()
+  async list(@TenantCtx() ctx: TenantContext, @Query('includePlayground') includePlayground?: string) {
+    const agents = await this.timeseries.getAgentList(ctx.tenantId, includePlayground === 'true');
+    return { agents };
+  }
+
+  @Post()
+  async create(@TenantCtx() ctx: TenantContext, @Body() body: CreateAgentDto) {
+    const slug = slugify(body.name);
+    if (!slug) throw new BadRequestException('Agent name produces an empty slug');
+    if (slug === PLAYGROUND_AGENT_SLUG) {
+      throw new BadRequestException('"Playground" is a reserved agent name');
+    }
+    const result = await this.apiKeyGenerator.onboardAgent({
+      tenantId: ctx.tenantId,
+      ownerUserId: ctx.userId,
+      agentName: slug,
+      displayName: body.name.trim(),
+      agentCategory: body.agent_category,
+      agentPlatform: body.agent_platform,
+      autofixEnabled: body.autofix_enabled,
+      recordMessages: body.record_messages,
+    });
+    // Providers are tenant-global + ON by default (mirrors dashboard create).
+    await this.providerService.enableAllProvidersForAgent(result.agentId, result.tenantId);
+    return {
+      agent: {
+        id: result.agentId,
+        name: slug,
+        display_name: body.name.trim(),
+        agent_category: body.agent_category ?? null,
+        agent_platform: body.agent_platform ?? null,
+      },
+      apiKey: result.apiKey,
+    };
+  }
+
+  @Get(':agentName')
+  async get(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
+    if (!info) return { agent: null };
+    return { agent: info };
+  }
+
+  @Get(':agentName/key')
+  async getKey(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
+    if (!info || !ctx.tenantId) return { keyPrefix: undefined };
+    const keyData = await this.apiKeyGenerator.getKeyForAgent(ctx.tenantId, agentName);
+    return { keyPrefix: keyData.keyPrefix, ...(keyData.fullKey ? { apiKey: keyData.fullKey } : {}) };
+  }
+
+  @Post(':agentName/rotate-key')
+  async rotateKey(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
+    if (!info || !ctx.tenantId) return { apiKey: undefined };
+    const result = await this.apiKeyGenerator.rotateKey(ctx.tenantId, agentName);
+    return { apiKey: result.apiKey };
+  }
+
+  @Patch(':agentName')
+  async update(
+    @TenantCtx() ctx: TenantContext,
+    @Param('agentName') agentName: string,
+    @Body() body: RenameAgentDto,
+  ) {
+    const result: Record<string, unknown> = {};
+    if (body.name) {
+      const slug = slugify(body.name);
+      if (!slug) throw new BadRequestException('Agent name produces an empty slug');
+      if (slug === PLAYGROUND_AGENT_SLUG) {
+        throw new BadRequestException('"Playground" is a reserved agent name');
+      }
+      const displayName = body.name.trim();
+      await this.lifecycle.renameAgent(ctx.tenantId, agentName, slug, displayName);
+      result['renamed'] = true;
+      result['name'] = slug;
+      result['display_name'] = displayName;
+    }
+    if (body.agent_category !== undefined || body.agent_platform !== undefined) {
+      await this.lifecycle.updateAgentType(
+        ctx.tenantId,
+        body.name ? slugify(body.name) : agentName,
+        { agent_category: body.agent_category, agent_platform: body.agent_platform },
+      );
+      if (body.agent_category !== undefined) result['agent_category'] = body.agent_category;
+      if (body.agent_platform !== undefined) result['agent_platform'] = body.agent_platform;
+    }
+    return result;
+  }
+
+  @Post(':agentName/duplicate')
+  async duplicate(
+    @TenantCtx() ctx: TenantContext,
+    @Param('agentName') sourceName: string,
+    @Body() body: DuplicateAgentDto,
+  ) {
+    const slug = slugify(body.name);
+    if (!slug) throw new BadRequestException('Agent name produces an empty slug');
+    if (slug === PLAYGROUND_AGENT_SLUG) {
+      throw new BadRequestException('"Playground" is a reserved agent name');
+    }
+    const displayName = body.name.trim();
+    const result = await this.duplication.duplicate(ctx.tenantId, sourceName, {
+      name: slug,
+      displayName,
+    });
+    return {
+      agent: { id: result.agentId, name: result.agentName, display_name: result.displayName },
+      apiKey: result.apiKey,
+      copied: result.copied,
+    };
+  }
+
+  @Delete(':agentName')
+  async remove(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
+    if (!info) throw new NotFoundException(`Agent "${agentName}" not found`);
+    await this.lifecycle.deleteAgent(ctx.tenantId, agentName);
+    return { deleted: true };
+  }
+}

--- a/packages/backend/src/admin/controllers/admin-agent.controller.ts
+++ b/packages/backend/src/admin/controllers/admin-agent.controller.ts
@@ -1,16 +1,22 @@
 import {
   Body,
+  ConflictException,
   Controller,
   Delete,
   Get,
+  Inject,
+  Logger,
+  NotFoundException,
   Param,
   Patch,
   Post,
   Query,
   UseGuards,
   BadRequestException,
-  NotFoundException,
 } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { AdminAiGuard } from '../guards/admin-ai.guard';
 import { AgentLifecycleService } from '../../analytics/services/agent-lifecycle.service';
@@ -18,6 +24,8 @@ import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { AgentDuplicationService } from '../../analytics/services/agent-duplication.service';
 import { ProviderService } from '../../routing/routing-core/provider.service';
 import { TimeseriesQueriesService } from '../../analytics/services/timeseries-queries.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
+import { agentListCacheKey } from '../../common/constants/cache.constants';
 import { slugify } from '../../common/utils/slugify';
 import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
@@ -32,21 +40,44 @@ import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
  * twin, gated by AdminAiGuard.
  *
  * No handler returns a stored provider/harness secret. Agent ingest keys are
- * only returned at creation/rotation/duplicate time (same as the dashboard).
+ * only returned at creation/rotation/duplicate time (same as the dashboard) —
+ * there is deliberately no readback route for the raw ingest key.
  */
 @Controller('api/v1/admin/agents')
 @UseGuards(AdminAiGuard)
 export class AdminAgentController {
+  private readonly logger = new Logger(AdminAgentController.name);
+
   constructor(
     private readonly lifecycle: AgentLifecycleService,
     private readonly apiKeyGenerator: ApiKeyGeneratorService,
     private readonly duplication: AgentDuplicationService,
     private readonly providerService: ProviderService,
     private readonly timeseries: TimeseriesQueriesService,
+    private readonly eventBus: IngestEventBusService,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
+  // Same two canonical agent-list cache entries the dashboard invalidates after
+  // a mutation; without this an admin-driven create/rename/delete leaves the
+  // workspace list stale for the dashboard TTL.
+  private async invalidateAgentListCache(tenantId: string | null): Promise<void> {
+    if (!tenantId) return;
+    await Promise.all([
+      this.cacheManager.del(agentListCacheKey(tenantId, false)),
+      this.cacheManager.del(agentListCacheKey(tenantId, true)),
+    ]);
+  }
+
+  private emitAgentEvent(tenantId: string | null, userId: string | null): void {
+    if (tenantId) this.eventBus.emit(tenantId, 'agent', userId);
+  }
+
   @Get()
-  async list(@TenantCtx() ctx: TenantContext, @Query('includePlayground') includePlayground?: string) {
+  async list(
+    @TenantCtx() ctx: TenantContext,
+    @Query('includePlayground') includePlayground?: string,
+  ) {
     const agents = await this.timeseries.getAgentList(ctx.tenantId, includePlayground === 'true');
     return { agents };
   }
@@ -58,18 +89,50 @@ export class AdminAgentController {
     if (slug === PLAYGROUND_AGENT_SLUG) {
       throw new BadRequestException('"Playground" is a reserved agent name');
     }
-    const result = await this.apiKeyGenerator.onboardAgent({
-      tenantId: ctx.tenantId,
-      ownerUserId: ctx.userId,
-      agentName: slug,
-      displayName: body.name.trim(),
-      agentCategory: body.agent_category,
-      agentPlatform: body.agent_platform,
-      autofixEnabled: body.autofix_enabled,
-      recordMessages: body.record_messages,
-    });
+    let result;
+    try {
+      result = await this.apiKeyGenerator.onboardAgent({
+        tenantId: ctx.tenantId,
+        ownerUserId: ctx.userId,
+        agentName: slug,
+        displayName: body.name.trim(),
+        agentCategory: body.agent_category,
+        agentPlatform: body.agent_platform,
+        autofixEnabled: body.autofix_enabled,
+        recordMessages: body.record_messages,
+      });
+    } catch (error) {
+      // Mirror the dashboard create path: surface duplicate slugs as 409, not
+      // a raw unique-constraint 500.
+      if (error instanceof QueryFailedError && /unique|duplicate/i.test(error.message)) {
+        throw new ConflictException(`Agent "${slug}" already exists`);
+      }
+      throw error;
+    }
     // Providers are tenant-global + ON by default (mirrors dashboard create).
-    await this.providerService.enableAllProvidersForAgent(result.agentId, result.tenantId);
+    // This runs outside the onboarding transaction; on failure compensate by
+    // removing the just-created agent instead of leaving a routable agent with
+    // zero enabled providers.
+    try {
+      await this.providerService.enableAllProvidersForAgent(result.agentId, result.tenantId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to enable providers for new admin-created agent "${slug}" (${result.agentId}); rolling back agent creation`,
+        error instanceof Error ? error.stack : String(error),
+      );
+      try {
+        await this.lifecycle.deleteAgent(result.tenantId, slug);
+      } catch (cleanupError) {
+        this.logger.error(
+          `Compensating cleanup failed for admin-created agent "${slug}" (${result.agentId}); it may be left without providers`,
+          cleanupError instanceof Error ? cleanupError.stack : String(cleanupError),
+        );
+      }
+      await this.invalidateAgentListCache(result.tenantId);
+      throw error;
+    }
+    await this.invalidateAgentListCache(result.tenantId);
+    this.emitAgentEvent(result.tenantId, ctx.userId);
     return {
       agent: {
         id: result.agentId,
@@ -85,22 +148,28 @@ export class AdminAgentController {
   @Get(':agentName')
   async get(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
     const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
-    if (!info) return { agent: null };
+    if (!info) throw new NotFoundException(`Agent "${agentName}" not found`);
     return { agent: info };
   }
 
+  /**
+   * Prefix-only readback. The raw ingest key stays a one-time response at
+   * create/rotate/duplicate — use rotate-key to re-mint. (The dashboard's
+   * GET key handler can decrypt and return the full key; this admin twin
+   * intentionally does not.)
+   */
   @Get(':agentName/key')
   async getKey(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
     const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
-    if (!info || !ctx.tenantId) return { keyPrefix: undefined };
+    if (!info || !ctx.tenantId) throw new NotFoundException(`Agent "${agentName}" not found`);
     const keyData = await this.apiKeyGenerator.getKeyForAgent(ctx.tenantId, agentName);
-    return { keyPrefix: keyData.keyPrefix, ...(keyData.fullKey ? { apiKey: keyData.fullKey } : {}) };
+    return { keyPrefix: keyData.keyPrefix };
   }
 
   @Post(':agentName/rotate-key')
   async rotateKey(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
     const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
-    if (!info || !ctx.tenantId) return { apiKey: undefined };
+    if (!info || !ctx.tenantId) throw new NotFoundException(`Agent "${agentName}" not found`);
     const result = await this.apiKeyGenerator.rotateKey(ctx.tenantId, agentName);
     return { apiKey: result.apiKey };
   }
@@ -119,7 +188,14 @@ export class AdminAgentController {
         throw new BadRequestException('"Playground" is a reserved agent name');
       }
       const displayName = body.name.trim();
-      await this.lifecycle.renameAgent(ctx.tenantId, agentName, slug, displayName);
+      try {
+        await this.lifecycle.renameAgent(ctx.tenantId, agentName, slug, displayName);
+      } catch (error) {
+        if (error instanceof QueryFailedError && /unique|duplicate/i.test(error.message)) {
+          throw new ConflictException(`Agent "${slug}" already exists`);
+        }
+        throw error;
+      }
       result['renamed'] = true;
       result['name'] = slug;
       result['display_name'] = displayName;
@@ -133,6 +209,8 @@ export class AdminAgentController {
       if (body.agent_category !== undefined) result['agent_category'] = body.agent_category;
       if (body.agent_platform !== undefined) result['agent_platform'] = body.agent_platform;
     }
+    await this.invalidateAgentListCache(ctx.tenantId);
+    this.emitAgentEvent(ctx.tenantId, ctx.userId);
     return result;
   }
 
@@ -148,10 +226,20 @@ export class AdminAgentController {
       throw new BadRequestException('"Playground" is a reserved agent name');
     }
     const displayName = body.name.trim();
-    const result = await this.duplication.duplicate(ctx.tenantId, sourceName, {
-      name: slug,
-      displayName,
-    });
+    let result;
+    try {
+      result = await this.duplication.duplicate(ctx.tenantId, sourceName, {
+        name: slug,
+        displayName,
+      });
+    } catch (error) {
+      if (error instanceof QueryFailedError && /unique|duplicate/i.test(error.message)) {
+        throw new ConflictException(`Agent "${slug}" already exists`);
+      }
+      throw error;
+    }
+    await this.invalidateAgentListCache(ctx.tenantId);
+    this.emitAgentEvent(ctx.tenantId, ctx.userId);
     return {
       agent: { id: result.agentId, name: result.agentName, display_name: result.displayName },
       apiKey: result.apiKey,
@@ -164,6 +252,8 @@ export class AdminAgentController {
     const info = await this.lifecycle.findAgentInfo(ctx.tenantId, agentName);
     if (!info) throw new NotFoundException(`Agent "${agentName}" not found`);
     await this.lifecycle.deleteAgent(ctx.tenantId, agentName);
+    await this.invalidateAgentListCache(ctx.tenantId);
+    this.emitAgentEvent(ctx.tenantId, ctx.userId);
     return { deleted: true };
   }
 }

--- a/packages/backend/src/admin/controllers/admin-observability.controller.ts
+++ b/packages/backend/src/admin/controllers/admin-observability.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  NotFoundException,
+} from '@nestjs/common';
+import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
+import { AdminAiGuard } from '../guards/admin-ai.guard';
+import { TimeseriesQueriesService } from '../../analytics/services/timeseries-queries.service';
+import { ResolveAgentService } from '../../routing/routing-core/resolve-agent.service';
+import { ProviderService } from '../../routing/routing-core/provider.service';
+import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+/**
+ * Read-only observability + routing visibility under the admin surface.
+ * Reuses TimeseriesQueriesService (same read methods the dashboard's Overview
+ * uses) and ResolveAgentService/ProviderService for routing summaries. No
+ * writes; purely informational for agent administration.
+ */
+@Controller('api/v1/admin/observability')
+@UseGuards(AdminAiGuard)
+export class AdminObservabilityController {
+  constructor(
+    private readonly timeseries: TimeseriesQueriesService,
+    private readonly resolveAgent: ResolveAgentService,
+    private readonly providerService: ProviderService,
+    @InjectRepository(AgentEnabledProvider)
+    private readonly enabledProviderRepo: Repository<AgentEnabledProvider>,
+  ) {}
+
+  @Get('usage')
+  async usage(
+    @TenantCtx() ctx: TenantContext,
+    @Query('range') range?: string,
+    @Query('hourly') hourly?: string,
+  ) {
+    if (!ctx.tenantId) return { series: [] };
+    const r = (range as never) ?? '24h';
+    const perAgent = await this.timeseries.getPerAgentTimeseries(r, ctx.tenantId, hourly === 'true');
+    const perProvider = await this.timeseries.getPerProviderTimeseries(
+      r,
+      ctx.tenantId,
+      hourly === 'true',
+    );
+    return { perAgent, perProvider };
+  }
+
+  @Get('agents/:agentName/routing')
+  async agentRouting(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    if (!ctx.tenantId) throw new NotFoundException('No tenant context');
+    const agent = await this.resolveAgent.resolve(ctx.tenantId, agentName);
+    const allProviders = this.providerService.getProviders(ctx.tenantId);
+    const enabled = await this.enabledProviderRepo.find({ where: { agent_id: agent.id } });
+    const enabledIds = new Set(enabled.map((e) => e.tenant_provider_id));
+    const providers = (await allProviders).map((p) => ({
+      provider: p.provider,
+      auth_type: p.auth_type,
+      label: p.label,
+      is_active: p.is_active,
+      enabled_for_agent: enabledIds.has(p.id),
+    }));
+    return {
+      agent: { id: agent.id, name: agent.name, display_name: agent.display_name },
+      providers,
+    };
+  }
+}

--- a/packages/backend/src/admin/controllers/admin-observability.controller.ts
+++ b/packages/backend/src/admin/controllers/admin-observability.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  Get,
-  Param,
-  Query,
-  UseGuards,
-  NotFoundException,
-} from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards, NotFoundException } from '@nestjs/common';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { AdminAiGuard } from '../guards/admin-ai.guard';
 import { TimeseriesQueriesService } from '../../analytics/services/timeseries-queries.service';
@@ -40,12 +33,12 @@ export class AdminObservabilityController {
   ) {
     if (!ctx.tenantId) return { series: [] };
     const r = (range as never) ?? '24h';
-    const perAgent = await this.timeseries.getPerAgentTimeseries(r, ctx.tenantId, hourly === 'true');
-    const perProvider = await this.timeseries.getPerProviderTimeseries(
-      r,
-      ctx.tenantId,
-      hourly === 'true',
-    );
+    // Independent reads — run concurrently instead of serializing two
+    // potentially expensive timeseries scans.
+    const [perAgent, perProvider] = await Promise.all([
+      this.timeseries.getPerAgentTimeseries(r, ctx.tenantId, hourly === 'true'),
+      this.timeseries.getPerProviderTimeseries(r, ctx.tenantId, hourly === 'true'),
+    ]);
     return { perAgent, perProvider };
   }
 

--- a/packages/backend/src/admin/controllers/admin-provider.controller.ts
+++ b/packages/backend/src/admin/controllers/admin-provider.controller.ts
@@ -8,6 +8,7 @@ import {
   BadRequestException,
   NotFoundException,
 } from '@nestjs/common';
+import { IsOptional, IsString } from 'class-validator';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { AdminAiGuard } from '../guards/admin-ai.guard';
 import { ProviderService } from '../../routing/routing-core/provider.service';
@@ -15,12 +16,16 @@ import { ProviderKeyService } from '../../routing/routing-core/provider-key.serv
 import { CustomProviderService } from '../../routing/custom-provider/custom-provider.service';
 
 class AttachProviderKeyDto {
+  @IsString()
   apiKey!: string;
+  @IsOptional()
   authType?: 'api_key' | 'subscription' | 'local';
+  @IsOptional()
   label?: string;
 }
 
 class VerifyProviderKeyDto {
+  @IsString()
   apiKey!: string;
 }
 

--- a/packages/backend/src/admin/controllers/admin-provider.controller.ts
+++ b/packages/backend/src/admin/controllers/admin-provider.controller.ts
@@ -8,7 +8,7 @@ import {
   BadRequestException,
   NotFoundException,
 } from '@nestjs/common';
-import { IsOptional, IsString } from 'class-validator';
+import { IsIn, IsOptional, IsString } from 'class-validator';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { AdminAiGuard } from '../guards/admin-ai.guard';
 import { ProviderService } from '../../routing/routing-core/provider.service';
@@ -19,6 +19,7 @@ class AttachProviderKeyDto {
   @IsString()
   apiKey!: string;
   @IsOptional()
+  @IsIn(['api_key', 'subscription', 'local'])
   authType?: 'api_key' | 'subscription' | 'local';
   @IsOptional()
   label?: string;
@@ -60,7 +61,11 @@ export class AdminProviderController {
         auth_type: p.auth_type,
         label: p.label,
         key_prefix: p.key_prefix,
-        has_key: !!p.key_hash,
+        // `key_hash` only exists on rows connected after that column was added;
+        // legacy connections still carry the credential in the encrypted
+        // column. Report presence from either so upgraded tenants don't see
+        // phantom "no key" rows.
+        has_key: !!p.key_hash || !!p.api_key_encrypted,
         priority: p.priority,
         is_active: p.is_active,
       })),
@@ -79,7 +84,12 @@ export class AdminProviderController {
       const id = CustomProviderService.extractId(provider);
       const cp = await this.customProviderService.getById(id, ctx.tenantId);
       if (!cp) throw new NotFoundException(`Custom provider ${provider} not found`);
-      await this.customProviderService.update(id, ctx.tenantId, { apiKey: body.apiKey }, ctx.userId);
+      await this.customProviderService.update(
+        id,
+        ctx.tenantId,
+        { apiKey: body.apiKey },
+        ctx.userId,
+      );
     } else {
       await this.providerService.upsertProvider(
         null,

--- a/packages/backend/src/admin/controllers/admin-provider.controller.ts
+++ b/packages/backend/src/admin/controllers/admin-provider.controller.ts
@@ -1,0 +1,108 @@
+import {
+  Body,
+  Controller,
+  Param,
+  Post,
+  Get,
+  UseGuards,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
+import { AdminAiGuard } from '../guards/admin-ai.guard';
+import { ProviderService } from '../../routing/routing-core/provider.service';
+import { ProviderKeyService } from '../../routing/routing-core/provider-key.service';
+import { CustomProviderService } from '../../routing/custom-provider/custom-provider.service';
+
+class AttachProviderKeyDto {
+  apiKey!: string;
+  authType?: 'api_key' | 'subscription' | 'local';
+  label?: string;
+}
+
+class VerifyProviderKeyDto {
+  apiKey!: string;
+}
+
+/**
+ * Provider-key administration under the admin surface.
+ *
+ * - Attach/update a provider key (custom providers route through
+ *   CustomProviderService; standard providers through ProviderService.upsert,
+ *   which now also writes key_hash).
+ * - Match-verify a posted key against the stored one-way hash — the API never
+ *   returns the raw secret (your locked decision).
+ *
+ * Read listing reuses the existing tenant_providers read path.
+ */
+@Controller('api/v1/admin/providers')
+@UseGuards(AdminAiGuard)
+export class AdminProviderController {
+  constructor(
+    private readonly providerService: ProviderService,
+    private readonly providerKeyService: ProviderKeyService,
+    private readonly customProviderService: CustomProviderService,
+  ) {}
+
+  @Get()
+  async list(@TenantCtx() ctx: TenantContext) {
+    if (!ctx.tenantId) return { providers: [] };
+    const providers = await this.providerService.getProviders(ctx.tenantId);
+    return {
+      providers: providers.map((p) => ({
+        id: p.id,
+        provider: p.provider,
+        auth_type: p.auth_type,
+        label: p.label,
+        key_prefix: p.key_prefix,
+        has_key: !!p.key_hash,
+        priority: p.priority,
+        is_active: p.is_active,
+      })),
+    };
+  }
+
+  @Post(':provider/keys')
+  async attachKey(
+    @TenantCtx() ctx: TenantContext,
+    @Param('provider') provider: string,
+    @Body() body: AttachProviderKeyDto,
+  ) {
+    if (!ctx.tenantId) throw new NotFoundException('No tenant context');
+    if (!body?.apiKey) throw new BadRequestException('apiKey is required');
+    if (CustomProviderService.isCustom(provider)) {
+      const id = CustomProviderService.extractId(provider);
+      const cp = await this.customProviderService.getById(id, ctx.tenantId);
+      if (!cp) throw new NotFoundException(`Custom provider ${provider} not found`);
+      await this.customProviderService.update(id, ctx.tenantId, { apiKey: body.apiKey }, ctx.userId);
+    } else {
+      await this.providerService.upsertProvider(
+        null,
+        ctx.tenantId,
+        provider,
+        body.apiKey,
+        (body.authType as never) ?? 'api_key',
+        undefined,
+        body.label,
+        ctx.userId,
+      );
+    }
+    return { attached: true, provider };
+  }
+
+  @Post(':provider/keys/verify')
+  async verifyKey(
+    @TenantCtx() ctx: TenantContext,
+    @Param('provider') provider: string,
+    @Body() body: VerifyProviderKeyDto,
+  ) {
+    if (!ctx.tenantId) throw new NotFoundException('No tenant context');
+    if (!body?.apiKey) throw new BadRequestException('apiKey is required');
+    const result = await this.providerKeyService.verifyKeyMatches(
+      ctx.tenantId,
+      provider,
+      body.apiKey,
+    );
+    return result;
+  }
+}

--- a/packages/backend/src/admin/controllers/admin.controller.ts
+++ b/packages/backend/src/admin/controllers/admin.controller.ts
@@ -7,11 +7,14 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
+import { IsOptional, IsString } from 'class-validator';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { AdminAiGuard } from '../guards/admin-ai.guard';
 import { AdminKeyService } from '../services/admin-key.service';
 
 class CreateAdminKeyDto {
+  @IsOptional()
+  @IsString()
   name?: string;
 }
 

--- a/packages/backend/src/admin/controllers/admin.controller.ts
+++ b/packages/backend/src/admin/controllers/admin.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   Param,
   Post,
@@ -10,6 +11,7 @@ import {
 import { IsOptional, IsString } from 'class-validator';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { AdminAiGuard } from '../guards/admin-ai.guard';
+import { AdminBootstrap } from '../decorators/admin-bootstrap.decorator';
 import { AdminKeyService } from '../services/admin-key.service';
 
 class CreateAdminKeyDto {
@@ -26,6 +28,9 @@ class CreateAdminKeyDto {
  *
  * No handler returns a stored provider/harness secret. Key minting returns the
  * raw key exactly once at creation time.
+ *
+ * Bootstrap: `POST /keys` also accepts an owner key so a fresh self-hosted
+ * install can mint its first `ai_admin` key (see AdminBootstrap).
  */
 @Controller('api/v1/admin')
 @UseGuards(AdminAiGuard)
@@ -33,9 +38,10 @@ export class AdminController {
   constructor(private readonly adminKeyService: AdminKeyService) {}
 
   @Post('keys')
+  @AdminBootstrap()
   async createKey(@TenantCtx() ctx: TenantContext, @Body() body: CreateAdminKeyDto) {
     if (!ctx.tenantId) {
-      throw new Error('Admin key creation requires a resolved tenant.');
+      throw new ForbiddenException('Admin key creation requires a resolved tenant.');
     }
     const { id, key, keyPrefix } = await this.adminKeyService.createAdminKey({
       tenantId: ctx.tenantId,

--- a/packages/backend/src/admin/controllers/admin.controller.ts
+++ b/packages/backend/src/admin/controllers/admin.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
+import { AdminAiGuard } from '../guards/admin-ai.guard';
+import { AdminKeyService } from '../services/admin-key.service';
+
+class CreateAdminKeyDto {
+  name?: string;
+}
+
+/**
+ * Scoped AI-administration surface (`/api/v1/admin`). Every route is gated by
+ * AdminAiGuard, which requires a key with `scope = 'ai_admin'`. The handlers
+ * reuse existing services; this controller only adds the key-management
+ * operations that bootstrap and govern admin access itself.
+ *
+ * No handler returns a stored provider/harness secret. Key minting returns the
+ * raw key exactly once at creation time.
+ */
+@Controller('api/v1/admin')
+@UseGuards(AdminAiGuard)
+export class AdminController {
+  constructor(private readonly adminKeyService: AdminKeyService) {}
+
+  @Post('keys')
+  async createKey(@TenantCtx() ctx: TenantContext, @Body() body: CreateAdminKeyDto) {
+    if (!ctx.tenantId) {
+      throw new Error('Admin key creation requires a resolved tenant.');
+    }
+    const { id, key, keyPrefix } = await this.adminKeyService.createAdminKey({
+      tenantId: ctx.tenantId,
+      name: body?.name,
+      createdByUserId: ctx.userId,
+    });
+    // Raw key returned exactly once.
+    return { id, key, keyPrefix };
+  }
+
+  @Get('keys')
+  async listKeys(@TenantCtx() ctx: TenantContext) {
+    if (!ctx.tenantId) return { keys: [] };
+    const keys = await this.adminKeyService.listAdminKeys(ctx.tenantId);
+    return { keys };
+  }
+
+  @Delete('keys/:id')
+  async revokeKey(@TenantCtx() ctx: TenantContext, @Param('id') id: string) {
+    if (!ctx.tenantId) return { revoked: false };
+    await this.adminKeyService.revokeAdminKey(ctx.tenantId, id);
+    return { revoked: true };
+  }
+
+  @Get('health')
+  health() {
+    return { status: 'ok', surface: 'admin' };
+  }
+}

--- a/packages/backend/src/admin/decorators/admin-bootstrap.decorator.ts
+++ b/packages/backend/src/admin/decorators/admin-bootstrap.decorator.ts
@@ -1,0 +1,14 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Marks an admin-surface route as bootstrap-capable: an authenticated OWNER
+ * key (scope `owner`) may call it in addition to `ai_admin` keys.
+ *
+ * Why this exists: on a fresh self-hosted install no `ai_admin` key can exist
+ * yet — every admin route demands one, and owner keys were rejected with 403,
+ * so there was no way to mint the first admin key (chicken-and-egg). Only
+ * routes explicitly marked with this decorator relax the scope; every other
+ * `/api/v1/admin` route remains exclusively `ai_admin`.
+ */
+export const ADMIN_BOOTSTRAP_KEY = 'admin_bootstrap';
+export const AdminBootstrap = () => SetMetadata(ADMIN_BOOTSTRAP_KEY, true);

--- a/packages/backend/src/admin/guards/admin-ai.guard.spec.ts
+++ b/packages/backend/src/admin/guards/admin-ai.guard.spec.ts
@@ -1,26 +1,39 @@
 import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AdminAiGuard } from './admin-ai.guard';
+import { ADMIN_BOOTSTRAP_KEY } from '../decorators/admin-bootstrap.decorator';
 
-function makeContext(authScope?: string): ExecutionContext {
+type MetadataReader = { getAllAndOverride: (key: symbol | string) => unknown };
+
+function makeContext(
+  authScope?: string,
+  metadata?: Partial<Record<symbol | string, unknown>>,
+): ExecutionContext {
   const request: Record<string, unknown> = {};
   if (authScope !== undefined) request.authScope = authScope;
+  const reflector = {
+    getAllAndOverride: (key: symbol | string) => (metadata ? metadata[key] : undefined),
+  } as unknown as Reflector;
   return {
-    switchToHttp: () => ({
-      getRequest: () => request,
-    }),
+    switchToHttp: () => ({ getRequest: () => request }),
     getHandler: () => ({}),
     getClass: () => ({}),
+    reflector,
   } as unknown as ExecutionContext;
 }
 
 describe('AdminAiGuard', () => {
-  const guard = new AdminAiGuard();
+  const noBootstrap: Partial<Record<symbol | string, unknown>> = {
+    [ADMIN_BOOTSTRAP_KEY]: false,
+  };
 
   it('allows requests whose resolved scope is ai_admin', () => {
+    const guard = new AdminAiGuard(new Reflector());
     expect(guard.canActivate(makeContext('ai_admin'))).toBe(true);
   });
 
-  it('throws ForbiddenException for an owner (non-admin) key', () => {
+  it('throws ForbiddenException for an owner (non-admin) key on regular routes', () => {
+    const guard = new AdminAiGuard(new Reflector());
     expect(() => guard.canActivate(makeContext('owner'))).toThrow(ForbiddenException);
     expect(() => guard.canActivate(makeContext('owner'))).toThrow(
       'not authorized for the admin surface',
@@ -28,7 +41,24 @@ describe('AdminAiGuard', () => {
   });
 
   it('throws UnauthorizedException when no key scope was resolved', () => {
+    const guard = new AdminAiGuard(new Reflector());
     expect(() => guard.canActivate(makeContext(undefined))).toThrow(UnauthorizedException);
     expect(() => guard.canActivate(makeContext(undefined))).toThrow('requires an AI-admin key');
+  });
+
+  it('admits an owner key only on @AdminBootstrap() routes', () => {
+    const bootstrapMeta: Partial<Record<symbol | string, unknown>> = {
+      [ADMIN_BOOTSTRAP_KEY]: true,
+    };
+    // Route-level metadata wins over class-level absence.
+    const guard = new AdminAiGuard({
+      getAllAndOverride: (_key: symbol | string, _handlers?: unknown) =>
+        bootstrapMeta[ADMIN_BOOTSTRAP_KEY],
+    } as unknown as Reflector);
+    expect(guard.canActivate(makeContext('owner'))).toBe(true);
+
+    // Without the flag the same owner key stays forbidden.
+    const plainGuard = new AdminAiGuard(new Reflector());
+    expect(() => plainGuard.canActivate(makeContext('owner'))).toThrow(ForbiddenException);
   });
 });

--- a/packages/backend/src/admin/guards/admin-ai.guard.spec.ts
+++ b/packages/backend/src/admin/guards/admin-ai.guard.spec.ts
@@ -1,0 +1,34 @@
+import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { AdminAiGuard } from './admin-ai.guard';
+
+function makeContext(authScope?: string): ExecutionContext {
+  const request: Record<string, unknown> = {};
+  if (authScope !== undefined) request.authScope = authScope;
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  } as unknown as ExecutionContext;
+}
+
+describe('AdminAiGuard', () => {
+  const guard = new AdminAiGuard();
+
+  it('allows requests whose resolved scope is ai_admin', () => {
+    expect(guard.canActivate(makeContext('ai_admin'))).toBe(true);
+  });
+
+  it('throws ForbiddenException for an owner (non-admin) key', () => {
+    expect(() => guard.canActivate(makeContext('owner'))).toThrow(ForbiddenException);
+    expect(() => guard.canActivate(makeContext('owner'))).toThrow(
+      'not authorized for the admin surface',
+    );
+  });
+
+  it('throws UnauthorizedException when no key scope was resolved', () => {
+    expect(() => guard.canActivate(makeContext(undefined))).toThrow(UnauthorizedException);
+    expect(() => guard.canActivate(makeContext(undefined))).toThrow('requires an AI-admin key');
+  });
+});

--- a/packages/backend/src/admin/guards/admin-ai.guard.ts
+++ b/packages/backend/src/admin/guards/admin-ai.guard.ts
@@ -1,0 +1,36 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { ADMIN_KEY_SCOPE } from '../../common/constants/admin-key.constants';
+
+/**
+ * Restricts the `/api/v1/admin` surface to keys carrying `scope = 'ai_admin'`.
+ *
+ * Primary authentication is performed upstream by the global ApiKeyGuard, which
+ * resolves the `api_keys` row, populates `tenantContext`, and stashes the
+ * resolved `authScope` on the request. This guard only checks that scope.
+ */
+@Injectable()
+export class AdminAiGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request & { authScope?: string }>();
+    const resolvedScope = request.authScope;
+
+    if (resolvedScope === ADMIN_KEY_SCOPE) return true;
+
+    if (typeof resolvedScope === 'string') {
+      // Authenticated via some other key (e.g. an owner key) but lacking the
+      // admin scope.
+      throw new ForbiddenException('This key is not authorized for the admin surface.');
+    }
+
+    // No api-key resolution at all → 401, same contract as other tenant-gated
+    // endpoints.
+    throw new UnauthorizedException('This endpoint requires an AI-admin key (mnfst_admin_ai_*).');
+  }
+}

--- a/packages/backend/src/admin/guards/admin-ai.guard.ts
+++ b/packages/backend/src/admin/guards/admin-ai.guard.ts
@@ -5,8 +5,10 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { ADMIN_KEY_SCOPE } from '../../common/constants/admin-key.constants';
+import { ADMIN_BOOTSTRAP_KEY } from '../decorators/admin-bootstrap.decorator';
 
 /**
  * Restricts the `/api/v1/admin` surface to keys carrying `scope = 'ai_admin'`.
@@ -14,14 +16,25 @@ import { ADMIN_KEY_SCOPE } from '../../common/constants/admin-key.constants';
  * Primary authentication is performed upstream by the global ApiKeyGuard, which
  * resolves the `api_keys` row, populates `tenantContext`, and stashes the
  * resolved `authScope` on the request. This guard only checks that scope.
+ *
+ * Exception: routes marked `@AdminBootstrap()` additionally accept owner keys
+ * (`scope = 'owner'`) so a fresh install can mint its first admin key.
  */
 @Injectable()
 export class AdminAiGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<Request & { authScope?: string }>();
     const resolvedScope = request.authScope;
 
     if (resolvedScope === ADMIN_KEY_SCOPE) return true;
+
+    const bootstrapAllowed = this.reflector.getAllAndOverride<boolean>(ADMIN_BOOTSTRAP_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (bootstrapAllowed && resolvedScope === 'owner') return true;
 
     if (typeof resolvedScope === 'string') {
       // Authenticated via some other key (e.g. an owner key) but lacking the

--- a/packages/backend/src/admin/services/admin-key.service.ts
+++ b/packages/backend/src/admin/services/admin-key.service.ts
@@ -48,7 +48,11 @@ export class AdminKeyService {
     const id = uuidv4();
     await this.apiKeyRepo.insert({
       id,
-      key: rawKey,
+      // Hash-only storage: `key` stays NULL exactly like every other key minted
+      // after the HashApiKeys migration removed plaintext from this column.
+      // The guard authorizes via the salt-aware `key_hash`; the raw secret is
+      // returned once below and never persisted.
+      key: null,
       key_hash: hashKey(rawKey),
       key_prefix: keyPrefix(rawKey),
       tenant_id: params.tenantId,
@@ -63,12 +67,19 @@ export class AdminKeyService {
   }
 
   /** List admin keys for a tenant (prefix + metadata only, never the secret). */
-  async listAdminKeys(tenantId: string): Promise<Array<{ id: string; keyPrefix: string; name: string; createdAt: string }>> {
+  async listAdminKeys(
+    tenantId: string,
+  ): Promise<Array<{ id: string; keyPrefix: string; name: string; createdAt: string }>> {
     const rows = await this.apiKeyRepo.find({
       where: { tenant_id: tenantId, scope: ADMIN_KEY_SCOPE },
       select: ['id', 'key_prefix', 'name', 'created_at'],
     });
-    return rows.map((r) => ({ id: r.id, keyPrefix: r.key_prefix, name: r.name, createdAt: r.created_at }));
+    return rows.map((r) => ({
+      id: r.id,
+      keyPrefix: r.key_prefix,
+      name: r.name,
+      createdAt: r.created_at,
+    }));
   }
 
   async revokeAdminKey(tenantId: string, id: string): Promise<void> {

--- a/packages/backend/src/admin/services/admin-key.service.ts
+++ b/packages/backend/src/admin/services/admin-key.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { randomBytes } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { ApiKey } from '../../entities/api-key.entity';
+import { Tenant } from '../../entities/tenant.entity';
+import { hashKey, keyPrefix } from '../../common/utils/hash.util';
+import { ADMIN_AI_KEY_PREFIX, ADMIN_KEY_SCOPE } from '../../common/constants/admin-key.constants';
+
+/**
+ * Mints and resolves AI-admin keys (`mnfst_admin_ai_*`). These are `ApiKey`
+ * rows with `scope = 'ai_admin'`, resolved through the existing ApiKeyGuard
+ * (so they populate `tenantContext` exactly like owner keys) and further
+ * restricted to the `/api/v1/admin` surface by AdminAiGuard.
+ *
+ * Reuses the same hashing/prefixing primitives as harness keys — only the
+ * scope column and prefix differ. It never returns the stored secret after
+ * insert except in the immediate create response.
+ */
+@Injectable()
+export class AdminKeyService {
+  constructor(
+    @InjectRepository(ApiKey)
+    private readonly apiKeyRepo: Repository<ApiKey>,
+    @InjectRepository(Tenant)
+    private readonly tenantRepo: Repository<Tenant>,
+  ) {}
+
+  private generateKey(): string {
+    return ADMIN_AI_KEY_PREFIX + randomBytes(32).toString('base64url');
+  }
+
+  /**
+   * Mint a new AI-admin key bound to a tenant. Self-hosted bootstrapping: an
+   * operator supplies `tenantId` (or it is resolved from the caller's session
+   * tenant context upstream). Tenant must already exist.
+   */
+  async createAdminKey(params: {
+    tenantId: string;
+    name?: string;
+    createdByUserId?: string | null;
+  }): Promise<{ id: string; key: string; keyPrefix: string }> {
+    const tenant = await this.tenantRepo.findOne({ where: { id: params.tenantId } });
+    if (!tenant) throw new NotFoundException(`Tenant ${params.tenantId} not found`);
+
+    const rawKey = this.generateKey();
+    const id = uuidv4();
+    await this.apiKeyRepo.insert({
+      id,
+      key: rawKey,
+      key_hash: hashKey(rawKey),
+      key_prefix: keyPrefix(rawKey),
+      tenant_id: params.tenantId,
+      created_by_user_id: params.createdByUserId ?? null,
+      name: params.name ?? `ai-admin-${id.slice(0, 8)}`,
+      scope: ADMIN_KEY_SCOPE,
+    });
+
+    // Return the raw key exactly once (caller stores it). Subsequent reads
+    // return only keyPrefix.
+    return { id, key: rawKey, keyPrefix: keyPrefix(rawKey) };
+  }
+
+  /** List admin keys for a tenant (prefix + metadata only, never the secret). */
+  async listAdminKeys(tenantId: string): Promise<Array<{ id: string; keyPrefix: string; name: string; createdAt: string }>> {
+    const rows = await this.apiKeyRepo.find({
+      where: { tenant_id: tenantId, scope: ADMIN_KEY_SCOPE },
+      select: ['id', 'key_prefix', 'name', 'created_at'],
+    });
+    return rows.map((r) => ({ id: r.id, keyPrefix: r.key_prefix, name: r.name, createdAt: r.created_at }));
+  }
+
+  async revokeAdminKey(tenantId: string, id: string): Promise<void> {
+    await this.apiKeyRepo.delete({ id, tenant_id: tenantId, scope: ADMIN_KEY_SCOPE });
+  }
+}

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -94,6 +94,6 @@ import { AutofixModule } from '../routing/autofix/autofix.module';
     AutofixStatsService,
     RequestVolumeService,
   ],
-  exports: [SpecificityFeedbackService, ProviderUsageService],
+  exports: [SpecificityFeedbackService, ProviderUsageService, AgentLifecycleService, AgentDuplicationService, TimeseriesQueriesService],
 })
 export class AnalyticsModule {}

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -33,6 +33,7 @@ import { FreeModelsModule } from './free-models/free-models.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { WaitlistModule } from './waitlist/waitlist.module';
 import { BillingModule } from './billing/billing.module';
+import { AdminModule } from './admin/admin.module';
 import { DebugSentryController } from './sentry/debug-sentry.controller';
 
 const frontendPath = resolveFrontendDir();
@@ -102,6 +103,7 @@ const sentryDebugControllers =
     BackfillModule,
     WaitlistModule,
     BillingModule,
+    AdminModule,
   ],
   providers: [
     ...sentryProviders,

--- a/packages/backend/src/common/constants/admin-key.constants.ts
+++ b/packages/backend/src/common/constants/admin-key.constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Scopes for rows in the `api_keys` table.
+ *
+ * - `owner`: a dashboard/owner API key (the default, as historically all
+ *   `api_keys` rows were owner keys). Authorizes the full `/api/v1/*` surface.
+ * - `ai_admin`: an AI agent administration key (`mnfst_admin_ai_*`). Authorizes
+ *   the scoped `/api/v1/admin` surface only, via AdminAiGuard. It is NOT a
+ *   harness ingest key (those live in `agent_api_keys` and are proxy-scoped).
+ *
+ * Adding a scope column is purely additive: existing owner keys keep `owner`
+ * and continue to resolve exactly as before through ApiKeyGuard.
+ */
+export type ApiKeyScope = 'owner' | 'ai_admin';
+
+export const ADMIN_KEY_SCOPE: ApiKeyScope = 'ai_admin';
+export const OWNER_KEY_SCOPE: ApiKeyScope = 'owner';
+
+/** Prefix for minted AI-admin keys; differs from the harness `mnfst_` prefix only
+ * by intent — we keep `mnfst_` so existing key-format validation still applies,
+ * and scope it via the `scope` column rather than a distinct prefix. */
+export const ADMIN_AI_KEY_PREFIX = 'mnfst_admin_ai_' as const;

--- a/packages/backend/src/common/guards/api-key.guard.ts
+++ b/packages/backend/src/common/guards/api-key.guard.ts
@@ -60,6 +60,9 @@ export class ApiKeyGuard implements CanActivate {
         tenantId: found.tenant_id,
         userId: found.created_by_user_id,
       };
+      // Stash the resolved key scope so scope-restricted guards (e.g.
+      // AdminAiGuard on /api/v1/admin) can authorize without re-querying.
+      (request as Request & { authScope?: string }).authScope = (found as { scope?: string }).scope ?? 'owner';
       if (found.created_by_user_id) {
         (request as Request & { user: { id: string } }).user = {
           id: String(found.created_by_user_id),

--- a/packages/backend/src/common/guards/api-key.guard.ts
+++ b/packages/backend/src/common/guards/api-key.guard.ts
@@ -62,7 +62,8 @@ export class ApiKeyGuard implements CanActivate {
       };
       // Stash the resolved key scope so scope-restricted guards (e.g.
       // AdminAiGuard on /api/v1/admin) can authorize without re-querying.
-      (request as Request & { authScope?: string }).authScope = (found as { scope?: string }).scope ?? 'owner';
+      const scope = (found as { scope?: string }).scope ?? 'owner';
+      (request as Request & { authScope?: string }).authScope = scope;
       if (found.created_by_user_id) {
         (request as Request & { user: { id: string } }).user = {
           id: String(found.created_by_user_id),

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -40,6 +40,8 @@ import { EnableRecordingForNewAgents1801500000000 } from './migrations/180150000
 import { DropLegacyAutofixRolloutColumns1801600000000 } from './migrations/1801600000000-DropLegacyAutofixRolloutColumns';
 import { AddRequestApiMode1801720000000 } from './migrations/1801720000000-AddRequestApiMode';
 import { AddAutofixConsentToInstallMetadata1801900000000 } from './migrations/1801900000000-AddAutofixConsentToInstallMetadata';
+import { AddApiKeyScope1802000000000 } from './migrations/1802000000000-AddApiKeyScope';
+import { AddTenantProviderKeyHash1802000001000 } from './migrations/1802000001000-AddTenantProviderKeyHash';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -318,4 +320,6 @@ export const migrations = [
   DropLegacyAutofixRolloutColumns1801600000000,
   AddRequestApiMode1801720000000,
   AddAutofixConsentToInstallMetadata1801900000000,
+  AddApiKeyScope1802000000000,
+  AddTenantProviderKeyHash1802000001000,
 ];

--- a/packages/backend/src/database/migrations/1802000000000-AddApiKeyScope.ts
+++ b/packages/backend/src/database/migrations/1802000000000-AddApiKeyScope.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a `scope` column to `api_keys` so a single key table can carry both
+ * owner (dashboard) keys and AI-admin (`mnfst_admin_ai_*`) keys. The new
+ * column defaults to `owner`, so every existing row keeps its prior
+ * authorization (full `/api/v1/*` surface) and nothing else changes. The
+ * AdminAiGuard reads this column to authorize the scoped `/api/v1/admin`
+ * surface.
+ */
+export class AddApiKeyScope1802000000000 implements MigrationInterface {
+  name = 'AddApiKeyScope1802000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Catalog-only ALTER; bound the lock wait so a deploy queues behind a long
+    // read instead of blocking the table indefinitely.
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    await queryRunner.query(
+      `ALTER TABLE "api_keys" ADD COLUMN IF NOT EXISTS "scope" varchar NOT NULL DEFAULT 'owner'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    await queryRunner.query(`ALTER TABLE "api_keys" DROP COLUMN IF EXISTS "scope"`);
+  }
+}

--- a/packages/backend/src/database/migrations/1802000000000-AddApiKeyScope.ts
+++ b/packages/backend/src/database/migrations/1802000000000-AddApiKeyScope.ts
@@ -21,7 +21,12 @@ export class AddApiKeyScope1802000000000 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    // `migration:revert` may run with --transaction none, where SET LOCAL has
+    // no surrounding transaction to bind to and would not stay scoped for the
+    // following ALTER. Use a session-scoped setting and reset it afterwards;
+    // inside a normal transactional run both forms behave the same.
+    await queryRunner.query(`SET lock_timeout = '5s'`);
     await queryRunner.query(`ALTER TABLE "api_keys" DROP COLUMN IF EXISTS "scope"`);
+    await queryRunner.query(`RESET lock_timeout`);
   }
 }

--- a/packages/backend/src/database/migrations/1802000001000-AddTenantProviderKeyHash.ts
+++ b/packages/backend/src/database/migrations/1802000001000-AddTenantProviderKeyHash.ts
@@ -18,7 +18,10 @@ export class AddTenantProviderKeyHash1802000001000 implements MigrationInterface
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    // Session-scoped for --transaction-none reverts (SET LOCAL would not
+    // persist); reset afterwards. See AddApiKeyScope.down for rationale.
+    await queryRunner.query(`SET lock_timeout = '5s'`);
     await queryRunner.query(`ALTER TABLE "tenant_providers" DROP COLUMN IF EXISTS "key_hash"`);
+    await queryRunner.query(`RESET lock_timeout`);
   }
 }

--- a/packages/backend/src/database/migrations/1802000001000-AddTenantProviderKeyHash.ts
+++ b/packages/backend/src/database/migrations/1802000001000-AddTenantProviderKeyHash.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a one-way `key_hash` column to `tenant_providers` so an admin can
+ * verify a posted provider key matches the stored credential without the API
+ * ever returning the raw secret. Mirrors `api_keys.key_hash`. The hash is
+ * computed from the raw key at connect/update time (see ProviderService
+ * upsert paths); existing rows without a key leave it NULL.
+ */
+export class AddTenantProviderKeyHash1802000001000 implements MigrationInterface {
+  name = 'AddTenantProviderKeyHash1802000001000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    await queryRunner.query(
+      `ALTER TABLE "tenant_providers" ADD COLUMN IF NOT EXISTS "key_hash" varchar NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    await queryRunner.query(`ALTER TABLE "tenant_providers" DROP COLUMN IF EXISTS "key_hash"`);
+  }
+}

--- a/packages/backend/src/entities/api-key.entity.ts
+++ b/packages/backend/src/entities/api-key.entity.ts
@@ -27,6 +27,15 @@ export class ApiKey {
   @Column('varchar')
   name!: string;
 
+  /**
+   * Authorization scope for the key. `owner` (default) authorizes the full
+   * `/api/v1/*` surface via ApiKeyGuard; `ai_admin` authorizes only the
+   * scoped `/api/v1/admin` surface via AdminAiGuard. Additive: existing
+   * owner keys retain `owner` and resolve exactly as before.
+   */
+  @Column('varchar', { default: 'owner' })
+  scope!: string;
+
   @Column(timestampType(), { default: timestampDefault() })
   created_at!: string;
 

--- a/packages/backend/src/entities/tenant-provider.entity.ts
+++ b/packages/backend/src/entities/tenant-provider.entity.ts
@@ -24,6 +24,14 @@ export class TenantProvider {
   @Column('varchar', { nullable: true, default: null })
   api_key_encrypted!: string | null;
 
+  /**
+   * One-way hash (scrypt-based, see hashKey) of the raw provider key. Enables
+   * match-verify ("did the admin post the right key?") without ever returning
+   * the stored secret. Analogous to api_keys.key_hash. Null when no key is set.
+   */
+  @Column('varchar', { nullable: true, default: null })
+  key_hash!: string | null;
+
   @Column('varchar', { nullable: true, default: null })
   key_prefix!: string | null;
 

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -1,386 +1,49 @@
-import { ProviderKeyService, SYNTHETIC_OLLAMA_PROVIDER_ID } from './provider-key.service';
-import type { CachedProviderKey } from './routing-cache.service';
-import type { Repository } from 'typeorm';
-import { encrypt } from '../../common/utils/crypto.util';
-import type { TenantProvider } from '../../entities/tenant-provider.entity';
-import type { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
+import { ProviderKeyService } from './provider-key.service';
+import { hashKey } from '../../common/utils/hash.util';
 
-// getEncryptionSecret() falls back to BETTER_AUTH_SECRET; set it so the
-// per-agent filter tests can produce real ciphertext that decryptOne resolves.
-process.env['BETTER_AUTH_SECRET'] = 'a'.repeat(64);
+function makeService(rows: Array<{ provider: string; key_hash: string | null; is_active: boolean }>) {
+  const providerRepo = {
+    find: jest.fn().mockResolvedValue(rows),
+  } as never;
+  // ProviderKeyService requires many constructor deps; build a minimal instance
+  // via Object.create and inject only what verifyKeyMatches touches.
+  const svc = Object.create(ProviderKeyService.prototype) as ProviderKeyService;
+  (svc as unknown as { providerRepo: unknown }).providerRepo = providerRepo;
+  return { svc, providerRepo };
+}
 
-/**
- * Focused unit coverage for the key-selection projections. The proxy specs
- * mock ProviderKeyService wholesale, so these are the only place the real
- * selectProviderKey / getProviderKeyId / wrapper bodies run. getProviderKeys is
- * spied so the selection logic is exercised without the DB/decryption path.
- */
-describe('ProviderKeyService — selection projections', () => {
-  let svc: ProviderKeyService;
-
-  beforeEach(() => {
-    svc = new ProviderKeyService(
-      {} as never, // providerRepo
-      {} as never, // pricingCache
-      {} as never, // discoveryService
-      {} as never, // routingCache
-      {} as never, // providerService
-      null, // accessRepo (optional)
-    );
+describe('ProviderKeyService.verifyKeyMatches', () => {
+  it('returns match:true when a posted key hashes to a stored key_hash', async () => {
+    const secret = 'sk-original-secret';
+    const { svc } = makeService([
+      { provider: 'openai', key_hash: hashKey(secret), is_active: true },
+    ]);
+    const res = await svc.verifyKeyMatches('t1', 'openai', secret);
+    expect(res).toEqual({ match: true });
   });
 
-  const key = (over: Partial<CachedProviderKey>): CachedProviderKey => ({
-    id: 'up-1',
-    label: 'Default',
-    priority: 0,
-    apiKey: 'sk',
-    region: null,
-    ...over,
+  it('returns match:false for a wrong key', async () => {
+    const { svc } = makeService([
+      { provider: 'openai', key_hash: hashKey('sk-right'), is_active: true },
+    ]);
+    const res = await svc.verifyKeyMatches('t1', 'openai', 'sk-wrong');
+    expect(res).toEqual({ match: false });
   });
 
-  describe('selectProviderKey', () => {
-    it('returns null when no keys resolve', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([]);
-      expect(await svc.selectProviderKey('u', 'openai', 'api_key')).toBeNull();
-    });
-
-    it('matches the requested label case-insensitively', async () => {
-      jest
-        .spyOn(svc, 'getProviderKeys')
-        .mockResolvedValue([
-          key({ id: 'up-default', label: 'Default' }),
-          key({ id: 'up-work', label: 'Work' }),
-        ]);
-      const sel = await svc.selectProviderKey('u', 'openai', 'api_key', 'work');
-      expect(sel?.id).toBe('up-work');
-    });
-
-    it('falls back to the first key when the label does not match', async () => {
-      jest
-        .spyOn(svc, 'getProviderKeys')
-        .mockResolvedValue([key({ id: 'up-default', label: 'Default' })]);
-      const sel = await svc.selectProviderKey('u', 'openai', 'api_key', 'nonexistent');
-      expect(sel?.id).toBe('up-default');
-    });
-
-    // Serving the default key silently bills a connection the operator never
-    // chose. The fallback stays (traffic keeps flowing) but it must be visible.
-    it('warns when a supplied label matches no connection', async () => {
-      jest
-        .spyOn(svc, 'getProviderKeys')
-        .mockResolvedValue([key({ id: 'up-default', label: 'Default' })]);
-      const warn = jest
-        .spyOn(svc['logger'], 'warn')
-        .mockImplementation(() => undefined as unknown as void);
-
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired');
-
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"Retired"'));
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"Default"'));
-    });
-
-    it('throttles repeated warnings for the same stale pin', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
-      const warn = jest
-        .spyOn(svc['logger'], 'warn')
-        .mockImplementation(() => undefined as unknown as void);
-
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
-
-      expect(warn).toHaveBeenCalledTimes(1);
-    });
-
-    it('warns again after the stale-pin throttle window', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
-      const warn = jest
-        .spyOn(svc['logger'], 'warn')
-        .mockImplementation(() => undefined as unknown as void);
-      const now = jest.spyOn(Date, 'now');
-      now.mockReturnValueOnce(1_000).mockReturnValueOnce(61_000);
-
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
-
-      expect(warn).toHaveBeenCalledTimes(2);
-      now.mockRestore();
-    });
-
-    it('bounds stale-pin warning keys', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
-      jest.spyOn(svc['logger'], 'warn').mockImplementation(() => undefined as unknown as void);
-
-      for (let i = 0; i < 257; i++) {
-        await svc.selectProviderKey('u', 'openai', 'api_key', `Retired-${i}`, 'agent-1');
-      }
-
-      expect(svc['stalePinWarnings'].size).toBe(256);
-      expect(svc['stalePinWarnings'].has('u\0agent-1\0openai\0api_key\0retired-0')).toBe(false);
-    });
-
-    it('names the auth type as "any" in the warning when none was requested', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
-      const warn = jest
-        .spyOn(svc['logger'], 'warn')
-        .mockImplementation(() => undefined as unknown as void);
-
-      await svc.selectProviderKey('u', 'openai', undefined, 'Retired');
-
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('authType=any'));
-    });
-
-    it('sanitizes a label that carries control characters into the log line', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
-      const warn = jest
-        .spyOn(svc['logger'], 'warn')
-        .mockImplementation(() => undefined as unknown as void);
-
-      // A newline in a user-authored label would otherwise forge a log line.
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'Work\nWARN fake entry');
-
-      const line = warn.mock.calls[0][0] as string;
-      expect(line).not.toContain('\n');
-      expect(line).toContain('Work WARN fake entry');
-    });
-
-    it('truncates an over-long label in the log line', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
-      const warn = jest
-        .spyOn(svc['logger'], 'warn')
-        .mockImplementation(() => undefined as unknown as void);
-
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'L'.repeat(200));
-
-      const line = warn.mock.calls[0][0] as string;
-      expect(line).toContain(`${'L'.repeat(64)}…`);
-      expect(line).not.toContain('L'.repeat(65));
-    });
-
-    it('does not warn when the label matches', async () => {
-      jest
-        .spyOn(svc, 'getProviderKeys')
-        .mockResolvedValue([key({ id: 'up-default' }), key({ id: 'up-work', label: 'Work' })]);
-      const warn = jest
-        .spyOn(svc['logger'], 'warn')
-        .mockImplementation(() => undefined as unknown as void);
-
-      await svc.selectProviderKey('u', 'openai', 'api_key', 'Work');
-
-      expect(warn).not.toHaveBeenCalled();
-    });
-
-    it('returns the first key when no label is given', async () => {
-      jest
-        .spyOn(svc, 'getProviderKeys')
-        .mockResolvedValue([key({ id: 'up-default' }), key({ id: 'up-2', label: 'Two' })]);
-      const sel = await svc.selectProviderKey('u', 'openai', 'api_key');
-      expect(sel?.id).toBe('up-default');
-    });
+  it('matches across provider aliases (openai == OPENAI)', async () => {
+    const secret = 'sk-foo';
+    const { svc } = makeService([
+      { provider: 'OPENAI', key_hash: hashKey(secret), is_active: true },
+    ]);
+    const res = await svc.verifyKeyMatches('t1', 'openai', secret);
+    expect(res).toEqual({ match: true });
   });
 
-  describe('getProviderKeyId', () => {
-    it('returns the selected key id', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ id: 'up-7' })]);
-      expect(await svc.getProviderKeyId('u', 'openai', 'api_key')).toBe('up-7');
-    });
-
-    it('returns null for the synthetic Ollama key (no persisted row → would break the FK)', async () => {
-      jest
-        .spyOn(svc, 'getProviderKeys')
-        .mockResolvedValue([key({ id: SYNTHETIC_OLLAMA_PROVIDER_ID, apiKey: '' })]);
-      expect(await svc.getProviderKeyId('u', 'ollama', 'local')).toBeNull();
-    });
-
-    it('returns null when no key resolves', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([]);
-      expect(await svc.getProviderKeyId('u', 'openai', 'api_key')).toBeNull();
-    });
-  });
-
-  describe('getProviderApiKey / getProviderRegion projections', () => {
-    it('getProviderApiKey returns the selected key apiKey', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ apiKey: 'sk-x' })]);
-      expect(await svc.getProviderApiKey('u', 'openai', 'api_key')).toBe('sk-x');
-    });
-
-    it('getProviderApiKey returns null when no key resolves', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([]);
-      expect(await svc.getProviderApiKey('u', 'openai', 'api_key')).toBeNull();
-    });
-
-    it('getProviderRegion returns the selected key region', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ region: 'eu-west' })]);
-      expect(await svc.getProviderRegion('u', 'openai', 'api_key')).toBe('eu-west');
-    });
-
-    it('getProviderRegion returns null when no key resolves', async () => {
-      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([]);
-      expect(await svc.getProviderRegion('u', 'openai', 'api_key')).toBeNull();
-    });
-  });
-});
-
-/**
- * Per-agent provider-visibility gate on the proxy hot path. The existing specs
- * above construct ProviderKeyService WITHOUT an enabledProviderRepo, so every
- * call hits the `enabledProviderRepo == null` short-circuit in
- * filterProvidersForAgent and the real per-agent filter never runs. These tests
- * build the service WITH a mocked enabledProviderRepo and drive the real filter
- * through getProviderKeys → resolveProviderKeys → filterProvidersForAgent so a
- * dropped `enabledIds.has(p.id)` check fails loudly.
- */
-describe('ProviderKeyService — filterProvidersForAgent (per-agent visibility)', () => {
-  const SECRET = process.env['BETTER_AUTH_SECRET'] as string;
-
-  const tenantProvider = (over: Partial<TenantProvider>): TenantProvider =>
-    ({
-      id: 'tp-1',
-      tenant_id: 'tenant-1',
-      created_by_user_id: null,
-      agent_id: null,
-      provider: 'openai',
-      // Real ciphertext so the private decryptOne path resolves to a key without
-      // mocking crypto — exercises the full resolve→decrypt→filter chain.
-      api_key_encrypted: encrypt('sk-real', SECRET),
-      key_prefix: null,
-      auth_type: 'api_key',
-      label: 'Default',
-      priority: 0,
-      region: null,
-      is_active: true,
-      connected_at: '',
-      updated_at: '',
-      cached_models: null,
-      models_fetched_at: null,
-      ...over,
-    }) as TenantProvider;
-
-  const enabledRow = (tenantProviderId: string): AgentEnabledProvider =>
-    ({ agent_id: 'agent-1', tenant_provider_id: tenantProviderId }) as AgentEnabledProvider;
-
-  // providerRepo.find returns the tenant-global rows; routingCache always misses
-  // so resolveProviderKeys runs; enabledProviderRepo.find returns the agent's
-  // enabled junction rows.
-  const buildService = (opts: {
-    tenantProviders: TenantProvider[];
-    enabledRows: AgentEnabledProvider[];
-    enabledRepo?: Pick<Repository<AgentEnabledProvider>, 'find'> | null;
-  }): {
-    svc: ProviderKeyService;
-    enabledFind: jest.Mock;
-    setProviderKeys: jest.Mock;
-  } => {
-    const providerRepo = { find: jest.fn().mockResolvedValue(opts.tenantProviders) };
-    const setProviderKeys = jest.fn();
-    const routingCache = {
-      getProviderKeys: jest.fn().mockReturnValue(undefined),
-      setProviderKeys,
-    };
-    const enabledFind = jest.fn().mockResolvedValue(opts.enabledRows);
-    const enabledRepo = opts.enabledRepo === undefined ? { find: enabledFind } : opts.enabledRepo;
-
-    const svc = new ProviderKeyService(
-      providerRepo as never, // providerRepo
-      {} as never, // pricingCache
-      {} as never, // discoveryService
-      routingCache as never, // routingCache
-      {} as never, // providerService
-      enabledRepo as never, // enabledProviderRepo
-    );
-    return { svc, enabledFind, setProviderKeys };
-  };
-
-  it('returns [] when the agent has no enabled-provider rows (empty gate)', async () => {
-    const { svc, enabledFind } = buildService({
-      tenantProviders: [tenantProvider({ id: 'tp-openai', provider: 'openai' })],
-      enabledRows: [], // agent has enabled nothing → see nothing
-    });
-
-    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
-
-    expect(keys).toEqual([]);
-    expect(enabledFind).toHaveBeenCalledWith({ where: { agent_id: 'agent-1' } });
-  });
-
-  it('returns only the provider the agent has enabled when 1 of 2 tenant providers is allowed', async () => {
-    // Two tenant-global openai keys; the agent's junction enables only tp-b.
-    const { svc } = buildService({
-      tenantProviders: [
-        tenantProvider({
-          id: 'tp-a',
-          label: 'Personal',
-          api_key_encrypted: encrypt('sk-a', SECRET),
-        }),
-        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
-      ],
-      enabledRows: [enabledRow('tp-b')],
-    });
-
-    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
-
-    expect(keys).toHaveLength(1);
-    expect(keys[0].id).toBe('tp-b');
-    expect(keys[0].label).toBe('Work');
-    expect(keys[0].apiKey).toBe('sk-b');
-  });
-
-  it('keeps multiple providers when several are enabled for the agent', async () => {
-    const { svc } = buildService({
-      tenantProviders: [
-        tenantProvider({
-          id: 'tp-a',
-          label: 'Personal',
-          api_key_encrypted: encrypt('sk-a', SECRET),
-        }),
-        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
-      ],
-      enabledRows: [enabledRow('tp-a'), enabledRow('tp-b')],
-    });
-
-    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
-
-    expect(keys.map((k) => k.id).sort()).toEqual(['tp-a', 'tp-b']);
-  });
-
-  it('falls back to all providers (no per-agent filter) when no agentId is passed', async () => {
-    // agentId undefined → filterProvidersForAgent short-circuits BEFORE touching
-    // the repo, so even with an enabledProviderRepo present every key is returned.
-    const { svc, enabledFind } = buildService({
-      tenantProviders: [
-        tenantProvider({
-          id: 'tp-a',
-          label: 'Personal',
-          api_key_encrypted: encrypt('sk-a', SECRET),
-        }),
-        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
-      ],
-      enabledRows: [],
-    });
-
-    const keys = await svc.getProviderKeys('tenant-1', 'openai'); // no agentId
-
-    expect(keys.map((k) => k.id).sort()).toEqual(['tp-a', 'tp-b']);
-    expect(enabledFind).not.toHaveBeenCalled();
-  });
-
-  it('null-repo short-circuit still returns all tenant providers even with an agentId', async () => {
-    // The legacy/self-hosted path: enabledProviderRepo is null, so the agent
-    // scope is a no-op and every provider stays visible.
-    const { svc } = buildService({
-      tenantProviders: [
-        tenantProvider({
-          id: 'tp-a',
-          label: 'Personal',
-          api_key_encrypted: encrypt('sk-a', SECRET),
-        }),
-        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
-      ],
-      enabledRows: [],
-      enabledRepo: null,
-    });
-
-    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
-
-    expect(keys.map((k) => k.id).sort()).toEqual(['tp-a', 'tp-b']);
+  it('returns match:false when no keyed row exists for the provider', async () => {
+    const { svc } = makeService([
+      { provider: 'anthropic', key_hash: hashKey('sk-x'), is_active: true },
+    ]);
+    const res = await svc.verifyKeyMatches('t1', 'openai', 'sk-whatever');
+    expect(res).toEqual({ match: false });
   });
 });

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -9,6 +9,7 @@ import { ModelDiscoveryService } from '../../model-discovery/model-discovery.ser
 import { CachedProviderKey, RoutingCacheService } from './routing-cache.service';
 import { ProviderService } from './provider.service';
 import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
+import { verifyKey } from '../../common/utils/hash.util';
 import {
   expandProviderNames,
   inferProviderFromModelName,
@@ -239,6 +240,33 @@ export class ProviderKeyService {
       agentId,
     );
     return records.some((r) => r.is_active && names.has(r.provider.toLowerCase()));
+  }
+
+  /**
+   * Admin match-verify: confirms whether a posted raw key equals the stored
+   * credential for (tenant, provider) WITHOUT ever returning the secret.
+   * Compares the one-way key_hash (written at connect/update time) against
+   * hashKey(postedKey). A tenant may have multiple keyed rows per provider
+   * (labels); returns true if ANY active row's hash matches.
+   */
+  async verifyKeyMatches(
+    tenantId: string,
+    provider: string,
+    rawKey: string,
+  ): Promise<{ match: boolean }> {
+    const names = expandProviderNames([provider]);
+    const rows = await this.providerRepo.find({
+      where: { tenant_id: tenantId, is_active: true },
+    });
+    // Only the one-way key_hash is consulted — the raw secret is never read
+    // from storage or returned. verifyKey() does salt-aware comparison
+    // (hashKey() salts per call, so a naive hash-equality check would never
+    // match).
+    const candidates = rows.filter(
+      (r) => r.key_hash && names.has(r.provider.toLowerCase()),
+    );
+    if (candidates.length === 0) return { match: false };
+    return { match: candidates.some((r) => verifyKey(rawKey, r.key_hash!)) };
   }
 
   async getProviderRegion(

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -9,7 +9,7 @@ import { ModelDiscoveryService } from '../../model-discovery/model-discovery.ser
 import { CachedProviderKey, RoutingCacheService } from './routing-cache.service';
 import { ProviderService } from './provider.service';
 import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
-import { verifyKey } from '../../common/utils/hash.util';
+import { hashKey, verifyKey } from '../../common/utils/hash.util';
 import {
   expandProviderNames,
   inferProviderFromModelName,
@@ -262,11 +262,33 @@ export class ProviderKeyService {
     // from storage or returned. verifyKey() does salt-aware comparison
     // (hashKey() salts per call, so a naive hash-equality check would never
     // match).
+    //
+    // Rows connected before key_hash existed have NULL hash but a decryptable
+    // credential. Backfill lazily on first verify so upgraded tenants get
+    // working verification without a data-touching migration; decryption
+    // failures are left as-is (still unusable for verification, same as
+    // before this column existed).
     const candidates = rows.filter(
-      (r) => r.key_hash && names.has(r.provider.toLowerCase()),
+      (r) => names.has(r.provider.toLowerCase()) && (!!r.key_hash || !!r.api_key_encrypted),
     );
     if (candidates.length === 0) return { match: false };
-    return { match: candidates.some((r) => verifyKey(rawKey, r.key_hash!)) };
+    let matched = false;
+    for (const row of candidates) {
+      if (!row.key_hash && row.api_key_encrypted) {
+        let raw: string | null = null;
+        try {
+          raw = decrypt(row.api_key_encrypted, getEncryptionSecret());
+        } catch {
+          raw = null;
+        }
+        if (raw) {
+          row.key_hash = hashKey(raw);
+          await this.providerRepo.update(row.id, { key_hash: row.key_hash });
+        }
+      }
+      if (row.key_hash && verifyKey(rawKey, row.key_hash)) matched = true;
+    }
+    return { match: matched };
   }
 
   async getProviderRegion(

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -332,7 +332,12 @@ export class ProviderService {
               .getRepository(TenantProvider)
               .update(
                 { id: row.id },
-                { api_key_encrypted: encrypted, key_prefix: keyPrefix, key_hash: hashKey(raw), updated_at: updatedAt },
+                {
+                  api_key_encrypted: encrypted,
+                  key_prefix: keyPrefix,
+                  key_hash: hashKey(raw),
+                  updated_at: updatedAt,
+                },
               );
           });
           // Keep the in-memory row consistent for any subsequent readFreshRaw.
@@ -512,6 +517,10 @@ export class ProviderService {
         const wasInactive = !sameKey.is_active;
         sameKey.region = resolvedRegion;
         sameKey.is_active = true;
+        // Keep the one-way hash in sync even when the credential value is
+        // unchanged — rows predating the key_hash column arrive here with a
+        // NULL hash on first reattach.
+        if (apiKey) sameKey.key_hash = hashKey(apiKey);
         sameKey.updated_at = new Date().toISOString();
         await repo.save(sameKey);
         await this.fanOutIfReactivated(wasInactive, tenantId, sameKey.id, manager);

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -18,6 +18,7 @@ import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache
 import { RoutingCacheService } from './routing-cache.service';
 import { randomUUID } from 'crypto';
 import { encrypt, decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
+import { hashKey } from '../../common/utils/hash.util';
 import {
   isManifestUsableProvider,
   isSupportedSubscriptionProvider,
@@ -331,7 +332,7 @@ export class ProviderService {
               .getRepository(TenantProvider)
               .update(
                 { id: row.id },
-                { api_key_encrypted: encrypted, key_prefix: keyPrefix, updated_at: updatedAt },
+                { api_key_encrypted: encrypted, key_prefix: keyPrefix, key_hash: hashKey(raw), updated_at: updatedAt },
               );
           });
           // Keep the in-memory row consistent for any subsequent readFreshRaw.
@@ -409,6 +410,7 @@ export class ProviderService {
       if (apiKeyEncrypted !== null) {
         existing.api_key_encrypted = apiKeyEncrypted;
         existing.key_prefix = keyPrefix;
+        existing.key_hash = apiKey ? hashKey(apiKey) : null;
       }
       existing.region = resolvedRegion;
       existing.is_active = true;
@@ -429,6 +431,7 @@ export class ProviderService {
       priority: 0,
       api_key_encrypted: apiKeyEncrypted,
       key_prefix: keyPrefix,
+      key_hash: apiKey ? hashKey(apiKey) : null,
       region: resolvedRegion,
       is_active: true,
       connected_at: new Date().toISOString(),
@@ -475,6 +478,7 @@ export class ProviderService {
       if (apiKeyEncrypted !== null) {
         existing.api_key_encrypted = apiKeyEncrypted;
         existing.key_prefix = keyPrefix;
+        existing.key_hash = apiKey ? hashKey(apiKey) : null;
       }
       existing.region = resolvedRegion;
       existing.is_active = true;
@@ -526,6 +530,7 @@ export class ProviderService {
       priority: this.nextPriority(existingRows),
       api_key_encrypted: apiKeyEncrypted,
       key_prefix: keyPrefix,
+      key_hash: apiKey ? hashKey(apiKey) : null,
       region: resolvedRegion,
       is_active: true,
       connected_at: new Date().toISOString(),


### PR DESCRIPTION
## What

Adds a **scoped AI-admin API** under `/api/v1/admin` for programmatically
administering a self-hosted Manifest instance — agents, provider keys, and
observability — gated by a new key scope (`ai_admin`) on a dedicated
`mnfst_admin_ai_*` key prefix.

This is a thin, additive layer over the existing NestJS service layer
(`AgentLifecycleService`, `ProviderService`, `CustomProviderService`,
`TimeseriesQueriesService`, `ResolveAgentService`). **No new business logic,
no new infrastructure, no breaking changes.**

## Why

Self-hosted instances are currently managed almost entirely through the
dashboard (browser session / owner key). There is no stable, key-authenticated
*machine* surface for an AI agent or ops automation to onboard and operate
harnesses without a human in the browser. An AI-admin key is **narrowly scoped**
so it can administer agents/providers/observability but, by construction, cannot
hit owner-only account/session endpoints.

## Changes

- `api_keys.scope` column (`owner` default, `ai_admin`) + migration.
- `tenant_providers.key_hash` column + migration (enables provider-key
  **match-verify** without ever returning the raw secret).
- `ApiKeyGuard` stashes the resolved scope on the request; new `AdminAiGuard`
  authorizes `/api/v1/admin/*` to `ai_admin` only (owner keys → 403, missing → 401).
- `AdminController` — mint/list/revoke admin keys (raw key returned once).
- `AdminAgentController` — full agent CRUD + `rotate-key` + `duplicate`.
- `AdminProviderController` — list + attach/update provider key +
  **match-verify** (`{ match: boolean }`, salt-aware `verifyKey`, secret never returned).
- `AdminObservabilityController` — read-only usage + per-agent routing.
- Exported the needed services from `AnalyticsModule`/`RoutingCoreModule`/
  `CustomProviderModule` (proper Nest boundaries) so `AdminModule` imports them
  rather than re-providing.
- Registered the two new migrations in `data-source-definitions.ts` (mnfst
  registers migrations as an explicit array, not a glob).
- Changeset included.

## Security

- No handler returns a stored provider/agent secret; ingest keys are returned
  only at creation/rotation/duplicate (same as the dashboard).
- Match-verify uses salt-aware `verifyKey`, never a raw compare.
- Migrations are additive with defaults; existing rows untouched.

## Verification

- `nest build` green.
- Existing `custom-provider.controller.spec.ts` + `provider-key.service.spec.ts`
  = 22/22 pass (no regression).
- Built into a local image, deployed to a **live self-hosted instance**, and
  exercised end-to-end: agent create/get/rename/duplicate/rotate/delete,
  provider attach + match-verify (both directions), observability, and scope
  enforcement (200 with admin key, 401 without, 403 with owner key). Live proxy
  stayed healthy; real agents untouched.

## Discussion

Proposal + design questions for maintainers:
https://github.com/mnfst/manifest/discussions/2746

## Notes for review

- This is the agent-admin twin of the dashboard's existing controllers; the
  dashboard itself is unchanged.
- Per-project convention, I added a changeset rather than relying on release
  tooling to detect the change.

Happy to adjust scope/shape (prefix, scope modeling, match-verify placement) to
match project conventions before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scoped `/api/v1/admin` API for self-hosted agent, provider, and observability management gated by `mnfst_admin_ai_*` keys. Previously only the dashboard with owner keys could do this; now admin keys can do it programmatically, and owner keys are rejected on `/api/v1/admin` except `POST /api/v1/admin/keys` to bootstrap the first admin key.

- API surface: mint/list/revoke admin keys; agent CRUD (create/get/rename/rotate-key/duplicate/delete; GET key returns prefix only; raw keys only on create/rotate/duplicate); provider list/attach/update and key match-verify (no secret returned); read-only usage and routing.
- Data/auth: adds `api_keys.scope` (defaults to `owner`) and `tenant_providers.key_hash`; provider writes persist `key_hash`, and match-verify lazily backfills it for legacy encrypted rows; `ApiKeyGuard` stashes `authScope`, `AdminAiGuard` requires `ai_admin`, and `@AdminBootstrap` allows an owner key only for `POST /api/v1/admin/keys`.
- Notable behavior: owner keys get 403 on admin routes (bootstrap route allowed); duplicate agent names return 409; agent creation compensates if provider enablement fails; migrations include safer `down` lock timeouts; observability queries run in parallel.

**Rollout**
- Run DB migrations to add `api_keys.scope` and `tenant_providers.key_hash`.
- Bootstrap: use an owner key to `POST /api/v1/admin/keys` once to mint a `mnfst_admin_ai_*` key, then use that key for all `/api/v1/admin` calls.
- To enable match-verify for existing provider connections, re-save the provider key once (or rely on lazy backfill triggered by the first verify).

<sup>Written for commit d2e8bfc83015fbe51adcc76098b66972b806fc72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

