### PR TITLE
fix: invalidate routing cache after model refresh

### DIFF
--- a/.changeset/ollama-refresh-cache-invalidation.md
+++ b/.changeset/ollama-refresh-cache-invalidation.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Fix "Refresh models" not picking up newly-added Ollama (or any provider) models. Both refresh-models endpoints wrote the fresh model list straight to `tenant_providers.cached_models` but never invalidated `RoutingCacheService`'s 2-minute tenant-scoped provider-list cache, so `GET /api/v1/providers` (which the refresh button re-fetches right after refreshing) could keep serving the pre-refresh snapshot. Every other provider mutation already invalidated this cache; the refresh endpoints now do the same.
+Show refreshed provider metadata immediately after manual model discovery.

--- a/.changeset/ollama-refresh-cache-invalidation.md
+++ b/.changeset/ollama-refresh-cache-invalidation.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix "Refresh models" not picking up newly-added Ollama (or any provider) models. Both refresh-models endpoints wrote the fresh model list straight to `tenant_providers.cached_models` but never invalidated `RoutingCacheService`'s 2-minute tenant-scoped provider-list cache, so `GET /api/v1/providers` (which the refresh button re-fetches right after refreshing) could keep serving the pre-refresh snapshot. Every other provider mutation already invalidated this cache; the refresh endpoints now do the same.

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -7,6 +7,7 @@ import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { ProviderParamSpecService } from './routing-core/provider-param-spec.service';
+import { RoutingCacheService } from './routing-core/routing-cache.service';
 import { DiscoveredModel } from '../model-discovery/model-fetcher';
 import { Agent } from '../entities/agent.entity';
 
