### PR TITLE
Cap the provider connections list and add a Show all button

### DIFF
--- a/.changeset/connections-collapse.md
+++ b/.changeset/connections-collapse.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Cap the provider connections list at ten and a half rows so the supported-provider catalog below it stays reachable. The card scrolls, and a "Show all" button expands it to full height.

--- a/.changeset/connections-collapse.md
+++ b/.changeset/connections-collapse.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Cap the provider connections list at ten and a half rows so the supported-provider catalog below it stays reachable. The card scrolls, and a "Show all" button expands it to full height.
+Cap the provider connections list at six and a half rows so the supported-provider catalog below it stays reachable. The card scrolls, and a "Show all" button expands it to full height.

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -22,6 +22,7 @@ import {
   type TenantProviderSummary,
 } from '../../services/api/providers.js';
 import { analyticsPing, routingPing } from '../../services/sse.js';
+import { toggleScrollFade } from '../../services/scroll-fade.js';
 import { renameProviderKey } from '../../services/api/routing.js';
 import type { AuthType, CustomProviderData, RoutingProvider } from '../../services/api.js';
 import type { CustomProviderPrefill, ProviderDeepLink } from '../../services/routing-params.js';
@@ -115,6 +116,8 @@ const PAGE_COPY: Record<
     activePlural: 'connections',
   },
 };
