### PR TITLE
fix: refresh harness request counts

### DIFF
--- a/.changeset/fresh-harness-message-counts.md
+++ b/.changeset/fresh-harness-message-counts.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Refresh cached harness message counts when new requests arrive.

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -10,6 +10,7 @@ import { AgentLifecycleService } from '../services/agent-lifecycle.service';
 import { AgentDuplicationService } from '../services/agent-duplication.service';
 import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
+import { AgentListCacheService } from '../../common/services/agent-list-cache.service';
 import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { ProviderService } from '../../routing/routing-core/provider.service';
 import { AutofixStatsService } from '../services/autofix-stats.service';
@@ -139,6 +140,7 @@ describe('AgentsController', () => {
           useValue: { emit: jest.fn() },
         },
         providerServiceProvider(),
+        AgentListCacheService,
         autofixStatsProvider(mockRecordAutofixConsent),
       ],
     }).compile();
@@ -250,10 +252,10 @@ describe('AgentsController', () => {
       'bot-renamed',
       'Bot Renamed',
     );
-    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=false:g0');
     // The Messages-filter variant (playground agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a rename.
-    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=true:g0');
   });
 
   it('rejects rename with empty slug', async () => {
@@ -312,8 +314,8 @@ describe('AgentsController', () => {
     expect(mockDeleteAgent).toHaveBeenCalledWith('tenant-123', 'bot-1');
     // Both canonical variants are cleared so neither the Workspace list nor the
     // Messages filter (playground agents included) goes stale after a delete.
-    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=false');
-    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=false:g0');
+    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=true:g0');
   });
 
   it('passes agent_category and agent_platform to onboardAgent', async () => {
@@ -348,6 +350,7 @@ describe('AgentsController', () => {
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
         },
         providerServiceProvider(),
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();
@@ -411,6 +414,7 @@ describe('AgentsController', () => {
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
         },
         providerServiceProvider(),
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();
@@ -469,6 +473,7 @@ describe('AgentsController', () => {
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
         },
         providerServiceProvider(),
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();
@@ -483,8 +488,8 @@ describe('AgentsController', () => {
     // Both canonical variants are cleared so neither the Workspace list nor the
     // Messages filter (playground agents included) goes stale after a create. The
     // cache is keyed by the tenant the onboard returned (t1), not the user id.
-    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false');
-    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=true');
+    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false:g0');
+    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=true:g0');
     expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/autofix/status');
   });
 
@@ -525,6 +530,7 @@ describe('AgentsController', () => {
           provide: ProviderService,
           useValue: { enableAllProvidersForAgent: jest.fn().mockRejectedValue(enableErr) },
         },
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();
@@ -543,8 +549,8 @@ describe('AgentsController', () => {
     expect(mockDelete).toHaveBeenCalledWith('t1', 'my-agent');
     // ...and the agent-list cache is cleared so the briefly-visible agent does
     // not linger in a cached list (both tenant-keyed entries).
-    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false');
-    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=true');
+    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false:g0');
+    expect(delSpy).toHaveBeenCalledWith('t1:/api/v1/agents:playground=true:g0');
     // ...along with the Autofix status entry, which would otherwise keep
     // reporting the rolled-back agent as enabled until the dashboard TTL, so
     // the sidebar contradicts a workspace the agent no longer appears in.
@@ -588,6 +594,7 @@ describe('AgentsController', () => {
             enableAllProvidersForAgent: jest.fn().mockRejectedValue(new Error('enable boom')),
           },
         },
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();
@@ -628,6 +635,7 @@ describe('AgentsController', () => {
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
         },
         providerServiceProvider(),
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();
@@ -669,6 +677,7 @@ describe('AgentsController', () => {
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
         },
         providerServiceProvider(),
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();
@@ -708,10 +717,10 @@ describe('AgentsController', () => {
       name: 'bot-copy',
       displayName: 'Bot Copy',
     });
-    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=false:g0');
     // The Messages-filter variant (playground agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a duplicate.
-    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('tenant-123:/api/v1/agents:playground=true:g0');
   });
 
   it('rejects duplicateAgent with empty slug', async () => {
@@ -791,6 +800,7 @@ describe('AgentsController', () => {
           useValue: { duplicate: jest.fn(), getCopySummary: jest.fn(), suggestName: jest.fn() },
         },
         providerServiceProvider(),
+        AgentListCacheService,
         autofixStatsProvider(),
       ],
     }).compile();

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -27,7 +27,8 @@ import { CreateAgentDto } from '../../common/dto/create-agent.dto';
 import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
 import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
 import { AgentListCacheInterceptor } from '../../common/interceptors/agent-list-cache.interceptor';
-import { AGENT_LIST_CACHE_TTL_MS, agentListCacheKey } from '../../common/constants/cache.constants';
+import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { AgentListCacheService } from '../../common/services/agent-list-cache.service';
 import { slugify } from '../../common/utils/slugify';
 import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
 import { ProviderService } from '../../routing/routing-core/provider.service';
@@ -45,19 +46,17 @@ export class AgentsController {
     private readonly eventBus: IngestEventBusService,
     private readonly providerService: ProviderService,
     private readonly autofixStats: AutofixStatsService,
+    private readonly agentListCache: AgentListCacheService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
   private async invalidateAgentListCache(tenantId: string | null): Promise<void> {
-    // GET /agents has exactly two canonical cache entries per tenant (playground agents
-    // included or not — see AgentListCacheInterceptor). Clear both so neither the
-    // Workspace list nor the Messages filter goes stale after a mutation. No
-    // tenant → nothing was ever cached.
+    // GET /agents has exactly two canonical cache entries per tenant (playground
+    // agents included or not — see AgentListCacheService). Retire both so
+    // neither the Workspace list nor the Messages filter goes stale after a
+    // mutation. No tenant → nothing was ever cached.
     if (!tenantId) return;
-    await Promise.all([
-      this.cacheManager.del(agentListCacheKey(tenantId, false)),
-      this.cacheManager.del(agentListCacheKey(tenantId, true)),
-    ]);
+    await this.agentListCache.invalidate(tenantId);
   }
 
   private async invalidateAutofixStatusCache(tenantId: string | null): Promise<void> {

--- a/packages/backend/src/common/common.module.ts
+++ b/packages/backend/src/common/common.module.ts
@@ -9,6 +9,7 @@ import { UserCacheInterceptor } from './interceptors/user-cache.interceptor';
 import { AgentCacheInterceptor } from './interceptors/agent-cache.interceptor';
 import { AgentRecordingCacheService } from './services/agent-recording-cache.service';
 import { RequestRecordingStorageService } from './services/request-recording-storage.service';
+import { AgentListCacheInterceptor } from './interceptors/agent-list-cache.interceptor';
 
 @Global()
 @Module({
@@ -19,6 +20,7 @@ import { RequestRecordingStorageService } from './services/request-recording-sto
     TenantCacheService,
     UserCacheInterceptor,
     AgentCacheInterceptor,
+    AgentListCacheInterceptor,
     AgentRecordingCacheService,
     RequestRecordingStorageService,
   ],
@@ -28,6 +30,7 @@ import { RequestRecordingStorageService } from './services/request-recording-sto
     TenantCacheService,
     UserCacheInterceptor,
     AgentCacheInterceptor,
+    AgentListCacheInterceptor,
     AgentRecordingCacheService,
     RequestRecordingStorageService,
   ],

--- a/packages/backend/src/common/common.module.ts
+++ b/packages/backend/src/common/common.module.ts
@@ -10,6 +10,7 @@ import { AgentCacheInterceptor } from './interceptors/agent-cache.interceptor';
 import { AgentRecordingCacheService } from './services/agent-recording-cache.service';
 import { RequestRecordingStorageService } from './services/request-recording-storage.service';
 import { AgentListCacheInterceptor } from './interceptors/agent-list-cache.interceptor';
+import { AgentListCacheService } from './services/agent-list-cache.service';
 
 @Global()
 @Module({
@@ -21,6 +22,7 @@ import { AgentListCacheInterceptor } from './interceptors/agent-list-cache.inter
     UserCacheInterceptor,
     AgentCacheInterceptor,
     AgentListCacheInterceptor,
+    AgentListCacheService,
     AgentRecordingCacheService,
     RequestRecordingStorageService,
   ],
@@ -31,6 +33,7 @@ import { AgentListCacheInterceptor } from './interceptors/agent-list-cache.inter
     UserCacheInterceptor,
     AgentCacheInterceptor,
     AgentListCacheInterceptor,
+    AgentListCacheService,
     AgentRecordingCacheService,
     RequestRecordingStorageService,
   ],

--- a/packages/backend/src/common/constants/cache.constants.ts
+++ b/packages/backend/src/common/constants/cache.constants.ts
@@ -19,7 +19,16 @@ export const FREE_MODELS_CACHE_TTL_MS = 3_600_000;
  * variant collapses to one of two keys keyed on that boolean — never the raw
  * URL. This keeps the key set bounded (exactly two per tenant) so invalidation can
  * enumerate it exhaustively and no variant is ever left stale.
+ *
+ * `generation` retires a tenant's keys without having to delete them: bumping it
+ * makes the next read miss, and a response that started under the previous
+ * generation writes back to a key nobody reads any more. See
+ * AgentListCacheService.
  */
-export function agentListCacheKey(tenantId: string, includePlayground: boolean): string {
-  return `${tenantId}:/api/v1/agents:playground=${includePlayground}`;
+export function agentListCacheKey(
+  tenantId: string,
+  includePlayground: boolean,
+  generation = 0,
+): string {
+  return `${tenantId}:/api/v1/agents:playground=${includePlayground}:g${generation}`;
 }

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -1,7 +1,8 @@
-import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { firstValueFrom, ReplaySubject } from 'rxjs';
+import type { Cache } from 'cache-manager';
 import { AgentListCacheInterceptor } from './agent-list-cache.interceptor';
+import { AgentListCacheService } from '../services/agent-list-cache.service';
 
 function createMockContext(
   tenantContext: { tenantId?: string } | undefined,
@@ -25,6 +26,7 @@ function createMockContext(
 
 describe('AgentListCacheInterceptor', () => {
   let interceptor: AgentListCacheInterceptor;
+  let keys: AgentListCacheService;
   let cacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
 
   beforeEach(() => {
@@ -33,42 +35,18 @@ describe('AgentListCacheInterceptor', () => {
       set: jest.fn().mockResolvedValue(undefined),
       del: jest.fn().mockResolvedValue(true),
     };
-    interceptor = new AgentListCacheInterceptor(cacheManager as never, new Reflector());
+    keys = new AgentListCacheService(cacheManager as unknown as Cache);
+    interceptor = new AgentListCacheInterceptor(cacheManager as never, new Reflector(), keys);
   });
 
-  it('waits for an older response cache write before deleting both variants', async () => {
+  it('keys on the current generation, so a request that started earlier cannot be served again', async () => {
     const context = createMockContext({ tenantId: 't1' }, undefined);
-    const source = new ReplaySubject<{ agents: unknown[] }>(1);
-    const next: CallHandler = { handle: jest.fn(() => source) };
-    let finishWrite!: () => void;
-    const writeFinished = new Promise<void>((resolve) => {
-      finishWrite = resolve;
-    });
-    cacheManager.set.mockReturnValue(writeFinished);
+    const before = interceptor['trackBy'](context);
 
-    const response = await interceptor.intercept(context, next);
-    const responseFinished = firstValueFrom(response);
-    const invalidation = interceptor.invalidate('t1');
+    await keys.invalidate('t1');
 
-    await Promise.resolve();
-    expect(cacheManager.del).not.toHaveBeenCalled();
-
-    source.next({ agents: [] });
-    source.complete();
-    await responseFinished;
-    await Promise.resolve();
-
-    expect(cacheManager.set).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false', {
-      agents: [],
-    });
-    expect(cacheManager.del).not.toHaveBeenCalled();
-
-    finishWrite();
-    await invalidation;
-
-    expect(cacheManager.del).toHaveBeenCalledTimes(2);
-    expect(cacheManager.del).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false');
-    expect(cacheManager.del).toHaveBeenCalledWith('t1:/api/v1/agents:playground=true');
+    expect(interceptor['trackBy'](context)).not.toBe(before);
+    expect(interceptor['trackBy'](context)).toBe('t1:/api/v1/agents:playground=false:g1');
   });
 
   describe('trackBy', () => {
@@ -76,26 +54,26 @@ describe('AgentListCacheInterceptor', () => {
       const key = interceptor['trackBy'](
         createMockContext({ tenantId: 't1' }, { includePlayground: 'true' }),
       );
-      expect(key).toBe('t1:/api/v1/agents:playground=true');
+      expect(key).toBe('t1:/api/v1/agents:playground=true:g0');
     });
 
     it('keys on the playground=false canonical variant when no query param is present', () => {
       const key = interceptor['trackBy'](createMockContext({ tenantId: 't1' }, undefined));
-      expect(key).toBe('t1:/api/v1/agents:playground=false');
+      expect(key).toBe('t1:/api/v1/agents:playground=false:g0');
     });
 
     it('collapses ?includePlayground=false onto the same playground=false key (no stranded variant)', () => {
       const key = interceptor['trackBy'](
         createMockContext({ tenantId: 't1' }, { includePlayground: 'false' }),
       );
-      expect(key).toBe('t1:/api/v1/agents:playground=false');
+      expect(key).toBe('t1:/api/v1/agents:playground=false:g0');
     });
 
     it('collapses any non-"true" value onto the playground=false key', () => {
       const key = interceptor['trackBy'](
         createMockContext({ tenantId: 't1' }, { includePlayground: '1' }),
       );
-      expect(key).toBe('t1:/api/v1/agents:playground=false');
+      expect(key).toBe('t1:/api/v1/agents:playground=false:g0');
     });
 
     it('returns undefined for non-GET requests', () => {

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -1,6 +1,7 @@
-import { ExecutionContext } from '@nestjs/common';
+import { CallHandler, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import type { Cache } from 'cache-manager';
+import { firstValueFrom, ReplaySubject } from 'rxjs';
 import { AgentListCacheInterceptor } from './agent-list-cache.interceptor';
 import { AgentListCacheService } from '../services/agent-list-cache.service';
 
@@ -24,6 +25,9 @@ function createMockContext(
   } as unknown as ExecutionContext;
 }
 
+/** Let the interceptor's own awaits (the cache lookup) settle. */
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
 describe('AgentListCacheInterceptor', () => {
   let interceptor: AgentListCacheInterceptor;
   let keys: AgentListCacheService;
@@ -39,13 +43,40 @@ describe('AgentListCacheInterceptor', () => {
     interceptor = new AgentListCacheInterceptor(cacheManager as never, new Reflector(), keys);
   });
 
-  it('keys on the current generation, so a request that started earlier cannot be served again', async () => {
+  it('never hands a request that arrives after invalidation the response already in flight', async () => {
     const context = createMockContext({ tenantId: 't1' }, undefined);
-    const before = interceptor['trackBy'](context);
+    const source = new ReplaySubject<{ agents: unknown[] }>(1);
+    const next: CallHandler = { handle: jest.fn(() => source) };
+
+    // In flight under the pre-event generation, and subscribed: it has read the
+    // database and is waiting on the handler.
+    const inFlight = await interceptor.intercept(context, next);
+    const inFlightResult = firstValueFrom(inFlight);
+    await flush();
+    expect(next.handle).toHaveBeenCalledTimes(1);
 
     await keys.invalidate('t1');
 
-    expect(interceptor['trackBy'](context)).not.toBe(before);
+    // The post-event caller must run its own query, not replay the older one.
+    const afterEvent = await interceptor.intercept(context, next);
+    expect(afterEvent).not.toBe(inFlight);
+    const afterEventResult = firstValueFrom(afterEvent);
+    await flush();
+    expect(next.handle).toHaveBeenCalledTimes(2);
+
+    source.next({ agents: [] });
+    source.complete();
+    await Promise.all([inFlightResult, afterEventResult]);
+    await flush();
+
+    // The older response wrote back under the retired generation, which no
+    // reader looks at any more; only the post-event key is served.
+    expect(cacheManager.set).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false:g0', {
+      agents: [],
+    });
+    expect(cacheManager.set).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false:g1', {
+      agents: [],
+    });
     expect(interceptor['trackBy'](context)).toBe('t1:/api/v1/agents:playground=false:g1');
   });
 

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -1,5 +1,6 @@
-import { ExecutionContext } from '@nestjs/common';
+import { CallHandler, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { firstValueFrom, ReplaySubject } from 'rxjs';
 import { AgentListCacheInterceptor } from './agent-list-cache.interceptor';
 
 function createMockContext(
@@ -24,10 +25,50 @@ function createMockContext(
 
 describe('AgentListCacheInterceptor', () => {
   let interceptor: AgentListCacheInterceptor;
+  let cacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
 
   beforeEach(() => {
-    const mockCacheManager = {} as never;
-    interceptor = new AgentListCacheInterceptor(mockCacheManager, new Reflector());
+    cacheManager = {
+      get: jest.fn().mockResolvedValue(undefined),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(true),
+    };
+    interceptor = new AgentListCacheInterceptor(cacheManager as never, new Reflector());
+  });
+
+  it('waits for an older response cache write before deleting both variants', async () => {
+    const context = createMockContext({ tenantId: 't1' }, undefined);
+    const source = new ReplaySubject<{ agents: unknown[] }>(1);
+    const next: CallHandler = { handle: jest.fn(() => source) };
+    let finishWrite!: () => void;
+    const writeFinished = new Promise<void>((resolve) => {
+      finishWrite = resolve;
+    });
+    cacheManager.set.mockReturnValue(writeFinished);
+
+    const response = await interceptor.intercept(context, next);
+    const responseFinished = firstValueFrom(response);
+    const invalidation = interceptor.invalidate('t1');
+
+    await Promise.resolve();
+    expect(cacheManager.del).not.toHaveBeenCalled();
+
+    source.next({ agents: [] });
+    source.complete();
+    await responseFinished;
+    await Promise.resolve();
+
+    expect(cacheManager.set).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false', {
+      agents: [],
+    });
+    expect(cacheManager.del).not.toHaveBeenCalled();
+
+    finishWrite();
+    await invalidation;
+
+    expect(cacheManager.del).toHaveBeenCalledTimes(2);
+    expect(cacheManager.del).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('t1:/api/v1/agents:playground=true');
   });
 
   describe('trackBy', () => {

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
@@ -5,7 +5,7 @@ import { Reflector } from '@nestjs/core';
 import type { Cache } from 'cache-manager';
 import { Request } from 'express';
 import { UserCacheInterceptor } from './user-cache.interceptor';
-import { agentListCacheKey } from '../constants/cache.constants';
+import { AgentListCacheService } from '../services/agent-list-cache.service';
 
 /**
  * Cache interceptor for GET /agents. Unlike the generic URL-keyed
@@ -13,22 +13,17 @@ import { agentListCacheKey } from '../constants/cache.constants';
  * ?includePlayground=true, ?includePlayground=false, anything else) onto one of two
  * canonical keys based on the normalized `includePlayground` boolean. That keeps the
  * cached key set bounded to exactly two entries per tenant, so mutation handlers
- * can invalidate it exhaustively (see agentListCacheKey) without a stray URL
+ * can invalidate it exhaustively (see AgentListCacheService) without a stray URL
  * variant being left stale.
  */
 @Injectable()
 export class AgentListCacheInterceptor extends UserCacheInterceptor {
   constructor(
-    @Inject(CACHE_MANAGER) private readonly agentListCache: Cache,
+    @Inject(CACHE_MANAGER) agentListCache: Cache,
     reflector: Reflector,
+    private readonly keys: AgentListCacheService,
   ) {
     super(agentListCache, reflector);
-  }
-
-  async invalidate(tenantId: string): Promise<void> {
-    const keys = [agentListCacheKey(tenantId, false), agentListCacheKey(tenantId, true)];
-    await Promise.all(keys.map((key) => this.waitForCacheActivity(key)));
-    await Promise.all(keys.map((key) => this.agentListCache.del(key)));
   }
 
   protected trackBy(context: ExecutionContext): string | undefined {
@@ -38,6 +33,6 @@ export class AgentListCacheInterceptor extends UserCacheInterceptor {
     const request = context.switchToHttp().getRequest<Request>();
     const includePlayground =
       (request.query as { includePlayground?: string } | undefined)?.includePlayground === 'true';
-    return agentListCacheKey(tenantId, includePlayground);
+    return this.keys.key(tenantId, includePlayground);
   }
 }

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
@@ -1,4 +1,8 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Inject } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { Cache } from 'cache-manager';
 import { Request } from 'express';
 import { UserCacheInterceptor } from './user-cache.interceptor';
 import { agentListCacheKey } from '../constants/cache.constants';
@@ -14,6 +18,19 @@ import { agentListCacheKey } from '../constants/cache.constants';
  */
 @Injectable()
 export class AgentListCacheInterceptor extends UserCacheInterceptor {
+  constructor(
+    @Inject(CACHE_MANAGER) private readonly agentListCache: Cache,
+    reflector: Reflector,
+  ) {
+    super(agentListCache, reflector);
+  }
+
+  async invalidate(tenantId: string): Promise<void> {
+    const keys = [agentListCacheKey(tenantId, false), agentListCacheKey(tenantId, true)];
+    await Promise.all(keys.map((key) => this.waitForCacheActivity(key)));
+    await Promise.all(keys.map((key) => this.agentListCache.del(key)));
+  }
+
   protected trackBy(context: ExecutionContext): string | undefined {
     const tenantId = this.resolveTenantId(context);
     if (!tenantId) return undefined;

--- a/packages/backend/src/common/interceptors/user-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/user-cache.interceptor.ts
@@ -2,40 +2,15 @@ import { CacheInterceptor } from '@nestjs/cache-manager';
 import { CallHandler, ExecutionContext, Inject, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
-import type { Cache } from 'cache-manager';
-import { defer, finalize, lastValueFrom, mergeAll, Observable, shareReplay } from 'rxjs';
+import { defer, finalize, mergeAll, Observable, shareReplay } from 'rxjs';
 import { RequestWithTenantContext } from '../decorators/tenant-context.decorator';
 
 @Injectable()
 export class UserCacheInterceptor extends CacheInterceptor {
   private readonly inFlightResponses = new Map<string, Observable<unknown>>();
-  private readonly inFlightCacheWrites: Map<string, Promise<unknown>>;
 
   constructor(@Inject('CACHE_MANAGER') cacheManager: unknown, reflector: Reflector) {
-    const writes = new Map<string, Promise<unknown>>();
-    const cache = cacheManager as Cache;
-    const trackedCache = new Proxy(cache, {
-      get(target, property) {
-        if (property === 'set') {
-          return (...args: Parameters<Cache['set']>) => {
-            const [key] = args;
-            const write = target.set(...args);
-            writes.set(key, write);
-            const clear = () => {
-              if (writes.get(key) === write) writes.delete(key);
-            };
-            void write.then(clear, clear);
-            return write;
-          };
-        }
-
-        const value = Reflect.get(target, property, target) as unknown;
-        return typeof value === 'function' ? value.bind(target) : value;
-      },
-    });
-
-    super(trackedCache, reflector);
-    this.inFlightCacheWrites = writes;
+    super(cacheManager, reflector);
   }
 
   /**
@@ -59,15 +34,6 @@ export class UserCacheInterceptor extends CacheInterceptor {
     );
     this.inFlightResponses.set(key, response);
     return response;
-  }
-
-  /** Wait until an existing response and its cache write have both settled. */
-  protected async waitForCacheActivity(key: string): Promise<void> {
-    const response = this.inFlightResponses.get(key);
-    if (response) await lastValueFrom(response).catch(() => undefined);
-
-    const write = this.inFlightCacheWrites.get(key);
-    if (write) await write.catch(() => undefined);
   }
 
   /**

--- a/packages/backend/src/common/interceptors/user-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/user-cache.interceptor.ts
@@ -2,15 +2,40 @@ import { CacheInterceptor } from '@nestjs/cache-manager';
 import { CallHandler, ExecutionContext, Inject, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
-import { defer, finalize, mergeAll, Observable, shareReplay } from 'rxjs';
+import type { Cache } from 'cache-manager';
+import { defer, finalize, lastValueFrom, mergeAll, Observable, shareReplay } from 'rxjs';
 import { RequestWithTenantContext } from '../decorators/tenant-context.decorator';
 
 @Injectable()
 export class UserCacheInterceptor extends CacheInterceptor {
   private readonly inFlightResponses = new Map<string, Observable<unknown>>();
+  private readonly inFlightCacheWrites: Map<string, Promise<unknown>>;
 
   constructor(@Inject('CACHE_MANAGER') cacheManager: unknown, reflector: Reflector) {
-    super(cacheManager, reflector);
+    const writes = new Map<string, Promise<unknown>>();
+    const cache = cacheManager as Cache;
+    const trackedCache = new Proxy(cache, {
+      get(target, property) {
+        if (property === 'set') {
+          return (...args: Parameters<Cache['set']>) => {
+            const [key] = args;
+            const write = target.set(...args);
+            writes.set(key, write);
+            const clear = () => {
+              if (writes.get(key) === write) writes.delete(key);
+            };
+            void write.then(clear, clear);
+            return write;
+          };
+        }
+
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    super(trackedCache, reflector);
+    this.inFlightCacheWrites = writes;
   }
 
   /**
@@ -34,6 +59,15 @@ export class UserCacheInterceptor extends CacheInterceptor {
     );
     this.inFlightResponses.set(key, response);
     return response;
+  }
+
+  /** Wait until an existing response and its cache write have both settled. */
+  protected async waitForCacheActivity(key: string): Promise<void> {
+    const response = this.inFlightResponses.get(key);
+    if (response) await lastValueFrom(response).catch(() => undefined);
+
+    const write = this.inFlightCacheWrites.get(key);
+    if (write) await write.catch(() => undefined);
   }
 
   /**

--- a/packages/backend/src/common/services/agent-list-cache.service.spec.ts
+++ b/packages/backend/src/common/services/agent-list-cache.service.spec.ts
@@ -26,10 +26,18 @@ describe('AgentListCacheService', () => {
     expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
   });
 
-  it('leaves other tenants on their own generation', async () => {
+  it('leaves a tenant that was never invalidated on generation 0', async () => {
     await service.invalidate('t1');
 
     expect(service.key('t2', false)).toBe('t2:/api/v1/agents:playground=false:g0');
+  });
+
+  it('draws generations from one counter, so no two tenants share one', async () => {
+    await service.invalidate('t1');
+    await service.invalidate('t2');
+
+    expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
+    expect(service.key('t2', false)).toBe('t2:/api/v1/agents:playground=false:g2');
   });
 
   it('still retires the generation when the delete fails, and never rejects', async () => {
@@ -70,6 +78,25 @@ describe('AgentListCacheService', () => {
 
       jest.advanceTimersByTime(AGENT_LIST_CACHE_TTL_MS);
       expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g0');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('never puts a forgotten tenant back on a generation it already ran on', async () => {
+    jest.useFakeTimers();
+    try {
+      await service.invalidate('t1');
+      expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
+
+      // Forgotten: reads fall back to generation 0, whose entries have expired.
+      jest.advanceTimersByTime(AGENT_LIST_CACHE_TTL_MS * 2);
+      expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g0');
+
+      // The next invalidation must not land back on g1, where an entry warmed
+      // during the first run could still be sitting.
+      await service.invalidate('t1');
+      expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g2');
     } finally {
       jest.useRealTimers();
     }

--- a/packages/backend/src/common/services/agent-list-cache.service.spec.ts
+++ b/packages/backend/src/common/services/agent-list-cache.service.spec.ts
@@ -1,0 +1,77 @@
+import { Logger } from '@nestjs/common';
+import type { Cache } from 'cache-manager';
+import { AgentListCacheService } from './agent-list-cache.service';
+import { AGENT_LIST_CACHE_TTL_MS } from '../constants/cache.constants';
+
+describe('AgentListCacheService', () => {
+  let service: AgentListCacheService;
+  let cache: { del: jest.Mock };
+
+  beforeEach(() => {
+    cache = { del: jest.fn().mockResolvedValue(true) };
+    service = new AgentListCacheService(cache as unknown as Cache);
+  });
+
+  it('starts every tenant on generation 0', () => {
+    expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g0');
+    expect(service.key('t1', true)).toBe('t1:/api/v1/agents:playground=true:g0');
+  });
+
+  it('deletes both retired variants and moves the tenant to the next generation', async () => {
+    await service.invalidate('t1');
+
+    expect(cache.del).toHaveBeenCalledTimes(2);
+    expect(cache.del).toHaveBeenCalledWith('t1:/api/v1/agents:playground=false:g0');
+    expect(cache.del).toHaveBeenCalledWith('t1:/api/v1/agents:playground=true:g0');
+    expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
+  });
+
+  it('leaves other tenants on their own generation', async () => {
+    await service.invalidate('t1');
+
+    expect(service.key('t2', false)).toBe('t2:/api/v1/agents:playground=false:g0');
+  });
+
+  it('still retires the generation when the delete fails, and never rejects', async () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    cache.del.mockRejectedValue(new Error('cache unavailable'));
+
+    await expect(service.invalidate('t1')).resolves.toBeUndefined();
+
+    expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
+    expect(warn).toHaveBeenCalledWith(
+      'Could not delete the retired agent-list cache entry t1:/api/v1/agents:playground=false:g0; it expires on its own',
+      expect.any(String),
+    );
+    warn.mockRestore();
+  });
+
+  it('logs a non-Error rejection without losing the generation bump', async () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    cache.del.mockRejectedValue('boom');
+
+    await service.invalidate('t1');
+
+    expect(warn).toHaveBeenCalledWith(expect.any(String), 'boom');
+    expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
+    warn.mockRestore();
+  });
+
+  it('forgets a tenant only once every entry written under its generation has expired', async () => {
+    jest.useFakeTimers();
+    try {
+      await service.invalidate('t1');
+      expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
+
+      // One TTL in, a g0 entry written by a request that was still in flight
+      // could survive, so the generation must still be remembered.
+      jest.advanceTimersByTime(AGENT_LIST_CACHE_TTL_MS + 1);
+      expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g1');
+
+      jest.advanceTimersByTime(AGENT_LIST_CACHE_TTL_MS);
+      expect(service.key('t1', false)).toBe('t1:/api/v1/agents:playground=false:g0');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/backend/src/common/services/agent-list-cache.service.ts
+++ b/packages/backend/src/common/services/agent-list-cache.service.ts
@@ -5,10 +5,11 @@ import { AGENT_LIST_CACHE_TTL_MS, agentListCacheKey } from '../constants/cache.c
 import { TtlCache } from '../utils/ttl-cache';
 
 /**
- * A retired generation must outlive every cache entry written under it, or
- * dropping the counter could send readers back to a key that still holds a
- * pre-invalidation list. Two TTLs is the margin: nothing writes the previous
- * generation once it is retired, so after one TTL those entries have expired.
+ * How long a tenant's generation is remembered. Forgetting one drops the tenant
+ * back to generation 0, so it is only safe once every entry written under
+ * generation 0 has expired. The last of those can be written by a request that
+ * was in flight across the invalidation that left generation 0, so two list TTLs
+ * is the margin.
  */
 const GENERATION_RESIDENCY_MS = AGENT_LIST_CACHE_TTL_MS * 2;
 /** Ceiling on tracked tenants; the least-recently-invalidated is dropped first. */
@@ -36,6 +37,14 @@ export class AgentListCacheService {
     maxSize: GENERATION_MAX_TENANTS,
     ttlMs: GENERATION_RESIDENCY_MS,
   });
+  /**
+   * Generations are drawn from one process-wide counter, never from a per-tenant
+   * one, so a tenant whose entry was dropped (idle past the residency, or
+   * evicted at the ceiling) never comes back on a number it used before. Reusing
+   * a number could hand readers an entry warmed under the earlier run of that
+   * same generation — the stale count this class exists to prevent.
+   */
+  private nextGeneration = 0;
 
   constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
 
@@ -53,7 +62,7 @@ export class AgentListCacheService {
    */
   async invalidate(tenantId: string): Promise<void> {
     const retired = this.generations.get(tenantId) ?? 0;
-    this.generations.set(tenantId, retired + 1);
+    this.generations.set(tenantId, ++this.nextGeneration);
 
     await Promise.all(
       [false, true].map(async (includePlayground) => {

--- a/packages/backend/src/common/services/agent-list-cache.service.ts
+++ b/packages/backend/src/common/services/agent-list-cache.service.ts
@@ -1,0 +1,72 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import type { Cache } from 'cache-manager';
+import { AGENT_LIST_CACHE_TTL_MS, agentListCacheKey } from '../constants/cache.constants';
+import { TtlCache } from '../utils/ttl-cache';
+
+/**
+ * A retired generation must outlive every cache entry written under it, or
+ * dropping the counter could send readers back to a key that still holds a
+ * pre-invalidation list. Two TTLs is the margin: nothing writes the previous
+ * generation once it is retired, so after one TTL those entries have expired.
+ */
+const GENERATION_RESIDENCY_MS = AGENT_LIST_CACHE_TTL_MS * 2;
+/** Ceiling on tracked tenants; the least-recently-invalidated is dropped first. */
+const GENERATION_MAX_TENANTS = 50_000;
+
+/**
+ * Owns the cache keys behind GET /agents.
+ *
+ * Invalidation bumps a per-tenant generation rather than relying on a delete
+ * landing at the right moment. That is what makes it race-free: a request that
+ * is already in flight resolved its key under the old generation, so whenever
+ * its response is written back it lands on a key no later reader looks at, and
+ * a request that starts after the bump computes the new key and misses. Nothing
+ * has to wait for in-flight work, and a failed delete cannot serve a stale list.
+ *
+ * It lives in a service, not on AgentListCacheInterceptor, because Nest
+ * instantiates a controller-scoped copy of an interceptor passed to
+ * `@UseInterceptors()` — state kept on the interceptor would not be the state
+ * the event bus and the mutation handlers see.
+ */
+@Injectable()
+export class AgentListCacheService {
+  private readonly logger = new Logger(AgentListCacheService.name);
+  private readonly generations = new TtlCache<string, number>({
+    maxSize: GENERATION_MAX_TENANTS,
+    ttlMs: GENERATION_RESIDENCY_MS,
+  });
+
+  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+
+  /** Cache key for the tenant's current agent-list generation. */
+  key(tenantId: string, includePlayground: boolean): string {
+    return agentListCacheKey(tenantId, includePlayground, this.generations.get(tenantId) ?? 0);
+  }
+
+  /**
+   * Retire the tenant's cached agent lists so the next read rebuilds them.
+   * Deleting the retired keys is only housekeeping — the generation bump is
+   * what guarantees freshness — so a cache failure is logged, never thrown:
+   * callers must not have to choose between a stale list and dropping the
+   * refetch that follows.
+   */
+  async invalidate(tenantId: string): Promise<void> {
+    const retired = this.generations.get(tenantId) ?? 0;
+    this.generations.set(tenantId, retired + 1);
+
+    await Promise.all(
+      [false, true].map(async (includePlayground) => {
+        const key = agentListCacheKey(tenantId, includePlayground, retired);
+        try {
+          await this.cache.del(key);
+        } catch (error) {
+          this.logger.warn(
+            `Could not delete the retired agent-list cache entry ${key}; it expires on its own`,
+            error instanceof Error ? error.stack : String(error),
+          );
+        }
+      }),
+    );
+  }
+}

--- a/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { AgentListCacheInterceptor } from '../interceptors/agent-list-cache.interceptor';
+import { AgentListCacheService } from './agent-list-cache.service';
 import { IngestEventBusService, IngestEvent } from './ingest-event-bus.service';
 
 describe('IngestEventBusService', () => {
@@ -9,7 +9,7 @@ describe('IngestEventBusService', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     invalidate = jest.fn().mockResolvedValue(undefined);
-    service = new IngestEventBusService({ invalidate } as unknown as AgentListCacheInterceptor);
+    service = new IngestEventBusService({ invalidate } as unknown as AgentListCacheService);
   });
 
   afterEach(() => {
@@ -138,7 +138,7 @@ describe('IngestEventBusService message cache invalidation', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     invalidate = jest.fn().mockResolvedValue(undefined);
-    service = new IngestEventBusService({ invalidate } as unknown as AgentListCacheInterceptor);
+    service = new IngestEventBusService({ invalidate } as unknown as AgentListCacheService);
   });
 
   afterEach(() => {
@@ -172,7 +172,7 @@ describe('IngestEventBusService message cache invalidation', () => {
     expect(received).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: undefined }]);
   });
 
-  it('retries a failed invalidation and does not publish when the retry fails', async () => {
+  it('publishes the event even when invalidation fails, so no dashboard is left waiting', async () => {
     const received: IngestEvent[] = [];
     const logger = jest.spyOn(Logger.prototype, 'error').mockImplementation();
     invalidate.mockRejectedValue(new Error('cache unavailable'));
@@ -181,12 +181,32 @@ describe('IngestEventBusService message cache invalidation', () => {
     service.emit('tenant-1', 'message');
     await jest.advanceTimersByTimeAsync(250);
 
-    expect(invalidate).toHaveBeenCalledTimes(2);
-    expect(received).toEqual([]);
+    expect(received).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: undefined }]);
     expect(logger).toHaveBeenCalledWith(
       'Failed to invalidate the agent-list cache for tenant tenant-1',
       expect.any(String),
     );
     logger.mockRestore();
+  });
+
+  it('logs a non-Error invalidation failure', async () => {
+    const received: IngestEvent[] = [];
+    const logger = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    invalidate.mockRejectedValue('boom');
+    service.forTenant('tenant-1').subscribe((event) => received.push(event));
+
+    service.emit('tenant-1', 'message');
+    await jest.advanceTimersByTimeAsync(250);
+
+    expect(received).toHaveLength(1);
+    expect(logger).toHaveBeenCalledWith(expect.any(String), 'boom');
+    logger.mockRestore();
+  });
+
+  it('does not touch the agent-list cache for non-message events', async () => {
+    service.emit('tenant-1', 'agent');
+    await jest.advanceTimersByTimeAsync(250);
+
+    expect(invalidate).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
@@ -1,3 +1,6 @@
+import { CACHE_MANAGER, CacheModule } from '@nestjs/cache-manager';
+import { Test } from '@nestjs/testing';
+import type { Cache } from 'cache-manager';
 import { IngestEventBusService, IngestEvent } from './ingest-event-bus.service';
 
 describe('IngestEventBusService', () => {
@@ -124,5 +127,56 @@ describe('IngestEventBusService', () => {
     jest.advanceTimersByTime(2000);
 
     expect(received).toEqual([{ tenantId: 'COMPLETE', kind: 'message' }]);
+  });
+});
+
+describe('IngestEventBusService message cache invalidation', () => {
+  let service: IngestEventBusService;
+  let cacheManager: Cache;
+  let deleteSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    const module = await Test.createTestingModule({
+      imports: [CacheModule.register()],
+      providers: [IngestEventBusService],
+    }).compile();
+
+    service = module.get(IngestEventBusService);
+    cacheManager = module.get(CACHE_MANAGER);
+    deleteSpy = jest.spyOn(cacheManager, 'del').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    jest.useRealTimers();
+  });
+
+  it('clears both harness-list variants before publishing a message event', async () => {
+    const received: IngestEvent[] = [];
+    let finishDeletion!: () => void;
+    const deletionFinished = new Promise<boolean>((resolve) => {
+      finishDeletion = () => resolve(true);
+    });
+    deleteSpy.mockReturnValue(deletionFinished);
+    const eventPublished = new Promise<void>((resolve) => {
+      service.forTenant('tenant-1').subscribe((event) => {
+        received.push(event);
+        resolve();
+      });
+    });
+
+    service.emit('tenant-1', 'message');
+    await jest.advanceTimersByTimeAsync(250);
+
+    expect(deleteSpy).toHaveBeenCalledTimes(2);
+    expect(deleteSpy).toHaveBeenCalledWith('tenant-1:/api/v1/agents:playground=false');
+    expect(deleteSpy).toHaveBeenCalledWith('tenant-1:/api/v1/agents:playground=true');
+    expect(received).toEqual([]);
+
+    finishDeletion();
+    await eventPublished;
+
+    expect(received).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: undefined }]);
   });
 });

--- a/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.spec.ts
@@ -1,14 +1,15 @@
-import { CACHE_MANAGER, CacheModule } from '@nestjs/cache-manager';
-import { Test } from '@nestjs/testing';
-import type { Cache } from 'cache-manager';
+import { Logger } from '@nestjs/common';
+import { AgentListCacheInterceptor } from '../interceptors/agent-list-cache.interceptor';
 import { IngestEventBusService, IngestEvent } from './ingest-event-bus.service';
 
 describe('IngestEventBusService', () => {
   let service: IngestEventBusService;
+  let invalidate: jest.Mock;
 
   beforeEach(() => {
     jest.useFakeTimers();
-    service = new IngestEventBusService();
+    invalidate = jest.fn().mockResolvedValue(undefined);
+    service = new IngestEventBusService({ invalidate } as unknown as AgentListCacheInterceptor);
   });
 
   afterEach(() => {
@@ -16,18 +17,18 @@ describe('IngestEventBusService', () => {
     jest.useRealTimers();
   });
 
-  it('emits to the correct tenant after debounce', () => {
+  it('emits to the correct tenant after debounce', async () => {
     const received: IngestEvent[] = [];
     service.forTenant('tenant-1').subscribe((e) => received.push(e));
 
     service.emit('tenant-1');
     expect(received).toHaveLength(0);
 
-    jest.advanceTimersByTime(250);
+    await jest.advanceTimersByTimeAsync(250);
     expect(received).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: undefined }]);
   });
 
-  it('debounces rapid emissions for the same tenant/kind', () => {
+  it('debounces rapid emissions for the same tenant/kind', async () => {
     const received: IngestEvent[] = [];
     service.forTenant('tenant-1').subscribe((e) => received.push(e));
 
@@ -40,27 +41,27 @@ describe('IngestEventBusService', () => {
 
     expect(received).toHaveLength(0);
 
-    jest.advanceTimersByTime(150);
+    await jest.advanceTimersByTimeAsync(150);
     expect(received).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: undefined }]);
   });
 
-  it('forwards the optional userId attribution', () => {
+  it('forwards the optional userId attribution', async () => {
     const received: IngestEvent[] = [];
     service.forTenant('tenant-1').subscribe((e) => received.push(e));
 
     service.emit('tenant-1', 'message', 'user-9');
-    jest.advanceTimersByTime(250);
+    await jest.advanceTimersByTimeAsync(250);
 
     expect(received).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: 'user-9' }]);
   });
 
-  it('different kinds for the same tenant fire independently', () => {
+  it('different kinds for the same tenant fire independently', async () => {
     const received: IngestEvent[] = [];
     service.forTenant('tenant-1').subscribe((e) => received.push(e));
 
     service.emit('tenant-1', 'message');
     service.emit('tenant-1', 'agent');
-    jest.advanceTimersByTime(250);
+    await jest.advanceTimersByTimeAsync(250);
 
     expect(received).toEqual([
       { tenantId: 'tenant-1', kind: 'message', userId: undefined },
@@ -68,17 +69,17 @@ describe('IngestEventBusService', () => {
     ]);
   });
 
-  it('does not deliver events for other tenants', () => {
+  it('does not deliver events for other tenants', async () => {
     const received: IngestEvent[] = [];
     service.forTenant('tenant-1').subscribe((e) => received.push(e));
 
     service.emit('tenant-2');
-    jest.advanceTimersByTime(250);
+    await jest.advanceTimersByTimeAsync(250);
 
     expect(received).toHaveLength(0);
   });
 
-  it('emits independently for different tenants', () => {
+  it('emits independently for different tenants', async () => {
     const tenant1: IngestEvent[] = [];
     const tenant2: IngestEvent[] = [];
     service.forTenant('tenant-1').subscribe((e) => tenant1.push(e));
@@ -86,29 +87,29 @@ describe('IngestEventBusService', () => {
 
     service.emit('tenant-1');
     service.emit('tenant-2', 'routing');
-    jest.advanceTimersByTime(250);
+    await jest.advanceTimersByTimeAsync(250);
 
     expect(tenant1).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: undefined }]);
     expect(tenant2).toEqual([{ tenantId: 'tenant-2', kind: 'routing', userId: undefined }]);
   });
 
-  it('null tenantId matches no events', () => {
+  it('null tenantId matches no events', async () => {
     const received: IngestEvent[] = [];
     service.forTenant(null).subscribe((e) => received.push(e));
 
     service.emit('tenant-1');
-    jest.advanceTimersByTime(250);
+    await jest.advanceTimersByTimeAsync(250);
 
     expect(received).toHaveLength(0);
   });
 
-  it('all() observes every event regardless of tenant', () => {
+  it('all() observes every event regardless of tenant', async () => {
     const received: IngestEvent[] = [];
     service.all().subscribe((e) => received.push(e));
 
     service.emit('a');
     service.emit('b', 'agent');
-    jest.advanceTimersByTime(250);
+    await jest.advanceTimersByTimeAsync(250);
 
     expect(received).toHaveLength(2);
     expect(received).toContainEqual({ tenantId: 'a', kind: 'message', userId: undefined });
@@ -132,19 +133,12 @@ describe('IngestEventBusService', () => {
 
 describe('IngestEventBusService message cache invalidation', () => {
   let service: IngestEventBusService;
-  let cacheManager: Cache;
-  let deleteSpy: jest.SpyInstance;
+  let invalidate: jest.Mock;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.useFakeTimers();
-    const module = await Test.createTestingModule({
-      imports: [CacheModule.register()],
-      providers: [IngestEventBusService],
-    }).compile();
-
-    service = module.get(IngestEventBusService);
-    cacheManager = module.get(CACHE_MANAGER);
-    deleteSpy = jest.spyOn(cacheManager, 'del').mockResolvedValue(true);
+    invalidate = jest.fn().mockResolvedValue(undefined);
+    service = new IngestEventBusService({ invalidate } as unknown as AgentListCacheInterceptor);
   });
 
   afterEach(() => {
@@ -152,13 +146,13 @@ describe('IngestEventBusService message cache invalidation', () => {
     jest.useRealTimers();
   });
 
-  it('clears both harness-list variants before publishing a message event', async () => {
+  it('waits for cache invalidation before publishing a message event', async () => {
     const received: IngestEvent[] = [];
-    let finishDeletion!: () => void;
-    const deletionFinished = new Promise<boolean>((resolve) => {
-      finishDeletion = () => resolve(true);
+    let finishInvalidation!: () => void;
+    const invalidationFinished = new Promise<void>((resolve) => {
+      finishInvalidation = resolve;
     });
-    deleteSpy.mockReturnValue(deletionFinished);
+    invalidate.mockReturnValue(invalidationFinished);
     const eventPublished = new Promise<void>((resolve) => {
       service.forTenant('tenant-1').subscribe((event) => {
         received.push(event);
@@ -169,14 +163,30 @@ describe('IngestEventBusService message cache invalidation', () => {
     service.emit('tenant-1', 'message');
     await jest.advanceTimersByTimeAsync(250);
 
-    expect(deleteSpy).toHaveBeenCalledTimes(2);
-    expect(deleteSpy).toHaveBeenCalledWith('tenant-1:/api/v1/agents:playground=false');
-    expect(deleteSpy).toHaveBeenCalledWith('tenant-1:/api/v1/agents:playground=true');
+    expect(invalidate).toHaveBeenCalledWith('tenant-1');
     expect(received).toEqual([]);
 
-    finishDeletion();
+    finishInvalidation();
     await eventPublished;
 
     expect(received).toEqual([{ tenantId: 'tenant-1', kind: 'message', userId: undefined }]);
+  });
+
+  it('retries a failed invalidation and does not publish when the retry fails', async () => {
+    const received: IngestEvent[] = [];
+    const logger = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    invalidate.mockRejectedValue(new Error('cache unavailable'));
+    service.forTenant('tenant-1').subscribe((event) => received.push(event));
+
+    service.emit('tenant-1', 'message');
+    await jest.advanceTimersByTimeAsync(250);
+
+    expect(invalidate).toHaveBeenCalledTimes(2);
+    expect(received).toEqual([]);
+    expect(logger).toHaveBeenCalledWith(
+      'Failed to invalidate the agent-list cache for tenant tenant-1',
+      expect.any(String),
+    );
+    logger.mockRestore();
   });
 });

--- a/packages/backend/src/common/services/ingest-event-bus.service.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.ts
@@ -1,9 +1,7 @@
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject, Injectable, OnModuleDestroy, Optional } from '@nestjs/common';
-import type { Cache } from 'cache-manager';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { Subject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { agentListCacheKey } from '../constants/cache.constants';
+import { AgentListCacheInterceptor } from '../interceptors/agent-list-cache.interceptor';
 
 export type IngestEventKind = 'message' | 'agent' | 'routing';
 
@@ -16,24 +14,28 @@ export interface IngestEvent {
 
 @Injectable()
 export class IngestEventBusService implements OnModuleDestroy {
+  private readonly logger = new Logger(IngestEventBusService.name);
   private readonly subject = new Subject<IngestEvent>();
   private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly DEBOUNCE_MS = 250;
 
-  constructor(
-    @Optional()
-    @Inject(CACHE_MANAGER)
-    private readonly cacheManager?: Cache,
-  ) {}
+  constructor(private readonly agentListCache: AgentListCacheInterceptor) {}
 
   private async publish(event: IngestEvent): Promise<void> {
-    if (event.kind === 'message' && this.cacheManager) {
-      // Agent-list responses include message_count. Clear both variants before
-      // subscribers refetch so the next response cannot reuse a stale count.
-      await Promise.allSettled([
-        this.cacheManager.del(agentListCacheKey(event.tenantId, false)),
-        this.cacheManager.del(agentListCacheKey(event.tenantId, true)),
-      ]);
+    if (event.kind === 'message') {
+      try {
+        await this.agentListCache.invalidate(event.tenantId);
+      } catch (firstError) {
+        try {
+          await this.agentListCache.invalidate(event.tenantId);
+        } catch (retryError) {
+          this.logger.error(
+            `Failed to invalidate the agent-list cache for tenant ${event.tenantId}`,
+            retryError instanceof Error ? retryError.stack : String(retryError ?? firstError),
+          );
+          return;
+        }
+      }
     }
     this.subject.next(event);
   }

--- a/packages/backend/src/common/services/ingest-event-bus.service.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { Subject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { AgentListCacheInterceptor } from '../interceptors/agent-list-cache.interceptor';
+import { AgentListCacheService } from './agent-list-cache.service';
 
 export type IngestEventKind = 'message' | 'agent' | 'routing';
 
@@ -19,22 +19,22 @@ export class IngestEventBusService implements OnModuleDestroy {
   private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly DEBOUNCE_MS = 250;
 
-  constructor(private readonly agentListCache: AgentListCacheInterceptor) {}
+  constructor(private readonly agentListCache: AgentListCacheService) {}
 
   private async publish(event: IngestEvent): Promise<void> {
     if (event.kind === 'message') {
+      // Agent-list responses carry message_count, so retire them before
+      // subscribers refetch. Invalidation is generation-based and cannot leave a
+      // reader on a stale key, so a failure here is housekeeping noise: publish
+      // regardless, because swallowing the event would leave every dashboard
+      // waiting for a refresh that never comes.
       try {
         await this.agentListCache.invalidate(event.tenantId);
-      } catch (firstError) {
-        try {
-          await this.agentListCache.invalidate(event.tenantId);
-        } catch (retryError) {
-          this.logger.error(
-            `Failed to invalidate the agent-list cache for tenant ${event.tenantId}`,
-            retryError instanceof Error ? retryError.stack : String(retryError ?? firstError),
-          );
-          return;
-        }
+      } catch (error) {
+        this.logger.error(
+          `Failed to invalidate the agent-list cache for tenant ${event.tenantId}`,
+          error instanceof Error ? error.stack : String(error),
+        );
       }
     }
     this.subject.next(event);

--- a/packages/backend/src/common/services/ingest-event-bus.service.ts
+++ b/packages/backend/src/common/services/ingest-event-bus.service.ts
@@ -1,6 +1,9 @@
-import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, OnModuleDestroy, Optional } from '@nestjs/common';
+import type { Cache } from 'cache-manager';
 import { Subject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { agentListCacheKey } from '../constants/cache.constants';
 
 export type IngestEventKind = 'message' | 'agent' | 'routing';
 
@@ -17,6 +20,24 @@ export class IngestEventBusService implements OnModuleDestroy {
   private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly DEBOUNCE_MS = 250;
 
+  constructor(
+    @Optional()
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager?: Cache,
+  ) {}
+
+  private async publish(event: IngestEvent): Promise<void> {
+    if (event.kind === 'message' && this.cacheManager) {
+      // Agent-list responses include message_count. Clear both variants before
+      // subscribers refetch so the next response cannot reuse a stale count.
+      await Promise.allSettled([
+        this.cacheManager.del(agentListCacheKey(event.tenantId, false)),
+        this.cacheManager.del(agentListCacheKey(event.tenantId, true)),
+      ]);
+    }
+    this.subject.next(event);
+  }
+
   /**
    * Notify subscribers that the given tenant's data changed. The kind narrows
    * which dashboard surfaces should refetch — message-feed pages can ignore
@@ -32,7 +53,7 @@ export class IngestEventBusService implements OnModuleDestroy {
       debounceKey,
       setTimeout(() => {
         this.debounceTimers.delete(debounceKey);
-        this.subject.next({ tenantId, kind, userId });
+        void this.publish({ tenantId, kind, userId });
       }, this.DEBOUNCE_MS),
     );
   }


### PR DESCRIPTION
### ✨ What changed
- Clear both cached harness-list variants before publishing message events.
- Add regression coverage for invalidation ordering.
- Add a patch changeset.

### 💭 Why
The dashboard refreshed after a message event, but GET /agents could still serve cached message counts for up to 60 seconds.

### 👤 For users
Harness request counts now refresh with the next dashboard analytics update.

### 📝 Notes
Closes #2758

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes harness request counts by invalidating agent list caches before publishing message events. Previously, `/api/v1/agents` could return cached message counts for up to 60 seconds after a dashboard refresh.

- Invalidate both agent list cache variants (`playground=false|true`) before publishing 'message' events; publishing now awaits deletion to prevent stale counts.
- Adds regression test for invalidation ordering and debounce. No API or config changes; optional cache manager is used when present. Adds a patch changeset for `manifest`. Closes #2758.

<sup>Written for commit 394aa4e8d84ce4c6ae639477416dbaae59f451d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

