### PR TITLE
perf(db): slim agent_messages dedup index to tenant+agent+model

### DIFF
--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -40,6 +40,7 @@ import { EnableRecordingForNewAgents1801500000000 } from './migrations/180150000
 import { DropLegacyAutofixRolloutColumns1801600000000 } from './migrations/1801600000000-DropLegacyAutofixRolloutColumns';
 import { AddRequestApiMode1801720000000 } from './migrations/1801720000000-AddRequestApiMode';
 import { AddAutofixConsentToInstallMetadata1801900000000 } from './migrations/1801900000000-AddAutofixConsentToInstallMetadata';
+import { SlimTenantAgentModelIndex1802000000000 } from './migrations/1802000000000-SlimTenantAgentModelIndex';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -318,4 +319,5 @@ export const migrations = [
   DropLegacyAutofixRolloutColumns1801600000000,
   AddRequestApiMode1801720000000,
   AddAutofixConsentToInstallMetadata1801900000000,
+  SlimTenantAgentModelIndex1802000000000,
 ];

--- a/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.spec.ts
@@ -3,16 +3,19 @@ import { SlimTenantAgentModelIndex1802000000000 } from './1802000000000-SlimTena
 describe('SlimTenantAgentModelIndex1802000000000', () => {
   const migration = new SlimTenantAgentModelIndex1802000000000();
   let queries: string[];
+  let args: unknown[][];
 
   const mockQueryRunner = {
-    query: jest.fn().mockImplementation((sql: string) => {
+    query: jest.fn().mockImplementation((sql: string, ...params: unknown[]) => {
       queries.push(sql);
-      return Promise.resolve();
+      args.push(params);
+      return Promise.resolve([]);
     }),
   } as never;
 
   beforeEach(() => {
     queries = [];
+    args = [];
     jest.clearAllMocks();
   });
 
@@ -22,25 +25,29 @@ describe('SlimTenantAgentModelIndex1802000000000', () => {
 
   it('builds the slim agent+model index then drops the fat dedup index', async () => {
     await migration.up(mockQueryRunner);
-    expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain(
+    expect(queries).toHaveLength(3);
+    expect(queries[0]).toContain('NOT i.indisvalid');
+    expect(args[0]).toEqual([['IDX_agent_messages_tenant_agent_id_model']]);
+    expect(queries[1]).toContain(
       'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_agent_id_model"',
     );
-    expect(queries[0]).toContain('ON "agent_messages"');
-    expect(queries[0]).toContain('("tenant_id", "agent_id", "model")');
-    expect(queries[1]).toContain(
+    expect(queries[1]).toContain('ON "agent_messages"');
+    expect(queries[1]).toContain('("tenant_id", "agent_id", "model")');
+    expect(queries[2]).toContain(
       'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_model_status_ts"',
     );
   });
 
   it('restores the fat dedup index then drops the slim index on rollback', async () => {
     await migration.down(mockQueryRunner);
-    expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain(
+    expect(queries).toHaveLength(3);
+    expect(queries[0]).toContain('NOT i.indisvalid');
+    expect(args[0]).toEqual([['IDX_agent_messages_tenant_agent_model_status_ts']]);
+    expect(queries[1]).toContain(
       'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_agent_model_status_ts"',
     );
-    expect(queries[0]).toContain('("tenant_id", "agent_id", "model", "status", "timestamp")');
-    expect(queries[1]).toContain(
+    expect(queries[1]).toContain('("tenant_id", "agent_id", "model", "status", "timestamp")');
+    expect(queries[2]).toContain(
       'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_id_model"',
     );
   });

--- a/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.spec.ts
@@ -4,11 +4,15 @@ describe('SlimTenantAgentModelIndex1802000000000', () => {
   const migration = new SlimTenantAgentModelIndex1802000000000();
   let queries: string[];
   let args: unknown[][];
+  let invalidRows: unknown[];
 
   const mockQueryRunner = {
     query: jest.fn().mockImplementation((sql: string, ...params: unknown[]) => {
       queries.push(sql);
       args.push(params);
+      if (sql.includes('NOT i.indisvalid')) {
+        return Promise.resolve(invalidRows);
+      }
       return Promise.resolve([]);
     }),
   } as never;
@@ -16,6 +20,7 @@ describe('SlimTenantAgentModelIndex1802000000000', () => {
   beforeEach(() => {
     queries = [];
     args = [];
+    invalidRows = [];
     jest.clearAllMocks();
   });
 
@@ -48,6 +53,38 @@ describe('SlimTenantAgentModelIndex1802000000000', () => {
     );
     expect(queries[1]).toContain('("tenant_id", "agent_id", "model", "status", "timestamp")');
     expect(queries[2]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_id_model"',
+    );
+  });
+
+  it('drops an INVALID slim-index shell before rebuilding on up', async () => {
+    invalidRows = [{}];
+    await migration.up(mockQueryRunner);
+    expect(queries).toHaveLength(4);
+    expect(queries[0]).toContain('NOT i.indisvalid');
+    expect(queries[1]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_id_model"',
+    );
+    expect(queries[2]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_agent_id_model"',
+    );
+    expect(queries[3]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_model_status_ts"',
+    );
+  });
+
+  it('drops an INVALID fat-index shell before rebuilding on down', async () => {
+    invalidRows = [{}];
+    await migration.down(mockQueryRunner);
+    expect(queries).toHaveLength(4);
+    expect(queries[0]).toContain('NOT i.indisvalid');
+    expect(queries[1]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_model_status_ts"',
+    );
+    expect(queries[2]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_agent_model_status_ts"',
+    );
+    expect(queries[3]).toContain(
       'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_id_model"',
     );
   });

--- a/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.spec.ts
@@ -1,0 +1,47 @@
+import { SlimTenantAgentModelIndex1802000000000 } from './1802000000000-SlimTenantAgentModelIndex';
+
+describe('SlimTenantAgentModelIndex1802000000000', () => {
+  const migration = new SlimTenantAgentModelIndex1802000000000();
+  let queries: string[];
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve();
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('exposes the expected migration name', () => {
+    expect(migration.name).toBe('SlimTenantAgentModelIndex1802000000000');
+  });
+
+  it('builds the slim agent+model index then drops the fat dedup index', async () => {
+    await migration.up(mockQueryRunner);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_agent_id_model"',
+    );
+    expect(queries[0]).toContain('ON "agent_messages"');
+    expect(queries[0]).toContain('("tenant_id", "agent_id", "model")');
+    expect(queries[1]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_model_status_ts"',
+    );
+  });
+
+  it('restores the fat dedup index then drops the slim index on rollback', async () => {
+    await migration.down(mockQueryRunner);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_agent_model_status_ts"',
+    );
+    expect(queries[0]).toContain('("tenant_id", "agent_id", "model", "status", "timestamp")');
+    expect(queries[1]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_id_model"',
+    );
+  });
+});

--- a/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.ts
+++ b/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.ts
@@ -21,6 +21,12 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * Build-new-then-drop CONCURRENTLY so a usable index always exists and no
  * ACCESS EXCLUSIVE lock is taken against live writes. The new key is a strict
  * prefix of the old, so no query loses index coverage during the swap.
+ *
+ * A cancelled CONCURRENTLY build leaves an INVALID index shell behind. `CREATE
+ * ... IF NOT EXISTS` matches on name and would skip over it, so a retry would
+ * then drop the still-usable old index and leave the table with nothing valid.
+ * Both directions clear an INVALID leftover before creating, mirroring
+ * 1801200000000's `indexIsInvalid` guard.
  */
 export class SlimTenantAgentModelIndex1802000000000 implements MigrationInterface {
   name = 'SlimTenantAgentModelIndex1802000000000';
@@ -31,6 +37,9 @@ export class SlimTenantAgentModelIndex1802000000000 implements MigrationInterfac
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     const { OLD_INDEX, NEW_INDEX } = SlimTenantAgentModelIndex1802000000000;
+    if (await this.indexIsInvalid(queryRunner, NEW_INDEX)) {
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${NEW_INDEX}"`);
+    }
     await queryRunner.query(
       `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${NEW_INDEX}" ON "agent_messages" ("tenant_id", "agent_id", "model")`,
     );
@@ -39,9 +48,21 @@ export class SlimTenantAgentModelIndex1802000000000 implements MigrationInterfac
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     const { OLD_INDEX, NEW_INDEX } = SlimTenantAgentModelIndex1802000000000;
+    if (await this.indexIsInvalid(queryRunner, OLD_INDEX)) {
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${OLD_INDEX}"`);
+    }
     await queryRunner.query(
       `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${OLD_INDEX}" ON "agent_messages" ("tenant_id", "agent_id", "model", "status", "timestamp")`,
     );
     await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${NEW_INDEX}"`);
+  }
+
+  /** True when an index of this name exists but is INVALID (interrupted build). */
+  private async indexIsInvalid(queryRunner: QueryRunner, indexName: string): Promise<boolean> {
+    const rows: unknown[] = await queryRunner.query(
+      `SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = $1 AND NOT i.indisvalid`,
+      [indexName],
+    );
+    return rows.length > 0;
   }
 }

--- a/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.ts
+++ b/packages/backend/src/database/migrations/1802000000000-SlimTenantAgentModelIndex.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Replaces the dedup composite index with a slimmer tenant+agent+model index.
+ *
+ * `IDX_agent_messages_tenant_agent_model_status_ts`
+ * (`tenant_id, agent_id, model, status, timestamp`) was added (1790200000000)
+ * for the per-completion success-dedup lookup, which has since been removed.
+ * The planner still picks it for the per-agent "cost by model" read in
+ * `agent-analytics.service.ts` (`WHERE tenant_id + agent_id + model IS NOT NULL
+ * GROUP BY model`), which only needs the leading three columns. The trailing
+ * `status` and `timestamp` columns are vestigial, so the index carries dead
+ * weight on the hottest write path (every insert maintains it).
+ *
+ * Replaced with `IDX_agent_messages_tenant_agent_id_model`
+ * (`tenant_id, agent_id, model`), which serves the same read with a narrower
+ * key and benefits from B-tree deduplication on repeated (tenant, agent, model)
+ * tuples. Named with `agent_id` to avoid colliding with the existing
+ * `IDX_agent_messages_tenant_agent_model` (tenant_id, agent_name, model).
+ *
+ * Build-new-then-drop CONCURRENTLY so a usable index always exists and no
+ * ACCESS EXCLUSIVE lock is taken against live writes. The new key is a strict
+ * prefix of the old, so no query loses index coverage during the swap.
+ */
+export class SlimTenantAgentModelIndex1802000000000 implements MigrationInterface {
+  name = 'SlimTenantAgentModelIndex1802000000000';
+  transaction = false;
+
+  private static readonly OLD_INDEX = 'IDX_agent_messages_tenant_agent_model_status_ts';
+  private static readonly NEW_INDEX = 'IDX_agent_messages_tenant_agent_id_model';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const { OLD_INDEX, NEW_INDEX } = SlimTenantAgentModelIndex1802000000000;
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${NEW_INDEX}" ON "agent_messages" ("tenant_id", "agent_id", "model")`,
+    );
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${OLD_INDEX}"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const { OLD_INDEX, NEW_INDEX } = SlimTenantAgentModelIndex1802000000000;
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${OLD_INDEX}" ON "agent_messages" ("tenant_id", "agent_id", "model", "status", "timestamp")`,
+    );
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${NEW_INDEX}"`);
+  }
+}

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -12,10 +12,11 @@ import type { CallerAttribution } from '../routing/proxy/caller-classifier';
 @Index(['tenant_id', 'trace_id'])
 @Index(['tenant_id', 'model'])
 @Index(['tenant_id', 'agent_id', 'status'])
-// Originally added for the per-completion success dedup, which is gone. Kept
-// because the planner still picks it for other tenant+agent+model reads; at
-// ~1.7 GB it is a drop candidate once those are attributed to another index.
-@Index(['tenant_id', 'agent_id', 'model', 'status', 'timestamp'])
+// Originally (tenant_id, agent_id, model, status, timestamp) for the
+// per-completion success dedup, which is gone. The per-agent "cost by model"
+// read (agent-analytics.service.ts) only needs the leading three columns, so
+// the trailing status/timestamp were dropped in 1802000000000.
+@Index(['tenant_id', 'agent_id', 'model'])
 // Per-connection analytics scope by the exact key that served each message
 // (tenant_provider_id) ordered by recency, and the FK below resolves its
 // ON DELETE SET NULL against the same column. tenant_provider_id leads so one


### PR DESCRIPTION
## What

Replaces the `(tenant_id, agent_id, model, status, timestamp)` index on `agent_messages` with a narrower `(tenant_id, agent_id, model)` index.

## Why

The composite index was added (migration `1790200000000`) for the per-completion success-dedup lookup, which has since been removed. The planner still picks it for the per-agent "cost by model" read in `agent-analytics.service.ts`, which only needs the leading three columns. The trailing `status` + `timestamp` columns are vestigial, so the index carries ~2.1 GB of dead weight on the hottest table's write path (every insert maintains it, plus the daily recording-retention update).

The new index is a strict prefix of the old, so no query loses index coverage; it also benefits from B-tree dedup on repeated (tenant, agent, model) tuples.

## Validation

- Unit spec (`1802000000000-SlimTenantAgentModelIndex.spec.ts`) passes.
- Ran `validate-production-migrations` against a disposable clone of the production schema (PostgreSQL 17, hardened `migration_exporter` role): migration applies cleanly, is idempotent (second run finds nothing pending), and leaves the new index present with the old one dropped.

## Notes

- Build-new-then-drop `CONCURRENTLY`, so no ACCESS EXCLUSIVE lock is taken against live writes.
- No data migration; schema/index-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slims the agent_messages index from (tenant_id, agent_id, model, status, timestamp) to (tenant_id, agent_id, model) to cut write amplification and disk while preserving the per-agent “cost by model” read. Adds guards that drop INVALID concurrent-build shells so retries never leave the table without a valid index.

- Creates "IDX_agent_messages_tenant_agent_id_model" CONCURRENTLY and drops "IDX_agent_messages_tenant_agent_model_status_ts"; both up and down clear any INVALID shell before create; non-transactional, online-only, no data migration.
- Updates the entity @Index to the new key; registers the migration; adds tests that cover normal paths and the INVALID-shell drop for both up and down.
- Rollout: run backend migrations after deploy; rollback recreates the old index CONCURRENTLY and drops the new one.

<sup>Written for commit 0ebba2bc69ed65b094bf43731272d07f3b125562. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