+
+const CONNECTIONS_COLLAPSE_THRESHOLD = 10;
 
 const providerListForKind = (kind: ProviderPageKind): ProviderDef[] => {
   if (kind === 'subscriptions')
@@ -224,6 +227,11 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   const [customProviderPrefill, setCustomProviderPrefill] =
     createSignal<CustomProviderPrefill | null>(null);
   const [viewMode, setViewMode] = createSignal<ViewMode>('grid');
+  // Past this many connections the list is capped inside its own card, so the
+  // supported-provider catalog below stays reachable without a long scroll.
+  const [connectionsExpanded, setConnectionsExpanded] = createSignal(false);
+  const connectionsCollapsible = () => connectedRows().length > CONNECTIONS_COLLAPSE_THRESHOLD;
+  const connectionsCollapsed = () => connectionsCollapsible() && !connectionsExpanded();
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Inline rename state
@@ -582,216 +590,266 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
         <h3 style="font-size: var(--font-size-base); font-weight: 600; color: hsl(var(--foreground)); margin-bottom: 12px;">
           {copy().connectedHeading}
         </h3>
-        <div class="panel" style="padding: 0; margin-bottom: 24px; overflow-x: auto;">
-          <table class="data-table" style="width: 100%;">
-            <thead>
-              <tr>
-                <th>Provider</th>
-                <th>Connection</th>
-                <th>Status</th>
-                <th>Usage (30d)</th>
-                <Show when={copy().rowMetricHeading}>
-                  <th>{copy().rowMetricHeading}</th>
-                </Show>
-                <th class="rel-col">
-                  Total attempts (30d)
-                  <InfoTooltip text={totalAttemptsTooltip(true)} />
-                </th>
-                <th class="rel-col">
-                  Success rate (30d)
-                  <InfoTooltip text={CONNECTION_SUCCESS_RATE_TOOLTIP_30D} />
-                </th>
-                <th>Last used</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              <For each={connectedRows()}>
-                {(row) => (
-                  <tr
-                    style="cursor: pointer;"
-                    onClick={() => navigate(`/providers/connections/${row.connection.id}`)}
-                    onKeyDown={(event) => {
-                      if (event.target !== event.currentTarget) return;
-                      if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        navigate(`/providers/connections/${row.connection.id}`);
-                      }
-                    }}
-                    tabindex="0"
-                  >
-                    <td>
-                      <span style="display: flex; align-items: center; gap: 10px;">
-                        <ProviderMark providerId={row.summary.provider} name={row.name} />
-                        <span style="font-weight: 500;">{row.name}</span>
-                        <Show when={row.summary.provider.startsWith('custom:')}>
-                          <span style="display: inline-flex; padding: 1px 6px; border-radius: var(--radius-sm); border: 1px solid hsl(var(--border)); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            Custom
-                          </span>
-                        </Show>
-                      </span>
-                    </td>
-                    <td
-                      style="color: hsl(var(--muted-foreground));"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Show
-                        when={renamingId() === row.connection.id}
-                        fallback={
-                          <span
-                            style="display: inline-flex; align-items: center; gap: 6px; cursor: default;"
-                            class="connection-label-cell"
-                          >
-                            {row.connection.label}
-                            <button
-                              type="button"
-                              class="connection-label-cell__edit"
-                              onClick={(e) =>
-                                startRename(row.connection.id, row.connection.label, e)
-                              }
-                              aria-label={`Rename ${row.connection.label}`}
-                              style="background: none; border: none; cursor: pointer; padding: 2px; color: hsl(var(--muted-foreground)); opacity: 0; transition: opacity 0.15s; display: inline-flex; align-items: center; line-height: 1;"
-                            >
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M5 21h14c1.1 0 2-.9 2-2v-7h-2v7H5V5h7V3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2" />
-                                <path d="M7 13v3c0 .55.45 1 1 1h3c.27 0 .52-.11.71-.29l9-9a.996.996 0 0 0 0-1.41l-3-3a.996.996 0 0 0-1.41 0l-9.01 8.99A1 1 0 0 0 7 13m10-7.59L18.59 7 17.5 8.09 15.91 6.5zm-8 8 5.5-5.5 1.59 1.59-5.5 5.5H9z" />
-                              </svg>
-                            </button>
-                          </span>
-                        }
+        <div
+          class="panel connections-panel"
+          classList={{ 'connections-panel--collapsed': connectionsCollapsed() }}
+          style="padding: 0; margin-bottom: 24px;"
+        >
+          <div class="connections-panel__viewport">
+            <div
+              class="connections-panel__body"
+              id="connected-connections"
+              onScroll={toggleScrollFade}
+            >
+              <table class="data-table" style="width: 100%;">
+                <thead>
+                  <tr>
+                    <th>Provider</th>
+                    <th>Connection</th>
+                    <th>Status</th>
+                    <th>Usage (30d)</th>
+                    <Show when={copy().rowMetricHeading}>
+                      <th>{copy().rowMetricHeading}</th>
+                    </Show>
+                    <th class="rel-col">
+                      Total attempts (30d)
+                      <InfoTooltip text={totalAttemptsTooltip(true)} />
+                    </th>
+                    <th class="rel-col">
+                      Success rate (30d)
+                      <InfoTooltip text={CONNECTION_SUCCESS_RATE_TOOLTIP_30D} />
+                    </th>
+                    <th>Last used</th>
+                    <th />
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={connectedRows()}>
+                    {(row) => (
+                      <tr
+                        style="cursor: pointer;"
+                        onClick={() => navigate(`/providers/connections/${row.connection.id}`)}
+                        onKeyDown={(event) => {
+                          if (event.target !== event.currentTarget) return;
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            navigate(`/providers/connections/${row.connection.id}`);
+                          }
+                        }}
+                        tabindex="0"
                       >
-                        <div style="display: flex; align-items: center; gap: 6px;">
-                          <input
-                            type="text"
-                            class={`provider-detail__input${renameError() ? ' provider-detail__input--error' : ''}`}
-                            value={renameValue()}
-                            onInput={(e) => {
-                              setRenameValue(e.currentTarget.value);
-                              setRenameError('');
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter')
-                                submitRename(
-                                  row.summary.provider,
-                                  row.connection.label,
-                                  row.summary.auth_type ?? copy().authType,
-                                  e,
-                                );
-                              if (e.key === 'Escape') cancelRename(e);
-                            }}
-                            style="width: 120px;"
-                            ref={(el) => requestAnimationFrame(() => el.focus())}
-                          />
-                          <button
-                            class="btn btn--primary btn--sm"
-                            style="font-size: var(--font-size-xs); padding: 4px 10px;"
-                            disabled={renameBusy()}
-                            onClick={(e) =>
-                              submitRename(
-                                row.summary.provider,
-                                row.connection.label,
-                                row.summary.auth_type ?? copy().authType,
-                                e,
-                              )
+                        <td>
+                          <span style="display: flex; align-items: center; gap: 10px;">
+                            <ProviderMark providerId={row.summary.provider} name={row.name} />
+                            <span style="font-weight: 500;">{row.name}</span>
+                            <Show when={row.summary.provider.startsWith('custom:')}>
+                              <span style="display: inline-flex; padding: 1px 6px; border-radius: var(--radius-sm); border: 1px solid hsl(var(--border)); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                                Custom
+                              </span>
+                            </Show>
+                          </span>
+                        </td>
+                        <td
+                          style="color: hsl(var(--muted-foreground));"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Show
+                            when={renamingId() === row.connection.id}
+                            fallback={
+                              <span
+                                style="display: inline-flex; align-items: center; gap: 6px; cursor: default;"
+                                class="connection-label-cell"
+                              >
+                                {row.connection.label}
+                                <button
+                                  type="button"
+                                  class="connection-label-cell__edit"
+                                  onClick={(e) =>
+                                    startRename(row.connection.id, row.connection.label, e)
+                                  }
+                                  aria-label={`Rename ${row.connection.label}`}
+                                  style="background: none; border: none; cursor: pointer; padding: 2px; color: hsl(var(--muted-foreground)); opacity: 0; transition: opacity 0.15s; display: inline-flex; align-items: center; line-height: 1;"
+                                >
+                                  <svg
+                                    width="14"
+                                    height="14"
+                                    viewBox="0 0 24 24"
+                                    fill="currentColor"
+                                  >
+                                    <path d="M5 21h14c1.1 0 2-.9 2-2v-7h-2v7H5V5h7V3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2" />
+                                    <path d="M7 13v3c0 .55.45 1 1 1h3c.27 0 .52-.11.71-.29l9-9a.996.996 0 0 0 0-1.41l-3-3a.996.996 0 0 0-1.41 0l-9.01 8.99A1 1 0 0 0 7 13m10-7.59L18.59 7 17.5 8.09 15.91 6.5zm-8 8 5.5-5.5 1.59 1.59-5.5 5.5H9z" />
+                                  </svg>
+                                </button>
+                              </span>
                             }
                           >
-                            Save
-                          </button>
-                          <button
-                            class="btn btn--outline btn--sm"
-                            style="font-size: var(--font-size-xs); padding: 4px 10px;"
-                            onClick={cancelRename}
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                        <Show when={renameError()}>
-                          <div style="color: hsl(var(--destructive)); font-size: var(--font-size-xs); margin-top: 2px;">
-                            {renameError()}
-                          </div>
+                            <div style="display: flex; align-items: center; gap: 6px;">
+                              <input
+                                type="text"
+                                class={`provider-detail__input${renameError() ? ' provider-detail__input--error' : ''}`}
+                                value={renameValue()}
+                                onInput={(e) => {
+                                  setRenameValue(e.currentTarget.value);
+                                  setRenameError('');
+                                }}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter')
+                                    submitRename(
+                                      row.summary.provider,
+                                      row.connection.label,
+                                      row.summary.auth_type ?? copy().authType,
+                                      e,
+                                    );
+                                  if (e.key === 'Escape') cancelRename(e);
+                                }}
+                                style="width: 120px;"
+                                ref={(el) => requestAnimationFrame(() => el.focus())}
+                              />
+                              <button
+                                class="btn btn--primary btn--sm"
+                                style="font-size: var(--font-size-xs); padding: 4px 10px;"
+                                disabled={renameBusy()}
+                                onClick={(e) =>
+                                  submitRename(
+                                    row.summary.provider,
+                                    row.connection.label,
+                                    row.summary.auth_type ?? copy().authType,
+                                    e,
+                                  )
+                                }
+                              >
+                                Save
+                              </button>
+                              <button
+                                class="btn btn--outline btn--sm"
+                                style="font-size: var(--font-size-xs); padding: 4px 10px;"
+                                onClick={cancelRename}
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                            <Show when={renameError()}>
+                              <div style="color: hsl(var(--destructive)); font-size: var(--font-size-xs); margin-top: 2px;">
+                                {renameError()}
+                              </div>
+                            </Show>
+                          </Show>
+                        </td>
+                        <td>
+                          <StatusBadge active={row.connection.is_active} />
+                        </td>
+                        <td>
+                          <Show when={!usageLoading()} fallback={<UsageShimmer width={96} />}>
+                            <div style="display: flex; align-items: center; gap: 8px;">
+                              {(() => {
+                                const u = usageForConnection(row.summary, row.connection);
+                                const spark = u?.sparkline_7d ?? row.summary.sparkline_7d;
+                                return (
+                                  <>
+                                    <Show when={spark?.length}>
+                                      <span style="flex-shrink: 0;">
+                                        <Sparkline data={spark} width={60} height={20} />
+                                      </span>
+                                    </Show>
+                                    <span>
+                                      {formatNumber(
+                                        perConnectionTokens(row.summary, row.connection),
+                                      )}{' '}
+                                      tokens
+                                    </span>
+                                  </>
+                                );
+                              })()}
+                            </div>
+                          </Show>
+                        </td>
+                        <Show when={copy().rowMetricHeading}>
+                          <td>
+                            <Show when={!usageLoading()} fallback={<UsageShimmer />}>
+                              {formatCost(perConnectionCost(row.summary, row.connection)) ??
+                                '$0.00'}
+                            </Show>
+                          </td>
                         </Show>
-                      </Show>
-                    </td>
-                    <td>
-                      <StatusBadge active={row.connection.is_active} />
-                    </td>
-                    <td>
-                      <Show when={!usageLoading()} fallback={<UsageShimmer width={96} />}>
-                        <div style="display: flex; align-items: center; gap: 8px;">
-                          {(() => {
-                            const u = usageForConnection(row.summary, row.connection);
-                            const spark = u?.sparkline_7d ?? row.summary.sparkline_7d;
-                            return (
-                              <>
-                                <Show when={spark?.length}>
-                                  <span style="flex-shrink: 0;">
-                                    <Sparkline data={spark} width={60} height={20} />
-                                  </span>
-                                </Show>
-                                <span>
-                                  {formatNumber(perConnectionTokens(row.summary, row.connection))}{' '}
-                                  tokens
-                                </span>
-                              </>
-                            );
-                          })()}
-                        </div>
-                      </Show>
-                    </td>
-                    <Show when={copy().rowMetricHeading}>
-                      <td>
-                        <Show when={!usageLoading()} fallback={<UsageShimmer />}>
-                          {formatCost(perConnectionCost(row.summary, row.connection)) ?? '$0.00'}
-                        </Show>
-                      </td>
-                    </Show>
-                    {/* Attempt reliability at the row's own grain (provider +
+                        {/* Attempt reliability at the row's own grain (provider +
                         auth_type): a subscription row never shows a rate
                         blended with the provider's api_key traffic. */}
-                    <td class="rel-col">
-                      <Show when={!usageLoading()} fallback={<UsageShimmer width={48} />}>
-                        {formatNumber(
-                          usageForConnection(row.summary, row.connection)?.attempts_30d ??
-                            row.summary.attempts_30d,
-                        )}
-                      </Show>
-                    </td>
-                    <td class="rel-col">
-                      <Show when={!usageLoading()} fallback={<UsageShimmer width={48} />}>
-                        {(() => {
-                          const u = usageForConnection(row.summary, row.connection);
-                          const rate = attemptSuccessRate({
-                            attempts: u?.attempts_30d ?? row.summary.attempts_30d,
-                            succeeded: u?.succeeded_30d ?? row.summary.succeeded_30d,
-                          });
-                          return rate == null ? '—' : `${(rate * 100).toFixed(1)}%`;
-                        })()}
-                      </Show>
-                    </td>
-                    <td style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs);">
-                      <Show when={!usageLoading()} fallback={<UsageShimmer width={48} />}>
-                        {connectionLastUsedAt(row.summary, row.connection)
-                          ? formatTimeAgo(connectionLastUsedAt(row.summary, row.connection)!)
-                          : '-'}
-                      </Show>
-                    </td>
-                    <td style="text-align: right;">
-                      <button
-                        class="btn btn--outline btn--sm"
-                        style="font-size: var(--font-size-xs); white-space: nowrap;"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          navigate(`/providers/connections/${row.connection.id}`);
-                        }}
-                      >
-                        View details
-                      </button>
-                    </td>
-                  </tr>
-                )}
-              </For>
-            </tbody>
-          </table>
+                        <td class="rel-col">
+                          <Show when={!usageLoading()} fallback={<UsageShimmer width={48} />}>
+                            {formatNumber(
+                              usageForConnection(row.summary, row.connection)?.attempts_30d ??
+                                row.summary.attempts_30d,
+                            )}
+                          </Show>
+                        </td>
+                        <td class="rel-col">
+                          <Show when={!usageLoading()} fallback={<UsageShimmer width={48} />}>
+                            {(() => {
+                              const u = usageForConnection(row.summary, row.connection);
+                              const rate = attemptSuccessRate({
+                                attempts: u?.attempts_30d ?? row.summary.attempts_30d,
+                                succeeded: u?.succeeded_30d ?? row.summary.succeeded_30d,
+                              });
+                              return rate == null ? '—' : `${(rate * 100).toFixed(1)}%`;
+                            })()}
+                          </Show>
+                        </td>
+                        <td style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs);">
+                          <Show when={!usageLoading()} fallback={<UsageShimmer width={48} />}>
+                            {connectionLastUsedAt(row.summary, row.connection)
+                              ? formatTimeAgo(connectionLastUsedAt(row.summary, row.connection)!)
+                              : '-'}
+                          </Show>
+                        </td>
+                        <td style="text-align: right;">
+                          <button
+                            class="btn btn--outline btn--sm"
+                            style="font-size: var(--font-size-xs); white-space: nowrap;"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              navigate(`/providers/connections/${row.connection.id}`);
+                            }}
+                          >
+                            View details
+                          </button>
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <Show when={connectionsCollapsible()}>
+            <button
+              type="button"
+              class="connections-panel__toggle"
+              aria-expanded={connectionsExpanded()}
+              aria-controls="connected-connections"
+              onClick={() => setConnectionsExpanded((open) => !open)}
+            >
+              <Show
+                when={connectionsExpanded()}
+                fallback={`Show all ${connectedRows().length} connections`}
+              >
+                Show less
+              </Show>
+              <svg
+                class="connections-panel__chevron"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+          </Show>
         </div>
       </Show>
 

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -117,7 +117,7 @@ const PAGE_COPY: Record<
   },
 };
 