@@ -41,6 +42,7 @@ describe('ModelController', () => {
   let mockProviderParamSpecs: Record<string, jest.Mock>;
   let mockModelsDevSync: Record<string, jest.Mock>;
   let mockOpencodeGoCatalog: Record<string, jest.Mock>;
+  let mockRoutingCache: Record<string, jest.Mock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -82,6 +84,10 @@ describe('ModelController', () => {
     mockOpencodeGoCatalog = {
       resolveCostPerRequest: jest.fn().mockResolvedValue(null),
     };
+    mockRoutingCache = {
+      invalidateAgent: jest.fn(),
+      invalidateTenant: jest.fn(),
+    };
 
     controller = new ModelController(
       mockDiscoveryService as unknown as ModelDiscoveryService,
@@ -92,6 +98,7 @@ describe('ModelController', () => {
       mockProviderParamSpecs as unknown as ProviderParamSpecService,
       mockModelsDevSync as unknown as ModelsDevSyncService,
       mockOpencodeGoCatalog as unknown as OpencodeGoCatalogService,
+      mockRoutingCache as unknown as RoutingCacheService,
     );
   });
 
@@ -188,6 +195,20 @@ describe('ModelController', () => {
       });
       expect(result).toEqual({ ok: true });
     });
+
+    it('invalidates the tenant-scoped routing cache so newly discovered models are visible immediately', async () => {
+      await controller.refreshModels(mockCtx, mockAgentName);
+
+      // discoverAllForAgent() writes straight to tenant_providers.cached_models,
+      // but ProviderService.getProviders() serves that table through
+      // RoutingCacheService's 2-minute cache. Without this invalidation a
+      // caller that re-fetches the provider list right after refreshing (the
+      // "Refresh models" button's own follow-up request) would keep observing
+      // the pre-refresh snapshot, including a model just added on the
+      // provider's end.
+      expect(mockRoutingCache.invalidateAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
+      expect(mockRoutingCache.invalidateTenant).toHaveBeenCalledWith(TEST_TENANT_ID);
+    });
   });
 
   /* ── refreshProviderModels ── */
@@ -239,6 +260,20 @@ describe('ModelController', () => {
 
       expect(result.ok).toBe(false);
       expect(result.error).toBe('Provider returned no models');
+    });
+
+    it('invalidates the tenant-scoped routing cache so the refreshed model list is visible immediately', async () => {
+      mockDiscoveryService.refreshProvider.mockResolvedValue({
+        ok: true,
+        model_count: 3,
+        last_fetched_at: '2026-04-12T12:00:00.000Z',
+        error: null,
+      });
+
+      await controller.refreshProviderModels(mockCtx, mockParams, {});
+
+      expect(mockRoutingCache.invalidateAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
+      expect(mockRoutingCache.invalidateTenant).toHaveBeenCalledWith(TEST_TENANT_ID);
     });
   });
 

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -42,7 +42,7 @@ describe('ModelController', () => {
   let mockProviderParamSpecs: Record<string, jest.Mock>;
   let mockModelsDevSync: Record<string, jest.Mock>;
   let mockOpencodeGoCatalog: Record<string, jest.Mock>;
-  let mockRoutingCache: Record<string, jest.Mock>;
+  let routingCache: RoutingCacheService;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -84,10 +84,7 @@ describe('ModelController', () => {
     mockOpencodeGoCatalog = {
       resolveCostPerRequest: jest.fn().mockResolvedValue(null),
     };
-    mockRoutingCache = {
-      invalidateAgent: jest.fn(),
-      invalidateTenant: jest.fn(),
-    };
+    routingCache = new RoutingCacheService();
 
     controller = new ModelController(
       mockDiscoveryService as unknown as ModelDiscoveryService,
@@ -98,7 +95,7 @@ describe('ModelController', () => {
       mockProviderParamSpecs as unknown as ProviderParamSpecService,
       mockModelsDevSync as unknown as ModelsDevSyncService,
       mockOpencodeGoCatalog as unknown as OpencodeGoCatalogService,
-      mockRoutingCache as unknown as RoutingCacheService,
+      routingCache,
     );
   });
 
@@ -196,18 +193,14 @@ describe('ModelController', () => {
       expect(result).toEqual({ ok: true });
     });
 
-    it('invalidates the tenant-scoped routing cache so newly discovered models are visible immediately', async () => {
+    it('clears agent and tenant caches after refreshing all providers', async () => {
+      routingCache.setModelParams(TEST_AGENT_ID, []);
+      routingCache.setProviders(TEST_TENANT_ID, []);
+
       await controller.refreshModels(mockCtx, mockAgentName);
 
-      // discoverAllForAgent() writes straight to tenant_providers.cached_models,
-      // but ProviderService.getProviders() serves that table through
-      // RoutingCacheService's 2-minute cache. Without this invalidation a
-      // caller that re-fetches the provider list right after refreshing (the
-      // "Refresh models" button's own follow-up request) would keep observing
-      // the pre-refresh snapshot, including a model just added on the
-      // provider's end.
-      expect(mockRoutingCache.invalidateAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
-      expect(mockRoutingCache.invalidateTenant).toHaveBeenCalledWith(TEST_TENANT_ID);
+      expect(routingCache.getModelParams(TEST_AGENT_ID)).toBeNull();
+      expect(routingCache.getProviders(TEST_TENANT_ID)).toBeNull();
     });
   });
 
@@ -262,18 +255,20 @@ describe('ModelController', () => {
       expect(result.error).toBe('Provider returned no models');
     });
 
-    it('invalidates the tenant-scoped routing cache so the refreshed model list is visible immediately', async () => {
+    it('clears agent and tenant caches after refreshing one provider', async () => {
       mockDiscoveryService.refreshProvider.mockResolvedValue({
         ok: true,
         model_count: 3,
         last_fetched_at: '2026-04-12T12:00:00.000Z',
         error: null,
       });
+      routingCache.setModelParams(TEST_AGENT_ID, []);
+      routingCache.setProviders(TEST_TENANT_ID, []);
 
       await controller.refreshProviderModels(mockCtx, mockParams, {});
 
-      expect(mockRoutingCache.invalidateAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
-      expect(mockRoutingCache.invalidateTenant).toHaveBeenCalledWith(TEST_TENANT_ID);
+      expect(routingCache.getModelParams(TEST_AGENT_ID)).toBeNull();
+      expect(routingCache.getProviders(TEST_TENANT_ID)).toBeNull();
     });
   });
 

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -8,6 +8,7 @@ import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
+import { RoutingCacheService } from './routing-core/routing-cache.service';
 import { resolveProviderMetadataIdentity } from 'manifest-shared';
 import {
   inputModalitiesFromCapabilities,
@@ -63,6 +64,7 @@ export class ModelController {
     private readonly providerParamSpecs: ProviderParamSpecService,
     private readonly modelsDevSync: ModelsDevSyncService,
     private readonly opencodeGoCatalog: OpencodeGoCatalogService,
+    private readonly routingCache: RoutingCacheService,
   ) {}
 
   @Get('pricing-health')
@@ -87,6 +89,19 @@ export class ModelController {
   async refreshModels(@TenantCtx() ctx: TenantContext, @Param() params: AgentNameParamDto) {
     const agent = await this.resolveAgentService.resolve(ctx.tenantId, params.agentName);
     await this.discoveryService.discoverAllForAgent(agent.tenant_id, { forceRefresh: true });
+    // discoverAllForAgent() persists the freshly fetched model lists straight to
+    // tenant_providers.cached_models, but ProviderService.getProviders() serves
+    // that same table through RoutingCacheService's 2-minute tenant-scoped cache
+    // (see RoutingCacheService.getProviders/setProviders). Nothing on the
+    // discovery write path invalidates it, so a caller that re-fetches the
+    // provider list immediately after this call (exactly what the "Refresh
+    // models" button does) can keep observing the pre-refresh cached_models
+    // snapshot, including missing a newly-added local model, until the cache
+    // entry naturally expires. Every other provider mutation (connect,
+    // disconnect, rename, reorder in ProviderService) already invalidates
+    // both caches; do the same here so a refresh takes effect immediately.
+    this.routingCache.invalidateAgent(agent.id);
+    this.routingCache.invalidateTenant(agent.tenant_id);
     return { ok: true };
   }
 
@@ -102,6 +117,11 @@ export class ModelController {
       params.provider,
       query.authType,
     );
+    // See the comment in refreshModels() above: refreshProvider() writes
+    // cached_models directly but never touches RoutingCacheService, so the
+    // tenant-scoped provider-list cache must be invalidated here.
+    this.routingCache.invalidateAgent(agent.id);
+    this.routingCache.invalidateTenant(agent.tenant_id);
     return result;
   }
 

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -89,17 +89,7 @@ export class ModelController {
   async refreshModels(@TenantCtx() ctx: TenantContext, @Param() params: AgentNameParamDto) {
     const agent = await this.resolveAgentService.resolve(ctx.tenantId, params.agentName);
     await this.discoveryService.discoverAllForAgent(agent.tenant_id, { forceRefresh: true });
-    // discoverAllForAgent() persists the freshly fetched model lists straight to
-    // tenant_providers.cached_models, but ProviderService.getProviders() serves
-    // that same table through RoutingCacheService's 2-minute tenant-scoped cache
-    // (see RoutingCacheService.getProviders/setProviders). Nothing on the
-    // discovery write path invalidates it, so a caller that re-fetches the
-    // provider list immediately after this call (exactly what the "Refresh
-    // models" button does) can keep observing the pre-refresh cached_models
-    // snapshot, including missing a newly-added local model, until the cache
-    // entry naturally expires. Every other provider mutation (connect,
-    // disconnect, rename, reorder in ProviderService) already invalidates
-    // both caches; do the same here so a refresh takes effect immediately.
+    // Discovery bypasses ProviderService, so clear its caches explicitly.
     this.routingCache.invalidateAgent(agent.id);
     this.routingCache.invalidateTenant(agent.tenant_id);
     return { ok: true };
@@ -117,9 +107,6 @@ export class ModelController {
       params.provider,
       query.authType,
     );
-    // See the comment in refreshModels() above: refreshProvider() writes
-    // cached_models directly but never touches RoutingCacheService, so the
-    // tenant-scoped provider-list cache must be invalidated here.
     this.routingCache.invalidateAgent(agent.id);
     this.routingCache.invalidateTenant(agent.tenant_id);
     return result;


### PR DESCRIPTION
### ✨ What changed
- Invalidate agent and tenant routing caches after model refresh.
- Test both refresh endpoints with real cache instances.

### 💭 Why
Model discovery writes cached models outside `ProviderService`. A warm provider cache could keep stale metadata for up to two minutes.

### 👤 For users
Refreshed provider metadata appears immediately after a manual model refresh.

### 📝 Notes
Related to #2029. The original Manifest 6.6.2 behavior is not reproduced here.