### PR TITLE
fix: show loading state when switching agents on the overview page

### DIFF
--- a/.changeset/agent-detail-loading-state.md
+++ b/.changeset/agent-detail-loading-state.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show the loading skeleton on the Agent Overview page while switching between agents, instead of leaving the previous agent's data on screen until the new fetch resolves.

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -176,14 +176,6 @@ const Overview: Component = () => {
   // treat it as a change that should show the skeleton instead of stale data.
   const [loadedRange, setLoadedRange] = createSignal(effectiveRange());
   const [loadedAgent, setLoadedAgent] = createSignal(params.agentName);
-  createEffect(() => {
-    if (!data.loading && data() !== undefined) {
-      setLoadedRange(effectiveRange());
-      setLoadedAgent(params.agentName);
-    }
-  });
-  const rangeChanging = () => data.loading && loadedRange() !== effectiveRange();
-  const agentChanging = () => data.loading && loadedAgent() !== params.agentName;
 
   const showDashboard = () => {
     const d = data();
@@ -293,6 +285,27 @@ const Overview: Component = () => {
     }),
     (p) => getPerModelReliability(p.range, p.agent),
   );
+
+  const supportingDataLoading = () =>
+    providerTokenTs.loading ||
+    providerMessageTs.loading ||
+    providerCostTs.loading ||
+    autofixStats.loading ||
+    statusTimeseries.loading ||
+    modelReliability.loading;
+
+  createEffect(() => {
+    if (data.loading) return;
+    if (data.error === undefined) {
+      if (data() === undefined) return;
+      if (showDashboard() && supportingDataLoading()) return;
+    }
+    setLoadedRange(effectiveRange());
+    setLoadedAgent(params.agentName);
+  });
+  const scopeChanging = () =>
+    loadedRange() !== effectiveRange() || loadedAgent() !== params.agentName;
+
   const selfHealedTs = () => {
     const ts = statusTimeseries();
     if (!ts) return undefined;
@@ -402,7 +415,7 @@ const Overview: Component = () => {
       </div>
 
       <Show
-        when={(data() !== undefined || !data.loading) && !rangeChanging() && !agentChanging()}
+        when={(data() !== undefined || !data.loading) && !scopeChanging()}
         fallback={<OverviewSkeleton />}
       >
         <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -164,18 +164,27 @@ const Overview: Component = () => {
 
   // Never waits on billing/status: the plan-hint lock resolves the range
   // synchronously, so this fetches exactly once at the right range.
-  const [data, { refetch }] = createResource(
-    () => ({ range: effectiveRange(), agentName: params.agentName, _ping: analyticsPing() }),
-    (p) => getOverview(p.range, p.agentName) as Promise<OverviewData>,
+  // The memo's identity changes on every range/agent transition (including
+  // A → B → A) but stays stable across same-scope SSE refreshes.
+  const overviewScope = createMemo(() => ({
+    range: effectiveRange(),
+    agentName: params.agentName,
+  }));
+  const [overviewResult, { refetch }] = createResource(
+    () => ({ scope: overviewScope(), _ping: analyticsPing() }),
+    async (p) => ({
+      scope: p.scope,
+      data: (await getOverview(p.scope.range, p.scope.agentName)) as OverviewData,
+    }),
   );
+  const data = () => overviewResult()?.data;
 
   // The resource re-fetches on range, agent, and every SSE `_ping`. We only want
   // the loading skeleton on a range change or agent switch — not on the frequent
   // background ping refetches (which should update in place). Track the range
   // and agent the visible data belongs to; while a newer range/agent is loading,
   // treat it as a change that should show the skeleton instead of stale data.
-  const [loadedRange, setLoadedRange] = createSignal(effectiveRange());
-  const [loadedAgent, setLoadedAgent] = createSignal(params.agentName);
+  const [loadedScope, setLoadedScope] = createSignal(overviewScope());
 
   const showDashboard = () => {
     const d = data();
@@ -295,16 +304,17 @@ const Overview: Component = () => {
     modelReliability.loading;
 
   createEffect(() => {
-    if (data.loading) return;
-    if (data.error === undefined) {
-      if (data() === undefined) return;
+    if (overviewResult.loading) return;
+    if (overviewResult.error === undefined) {
+      const result = overviewResult();
+      if (result === undefined || result.scope !== overviewScope()) return;
       if (showDashboard() && supportingDataLoading()) return;
+      setLoadedScope(result.scope);
+      return;
     }
-    setLoadedRange(effectiveRange());
-    setLoadedAgent(params.agentName);
+    setLoadedScope(overviewScope());
   });
-  const scopeChanging = () =>
-    loadedRange() !== effectiveRange() || loadedAgent() !== params.agentName;
+  const scopeChanging = () => loadedScope() !== overviewScope();
 
   const selfHealedTs = () => {
     const ts = statusTimeseries();
@@ -415,10 +425,13 @@ const Overview: Component = () => {
       </div>
 
       <Show
-        when={(data() !== undefined || !data.loading) && !scopeChanging()}
+        when={(data() !== undefined || !overviewResult.loading) && !scopeChanging()}
         fallback={<OverviewSkeleton />}
       >
-        <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
+        <Show
+          when={!overviewResult.error}
+          fallback={<ErrorState error={overviewResult.error} onRetry={refetch} />}
+        >
           <Show when={showEmptyState()}>
             <Show
               when={setupCompleted()}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -170,14 +170,20 @@ const Overview: Component = () => {
   );
 
   // The resource re-fetches on range, agent, and every SSE `_ping`. We only want
-  // the loading skeleton on a range change — not on the frequent background ping
-  // refetches (which should update in place). Track the range the visible data
-  // belongs to; while a newer range is loading, treat it as a range change.
+  // the loading skeleton on a range change or agent switch — not on the frequent
+  // background ping refetches (which should update in place). Track the range
+  // and agent the visible data belongs to; while a newer range/agent is loading,
+  // treat it as a change that should show the skeleton instead of stale data.
   const [loadedRange, setLoadedRange] = createSignal(effectiveRange());
+  const [loadedAgent, setLoadedAgent] = createSignal(params.agentName);
   createEffect(() => {
-    if (!data.loading && data() !== undefined) setLoadedRange(effectiveRange());
+    if (!data.loading && data() !== undefined) {
+      setLoadedRange(effectiveRange());
+      setLoadedAgent(params.agentName);
+    }
   });
   const rangeChanging = () => data.loading && loadedRange() !== effectiveRange();
+  const agentChanging = () => data.loading && loadedAgent() !== params.agentName;
 
   const showDashboard = () => {
     const d = data();
@@ -396,7 +402,7 @@ const Overview: Component = () => {
       </div>
 
       <Show
-        when={(data() !== undefined || !data.loading) && !rangeChanging()}
+        when={(data() !== undefined || !data.loading) && !rangeChanging() && !agentChanging()}
         fallback={<OverviewSkeleton />}
       >
         <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -9,8 +9,18 @@ const pingBox = vi.hoisted(() => ({ read: (): number => 0, set: (_: number) => {
 let mockAgentName = 'test-agent';
 let mockLocationState: any = null;
 const mockNavigate = vi.fn();
+// Reactive agent-name source for `useParams().agentName`. Solid's router
+// returns a reactive params store, so switching agents (e.g. via the sidebar)
+// updates `agentName` in place without remounting the route component — a
+// plain object here would miss that. The getter re-reads the signal on every
+// access, which is enough for Solid's tracking to pick it up as a dependency.
+const agentNameBox = vi.hoisted(() => ({ read: (): string => 'test-agent', set: (_: string) => {} }));
 vi.mock('@solidjs/router', () => ({
-  useParams: () => ({ agentName: mockAgentName }),
+  useParams: () => ({
+    get agentName() {
+      return agentNameBox.read();
+    },
+  }),
   useLocation: () => ({ pathname: `/harnesses/${mockAgentName}`, state: mockLocationState }),
   useNavigate: () => mockNavigate,
   A: (props: any) => (
@@ -266,6 +276,9 @@ describe('Overview', () => {
     mockIsSetupPending.mockReturnValue(false);
     mockAgentName = 'test-agent';
     mockLocationState = null;
+    const [agentName, setAgentName] = createSignal(mockAgentName);
+    agentNameBox.read = agentName;
+    agentNameBox.set = setAgentName;
     mockGetAutofixStats.mockResolvedValue({
       success_rate: { value: 0.9, previous: 0.8 },
       autofix_saves: { value: 7, previous: 5 },
@@ -315,6 +328,26 @@ describe('Overview', () => {
     await fireEvent.change(select, { target: { value: '24h' } });
 
     // Stale data is replaced by the skeleton while the new range loads.
+    await vi.waitFor(() => {
+      expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
+    });
+    expect(container.textContent).not.toContain('$3.50');
+  });
+
+  it('shows the loading skeleton when switching to a different agent (issue #2267)', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('$3.50');
+    });
+
+    // Switch agents (e.g. clicking a different agent in the sidebar). The
+    // route component stays mounted — only the reactive `agentName` param
+    // changes — and the new agent's fetch never resolves.
+    mockGetOverview.mockReturnValue(new Promise(() => {}));
+    agentNameBox.set('other-agent');
+
+    // The previous agent's stale data must not linger; the skeleton takes over.
     await vi.waitFor(() => {
       expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
     });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -415,6 +415,84 @@ describe('Overview', () => {
     expect(container.textContent).not.toContain('777');
   });
 
+  it('keeps the skeleton when switching back before secondary metrics finish', async () => {
+    const firstAgentStats = {
+      success_rate: { value: 0.9, previous: 0.8 },
+      autofix_saves: { value: 777, previous: 5 },
+      fallback_saves: { value: 2, previous: 1 },
+      total_requests: { value: 100, previous: 90 },
+      errors_remaining: { value: 3, previous: 4 },
+      coverage: { rate: 0.7, previous_rate: 5 / 9 },
+    };
+    const secondAgentStats = {
+      ...firstAgentStats,
+      autofix_saves: { value: 888, previous: 6 },
+    };
+    const returningAgentStats = {
+      ...firstAgentStats,
+      autofix_saves: { value: 999, previous: 7 },
+    };
+    const secondAgentOverview = {
+      ...overviewData,
+      summary: {
+        ...overviewData.summary,
+        cost_today: { value: 9.99, trend_pct: 0 },
+      },
+    };
+    let resolveSecondAgentStats!: (value: typeof secondAgentStats) => void;
+    let resolveReturningAgentStats!: (value: typeof returningAgentStats) => void;
+    const secondAgentStatsPromise = new Promise<typeof secondAgentStats>((resolve) => {
+      resolveSecondAgentStats = resolve;
+    });
+    const returningAgentStatsPromise = new Promise<typeof returningAgentStats>((resolve) => {
+      resolveReturningAgentStats = resolve;
+    });
+    let firstAgentStatsCalls = 0;
+    mockGetOverview.mockImplementation((_range: string, agent: string) =>
+      Promise.resolve(agent === 'other-agent' ? secondAgentOverview : overviewData),
+    );
+    mockGetAutofixStats.mockImplementation((_range: string, agent: string) => {
+      if (agent === 'other-agent') return secondAgentStatsPromise;
+      firstAgentStatsCalls += 1;
+      return firstAgentStatsCalls === 1
+        ? Promise.resolve(firstAgentStats)
+        : returningAgentStatsPromise;
+    });
+
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('$3.50');
+      expect(container.textContent).toContain('777');
+    });
+
+    agentNameBox.set('other-agent');
+    await vi.waitFor(() => {
+      expect(mockGetOverview).toHaveBeenCalledWith('30d', 'other-agent');
+    });
+    agentNameBox.set('test-agent');
+    await vi.waitFor(() => {
+      expect(firstAgentStatsCalls).toBe(2);
+    });
+    await Promise.resolve();
+
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toContain('$9.99');
+    expect(container.textContent).not.toContain('777');
+
+    resolveSecondAgentStats(secondAgentStats);
+    await Promise.resolve();
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toContain('888');
+
+    resolveReturningAgentStats(returningAgentStats);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('$3.50');
+      expect(container.textContent).toContain('999');
+    });
+    expect(container.querySelectorAll('.skeleton').length).toBe(0);
+    expect(container.textContent).not.toContain('888');
+  });
+
   it('keeps showing data during a background ping refetch instead of skeletons', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -354,6 +354,67 @@ describe('Overview', () => {
     expect(container.textContent).not.toContain('$3.50');
   });
 
+  it('keeps the skeleton until the new agent secondary metrics finish loading', async () => {
+    const firstAgentStats = {
+      success_rate: { value: 0.9, previous: 0.8 },
+      autofix_saves: { value: 777, previous: 5 },
+      fallback_saves: { value: 2, previous: 1 },
+      total_requests: { value: 100, previous: 90 },
+      errors_remaining: { value: 3, previous: 4 },
+      coverage: { rate: 0.7, previous_rate: 5 / 9 },
+    };
+    const secondAgentStats = {
+      ...firstAgentStats,
+      autofix_saves: { value: 888, previous: 6 },
+    };
+    const secondAgentOverview = {
+      ...overviewData,
+      summary: {
+        ...overviewData.summary,
+        cost_today: { value: 9.99, trend_pct: 0 },
+      },
+    };
+    let overviewResolved = false;
+    let resolveSecondAgentStats!: (value: typeof secondAgentStats) => void;
+    const secondAgentStatsPromise = new Promise<typeof secondAgentStats>((resolve) => {
+      resolveSecondAgentStats = resolve;
+    });
+    mockGetOverview.mockImplementation((_range: string, agent: string) => {
+      if (agent !== 'other-agent') return Promise.resolve(overviewData);
+      return Promise.resolve(secondAgentOverview).then((value) => {
+        overviewResolved = true;
+        return value;
+      });
+    });
+    mockGetAutofixStats.mockImplementation((_range: string, agent: string) =>
+      agent === 'other-agent' ? secondAgentStatsPromise : Promise.resolve(firstAgentStats),
+    );
+
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('$3.50');
+      expect(container.textContent).toContain('777');
+    });
+
+    agentNameBox.set('other-agent');
+    await vi.waitFor(() => {
+      expect(overviewResolved).toBe(true);
+    });
+    await Promise.resolve();
+
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toContain('$9.99');
+    expect(container.textContent).not.toContain('777');
+
+    resolveSecondAgentStats(secondAgentStats);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('$9.99');
+      expect(container.textContent).toContain('888');
+    });
+    expect(container.querySelectorAll('.skeleton').length).toBe(0);
+    expect(container.textContent).not.toContain('777');
+  });
+
   it('keeps showing data during a background ping refetch instead of skeletons', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
@@ -538,6 +599,7 @@ describe('Overview', () => {
 
     await vi.waitFor(() => {
       expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+      expect(container.querySelectorAll('.chart-card__stat--clickable').length).toBe(4);
     });
     const stats = container.querySelectorAll('.chart-card__stat--clickable');
     fireEvent.click(stats[2]); // cost (Requests=0, Recovered=1, Cost=2, Token usage=3)


### PR DESCRIPTION
## Summary

The agent detail page briefly showed the previous agent's numbers after switching agents in the sidebar instead of showing a loading state.

## Root cause

Solid resources keep returning their previous value while a new fetch is in flight. The first version of this fix marked the new agent and range as loaded as soon as the primary overview request finished, while the supporting metric requests could still contain data from the previous agent.

## Fix

Keep the overview skeleton visible until the primary overview request and its supporting provider, Autofix, status, and model-reliability requests settle for the selected agent and range. Background refreshes for the same scope still keep the current dashboard visible.

## Tests

- Added coverage for switching agents while a secondary metric request is still pending.
- Overview tests: 63/63 passing.
- Full frontend suite with coverage and CI timezone: 4191/4191 passing.
- Frontend typecheck, frontend/backend/shared builds, and repository lint passed.
- Local browser smoke test passed against an isolated seeded PostgreSQL database for agent and date-range switching.
- Added a patch changeset.

## Related issue

Fixes #2267

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a loading skeleton on Agent Overview when switching agents to avoid briefly showing the previous agent’s data. Old: stale data remained visible until the new fetch resolved. New: skeleton displays during the switch; background ping refetches still update in place. Fixes #2267.

- Bug Fixes
  - Tracks the agent associated with the visible data and gates render until the new agent’s data loads.
  - Keeps ping-driven refetches from triggering the skeleton.

- Tests
  - Adds a test that switching agents shows the skeleton and hides the previous agent’s values.

<sup>Written for commit cd513ce1254023174aaf59c44df5314605643699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
