### PR TITLE
fix: route OpenCode Go Responses-only models to /v1/responses

### DIFF
--- a/.changeset/opencode-go-responses-routing.md
+++ b/.changeset/opencode-go-responses-routing.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route OpenCode Go Responses-only models (Grok 4.5, GPT 5.6 Luna, Muse Spark) to `/v1/responses` instead of `/v1/chat/completions`.

--- a/packages/backend/src/model-discovery/opencode-go-catalog.service.spec.ts
+++ b/packages/backend/src/model-discovery/opencode-go-catalog.service.spec.ts
@@ -3,14 +3,17 @@ import { OPENCODE_GO_BUDGET_5H_USD, OpencodeGoCatalogService } from './opencode-
 const BT = String.fromCharCode(96);
 const OAI = BT + 'https://opencode.ai/zen/go/v1/chat/completions' + BT;
 const ANT = BT + 'https://opencode.ai/zen/go/v1/messages' + BT;
+const RESP = BT + 'https://opencode.ai/zen/go/v1/responses' + BT;
 const OAI_SDK = BT + '@ai-sdk/openai-compatible' + BT;
 const ANT_SDK = BT + '@ai-sdk/anthropic' + BT;
+const RESP_SDK = BT + '@ai-sdk/openai' + BT;
 
 const ENDPOINTS_TABLE = [
   '## Endpoints',
   '',
   '| Model        | Model ID     | Endpoint                                         | AI SDK Package              |',
   '| ------------ | ------------ | ------------------------------------------------ | --------------------------- |',
+  `| Grok 4.5     | grok-4.5     | ${RESP} | ${RESP_SDK} |`,
   `| GLM-5.1      | glm-5.1      | ${OAI} | ${OAI_SDK} |`,
   `| GLM-5        | glm-5        | ${OAI} | ${OAI_SDK} |`,
   `| Kimi K2.5    | kimi-k2.5    | ${OAI} | ${OAI_SDK} |`,
@@ -27,6 +30,7 @@ const LIMITS_TABLE = [
   '',
   '| Model              | requests per 5 hour | requests per week | requests per month |',
   '| ------------------ | ------------------- | ----------------- | ------------------ |',
+  '| Grok 4.5           | 120                 | 300               | 600                |',
   '| GLM-5.1            | 880                 | 2,150             | 4,300              |',
   '| GLM-5              | 1,150               | 2,880             | 5,750              |',
   '| Kimi K2.5          | 1,850               | 4,630             | 9,250              |',
@@ -65,6 +69,7 @@ describe('OpencodeGoCatalogService', () => {
     it('extracts every model in the endpoints table', () => {
       const entries = service.parse(SAMPLE_MDX);
       expect(entries.map((e) => e.id)).toEqual([
+        'grok-4.5',
         'glm-5.1',
         'glm-5',
         'kimi-k2.5',
@@ -79,6 +84,7 @@ describe('OpencodeGoCatalogService', () => {
     it('keeps the docs display name verbatim', () => {
       const entries = service.parse(SAMPLE_MDX);
       const labels = Object.fromEntries(entries.map((e) => [e.id, e.displayName]));
+      expect(labels['grok-4.5']).toBe('Grok 4.5');
       expect(labels['glm-5.1']).toBe('GLM-5.1');
       expect(labels['kimi-k2.5']).toBe('Kimi K2.5');
       expect(labels['mimo-v2-omni']).toBe('MiMo-V2-Omni');
@@ -89,6 +95,7 @@ describe('OpencodeGoCatalogService', () => {
     it('tags docs rows with the endpoint format they declare', () => {
       const entries = service.parse(SAMPLE_MDX);
       const byId = Object.fromEntries(entries.map((e) => [e.id, e.format]));
+      expect(byId['grok-4.5']).toBe('responses');
       expect(byId['glm-5.1']).toBe('openai');
       expect(byId['kimi-k2.5']).toBe('openai');
       expect(byId['mimo-v2-pro']).toBe('openai');
@@ -119,6 +126,8 @@ describe('OpencodeGoCatalogService', () => {
     it('attaches per-request cost derived from the Usage Limits table', () => {
       const entries = service.parse(SAMPLE_MDX);
       const cost = Object.fromEntries(entries.map((e) => [e.id, e.costPerRequestUsd]));
+      // $12 / 120 = $0.10
+      expect(cost['grok-4.5']).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 120, 12);
       // $12 / 880 = ~0.01364
       expect(cost['glm-5.1']).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 880, 12);
       // $12 / 1150 = ~0.01043
@@ -199,6 +208,7 @@ describe('OpencodeGoCatalogService', () => {
       expect(service.getFormat('qwen3.7-max')).toBe('anthropic');
       expect(service.getFormat('opencode-go/qwen3.7-max')).toBe('anthropic');
       expect(service.getFormat('opencode-go/mimo-v2-pro')).toBe('openai');
+      expect(service.getFormat('opencode-go/grok-4.5')).toBe('responses');
     });
 
     it('warms the catalog for async format lookup', async () => {
@@ -351,7 +361,7 @@ describe('OpencodeGoCatalogService', () => {
       } as Response);
 
       const first = await service.list();
-      expect(first).toHaveLength(8);
+      expect(first).toHaveLength(9);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
 
       const second = await service.list();
@@ -366,7 +376,7 @@ describe('OpencodeGoCatalogService', () => {
         text: async () => SAMPLE_MDX,
       } as Response);
       const good = await service.list();
-      expect(good).toHaveLength(8);
+      expect(good).toHaveLength(9);
 
       // Force the success cache to look expired, but keep lastGood populated.
       (service as unknown as { cache: unknown }).cache = null;

--- a/packages/backend/src/model-discovery/opencode-go-catalog.service.ts
+++ b/packages/backend/src/model-discovery/opencode-go-catalog.service.ts
@@ -6,7 +6,7 @@ export interface OpencodeGoCatalogEntry {
   /** Human-readable display name from the docs (e.g. "GLM-5.1"). */
   displayName: string;
   /** Which upstream API format the model expects. */
-  format: 'openai' | 'anthropic';
+  format: 'openai' | 'anthropic' | 'responses';
   /**
    * Cost in USD attributed to one request, derived from the docs Usage Limits
    * table: `OPENCODE_GO_BUDGET_5H_USD / requestsPer5h`. `null` when the docs
@@ -196,7 +196,7 @@ export class OpencodeGoCatalogService implements OnModuleInit {
   parse(mdx: string): OpencodeGoCatalogEntry[] {
     const costByName = this.parseLimits(mdx);
     const rowRe =
-      /\|\s*([A-Za-z][^|]*?)\s*\|\s*([a-z][a-z0-9.-]*)\s*\|\s*`?https:\/\/opencode\.ai\/zen\/go\/v1\/(chat\/completions|messages)`?\s*\|/g;
+      /\|\s*([A-Za-z][^|]*?)\s*\|\s*([a-z][a-z0-9.-]*)\s*\|\s*`?https:\/\/opencode\.ai\/zen\/go\/v1\/(chat\/completions|messages|responses)`?\s*\|/g;
     const entries: OpencodeGoCatalogEntry[] = [];
     const seen = new Set<string>();
     let match: RegExpExecArray | null;
@@ -211,7 +211,12 @@ export class OpencodeGoCatalogService implements OnModuleInit {
       entries.push({
         id: modelId,
         displayName,
-        format: endpointSuffix === 'messages' ? 'anthropic' : 'openai',
+        format:
+          endpointSuffix === 'messages'
+            ? 'anthropic'
+            : endpointSuffix === 'responses'
+              ? 'responses'
+              : 'openai',
         costPerRequestUsd: costByName.get(normalizeDisplayName(displayName)) ?? null,
       });
     }

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2904,6 +2904,91 @@ describe('ProviderClient', () => {
       expect(sentBody.model).toBe('future-model');
     });
 
+    it('routes catalog-declared Responses models to /v1/responses with chatgpt conversion', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const catalogClient = new ProviderClient({
+        getFormat: jest.fn().mockReturnValue(null),
+        resolveFormat: jest.fn().mockResolvedValue('responses'),
+      } as any);
+
+      const result = await catalogClient.forward({
+        provider: 'opencode-go',
+        apiKey: 'og-token',
+        model: 'opencode-go/grok-4.5',
+        body,
+        stream: false,
+        authType: 'subscription',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://opencode.ai/zen/go/v1/responses',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer og-token',
+            'Content-Type': 'application/json',
+          }),
+        }),
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('grok-4.5');
+      // Body is Responses-API shape (input/store), not Chat Completions.
+      expect(Array.isArray(sentBody.input)).toBe(true);
+      expect(sentBody.store).toBe(false);
+      expect(sentBody.messages).toBeUndefined();
+      expect(sentBody.stream).toBe(false);
+      expect(result.isChatGpt).toBe(true);
+      expect(result.isAnthropic).toBe(false);
+    });
+
+    it('maps max_tokens to max_output_tokens for OpenCode Go Responses models', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const catalogClient = new ProviderClient({
+        resolveFormat: jest.fn().mockResolvedValue('responses'),
+      } as any);
+
+      await catalogClient.forward({
+        provider: 'opencode-go',
+        apiKey: 'og-token',
+        model: 'opencode-go/gpt-5.6-luna',
+        body: { ...body, max_tokens: 1536 },
+        stream: false,
+        authType: 'subscription',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://opencode.ai/zen/go/v1/responses',
+        expect.any(Object),
+      );
+      expect(sentBody.max_output_tokens).toBe(1536);
+      expect(sentBody.max_tokens).toBeUndefined();
+    });
+
+    it('forwards native Responses requests for OpenCode Go Responses models', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const catalogClient = new ProviderClient({
+        resolveFormat: jest.fn().mockResolvedValue('responses'),
+      } as any);
+
+      const result = await catalogClient.forward({
+        provider: 'opencode-go',
+        apiKey: 'og-token',
+        model: 'opencode-go/grok-4.5',
+        body: { input: 'Hello', max_output_tokens: 50 },
+        stream: false,
+        authType: 'subscription',
+        apiMode: 'responses',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://opencode.ai/zen/go/v1/responses');
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('grok-4.5');
+      expect(sentBody.input).toBe('Hello');
+      expect(sentBody.max_output_tokens).toBe(50);
+      expect(result.isResponses).toBe(true);
+    });
+
     it('uses catalog format over family fallback when available', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const catalogClient = new ProviderClient({

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -183,6 +183,7 @@ describe('resolveEndpointKey', () => {
     expect(known).toContain('kiro');
     expect(known).toContain('opencode-go');
     expect(known).toContain('opencode-go-anthropic');
+    expect(known).toContain('opencode-go-responses');
     expect(known).toContain('opencode-zen');
     expect(known).toContain('opencode-zen-google');
   });
@@ -723,6 +724,19 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(headers['Authorization']).toBeUndefined();
   });
 
+  it('opencode-go-responses targets /v1/responses with chatgpt format and Bearer auth', () => {
+    const ep = PROVIDER_ENDPOINTS['opencode-go-responses'];
+    expect(ep.baseUrl).toBe('https://opencode.ai/zen/go');
+    expect(ep.format).toBe('chatgpt');
+    expect(ep.buildPath('grok-4.5')).toBe('/v1/responses');
+    expect(ep.forwardResponsesStream).toBe(true);
+    expect(ep.acceptsMaxOutputTokens).toBe(true);
+    expect(ep.buildHeaders('og-token')).toEqual({
+      Authorization: 'Bearer og-token',
+      'Content-Type': 'application/json',
+    });
+  });
+
   it('opencode-zen uses OpenCode Zen base URL with OpenAI format', () => {
     const ep = PROVIDER_ENDPOINTS['opencode-zen'];
     expect(ep.baseUrl).toBe('https://opencode.ai/zen');
@@ -855,6 +869,7 @@ describe('PROVIDER_ENDPOINTS', () => {
       'minimax-subscription',
       'qwen-subscription-responses',
       'opencode-go-anthropic',
+      'opencode-go-responses',
       'opencode-zen-google',
     ];
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -502,10 +502,14 @@ export class ProviderClient {
     }
     if (resolved === 'opencode-go') {
       const bareOpenCodeModel = stripVendorPrefix(model).toLowerCase();
-      const knownAnthropicFamily = this.isKnownOpencodeGoAnthropicFamily(bareOpenCodeModel);
       const catalogFormat = await this.resolveOpencodeGoFormat(bareOpenCodeModel);
-      if (catalogFormat === 'anthropic' || (!catalogFormat && knownAnthropicFamily)) {
-        resolved = 'opencode-go-anthropic';
+      if (catalogFormat === 'responses') {
+        resolved = 'opencode-go-responses';
+      } else {
+        const knownAnthropicFamily = this.isKnownOpencodeGoAnthropicFamily(bareOpenCodeModel);
+        if (catalogFormat === 'anthropic' || (!catalogFormat && knownAnthropicFamily)) {
+          resolved = 'opencode-go-anthropic';
+        }
       }
     }
     if (resolved === 'commandcode') {
@@ -534,7 +538,9 @@ export class ProviderClient {
     return { endpoint: PROVIDER_ENDPOINTS[resolved], endpointKey: resolved };
   }
 
-  private async resolveOpencodeGoFormat(bareModel: string): Promise<'openai' | 'anthropic' | null> {
+  private async resolveOpencodeGoFormat(
+    bareModel: string,
+  ): Promise<'openai' | 'anthropic' | 'responses' | null> {
     if (!this.opencodeGoCatalog) return null;
     try {
       return await this.opencodeGoCatalog.resolveFormat(bareModel);

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -546,6 +546,17 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: () => '/v1/messages',
     format: 'anthropic',
   },
+  // OpenCode Go's Responses-only models (Grok 4.5, GPT 5.6 Luna, Muse Spark)
+  // reject /v1/chat/completions — the docs Endpoints table sends them to
+  // /v1/responses instead.
+  'opencode-go-responses': {
+    baseUrl: OPENCODE_GO_BASE,
+    buildHeaders: openaiHeaders,
+    buildPath: () => '/v1/responses',
+    format: 'chatgpt',
+    forwardResponsesStream: true,
+    acceptsMaxOutputTokens: true,
+  },
   // OpenCode Zen's /v1/chat/completions is a unified OpenAI-compatible
   // endpoint that handles Claude, GPT, and the long tail of OpenAI-compatible
   // models (Qwen, GLM, Kimi, MiniMax, …) on a single Bearer-auth route.


### PR DESCRIPTION
Closes #2744.

## Problem

OpenCode Go exposes three upstream API paths, but Manifest only configured two. Models the Go docs list on `/v1/responses` (Grok 4.5, GPT 5.6 Luna, Muse Spark 1.2 Contributor) were:

- forwarded to `/v1/chat/completions` at request time, where they fail upstream, and
- silently dropped from the docs catalog parse, so they also got no per-request cost attribution.

## Changes

- **`provider-endpoints.ts`** — new `opencode-go-responses` endpoint (`/v1/responses`, `format: 'chatgpt'`, Bearer auth, `forwardResponsesStream` + `acceptsMaxOutputTokens`), same pattern as `xai-responses` / `openai-responses`.
- **`opencode-go-catalog.service.ts`** — catalog `format` union gains `'responses'`; the Endpoints-table regex now accepts `responses`, so those rows parse (fixing both routing input and cost attribution).
- **`provider-client.ts`** — `resolveEndpoint` routes catalog-declared `responses` models to the new endpoint. Routing stays catalog-driven; when the catalog is unavailable, unknown models keep the existing default (`/v1/chat/completions`), matching prior degraded behavior.

## Test plan

- Catalog spec: `responses` rows parse with correct format tag and cost (`/120 = /bin/zsh.10` for Grok 4.5).
- Endpoints spec: new endpoint config + inclusion in the known-endpoints / no-stream-usage lists.
- Client spec: chat → Responses conversion on the wire, `max_tokens` → `max_output_tokens` mapping, and native `apiMode: 'responses'` passthrough.
- 442 tests pass across the catalog, endpoints, and client suites against latest `main`; `tsc --noEmit` and eslint clean on touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes OpenCode Go Responses-only models to /v1/responses and includes them in the catalog, fixing upstream request failures and restoring per-request cost attribution. Previously, models listed under `/v1/responses` were sent to `/v1/chat/completions` and omitted from the catalog; now they route to `/v1/responses` and are parsed with correct format and costs.

- New endpoint `opencode-go-responses`: base `https://opencode.ai/zen/go`, path `/v1/responses`, format `chatgpt`, Bearer auth, forwards Responses streams, and maps `max_tokens` to `max_output_tokens`.
- Catalog: accepts `responses` rows in the Endpoints table, adds `responses` to the format union, and derives costs from Usage Limits (e.g., Grok 4.5).
- Client routing: when the catalog marks a model as `responses`, `resolveEndpoint` targets `opencode-go-responses`; when the catalog is unavailable, unknown models still default to `/v1/chat/completions` (unchanged degraded behavior).
- Request handling: chat-shaped requests are converted to Responses shape; native Responses are supported via `apiMode: 'responses'`.

<sup>Written for commit 806062cf72362ca789c686b62497999d91761c24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