-const CONNECTIONS_COLLAPSE_THRESHOLD = 10;
+const CONNECTIONS_COLLAPSE_THRESHOLD = 6;
 
 const providerListForKind = (kind: ProviderPageKind): ProviderDef[] => {
   if (kind === 'subscriptions')

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -232,6 +232,17 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   const [connectionsExpanded, setConnectionsExpanded] = createSignal(false);
   const connectionsCollapsible = () => connectedRows().length > CONNECTIONS_COLLAPSE_THRESHOLD;
   const connectionsCollapsed = () => connectionsCollapsible() && !connectionsExpanded();
+  let connectionsScroller: HTMLDivElement | undefined;
+  const toggleConnections = () => {
+    setConnectionsExpanded((open) => !open);
+    // Expanding takes the cap off, which drops the scroll position. The
+    // at-bottom flag from before it would otherwise survive into the next
+    // collapse and keep the fade hidden at the top of the list.
+    if (connectionsScroller) {
+      connectionsScroller.scrollTop = 0;
+      connectionsScroller.parentElement?.classList.remove('scroll-panel--at-bottom');
+    }
+  };
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Inline rename state
@@ -599,6 +610,7 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
             <div
               class="connections-panel__body"
               id="connected-connections"
+              ref={connectionsScroller}
               onScroll={toggleScrollFade}
             >
               <table class="data-table" style="width: 100%;">
@@ -826,7 +838,7 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
               class="connections-panel__toggle"
               aria-expanded={connectionsExpanded()}
               aria-controls="connected-connections"
-              onClick={() => setConnectionsExpanded((open) => !open)}
+              onClick={toggleConnections}
             >
               <Show
                 when={connectionsExpanded()}

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -1251,6 +1251,15 @@ tr:hover .connection-label-cell__edit,
   --connections-rows: 10.5;
 }
 
