### PR TITLE
fix(pricing): stop billing DeepSeek peak rates at the weekend

### DIFF
--- a/.changeset/deepseek-weekend-offpeak.md
+++ b/.changeset/deepseek-weekend-offpeak.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop billing DeepSeek V4 peak rates on weekends: time-of-day pricing tiers now carry the weekdays they apply on, and DeepSeek's 01:00-04:00 / 06:00-10:00 UTC peak windows are Monday-Friday only. Also prices `deepseek-v4-flash-vision-exp`, which billed at the stale flat catalog rate.

--- a/packages/backend/src/common/utils/cost-calculator.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.spec.ts
@@ -384,6 +384,7 @@ describe('computeTokenCost', () => {
         time_tiers: [
           {
             windows: ['01:00-04:00'],
+            days: [1, 2, 3, 4, 5],
             input_price_per_token: 1.32e-6,
             output_price_per_token: 3.96e-6,
           },
@@ -481,6 +482,103 @@ describe('computeTokenCost', () => {
     it('bills the tier rate inside a peak window', () => {
       const cost = computeTokenCost({ ...base, at: new Date('2026-08-17T02:30:00Z') });
       expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('bills the base rate on a weekend hour inside a weekday-only window', () => {
+      // 2026-08-22 is a Saturday; 02:00 UTC sits inside 01:00-04:00, so only
+      // the day rule can move it off the peak rate.
+      const weekdayOnly: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [1, 2, 3, 4, 5] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: weekdayOnly,
+        at: new Date('2026-08-22T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('bills the tier rate on a weekday hour inside a weekday-only window', () => {
+      // 2026-08-21 is a Friday — same clock time as the Saturday case above.
+      const weekdayOnly: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [1, 2, 3, 4, 5] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: weekdayOnly,
+        at: new Date('2026-08-21T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('bills a Sunday at the tier rate when Sunday is listed', () => {
+      // ISO Sunday is 7, not 0 — getUTCDay() would say 0 and miss the match.
+      const sundayOnly: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [7] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: sundayOnly,
+        at: new Date('2026-08-23T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('treats an empty day list as every day', () => {
+      const everyDay: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: everyDay,
+        at: new Date('2026-08-22T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('credits a midnight-crossing window to the day it opened on', () => {
+      // 23:00-02:00 opens Friday and runs into Saturday. Saturday 00:30 is
+      // inside the Friday band; Saturday 23:30 opens a band Saturday does not
+      // have. Judging both by the wall-clock day would get one of them wrong.
+      const fridayNight: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['23:00-02:00'], days: [5] }],
+      };
+      expect(
+        computeTokenCost({
+          ...base,
+          pricing: fridayNight,
+          at: new Date('2026-08-22T00:30:00Z'),
+        }),
+      ).toBeCloseTo(0.44 + 1.32, 10);
+      expect(
+        computeTokenCost({
+          ...base,
+          pricing: fridayNight,
+          at: new Date('2026-08-22T23:30:00Z'),
+        }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('bills a window that opens Sunday and runs into Monday on Sunday terms', () => {
+      // The week circle has a seam at Monday 00:00. A Sunday-only band that
+      // wraps past midnight has to cross it, so this pins that the seam is not
+      // a boundary: 2026-08-24 is a Monday, 00:30 of it belongs to Sunday's.
+      const sundayNight: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['23:00-02:00'], days: [7] }],
+      };
+      expect(
+        computeTokenCost({
+          ...base,
+          pricing: sundayNight,
+          at: new Date('2026-08-24T00:30:00Z'),
+        }),
+      ).toBeCloseTo(0.44 + 1.32, 10);
     });
 
     it('treats window starts as inclusive and ends as exclusive', () => {
@@ -593,6 +691,29 @@ describe('computeTokenCost', () => {
       };
       expect(
         computeTokenCost({ ...base, pricing: malformed, at: new Date('2026-08-17T02:00:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('ignores an hour outside 00-23 instead of opening a band the next day', () => {
+      // As a plain minute count "25:00" was unreachable and harmless. As an arc
+      // it would open a real band on the following day, repricing a window
+      // nobody wrote. 2026-08-18 is a Tuesday, which is where 25:00 would land.
+      const corrupt: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['25:00-26:00'], days: [] }],
+      };
+      expect(
+        computeTokenCost({ ...base, pricing: corrupt, at: new Date('2026-08-18T01:30:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('ignores a minute outside 00-59', () => {
+      const corrupt: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['01:75-02:00'], days: [] }],
+      };
+      expect(
+        computeTokenCost({ ...base, pricing: corrupt, at: new Date('2026-08-18T01:50:00Z') }),
       ).toBeCloseTo(0.22 + 0.66, 10);
     });
 

--- a/packages/backend/src/common/utils/cost-calculator.ts
+++ b/packages/backend/src/common/utils/cost-calculator.ts
@@ -26,10 +26,10 @@ export interface CostInput {
    * (`usage.cost`, as OpenRouter and other gateways emit).
    *
    * This is what the provider says it charged, so it outranks every catalogue
-   * estimate — no seller lookup, no stale rate. It is believed from any
-   * upstream that reports it, which includes user-defined OpenAI-compatible
-   * endpoints; the parser accepts only a non-negative finite number, and that
-   * is the whole of the validation.
+   * estimate — no seller lookup, no peak-hour arithmetic, no stale rate. It is
+   * believed from any upstream that reports it, which includes user-defined
+   * OpenAI-compatible endpoints; the parser accepts only a non-negative finite
+   * number, and that is the whole of the validation.
    */
   reportedCostUsd?: number | null;
   /**
@@ -50,34 +50,73 @@ export interface CostInput {
 /**
  * Minutes since UTC midnight for a "HH:MM" string, or null when malformed.
  * Tier windows are validated upstream, so null only guards corrupted data.
+ *
+ * The range check earns its place under the week-circle matching below. An
+ * out-of-range hour used to be harmless — "25:00" was simply a minute count no
+ * clock reached — but as an arc it opens a real band on the following day, so
+ * corrupt input would silently reprice a window nobody wrote.
  */
 function toUtcMinutes(time: string | undefined): number | null {
   if (!time) return null;
   const [hours, minutes] = time.split(':').map(Number);
-  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null;
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
   return hours * 60 + minutes;
 }
 
-/** True when `minutes` falls inside a "HH:MM-HH:MM" window (end exclusive, wraps midnight). */
-function windowMatches(window: string, minutes: number): boolean {
-  const [start, end] = window.split('-').map(toUtcMinutes);
-  if (start == null || end == null) return false;
-  // A zero-length window matches nothing. Without this, start === end falls
-  // into the wrap branch and matches the whole day, letting a malformed
-  // upstream band override the base rate around the clock.
-  if (start === end) return false;
-  return start < end ? minutes >= start && minutes < end : minutes >= start || minutes < end;
+const MINUTES_PER_DAY = 24 * 60;
+const MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
+/** ISO weekdays, used when a tier names no `days` of its own. */
+const EVERY_DAY: readonly number[] = [1, 2, 3, 4, 5, 6, 7];
+
+/** Minutes since Monday 00:00 UTC (0 … 10079). */
+function weekMinutes(at: Date): number {
+  // getUTCDay() is 0-based on Sunday; ISO counts Monday as day 1.
+  const isoDay = (at.getUTCDay() + 6) % 7;
+  return isoDay * MINUTES_PER_DAY + at.getUTCHours() * 60 + at.getUTCMinutes();
 }
 
 /**
- * The time tier whose windows contain `at`, if any. A matching tier replaces
- * the base prices outright (tiers never compose with the base cost).
+ * True when `at` falls in one of the tier's windows.
+ *
+ * A window is an arc on the 10 080-minute week circle: it opens on each of the
+ * tier's `days` at the window's start minute and runs for its length. Framing
+ * it that way makes the two awkward cases definitional rather than special —
+ * a window whose end precedes its start simply runs past midnight into the
+ * next day, and it stays attributed to the day it opened on, so a Friday
+ * 23:00-02:00 band still bills at 00:30 on Saturday. A zero-length window is
+ * a zero-length arc, which contains nothing.
+ */
+function tierCovers(tier: PricingTimeTier, at: Date): boolean {
+  const now = weekMinutes(at);
+  const days = tier.days?.length ? tier.days : EVERY_DAY;
+  for (const window of tier.windows) {
+    const [start, end] = window.split('-').map(toUtcMinutes);
+    if (start == null || end == null) continue;
+    const length = (end - start + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+    for (const day of days) {
+      const opensAt = ((day - 1) * MINUTES_PER_DAY + start) % MINUTES_PER_WEEK;
+      // Distance travelled around the circle since the window opened; inside
+      // the window exactly while that distance is short of its length, which
+      // makes the start inclusive and the end exclusive.
+      if ((now - opensAt + MINUTES_PER_WEEK) % MINUTES_PER_WEEK < length) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The time tier covering `at`, if any. A matching tier replaces the base
+ * prices outright (tiers never compose with the base cost).
+ *
+ * A tier may narrow its windows to specific ISO weekdays (`days`, 1 = Monday
+ * … 7 = Sunday) — DeepSeek's peak hours are Monday through Friday, so the
+ * weekend is off-peak end to end. An absent or empty list means every day.
  */
 function resolveTimeTier(pricing: PricingEntry, at: Date): PricingTimeTier | undefined {
   const tiers = pricing.time_tiers;
   if (!tiers || tiers.length === 0) return undefined;
-  const minutes = at.getUTCHours() * 60 + at.getUTCMinutes();
-  return tiers.find((tier) => tier.windows.some((window) => windowMatches(window, minutes)));
+  return tiers.find((tier) => tierCovers(tier, at));
 }
 
 /**

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1108,6 +1108,7 @@ describe('ModelsDevSyncService', () => {
       expect(model!.timeTiers).toEqual([
         {
           windows: ['01:00-04:00', '06:00-10:00'],
+          days: null,
           inputPricePerToken: 2.0 / 1_000_000,
           outputPricePerToken: 4.0 / 1_000_000,
           cacheReadPricePerToken: 0.2 / 1_000_000,
@@ -1180,6 +1181,7 @@ describe('ModelsDevSyncService', () => {
       expect(service.lookupModel('openai', 'mixed-windows')!.timeTiers).toEqual([
         {
           windows: ['01:00-04:00'],
+          days: null,
           inputPricePerToken: 2.0 / 1_000_000,
           outputPricePerToken: null,
           cacheReadPricePerToken: null,
@@ -1225,6 +1227,7 @@ describe('ModelsDevSyncService', () => {
       expect(flash!.timeTiers).toEqual([
         {
           windows: ['01:00-04:00', '06:00-10:00'],
+          days: [1, 2, 3, 4, 5],
           inputPricePerToken: 0.44 / 1_000_000,
           outputPricePerToken: 1.32 / 1_000_000,
           cacheReadPricePerToken: 0.014 / 1_000_000,
@@ -1235,6 +1238,107 @@ describe('ModelsDevSyncService', () => {
       const chat = service.lookupModel('deepseek', 'deepseek-chat');
       expect(chat!.inputPricePerToken).toBe(0.14 / 1_000_000);
       expect(chat!.timeTiers).toBeNull();
+    });
+
+    it('seeds the vision preview on the Flash card', async () => {
+      const response = {
+        deepseek: {
+          id: 'deepseek',
+          name: 'DeepSeek',
+          models: {
+            'deepseek-v4-flash-vision-exp': {
+              id: 'deepseek-v4-flash-vision-exp',
+              name: 'DeepSeek V4 Flash Vision',
+              cost: { input: 0.14, output: 0.28, cache_read: 0.0028 },
+              modalities: { input: ['text', 'image'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const vision = service.lookupModel('deepseek', 'deepseek-v4-flash-vision-exp');
+      expect(vision!.inputPricePerToken).toBe(0.22 / 1_000_000);
+      expect(vision!.outputPricePerToken).toBe(0.66 / 1_000_000);
+      expect(vision!.timeTiers![0].days).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('carries a catalog day list through to the tier', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'weekday-model': {
+              id: 'weekday-model',
+              name: 'Weekday',
+              cost: {
+                input: 1.0,
+                output: 2.0,
+                tiers: [
+                  {
+                    tier: { type: 'time', windows: ['01:00-04:00'], days: [1, 2, 3, 4, 5] },
+                    input: 2.0,
+                    output: 4.0,
+                  },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'weekday-model')!.timeTiers![0].days).toEqual([
+        1, 2, 3, 4, 5,
+      ]);
+    });
+
+    it.each([
+      ['a non-array', 'weekdays'],
+      ['an out-of-range weekday', [1, 2, 3, 4, 5, 8]],
+      ['a non-integer weekday', [1, 2.5]],
+      ['a non-numeric entry', [1, 2, 3, 4, 5, '6']],
+      ['an empty list', []],
+    ])('drops %s day list whole rather than salvaging part of it', async (_label, days) => {
+      // Filtering [1,2,3,4,5,'6'] down to [1..5] would read as a clean weekday
+      // rule and quietly discount a day the provider charges peak for.
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'bad-days': {
+              id: 'bad-days',
+              name: 'Bad Days',
+              cost: {
+                input: 1.0,
+                output: 2.0,
+                tiers: [
+                  {
+                    tier: { type: 'time', windows: ['01:00-04:00'], days },
+                    input: 2.0,
+                    output: 4.0,
+                  },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const tiers = service.lookupModel('openai', 'bad-days')!.timeTiers;
+      expect(tiers).toHaveLength(1);
+      expect(tiers![0].days).toBeNull();
     });
 
     it('prefers catalog time tiers over the DeepSeek seed once models.dev has them', async () => {
@@ -1267,6 +1371,7 @@ describe('ModelsDevSyncService', () => {
       expect(flash!.timeTiers).toEqual([
         {
           windows: ['02:00-05:00'],
+          days: null,
           inputPricePerToken: 0.5 / 1_000_000,
           outputPricePerToken: 1.4 / 1_000_000,
           cacheReadPricePerToken: null,

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -86,6 +86,12 @@ function resolveProviderId(providerId: string): string {
  */
 export interface ModelsDevTimeTier {
   windows: readonly string[];
+  /**
+   * ISO weekdays (1 = Monday … 7 = Sunday) the windows apply on. Null means
+   * every day — a tier with no schedule is unrestricted, as it was before this
+   * field existed.
+   */
+  days: readonly number[] | null;
   inputPricePerToken: number | null;
   outputPricePerToken: number | null;
   cacheReadPricePerToken: number | null;
@@ -112,7 +118,7 @@ export interface ModelsDevModelEntry {
 }
 
 interface RawModelsDevCostTier {
-  tier?: { type?: string; size?: number; windows?: string[] };
+  tier?: { type?: string; size?: number; windows?: string[]; days?: unknown };
   input?: number;
   output?: number;
   cache_read?: number;
@@ -153,8 +159,9 @@ const TIME_WINDOW_RE = /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/;
 
 /**
  * DeepSeek V4 moved to peak/off-peak billing on 2026-08-16: peak hours are
- * 01:00-04:00 and 06:00-10:00 UTC, every other hour is off-peak at half the
- * peak rate. models.dev cannot express time-of-day pricing yet
+ * 01:00-04:00 and 06:00-10:00 UTC **Monday through Friday**, and every other
+ * hour — including all 48 weekend hours — is off-peak at half the peak rate.
+ * models.dev cannot express time-of-day pricing yet
  * (anomalyco/models.dev#4892 adds `cost.tiers[].tier.type = "time"`; #4891
  * corrects the flat numbers in the meantime), so until the catalog carries a
  * time tier for these models this seed replaces whatever flat rate the sync
@@ -166,6 +173,8 @@ const TIME_WINDOW_RE = /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/;
  * https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17).
  */
 const DEEPSEEK_PEAK_WINDOWS: readonly string[] = ['01:00-04:00', '06:00-10:00'];
+/** Monday–Friday: DeepSeek's peak schedule does not run on weekends. */
+const DEEPSEEK_PEAK_DAYS: readonly number[] = [1, 2, 3, 4, 5];
 const DEEPSEEK_V4_PEAK_SEED: ReadonlyMap<
   string,
   {
@@ -191,6 +200,16 @@ const DEEPSEEK_V4_PEAK_SEED: ReadonlyMap<
       output: 1.98,
       cacheRead: 0.022,
       peak: { input: 1.32, output: 3.96, cacheRead: 0.044 },
+    },
+  ],
+  // The vision preview is billed on the Flash card, not a card of its own.
+  [
+    'deepseek-v4-flash-vision-exp',
+    {
+      input: 0.22,
+      output: 0.66,
+      cacheRead: 0.007,
+      peak: { input: 0.44, output: 1.32, cacheRead: 0.014 },
     },
   ],
 ]);
@@ -637,6 +656,23 @@ export class ModelsDevSyncService implements OnModuleInit {
   }
 
   /**
+   * ISO weekdays a time tier is restricted to, or null for "every day".
+   *
+   * A malformed list is dropped **whole**, never filtered entry by entry:
+   * salvaging `[1,2,3,4,5,'6']` down to `[1..5]` would read as a clean weekday
+   * rule and quietly discount a day the provider charges peak for. Dropping it
+   * falls back to the unrestricted tier, which is what the catalog meant
+   * before the field existed and never bills below the published rate.
+   */
+  private parseTierDays(days: unknown): readonly number[] | null {
+    if (!Array.isArray(days) || days.length === 0) return null;
+    const valid = days.every(
+      (day) => typeof day === 'number' && Number.isInteger(day) && day >= 1 && day <= 7,
+    );
+    return valid ? (days as number[]) : null;
+  }
+
+  /**
    * Extract time-of-day pricing tiers from a raw models.dev cost block.
    * Context-size tiers (`tier.type = "context"`) are ignored — Manifest does
    * not price by context band. Returns null when no valid time tier exists.
@@ -660,6 +696,7 @@ export class ModelsDevSyncService implements OnModuleInit {
       if (windows.length === 0) continue;
       parsed.push({
         windows,
+        days: this.parseTierDays(tier.tier.days),
         inputPricePerToken: tier.input != null ? tier.input / 1_000_000 : null,
         outputPricePerToken: tier.output != null ? tier.output / 1_000_000 : null,
         cacheReadPricePerToken: tier.cache_read != null ? tier.cache_read / 1_000_000 : null,
@@ -696,6 +733,7 @@ export class ModelsDevSyncService implements OnModuleInit {
         timeTiers = [
           {
             windows: DEEPSEEK_PEAK_WINDOWS,
+            days: DEEPSEEK_PEAK_DAYS,
             inputPricePerToken: seed.peak.input / 1_000_000,
             outputPricePerToken: seed.peak.output / 1_000_000,
             cacheReadPricePerToken: seed.peak.cacheRead / 1_000_000,

--- a/packages/backend/src/model-prices/model-pricing-cache.provider-scope.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.provider-scope.spec.ts
@@ -17,6 +17,7 @@ import { normalizeProviderName } from 'manifest-shared';
 
 const DEEPSEEK_TIME_TIER = {
   windows: ['01:00-04:00', '06:00-10:00'],
+  days: [1, 2, 3, 4, 5],
   inputPricePerToken: 1.32 / 1_000_000,
   outputPricePerToken: 3.96 / 1_000_000,
   cacheReadPricePerToken: 0.044 / 1_000_000,
@@ -113,12 +114,12 @@ describe('ModelPricingCacheService — pricing scoped to the provider that serve
     expect(entry!.output_price_per_token).toBe(1.98 / 1_000_000);
   });
 
-  it("carries DeepSeek's peak-hour schedule on the scoped entry", async () => {
+  it("carries DeepSeek's weekday peak schedule on the scoped entry", async () => {
     await service.reload();
 
-    // The schedule belongs to the seller. Losing the entry loses the schedule.
     const tiers = service.getByModel('deepseek-v4-pro', 'deepseek')!.time_tiers;
     expect(tiers).toHaveLength(1);
+    expect(tiers![0].days).toEqual([1, 2, 3, 4, 5]);
     expect(tiers![0].input_price_per_token).toBe(1.32 / 1_000_000);
   });
 

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -29,6 +29,11 @@ const CUSTOM_PROVIDER_LABEL = 'Custom';
  */
 export interface PricingTimeTier {
   windows: readonly string[];
+  /**
+   * ISO weekdays (1 = Monday … 7 = Sunday) the windows apply on. Absent or
+   * empty means every day. DeepSeek's peak hours are Monday through Friday.
+   */
+  days?: readonly number[] | null;
   input_price_per_token: number | null;
   output_price_per_token: number | null;
   cache_read_price_per_token?: number | null;
@@ -349,6 +354,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
           cache_write_price_per_token: model.cacheWritePricePerToken ?? null,
           time_tiers: model.timeTiers?.map((tier) => ({
             windows: tier.windows,
+            days: tier.days ?? null,
             input_price_per_token: tier.inputPricePerToken,
             output_price_per_token: tier.outputPricePerToken,
             cache_read_price_per_token: tier.cacheReadPricePerToken,

--- a/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
@@ -14,6 +14,7 @@ import { ProviderModelRegistryService } from '../model-discovery/provider-model-
 
 const DEEPSEEK_TIME_TIER = {
   windows: ['01:00-04:00', '06:00-10:00'],
+  days: [1, 2, 3, 4, 5],
   inputPricePerToken: 0.44 / 1_000_000,
   outputPricePerToken: 1.32 / 1_000_000,
   cacheReadPricePerToken: 0.014 / 1_000_000,
@@ -80,6 +81,7 @@ describe('ModelPricingCacheService — time-of-day pricing tiers', () => {
     expect(entry!.time_tiers).toEqual([
       {
         windows: ['01:00-04:00', '06:00-10:00'],
+        days: [1, 2, 3, 4, 5],
         input_price_per_token: 0.44 / 1_000_000,
         output_price_per_token: 1.32 / 1_000_000,
         cache_read_price_per_token: 0.014 / 1_000_000,

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -1177,6 +1177,11 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
       perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
       reportedCostUsd: usage.reported_cost_usd,
+      // Bill a peak/off-peak model on when the attempt started, not on when
+      // this row is written: a long stream that opens at 09:59 and records at
+      // 10:01 is a peak request, and the fallback path already reads it this
+      // way. Falls back to now when the caller tracked no attempt.
+      at: attempt ? new Date(attempt.startedAt) : undefined,
     });
 
     const canonicalModel = canonical.model;


### PR DESCRIPTION
Closes #2755. Stacked on #2760 — review the two below it first.

## The bug

DeepSeek's published peak hours are 01:00-04:00 and 06:00-10:00 UTC, **Monday through Friday**. Every other hour, including all 48 weekend hours, is off-peak at half the rate.

`resolveTimeTier` read the hour and never the day, so Saturday and Sunday were billed at 2x — 14 of every 168 hours. Peak is 35 h/week, not 49.

> Off-peak rates are half of the peak rates. Peak hours are 01:00 - 04:00 and 06:00 - 10:00 UTC, Monday through Friday (all other hours are off-peak).
> — https://api-docs.deepseek.com/quick_start/pricing/

## The fix

**Time tiers carry the weekdays they apply on.** The field is optional; absent or empty means every day, so tiers without a schedule are untouched.

**A malformed day list is dropped whole**, never filtered entry by entry. Salvaging `[1,2,3,4,5,'6']` into `[1..5]` would read as a clean weekday rule and quietly discount a day the provider charges peak for. Dropping it degrades to the unrestricted tier, which never bills below the published rate.

**Windows are arcs on the 10,080-minute week circle.** A window opens on each of its days at its start minute and runs for its length. Two awkward cases then fall out of the arithmetic instead of needing special handling:

- a window whose end precedes its start simply runs past midnight;
- it stays attributed to the day it opened on, so a Friday `23:00-02:00` band still bills at 00:30 on Saturday, and a Sunday band still bills at 00:30 on Monday across the week seam.

Everything compares `getUTC*` accessors only, so the result does not depend on the server's timezone.

### On the UTC-vs-Beijing ambiguity

DeepSeek's Chinese page states the same windows in Beijing time (09:00-12:00, 14:00-18:00). Reading `days` as UTC weekdays is correct either way here, and not by luck: every peak window sits inside 01:00-10:00 UTC, i.e. 09:00-18:00 Beijing, entirely within one calendar day on both clocks. So for any instant in a peak window the UTC weekday and the Beijing weekday necessarily agree.

This would not hold for a provider whose weekday-qualified window crosses 16:00 UTC while meaning local weekdays. "Days are UTC weekdays" is the stated assumption; a `timezone` field can be added later without breaking anything (absent = UTC).

## Also in this PR

- **`deepseek-v4-flash-vision-exp` is now priced.** DeepSeek bills it on the Flash card ($0.22/$0.66 off-peak); it was picking up a stale flat catalogue rate and *under*-billing.
- **An attempt is billed on when it started**, not when its row is written. A stream that opens at 09:59 and records at 10:01 is a peak request; the fallback path already read it this way, so the two paths now agree.

## Verification

Discriminating cases — same clock time, only the day differs:

- `2026-08-21T02:00:00Z` (Friday) → peak
- `2026-08-22T02:00:00Z` (Saturday) → base

Live, through the real sync service and pricing cache, for one request of 48k cache-read + 2k input + 500 output tokens:

```
DeepSeek       Sat=$0.003366   Fri=$0.006732   ← weekday rule applies
OpenCode Zen   Sat=$0.012360   Fri=$0.012360   ← flat, no borrowed schedule
```

## Upstream

models.dev cannot express time-of-day pricing yet, so the DeepSeek rates are seeded locally and the seed retires itself the moment the catalogue carries a time tier. anomalyco/models.dev#4892 proposes the schema; the `days` dimension needs to be added to that proposal, which currently has the same weekend gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop billing DeepSeek V4 peak rates on weekends by making time-of-day tiers weekday-aware. Previously weekends matched peak; now peak windows apply Monday–Friday only, with all weekend hours off‑peak. Also fixes pricing for `deepseek-v4-flash-vision-exp` and bills attempts by their start time.

- Time tiers accept ISO weekdays (1–7); absent or empty means every day. Unreadable lists are dropped whole (treated as unrestricted).
- Window matching uses arcs on the 10,080‑minute UTC week. Handles midnight wrap; start inclusive/end exclusive; ignores zero‑length and malformed times (hours 0–23, minutes 0–59).
- DeepSeek seed sets days [1–5] for peak windows and prices `deepseek-v4-flash-vision-exp` on the Flash card.
- Cost calculation uses the attempt start time; falls back to now if unavailable.
- Model pricing cache and models.dev sync preserve and expose `days`.

- No migration needed; tiers without `days` behave as before.

<sup>Written for commit 06f98a497b5d659c4b20d1c3eb588a0aad90e727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

