### PR TITLE
fix(cost): prefer the provider's reported cost over catalogue estimates

### DIFF
--- a/.changeset/cost-source-precedence.md
+++ b/.changeset/cost-source-precedence.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Prefer the cost a provider reports over any catalogue estimate. Manifest already read `usage.cost` from responses but only used it for subscription providers, so an exact figure from a gateway such as OpenRouter was captured and then discarded in favour of catalogue arithmetic. Local inference (Ollama, llama.cpp, LM Studio) now records a known `$0` instead of an unknown `null`.

--- a/packages/backend/src/common/utils/cost-calculator.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.spec.ts
@@ -348,6 +348,106 @@ describe('computeTokenCost', () => {
     expect(result).toBeCloseTo(0.0075, 10);
   });
 
+  describe('cost source precedence', () => {
+    const catalogPricing: PricingEntry = {
+      model_name: 'deepseek-v4-pro',
+      provider: 'DeepSeek',
+      input_price_per_token: 0.66e-6,
+      output_price_per_token: 1.98e-6,
+      display_name: 'DeepSeek V4 Pro',
+    };
+    const base = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      model: 'deepseek-v4-pro',
+      pricing: catalogPricing,
+    };
+
+    it('prefers a provider-reported cost over the catalogue for non-subscription usage', () => {
+      // The gateway said what it charged. That beats any estimate we can make,
+      // and before this it was read only for subscription providers.
+      expect(computeTokenCost({ ...base, reportedCostUsd: 0.42 })).toBe(0.42);
+    });
+
+    it('prefers a reported cost of zero over the catalogue', () => {
+      // Zero is a real answer, not a missing one — a free-tier request.
+      expect(computeTokenCost({ ...base, reportedCostUsd: 0 })).toBe(0);
+    });
+
+    it('ignores a negative reported cost and falls back to the catalogue', () => {
+      expect(computeTokenCost({ ...base, reportedCostUsd: -1 })).toBeCloseTo(0.66 + 1.98, 10);
+    });
+
+    it('prefers a reported cost over a matching peak tier', () => {
+      const tiered: PricingEntry = {
+        ...catalogPricing,
+        time_tiers: [
+          {
+            windows: ['01:00-04:00'],
+            input_price_per_token: 1.32e-6,
+            output_price_per_token: 3.96e-6,
+          },
+        ],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: tiered,
+        reportedCostUsd: 0.1,
+        at: new Date('2026-08-21T02:00:00Z'),
+      });
+      expect(cost).toBe(0.1);
+    });
+
+    it('still prefers a reported cost for subscription usage', () => {
+      const cost = computeTokenCost({
+        ...base,
+        isSubscription: true,
+        reportedCostUsd: 0.07,
+        perRequestCostUsd: 0.05,
+      });
+      expect(cost).toBe(0.07);
+    });
+
+    it('ignores a reported cost too large for the cost_usd column', () => {
+      // `decimal(10, 6)` tops out at 9999.999999. A bigger number is a
+      // provider reporting credits or a session total, not a request price —
+      // and persisting it would throw and lose the whole telemetry row.
+      const cost = computeTokenCost({ ...base, reportedCostUsd: 25_000 });
+      expect(cost).toBeCloseTo(0.66 + 1.98, 10);
+    });
+
+    it('accepts a reported cost exactly at the column limit', () => {
+      expect(computeTokenCost({ ...base, reportedCostUsd: 9999.999999 })).toBe(9999.999999);
+    });
+
+    it('returns null for an unknown model even when a cost was reported', () => {
+      // "A cost for a model we cannot name" is not a row worth writing.
+      expect(computeTokenCost({ ...base, model: null, reportedCostUsd: 0.42 })).toBeNull();
+    });
+
+    it('records zero for local inference instead of an unknown null', () => {
+      // Ollama, llama.cpp and LM Studio run on the user's own hardware. There
+      // is no bill, and "free" is a different fact from "not known".
+      expect(computeTokenCost({ ...base, pricing: undefined, isLocalProvider: true })).toBe(0);
+    });
+
+    it('records zero for local inference even when no tokens were counted', () => {
+      expect(
+        computeTokenCost({
+          ...base,
+          inputTokens: 0,
+          outputTokens: 0,
+          pricing: undefined,
+          isLocalProvider: true,
+        }),
+      ).toBe(0);
+    });
+
+    it('returns null for a non-local provider with no pricing', () => {
+      expect(computeTokenCost({ ...base, pricing: undefined })).toBeNull();
+    });
+  });
+
   describe('time-of-day pricing tiers', () => {
     // DeepSeek V4 Flash shape: off-peak base, peak windows at double.
     const peakPricing: PricingEntry = {

--- a/packages/backend/src/common/utils/cost-calculator.ts
+++ b/packages/backend/src/common/utils/cost-calculator.ts
@@ -22,11 +22,22 @@ export interface CostInput {
    */
   perRequestCostUsd?: number | null;
   /**
-   * USD cost reported by the upstream provider in the response usage block.
-   * Used for subscription providers that debit a quota/balance per request
-   * (for example NousResearch Portal) instead of being flat-fee unlimited.
+   * USD cost reported by the upstream provider in its response usage block
+   * (`usage.cost`, as OpenRouter and other gateways emit).
+   *
+   * This is what the provider says it charged, so it outranks every catalogue
+   * estimate — no seller lookup, no stale rate. It is believed from any
+   * upstream that reports it, which includes user-defined OpenAI-compatible
+   * endpoints; the parser accepts only a non-negative finite number, and that
+   * is the whole of the validation.
    */
   reportedCostUsd?: number | null;
+  /**
+   * True when the model ran on the user's own hardware (Ollama, llama.cpp,
+   * LM Studio — `localOnly` in the provider registry). Local inference has no
+   * per-token bill, so the cost is a known `0` rather than an unknown `null`.
+   */
+  isLocalProvider?: boolean;
   /**
    * Billing timestamp used to resolve time-of-day pricing tiers (peak/off-peak
    * providers like DeepSeek V4). Pass the request start when available;
@@ -70,29 +81,54 @@ function resolveTimeTier(pricing: PricingEntry, at: Date): PricingTimeTier | und
 }
 
 /**
+ * Widest value `agent_messages.cost_usd` can hold — `decimal(10, 6)`.
+ *
+ * A larger number is not an expensive request, it is a provider reporting
+ * something other than per-request USD (credits, cents, a running session
+ * total). Storing it is not an option: PostgreSQL raises `numeric field
+ * overflow`, the insert throws, and the recorder swallows it — costing the
+ * whole telemetry row, not just its price. Ignoring the report and estimating
+ * from the catalogue keeps the request visible.
+ */
+const MAX_RECORDABLE_COST_USD = 9999.999999;
+
+/** True when a provider-reported cost is usable and will survive the column. */
+function isRecordableReportedCost(reported: number | null | undefined): boolean {
+  return reported != null && reported >= 0 && reported <= MAX_RECORDABLE_COST_USD;
+}
+
+/**
  * Computes the USD cost for a set of tokens given a pricing entry.
  *
- * Returns:
- * - `reportedCostUsd` when subscription usage includes a provider-reported
- *   non-negative USD cost (NousResearch Portal pattern)
- * - `perRequestCostUsd` when the usage is subscription-based AND a positive
- *   per-request rate is provided (OpenCode Go pattern)
- * - `0` when the usage is subscription-based with no per-request rate
- *   (flat-fee subscriptions: Claude Max, ChatGPT Plus, GLM Coding, etc.)
- * - `null` when the model is unknown, tokens are zero, or pricing is unavailable
- * - the computed cost otherwise
+ * Sources are tried most-accurate first, because they are not equally good
+ * answers to "what did this request cost":
+ *
+ * 1. `reportedCostUsd` — what the provider says it charged. Exact, so it wins
+ *    outright, for any provider that reports it. Ignored above
+ *    `MAX_RECORDABLE_COST_USD`, which is not a real per-request price.
+ * 2. `perRequestCostUsd` — a published per-request rate on a subscription
+ *    (OpenCode Go pattern); `0` for a flat-fee plan with no such rate
+ *    (Claude Max, ChatGPT Plus, GLM Coding).
+ * 3. `0` for local inference — free, and known to be free.
+ * 4. The token maths below, from the caller's `pricing` entry. An estimate:
+ *    it is only as right as the catalogue, and the catalogue only holds the
+ *    correct seller's rates when the caller looked them up by provider.
+ *
+ * Returns `null` when the model is unknown, tokens are zero, or no pricing is
+ * available — meaning "not known", which is not the same as free.
  */
 export function computeTokenCost(input: CostInput): number | null {
   if (!input.model) return null;
+  if (isRecordableReportedCost(input.reportedCostUsd)) {
+    return input.reportedCostUsd as number;
+  }
   if (input.isSubscription) {
-    if (input.reportedCostUsd != null && input.reportedCostUsd >= 0) {
-      return input.reportedCostUsd;
-    }
     if (input.perRequestCostUsd != null && input.perRequestCostUsd > 0) {
       return input.perRequestCostUsd;
     }
     return 0;
   }
+  if (input.isLocalProvider) return 0;
   if (input.inputTokens === 0 && input.outputTokens === 0) return null;
 
   const pricing = input.pricing;

--- a/packages/backend/src/playground/playground.module.ts
+++ b/packages/backend/src/playground/playground.module.ts
@@ -11,6 +11,8 @@ import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { RoutingCoreModule } from '../routing/routing-core/routing-core.module';
 import { ProxyModule } from '../routing/proxy/proxy.module';
 import { OAuthModule } from '../routing/oauth/oauth.module';
+import { ModelDiscoveryModule } from '../model-discovery/model-discovery.module';
+import { CustomProviderModule } from '../routing/custom-provider/custom-provider.module';
 import { PlaygroundController } from './playground.controller';
 import { PlaygroundService } from './playground.service';
 import { PlaygroundHistoryService } from './playground-history.service';
@@ -31,6 +33,8 @@ import { PlaygroundAgentService } from './playground-agent.service';
     RoutingCoreModule,
     ProxyModule,
     OAuthModule,
+    ModelDiscoveryModule,
+    CustomProviderModule,
   ],
   controllers: [PlaygroundController],
   providers: [PlaygroundService, PlaygroundHistoryService, PlaygroundAgentService],

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -1,6 +1,8 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import type { Response as ExpressResponse } from 'express';
 import { PlaygroundService } from './playground.service';
+import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
 import type { ProviderClient } from '../routing/proxy/provider-client';
 import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
 import type { PlaygroundAgentService } from './playground-agent.service';
@@ -160,6 +162,8 @@ function errorForward(status: number, bodyText: string) {
 }
 
 interface Mocks {
+  customProviders: { canonicalizeAgentMessageKeys: jest.Mock };
+  opencodeGoCatalog: { resolveCostPerRequest: jest.Mock };
   playgroundAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
@@ -222,6 +226,14 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     history: { saveColumn: jest.fn().mockResolvedValue('col-1') },
     messageRepo: { insert: jest.fn().mockResolvedValue(undefined) },
     customProviderRepo: { findOne: jest.fn().mockResolvedValue(null) },
+    customProviders: {
+      canonicalizeAgentMessageKeys: jest
+        .fn()
+        .mockImplementation((_t: string, provider: string | null, model: string | null) =>
+          Promise.resolve({ provider, model }),
+        ),
+    },
+    opencodeGoCatalog: { resolveCostPerRequest: jest.fn().mockResolvedValue(null) },
     ...mocks,
   };
   const service = new PlaygroundService(
@@ -239,6 +251,8 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     full.history as unknown as PlaygroundHistoryService,
     full.messageRepo as unknown as Repository<AgentMessage>,
     full.customProviderRepo as unknown as Repository<CustomProvider>,
+    full.customProviders as unknown as CustomProviderService,
+    full.opencodeGoCatalog as unknown as OpencodeGoCatalogService,
   );
   return { service, mocks: full };
 }
@@ -554,6 +568,56 @@ describe('PlaygroundService.runStream', () => {
     const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
     expect((done.metrics as Record<string, unknown>).cost).toBe(0);
     expect(mocks.messageRepo.insert.mock.calls[0][0].auth_type).toBe('subscription');
+  });
+
+  it('bills an OpenCode Go subscription run at its per-request rate, not $0', async () => {
+    // The recorder resolves this rate from the OpenCode Go catalogue. Without
+    // the same lookup here the playground records $0 for a run that really
+    // costs money, and the two cost writers disagree about the same provider.
+    const { service, mocks } = buildService();
+    mocks.providerKeyService.getAuthType.mockResolvedValue('subscription');
+    mocks.opencodeGoCatalog.resolveCostPerRequest.mockResolvedValue(0.04);
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      CTX,
+      makeDto({ provider: 'opencode-go', authType: 'subscription' }),
+      asRes(res),
+    );
+
+    const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
+    expect((done.metrics as Record<string, unknown>).cost).toBe(0.04);
+  });
+
+  it('records a known $0 for a tile-connected local runtime', async () => {
+    // llama.cpp reaches us as `custom:<uuid>`; only the canonical provider
+    // says it is local. Checking the raw name records `null` — "not known" —
+    // for inference that is free by construction, while the proxy recorder
+    // records 0 for the very same run.
+    const { service, mocks } = buildService();
+    mocks.customProviders.canonicalizeAgentMessageKeys.mockResolvedValue({
+      provider: 'llamacpp',
+      model: 'llamacpp/qwen2.5-0.5b-q4.gguf',
+    });
+    mocks.pricingCache.getByModel.mockReturnValue(undefined);
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(CTX, makeDto({ provider: 'custom:cp-llamacpp' }), asRes(res));
+
+    const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
+    expect((done.metrics as Record<string, unknown>).cost).toBe(0);
   });
 
   it('unwraps OpenAI OAuth blobs before forwarding subscription Playground requests', async () => {

--- a/packages/backend/src/playground/playground.service.truncation.spec.ts
+++ b/packages/backend/src/playground/playground.service.truncation.spec.ts
@@ -1,5 +1,7 @@
 import type { Response as ExpressResponse } from 'express';
 import { PlaygroundService } from './playground.service';
+import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
 import type { ProviderClient } from '../routing/proxy/provider-client';
 import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
 import type { PlaygroundAgentService } from './playground-agent.service';
@@ -85,6 +87,8 @@ function mockRes(): MockRes {
 const asRes = (r: MockRes): ExpressResponse => r as unknown as ExpressResponse;
 
 interface Mocks {
+  customProviders: { canonicalizeAgentMessageKeys: jest.Mock };
+  opencodeGoCatalog: { resolveCostPerRequest: jest.Mock };
   playgroundAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
@@ -144,6 +148,14 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     history: { saveColumn: jest.fn().mockResolvedValue('col-1') },
     messageRepo: { insert: jest.fn().mockResolvedValue(undefined) },
     customProviderRepo: { findOne: jest.fn().mockResolvedValue(null) },
+    customProviders: {
+      canonicalizeAgentMessageKeys: jest
+        .fn()
+        .mockImplementation((_t: string, provider: string | null, model: string | null) =>
+          Promise.resolve({ provider, model }),
+        ),
+    },
+    opencodeGoCatalog: { resolveCostPerRequest: jest.fn().mockResolvedValue(null) },
     ...mocks,
   };
   const service = new PlaygroundService(
@@ -161,6 +173,8 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     full.history as unknown as PlaygroundHistoryService,
     full.messageRepo as unknown as Repository<AgentMessage>,
     full.customProviderRepo as unknown as Repository<CustomProvider>,
+    full.customProviders as unknown as CustomProviderService,
+    full.opencodeGoCatalog as unknown as OpencodeGoCatalogService,
   );
   return { service, mocks: full };
 }

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -15,6 +15,9 @@ import {
   resolveApiKey,
 } from '../routing/proxy/oauth-credentials';
 import { ProviderKeyService } from '../routing/routing-core/provider-key.service';
+import { isLocalOnlyProvider } from '../common/utils/provider-availability';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
+import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 import { PlaygroundAgentService } from './playground-agent.service';
 import { OpenaiOauthService } from '../routing/oauth/openai/openai-oauth.service';
 import { MinimaxOauthService } from '../routing/oauth/minimax/minimax-oauth.service';
@@ -57,6 +60,8 @@ export class PlaygroundService {
     private readonly messageRepo: Repository<AgentMessage>,
     @InjectRepository(CustomProvider)
     private readonly customProviderRepo: Repository<CustomProvider>,
+    private readonly customProviders: CustomProviderService,
+    private readonly opencodeGoCatalog: OpencodeGoCatalogService,
   ) {}
 
   /**
@@ -327,6 +332,15 @@ export class PlaygroundService {
       const outputTokens = usage?.completion_tokens ?? 0;
       const cacheReadTokens = usage?.cache_read_tokens ?? 0;
       const cacheCreationTokens = usage?.cache_creation_tokens ?? 0;
+      const { provider: canonicalProvider } =
+        // Tile-connected local runtimes arrive as `custom:<uuid>`; only the
+        // canonical provider says whether one is local. A tenant-less context
+        // has no custom providers to resolve, so it degrades to the raw name.
+        await this.customProviders.canonicalizeAgentMessageKeys(
+          ctx.tenantId ?? '',
+          dto.provider,
+          dto.model,
+        );
       const cost = computeTokenCost({
         inputTokens,
         outputTokens,
@@ -335,6 +349,20 @@ export class PlaygroundService {
         model: dto.model,
         pricing: this.pricingCache.getByModel(dto.model, dto.provider),
         isSubscription: authType === 'subscription',
+        // Same source order as the proxy recorder: a playground run against
+        // the same provider must not report a different cost. That parity is
+        // the whole point, so each input is resolved the way the recorder
+        // resolves it — the local check on the canonical provider, because a
+        // tile-connected llama.cpp arrives as `custom:<uuid>`, and the
+        // per-request rate from the OpenCode Go catalogue.
+        isLocalProvider: isLocalOnlyProvider(canonicalProvider ?? dto.provider),
+        perRequestCostUsd:
+          authType === 'subscription' &&
+          PROVIDER_BY_ID_OR_ALIAS.get((canonicalProvider ?? dto.provider).toLowerCase())?.id ===
+            'opencode-go'
+            ? await this.opencodeGoCatalog.resolveCostPerRequest(dto.model)
+            : null,
+        reportedCostUsd: usage?.reported_cost_usd,
       });
       const tokensPerSec = outputTokens > 0 ? outputTokens / (Math.max(totalMs, 1) / 1000) : null;
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -2272,6 +2272,34 @@ describe('ProxyMessageRecorder with real CustomProviderService', () => {
     }
   });
 
+  it('costs a tile-connected llama.cpp run at a known zero, not an unknown null', async () => {
+    // llama.cpp and LM Studio are `tileOnly`, so they reach the recorder as
+    // `custom:<uuid>` and only become `llamacpp` after canonicalization. A
+    // local-provider check run on the raw string misses them entirely and the
+    // row falls through to `null` — "we don't know" for inference that is
+    // free by construction.
+    const { recorder, insertMock } = wire({
+      id: 'cp-llamacpp',
+      name: 'llama.cpp',
+      agent_id: 'agent-1',
+    });
+    try {
+      await recorder.recordSuccessMessage(
+        ctx,
+        'custom:cp-llamacpp/qwen2.5-0.5b-q4.gguf',
+        'default',
+        'test',
+        { prompt_tokens: 1000, completion_tokens: 500 } as never,
+        { provider: 'custom:cp-llamacpp' },
+      );
+
+      expect(insertMock).toHaveBeenCalled();
+      expect(insertMock.mock.calls[0][0]).toMatchObject({ cost_usd: 0 });
+    } finally {
+      recorder.onModuleDestroy();
+    }
+  });
+
   it('leaves a user-defined custom provider unchanged (no tileOnly match)', async () => {
     const { recorder, insertMock } = wire({
       id: 'cp-my-groq',

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -25,6 +25,7 @@ import type { ProviderAttemptRef, ProviderAttemptStart, ProxyApiMode } from './p
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
+import { isLocalOnlyProvider } from '../../common/utils/provider-availability';
 import { extractManifestErrorCode, type ManifestErrorCode } from '../../common/errors/error-codes';
 import {
   MANIFEST_CODE_TO_REASON,
@@ -1060,14 +1061,23 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     const inputTokens = usage?.prompt_tokens ?? 0;
     const outputTokens = usage?.completion_tokens ?? 0;
 
+    const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
+      ctx.tenantId,
+      provider,
+      model,
+    );
+
     const costUsd = computeTokenCost({
       inputTokens,
       outputTokens,
       cacheReadTokens: usage?.cache_read_tokens ?? 0,
       cacheCreationTokens: usage?.cache_creation_tokens ?? 0,
       model,
+      // Priced on the raw keys: a custom provider's rates are stored under
+      // `custom:<uuid>/<model>`, which is exactly what canonicalization strips.
       pricing: usage ? this.pricingCache.getByModel(model, provider) : undefined,
       isSubscription: authType === 'subscription',
+      isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
       perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
       reportedCostUsd: usage?.reported_cost_usd,
       // Bill the hour the provider attempt actually ran: `timestamp` is the
@@ -1076,11 +1086,6 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       at: attempt ? new Date(attempt.startedAt) : timestamp ? new Date(timestamp) : undefined,
     });
 
-    const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.tenantId,
-      provider,
-      model,
-    );
     const canonicalFallbackFrom = await this.customProviders.canonicalizeAgentMessageKeys(
       ctx.tenantId,
       null,
@@ -1151,18 +1156,6 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     } = opts ?? {};
     const requestId = providedRequestId ?? uuid();
 
-    const costUsd = computeTokenCost({
-      inputTokens: usage.prompt_tokens,
-      outputTokens: usage.completion_tokens,
-      cacheReadTokens: usage.cache_read_tokens ?? 0,
-      cacheCreationTokens: usage.cache_creation_tokens ?? 0,
-      model,
-      pricing: this.pricingCache.getByModel(model, provider),
-      isSubscription: authType === 'subscription',
-      perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
-      reportedCostUsd: usage.reported_cost_usd,
-    });
-
     // `model` is a required string, so the overload on
     // `canonicalizeAgentMessageKeys` keeps `canonical.model` non-null.
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
@@ -1170,6 +1163,22 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       provider,
       model,
     );
+
+    const costUsd = computeTokenCost({
+      inputTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      cacheReadTokens: usage.cache_read_tokens ?? 0,
+      cacheCreationTokens: usage.cache_creation_tokens ?? 0,
+      model,
+      // Priced on the raw keys: a custom provider's rates are stored under
+      // `custom:<uuid>/<model>`, which is exactly what canonicalization strips.
+      pricing: this.pricingCache.getByModel(model, provider),
+      isSubscription: authType === 'subscription',
+      isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
+      perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
+      reportedCostUsd: usage.reported_cost_usd,
+    });
+
     const canonicalModel = canonical.model;
     const canonicalProvider = canonical.provider;
 


### PR DESCRIPTION
Stacked on #2759 — review that one first.

## The bug

`readReportedCostUsd` already pulls `usage.cost` out of every response, which is what OpenRouter and other gateways emit. `computeTokenCost` then read that field **only inside the `isSubscription` branch**.

So for a non-subscription gateway, Manifest captured the exact amount the provider charged and threw it away, estimating from the catalogue instead. The precise number was in hand and discarded.

## The fix

Order cost sources by how good an answer each one is:

1. **`reportedCostUsd`** — what the provider says it charged. Exact: no seller lookup, no peak-hour arithmetic, no stale catalogue. Wins outright wherever present, for any provider.
2. **`perRequestCostUsd`** — a published per-request rate on a subscription (OpenCode Go); `0` for a flat-fee plan (Claude Max, ChatGPT Plus, GLM Coding).
3. **`0` for local inference** — free, and known to be free.
4. **Token maths** from the catalogue — an estimate, and only correct if the caller looked up the right seller (that is #PR1).

`null` is reserved for "not known", which is not the same as free.

## Local inference recorded `null`, not `0`

`ollama`, `llamacpp`, and `lmstudio` are not subscriptions and have no catalogue entry, so they fell through to `null`. For inference on the user's own hardware the cost is a known zero — the dashboard showed a gap where it should show `$0`.

The check runs on the **canonical** provider. `llama.cpp` and `LM Studio` are `tileOnly`: they reach the recorder as `custom:<uuid>` and only become `llamacpp`/`lmstudio` after canonicalization. A check on the raw string would have missed two of the three local providers. Pricing still resolves on the raw keys, because a custom provider's rates live under `custom:<uuid>/<model>` — exactly what canonicalization strips.

## Two bounds on the widened trust

This believes a `cost` field from any upstream, including user-defined OpenAI-compatible endpoints.

- The parser still accepts only a **non-negative finite number**.
- Anything above **9999.999999** is ignored. `agent_messages.cost_usd` is `decimal(10,6)`; a provider reporting credits, cents, or a running session total instead of per-request USD would overflow the column, throw on insert, and lose the **whole telemetry row** — worse than an estimated price.

What remains believed is a plausible-but-wrong figure (a `0`, or a non-USD amount inside the range). That is the deliberate trade for using the provider's own number.

## Also

The playground records cost through the same source order, so the two cost writers cannot disagree about the same provider.

## Known open question

For OpenRouter **BYOK** requests, `usage.cost` is OpenRouter's own fee and `cost_details.upstream_inference_cost` is what your own key was billed. The existing reader treats them as alternatives rather than a sum. OpenRouter's docs do not specify the relationship, so this PR leaves that behaviour untouched rather than guessing — summing would double-count for non-BYOK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the provider-reported USD cost (`usage.cost`) over catalogue estimates for all requests. Previously only subscriptions used it; now precedence is: reported > per-request subscription rate > 0 for local inference > token maths.

- Trust `reportedCostUsd` when it is a non-negative finite number ≤ 9999.999999; otherwise fall back (`packages/backend/src/common/utils/cost-calculator.ts`).
- Treat local providers (Ollama, `llamacpp`, `lmstudio`) as known $0 by checking the canonical provider; keep pricing lookups on raw `custom:<uuid>/<model>` keys (`packages/backend/src/routing/proxy/proxy-message-recorder.ts`).
- Apply the same source order in the Playground; resolve OpenCode Go per-request rates and canonicalization to avoid proxy/playground mismatches. Adds `ModelDiscoveryModule` and `CustomProviderModule`; uses `OpencodeGoCatalogService` (`packages/backend/src/playground/playground.module.ts`, `packages/backend/src/playground/playground.service.ts`).
- Tests cover precedence, column bounds, local inference, and playground parity (`packages/backend/src/common/utils/cost-calculator.spec.ts`, `packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts`, `packages/backend/src/playground/playground.service.spec.ts`, `packages/backend/src/playground/playground.service.truncation.spec.ts`).

<sup>Written for commit afd70b0ea9a916ab2c87af3c6bebf96a17ccddab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