+/* Under 768px the shared table rule drops cell padding from 12px to 10px, so
+   the row and header shrink with it. Measured the same way. */
+@media (max-width: 768px) {
+  .connections-panel {
+    --connections-header-h: 40px;
+    --connections-row-h: 53px;
+  }
+}
+
 .connections-panel__viewport {
   position: relative;
 }

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -1239,7 +1239,7 @@ tr:hover .connection-label-cell__edit,
 
 /* ── Collapsed connections table ─────────────────── */
 /* The connections list sits above the supported-provider catalog, so a long one
-   pushes the catalog off the screen. Collapsed, it keeps ten and a half rows
+   pushes the catalog off the screen. Collapsed, it keeps six and a half rows
    visible: the half row is the affordance that there is more below. Nothing is
    hidden, everything stays reachable by scrolling inside the card. */
 .connections-panel {
@@ -1248,7 +1248,7 @@ tr:hover .connection-label-cell__edit,
      border). Half a row is the affordance that there is more below. */
   --connections-header-h: 44px;
   --connections-row-h: 57px;
-  --connections-rows: 10.5;
+  --connections-rows: 6.5;
 }
 
 /* Under 768px the shared table rule drops cell padding from 12px to 10px, so

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -1236,3 +1236,89 @@ tr:hover .connection-label-cell__edit,
   color: hsl(var(--muted-foreground));
   margin: 6px 0 0;
 }
+
+/* ── Collapsed connections table ─────────────────── */
+/* The connections list sits above the supported-provider catalog, so a long one
+   pushes the catalog off the screen. Collapsed, it keeps ten and a half rows
+   visible: the half row is the affordance that there is more below. Nothing is
+   hidden, everything stays reachable by scrolling inside the card. */
+.connections-panel {
+  /* Measured in the browser: the header row is 44px with its bottom border, and
+     a body row is 57px (a 2rem btn--sm plus 12px of padding each side plus the
+     border). Half a row is the affordance that there is more below. */
+  --connections-header-h: 44px;
+  --connections-row-h: 57px;
+  --connections-rows: 10.5;
+}
+
+.connections-panel__viewport {
+  position: relative;
+}
+
+.connections-panel__body {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.connections-panel--collapsed .connections-panel__body {
+  max-height: calc(
+    var(--connections-header-h) + var(--connections-row-h) * var(--connections-rows)
+  );
+  overflow-y: auto;
+}
+
+/* Column headers have to survive the internal scroll. */
+.connections-panel--collapsed .connections-panel__body thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: hsl(var(--card));
+}
+
+/* Fade the cut-off row. Reuses the .scroll-panel--at-bottom class that
+   toggleScrollFade() sets on the scroller's parent, which is the viewport. */
+.connections-panel--collapsed .connections-panel__viewport::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 56px;
+  background: linear-gradient(transparent, hsl(var(--card)));
+  pointer-events: none;
+  transition: opacity var(--transition-fast);
+}
+
+.connections-panel--collapsed .connections-panel__viewport.scroll-panel--at-bottom::after {
+  opacity: 0;
+}
+
+.connections-panel__toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: var(--gap-md);
+  background: none;
+  border: none;
+  border-top: 1px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.connections-panel__toggle:hover {
+  background: hsl(var(--muted) / 0.5);
+  color: hsl(var(--foreground));
+}
+
+.connections-panel__chevron {
+  transition: transform var(--transition-fast);
+}
+
+.connections-panel__toggle[aria-expanded='true'] .connections-panel__chevron {
+  transform: rotate(180deg);
+}

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -879,37 +879,37 @@ describe('provider pages', () => {
     model_counts: {},
   });
 
