### PR TITLE
fix: sanitize /v1/messages tool_use ids to Anthropic's charset

### DIFF
--- a/.changeset/sanitize-tool-call-ids.md
+++ b/.changeset/sanitize-tool-call-ids.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Sanitize tool_use ids emitted on /v1/messages responses so non-Anthropic upstream ids (e.g. `Edit:0`) no longer poison session histories against Anthropic's id pattern

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -1169,3 +1169,47 @@ describe('Anthropic Messages adapter', () => {
     });
   });
 });
+
+describe('tool-call id sanitation on /v1/messages responses', () => {
+  it('chatCompletionsResponseToMessages sanitizes upstream tool_call ids', () => {
+    const result = chatCompletionsResponseToMessages(
+      {
+        choices: [
+          {
+            message: {
+              content: '',
+              tool_calls: [
+                { id: 'Edit:0', type: 'function', function: { name: 'Edit', arguments: '{}' } },
+                {
+                  id: 'call_ok-1',
+                  type: 'function',
+                  function: { name: 'Read', arguments: '{}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+      'kimi-k3',
+    );
+    const blocks = result.content as Array<Record<string, unknown>>;
+    expect(blocks[0].id).toBe('Edit_0');
+    expect(blocks[1].id).toBe('call_ok-1');
+  });
+
+  it('createMessagesStreamTransformer sanitizes the streamed tool_use id', () => {
+    const t = createMessagesStreamTransformer('kimi-k3');
+    const out = [
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"Edit:0","function":{"name":"Edit","arguments":""}}]}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+    ]
+      .map((c) => t.transform(c) ?? '')
+      .join('') + (t.finalize() ?? '');
+    const start = out
+      .split('\n\n')
+      .find((b) => b.startsWith('event: content_block_start') && b.includes('tool_use'))!;
+    const data = JSON.parse(start.split('\n')[1].replace('data: ', ''));
+    expect(data.content_block.id).toBe('Edit_0');
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -1213,3 +1213,40 @@ describe('tool-call id sanitation on /v1/messages responses', () => {
     expect(data.content_block.id).toBe('Edit_0');
   });
 });
+
+describe('empty upstream tool_call ids', () => {
+  it('mints a toolu_ id instead of emitting an empty one', () => {
+    const result = chatCompletionsResponseToMessages(
+      {
+        choices: [
+          {
+            message: {
+              content: '',
+              tool_calls: [{ id: '', type: 'function', function: { name: 'Read', arguments: '{}' } }],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+      'kimi-k3',
+    );
+    const blocks = result.content as Array<Record<string, unknown>>;
+    expect(blocks[0].id).toMatch(/^toolu_[0-9a-f]{32}$/);
+  });
+
+  it('mints a toolu_ id in the stream transformer as well', () => {
+    const t = createMessagesStreamTransformer('kimi-k3');
+    const out =
+      [
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"","function":{"name":"Read","arguments":""}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+      ]
+        .map((c) => t.transform(c) ?? '')
+        .join('') + (t.finalize() ?? '');
+    const start = out
+      .split('\n\n')
+      .find((b) => b.startsWith('event: content_block_start') && b.includes('tool_use'))!;
+    const data = JSON.parse(start.split('\n')[1].replace('data: ', ''));
+    expect(data.content_block.id).toMatch(/^toolu_[0-9a-f]{32}$/);
+  });
+});

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -352,7 +352,7 @@ export function chatCompletionsResponseToMessages(body: JsonRecord, model: strin
       content.push({
         type: 'tool_use',
         id:
-          typeof call.id === 'string'
+          typeof call.id === 'string' && call.id !== ''
             ? sanitizeToolUseId(call.id)
             : `toolu_${randomUUID().replace(/-/g, '')}`,
         name: typeof call.function.name === 'string' ? call.function.name : '',
@@ -530,7 +530,7 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
         if (!entry) {
           entry = {
             id:
-              typeof call.id === 'string'
+              typeof call.id === 'string' && call.id !== ''
                 ? sanitizeToolUseId(call.id)
                 : `toolu_${randomUUID().replace(/-/g, '')}`,
             index: nextBlockIndex(state),

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -8,6 +8,11 @@ import { randomUUID } from 'crypto';
 
 import { OpenAIMessage } from './proxy-types';
 
+// Anthropic rejects tool_use ids outside ^[a-zA-Z0-9_-]+$, but non-Anthropic
+// upstreams mint ids like `Edit:0`; passing one through poisons the client's
+// history and 400s every later turn routed to a real Anthropic upstream.
+const sanitizeToolUseId = (id: string): string => id.replace(/[^a-zA-Z0-9_-]/g, '_');
+
 type JsonRecord = Record<string, unknown>;
 
 const DEFAULT_CUSTOM_TOOL_INPUT_SCHEMA = {
@@ -346,7 +351,10 @@ export function chatCompletionsResponseToMessages(body: JsonRecord, model: strin
       if (!isRecord(call) || !isRecord(call.function)) continue;
       content.push({
         type: 'tool_use',
-        id: typeof call.id === 'string' ? call.id : `toolu_${randomUUID().replace(/-/g, '')}`,
+        id:
+          typeof call.id === 'string'
+            ? sanitizeToolUseId(call.id)
+            : `toolu_${randomUUID().replace(/-/g, '')}`,
         name: typeof call.function.name === 'string' ? call.function.name : '',
         input: safeParseJson(call.function.arguments),
       });
@@ -521,7 +529,10 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
         let entry = state.toolCalls.get(callIndex);
         if (!entry) {
           entry = {
-            id: typeof call.id === 'string' ? call.id : `toolu_${randomUUID().replace(/-/g, '')}`,
+            id:
+              typeof call.id === 'string'
+                ? sanitizeToolUseId(call.id)
+                : `toolu_${randomUUID().replace(/-/g, '')}`,
             index: nextBlockIndex(state),
             argBuffer: '',
             opened: false,


### PR DESCRIPTION
### ✨ What changed

The `/v1/messages` adapter now sanitizes upstream `tool_call` ids at its two emission points (non-streaming conversion and the messages stream transformer): characters outside Anthropic's `^[a-zA-Z0-9_-]+$` id pattern are replaced with `_`. Conforming ids pass through byte-identical. The whole fix is one helper line plus two guarded call sites.

### 💭 Why

Non-Anthropic upstreams mint tool-call ids outside Anthropic's charset (Moonshot-style `Edit:0`). The adapter passed them through, so the id landed in the client's stored session history, and every later turn routed to a real Anthropic upstream failed with `messages.N.content.M.tool_use.id: String should match pattern`. One Phoenix issue tracks 434 occurrences of exactly this since Aug 7. The adapter already translates responses into Anthropic dialect and already synthesizes `toolu_` ids when the upstream omits one; emitting an id the dialect itself rejects was a bug in that existing translation.

### 👤 For users

Sessions that mix Anthropic and non-Anthropic models through `/v1/messages` no longer break permanently after a tool-using turn on the non-Anthropic model.

### 📝 Notes

Ids are opaque to clients; the only invariant is tool_use/tool_result pairing, which holds because the client echoes back the sanitized id it was given. Already-poisoned histories are out of scope here; a Phoenix `sanitize_tool_ids` registry operation is the follow-up for those.