### PR TITLE
fix: keep model params syncing after modelparams.dev API change

### DIFF
--- a/.changeset/modelparams-nested-envelope.md
+++ b/.changeset/modelparams-nested-envelope.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Keep model parameter specs syncing after the modelparams.dev API moved to a nested models envelope

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -230,6 +230,16 @@ describe('ProviderParamSpecService API refresh', () => {
     expect((await service.getSpecs('openai', 'api_key', 'gpt-refreshed')).length).toBe(1);
   });
 
+  it('parses the nested models envelope the API now returns', async () => {
+    const nestedBody = JSON.stringify({ models: JSON.parse(CATALOG_BODY) });
+    fetchSpy.mockResolvedValue(jsonResponse(nestedBody));
+    const service = new ProviderParamSpecService();
+
+    await expect(service.refreshCatalog()).resolves.toBe(true);
+    const specs = await service.getSpecs('openai', 'api_key', 'gpt-refreshed');
+    expect(specs.map((spec) => spec.path)).toEqual(['max_tokens']);
+  });
+
   it('honors MODELPARAMS_API_URL and sends no conditional header on the first fetch', async () => {
     process.env.MODELPARAMS_API_URL = 'https://example.test/catalog.json';
     fetchSpy.mockResolvedValue(jsonResponse(CATALOG_BODY));
@@ -273,6 +283,11 @@ describe('ProviderParamSpecService API refresh', () => {
     [
       'a body that fails catalog validation',
       () => fetchSpy.mockResolvedValue(jsonResponse(JSON.stringify({ models: 'wat' }))),
+    ],
+    [
+      'a nested envelope that fails catalog validation',
+      () =>
+        fetchSpy.mockResolvedValue(jsonResponse(JSON.stringify({ models: { models: 'wat' } }))),
     ],
   ])('keeps the bundled catalog on %s', async (_label, arm) => {
     arm();

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -428,7 +428,13 @@ function freezeCatalog(catalog: ProviderParamSpecCatalog): ProviderParamSpecCata
 
 function parseModelParametersCatalog(raw: unknown): ProviderParamSpecCatalog | null {
   if (!isRecord(raw)) return null;
-  const models = (raw as ModelParametersApiResponse).models;
+  let models = (raw as ModelParametersApiResponse).models;
+  // The modelparams.dev API now nests the model list one level deeper
+  // ({ models: { models: [...] } }); the bundled package and older payloads
+  // still use the flat shape, so unwrap at most one extra layer.
+  if (isRecord(models)) {
+    models = (models as ModelParametersApiResponse).models;
+  }
   if (!Array.isArray(models)) return null;
 
   const catalog: ProviderModelParamSpec[] = [];


### PR DESCRIPTION
### 💭 Why
The modelparams.dev API changed its response format: the model list is now nested one level deeper (`{ models: { models: [...] } }`). Our parser only read the flat shape, so catalog refreshes would start failing validation and the params catalog would go stale.

### ✨ What changed
- Catalog parser unwraps the new nested `models` envelope.
- Flat shape still accepted, so the bundled offline catalog keeps loading.
- Tests cover the nested shape, valid and invalid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps model parameter catalog refresh working after modelparams.dev nested the model list. Previously we read a flat { models: [...] }; now we also accept { models: { models: [...] } } while still supporting the flat shape.

- Freezing/parsing now unwraps at most one nested models envelope and falls back to the bundled catalog on validation failures.
- Tests cover the nested envelope and invalid nested payloads; no config or migration changes.

<sup>Written for commit 3edaf7a3d3839e0b355504dfc246ec80de481d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