-  it('leaves the connections list uncapped at ten connections', async () => {
-    mockGetGlobalProviders.mockResolvedValue(manyConnections(10));
+  it('leaves the connections list uncapped at six connections', async () => {
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(6));
     mockGetProviderUsage.mockResolvedValue({ providers: [] });
     const { container } = render(() => <Byok />);
-    await waitFor(() => expect(screen.getByText('Key 10')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Key 6')).toBeDefined());
 
     expect(container.querySelector('.connections-panel--collapsed')).toBeNull();
     expect(screen.queryByText(/^Show all /)).toBeNull();
   });
 
-  it('caps the connections list past ten and names how many there are', async () => {
-    mockGetGlobalProviders.mockResolvedValue(manyConnections(14));
+  it('caps the connections list past six and names how many there are', async () => {
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(9));
     mockGetProviderUsage.mockResolvedValue({ providers: [] });
     const { container } = render(() => <Byok />);
-    await waitFor(() => expect(screen.getByText('Key 14')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Key 9')).toBeDefined());
 
     expect(container.querySelector('.connections-panel--collapsed')).not.toBeNull();
-    const toggle = screen.getByText('Show all 14 connections').closest('button')!;
+    const toggle = screen.getByText('Show all 9 connections').closest('button')!;
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     // Every row stays in the DOM: the card scrolls, it does not paginate.
     expect(screen.getByText('Key 1')).toBeDefined();
-    expect(screen.getByText('Key 14')).toBeDefined();
+    expect(screen.getByText('Key 9')).toBeDefined();
   });
 
   it('expands the connections list and collapses it again', async () => {
-    mockGetGlobalProviders.mockResolvedValue(manyConnections(12));
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(8));
     mockGetProviderUsage.mockResolvedValue({ providers: [] });
     const { container } = render(() => <Byok />);
-    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Show all 8 connections')).toBeDefined());
 
-    const toggle = screen.getByText('Show all 12 connections').closest('button')!;
+    const toggle = screen.getByText('Show all 8 connections').closest('button')!;
     // The button points at the region it expands.
     expect(container.querySelector(`#${toggle.getAttribute('aria-controls')}`)).not.toBeNull();
 
@@ -924,16 +924,16 @@ describe('provider pages', () => {
 
     fireEvent.click(screen.getByText('Show less').closest('button')!);
     await waitFor(() => {
-      expect(screen.getByText('Show all 12 connections')).toBeDefined();
+      expect(screen.getByText('Show all 8 connections')).toBeDefined();
       expect(container.querySelector('.connections-panel--collapsed')).not.toBeNull();
     });
   });
 
   it('brings the bottom fade back after expanding and collapsing again', async () => {
-    mockGetGlobalProviders.mockResolvedValue(manyConnections(12));
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(8));
     mockGetProviderUsage.mockResolvedValue({ providers: [] });
     const { container } = render(() => <Byok />);
-    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Show all 8 connections')).toBeDefined());
 
     const body = container.querySelector('.connections-panel__body') as HTMLElement;
     const viewport = container.querySelector('.connections-panel__viewport')!;
@@ -942,20 +942,20 @@ describe('provider pages', () => {
 
     // Expanding drops the scroll position, so the flag must not survive into
     // the next collapse and hide the fade at the top of the list.
-    fireEvent.click(screen.getByText('Show all 12 connections').closest('button')!);
+    fireEvent.click(screen.getByText('Show all 8 connections').closest('button')!);
     await waitFor(() => expect(screen.getByText('Show less')).toBeDefined());
     expect(viewport.classList.contains('scroll-panel--at-bottom')).toBe(false);
 
     fireEvent.click(screen.getByText('Show less').closest('button')!);
-    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Show all 8 connections')).toBeDefined());
     expect(viewport.classList.contains('scroll-panel--at-bottom')).toBe(false);
   });
 
   it('drops the bottom fade once the capped list is scrolled to the end', async () => {
-    mockGetGlobalProviders.mockResolvedValue(manyConnections(12));
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(8));
     mockGetProviderUsage.mockResolvedValue({ providers: [] });
     const { container } = render(() => <Byok />);
-    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Show all 8 connections')).toBeDefined());
 
     const body = container.querySelector('.connections-panel__body') as HTMLElement;
     const viewport = container.querySelector('.connections-panel__viewport')!;

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -929,6 +929,28 @@ describe('provider pages', () => {
     });
   });
 
+  it('brings the bottom fade back after expanding and collapsing again', async () => {
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(12));
+    mockGetProviderUsage.mockResolvedValue({ providers: [] });
+    const { container } = render(() => <Byok />);
+    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+
+    const body = container.querySelector('.connections-panel__body') as HTMLElement;
+    const viewport = container.querySelector('.connections-panel__viewport')!;
+    fireEvent.scroll(body);
+    expect(viewport.classList.contains('scroll-panel--at-bottom')).toBe(true);
+
+    // Expanding drops the scroll position, so the flag must not survive into
+    // the next collapse and hide the fade at the top of the list.
+    fireEvent.click(screen.getByText('Show all 12 connections').closest('button')!);
+    await waitFor(() => expect(screen.getByText('Show less')).toBeDefined());
+    expect(viewport.classList.contains('scroll-panel--at-bottom')).toBe(false);
+
+    fireEvent.click(screen.getByText('Show less').closest('button')!);
+    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+    expect(viewport.classList.contains('scroll-panel--at-bottom')).toBe(false);
+  });
+
   it('drops the bottom fade once the capped list is scrolled to the end', async () => {
     mockGetGlobalProviders.mockResolvedValue(manyConnections(12));
     mockGetProviderUsage.mockResolvedValue({ providers: [] });

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -855,4 +855,92 @@ describe('provider pages', () => {
       expect(spark.textContent).toBe('4');
     });
   });
+  // ── Collapsed connections list ──────────────────────────────────────────
+  // Past ten connections the list is capped inside its own card so the
+  // supported-provider catalog below stays reachable. Nothing is dropped: the
+  // card scrolls, and the footer button expands it to full height.
+  const manyConnections = (count: number) => ({
+    providers: [
+      {
+        provider: 'openai',
+        auth_type: 'api_key',
+        connection_count: count,
+        connections: Array.from({ length: count }, (_, i) =>
+          connection(`key-${i}`, `Key ${i + 1}`),
+        ),
+        total_models: 3,
+        consumption_tokens: 1,
+        consumption_messages: 1,
+        consumption_cost: 0,
+        last_used_at: null,
+        sparkline_7d: [],
+      },
+    ],
+    model_counts: {},
+  });
+
+  it('leaves the connections list uncapped at ten connections', async () => {
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(10));
+    mockGetProviderUsage.mockResolvedValue({ providers: [] });
+    const { container } = render(() => <Byok />);
+    await waitFor(() => expect(screen.getByText('Key 10')).toBeDefined());
+
+    expect(container.querySelector('.connections-panel--collapsed')).toBeNull();
+    expect(screen.queryByText(/^Show all /)).toBeNull();
+  });
+
+  it('caps the connections list past ten and names how many there are', async () => {
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(14));
+    mockGetProviderUsage.mockResolvedValue({ providers: [] });
+    const { container } = render(() => <Byok />);
+    await waitFor(() => expect(screen.getByText('Key 14')).toBeDefined());
+
+    expect(container.querySelector('.connections-panel--collapsed')).not.toBeNull();
+    const toggle = screen.getByText('Show all 14 connections').closest('button')!;
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    // Every row stays in the DOM: the card scrolls, it does not paginate.
+    expect(screen.getByText('Key 1')).toBeDefined();
+    expect(screen.getByText('Key 14')).toBeDefined();
+  });
+
+  it('expands the connections list and collapses it again', async () => {
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(12));
+    mockGetProviderUsage.mockResolvedValue({ providers: [] });
+    const { container } = render(() => <Byok />);
+    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+
+    const toggle = screen.getByText('Show all 12 connections').closest('button')!;
+    // The button points at the region it expands.
+    expect(container.querySelector(`#${toggle.getAttribute('aria-controls')}`)).not.toBeNull();
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByText('Show less')).toBeDefined();
+      expect(container.querySelector('.connections-panel--collapsed')).toBeNull();
+    });
+    expect(screen.getByText('Show less').closest('button')!.getAttribute('aria-expanded')).toBe(
+      'true',
+    );
+
+    fireEvent.click(screen.getByText('Show less').closest('button')!);
+    await waitFor(() => {
+      expect(screen.getByText('Show all 12 connections')).toBeDefined();
+      expect(container.querySelector('.connections-panel--collapsed')).not.toBeNull();
+    });
+  });
+
+  it('drops the bottom fade once the capped list is scrolled to the end', async () => {
+    mockGetGlobalProviders.mockResolvedValue(manyConnections(12));
+    mockGetProviderUsage.mockResolvedValue({ providers: [] });
+    const { container } = render(() => <Byok />);
+    await waitFor(() => expect(screen.getByText('Show all 12 connections')).toBeDefined());
+
+    const body = container.querySelector('.connections-panel__body') as HTMLElement;
+    const viewport = container.querySelector('.connections-panel__viewport')!;
+    expect(viewport.classList.contains('scroll-panel--at-bottom')).toBe(false);
+
+    // jsdom reports zero layout, which reads as "already at the end".
+    fireEvent.scroll(body);
+    expect(viewport.classList.contains('scroll-panel--at-bottom')).toBe(true);
+  });
 });

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -856,7 +856,7 @@ describe('provider pages', () => {
     });
   });
   // ── Collapsed connections list ──────────────────────────────────────────
-  // Past ten connections the list is capped inside its own card so the
+  // Past six connections the list is capped inside its own card so the
   // supported-provider catalog below stays reachable. Nothing is dropped: the
   // card scrolls, and the footer button expands it to full height.
   const manyConnections = (count: number) => ({


### PR DESCRIPTION
✨ What changed
- The connections list on a provider page now stops at six and a half rows and scrolls inside its own card
- A "Show all N connections" button under it expands the card to full height, and collapses it again
- The half-visible row fades out, and the fade clears once you reach the end of the list
- With six connections or fewer nothing changes at all

💭 Why
The supported-provider catalog sits underneath the connections table. An operator with twenty connections had to scroll past every one of them to reach the place where you add a new provider. Paginating would have hidden rows behind a page number, so the card scrolls instead: everything stays one gesture away.

Closes #2268.

👤 For users
Provider pages get shorter. The list of providers you can add is now visible without a long scroll, and every connection you already have is still reachable, either by scrolling inside the card or by expanding it.

🔧 For operators
No operator impact. No env vars, no migrations, no API change.

🧪 How to test
1. Open Providers then API keys on an account with more than six connections. The table stops after six and a half rows.
2. Scroll inside the card. Every connection is there, the column headers stay put, and the bottom fade clears at the end.
3. Click "Show all N connections". The card expands to full height and the button reads "Show less".
4. Open Subscriptions or Local with a handful of connections. No cap, no button, exactly as before.
