### PR TITLE
fix(pricing): re-land the DeepSeek weekend fix and cost-source precedence on main

### DIFF
--- a/.changeset/cost-source-precedence.md
+++ b/.changeset/cost-source-precedence.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Prefer the cost a provider reports over any catalogue estimate. Manifest already read `usage.cost` from responses but only used it for subscription providers, so an exact figure from a gateway such as OpenRouter was captured and then discarded in favour of catalogue arithmetic. Local inference (Ollama, llama.cpp, LM Studio) now records a known `$0` instead of an unknown `null`.

--- a/.changeset/deepseek-weekend-offpeak.md
+++ b/.changeset/deepseek-weekend-offpeak.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop billing DeepSeek V4 peak rates on weekends: time-of-day pricing tiers now carry the weekdays they apply on, and DeepSeek's 01:00-04:00 / 06:00-10:00 UTC peak windows are Monday-Friday only. Also prices `deepseek-v4-flash-vision-exp`, which billed at the stale flat catalog rate.

--- a/packages/backend/src/common/utils/cost-calculator.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.spec.ts
@@ -384,6 +384,7 @@ describe('computeTokenCost', () => {
         time_tiers: [
           {
             windows: ['01:00-04:00'],
+            days: [1, 2, 3, 4, 5],
             input_price_per_token: 1.32e-6,
             output_price_per_token: 3.96e-6,
           },
@@ -481,6 +482,103 @@ describe('computeTokenCost', () => {
     it('bills the tier rate inside a peak window', () => {
       const cost = computeTokenCost({ ...base, at: new Date('2026-08-17T02:30:00Z') });
       expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('bills the base rate on a weekend hour inside a weekday-only window', () => {
+      // 2026-08-22 is a Saturday; 02:00 UTC sits inside 01:00-04:00, so only
+      // the day rule can move it off the peak rate.
+      const weekdayOnly: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [1, 2, 3, 4, 5] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: weekdayOnly,
+        at: new Date('2026-08-22T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('bills the tier rate on a weekday hour inside a weekday-only window', () => {
+      // 2026-08-21 is a Friday — same clock time as the Saturday case above.
+      const weekdayOnly: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [1, 2, 3, 4, 5] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: weekdayOnly,
+        at: new Date('2026-08-21T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('bills a Sunday at the tier rate when Sunday is listed', () => {
+      // ISO Sunday is 7, not 0 — getUTCDay() would say 0 and miss the match.
+      const sundayOnly: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [7] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: sundayOnly,
+        at: new Date('2026-08-23T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('treats an empty day list as every day', () => {
+      const everyDay: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], days: [] }],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: everyDay,
+        at: new Date('2026-08-22T02:00:00Z'),
+      });
+      expect(cost).toBeCloseTo(0.44 + 1.32, 10);
+    });
+
+    it('credits a midnight-crossing window to the day it opened on', () => {
+      // 23:00-02:00 opens Friday and runs into Saturday. Saturday 00:30 is
+      // inside the Friday band; Saturday 23:30 opens a band Saturday does not
+      // have. Judging both by the wall-clock day would get one of them wrong.
+      const fridayNight: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['23:00-02:00'], days: [5] }],
+      };
+      expect(
+        computeTokenCost({
+          ...base,
+          pricing: fridayNight,
+          at: new Date('2026-08-22T00:30:00Z'),
+        }),
+      ).toBeCloseTo(0.44 + 1.32, 10);
+      expect(
+        computeTokenCost({
+          ...base,
+          pricing: fridayNight,
+          at: new Date('2026-08-22T23:30:00Z'),
+        }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('bills a window that opens Sunday and runs into Monday on Sunday terms', () => {
+      // The week circle has a seam at Monday 00:00. A Sunday-only band that
+      // wraps past midnight has to cross it, so this pins that the seam is not
+      // a boundary: 2026-08-24 is a Monday, 00:30 of it belongs to Sunday's.
+      const sundayNight: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['23:00-02:00'], days: [7] }],
+      };
+      expect(
+        computeTokenCost({
+          ...base,
+          pricing: sundayNight,
+          at: new Date('2026-08-24T00:30:00Z'),
+        }),
+      ).toBeCloseTo(0.44 + 1.32, 10);
     });
 
     it('treats window starts as inclusive and ends as exclusive', () => {
@@ -593,6 +691,29 @@ describe('computeTokenCost', () => {
       };
       expect(
         computeTokenCost({ ...base, pricing: malformed, at: new Date('2026-08-17T02:00:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('ignores an hour outside 00-23 instead of opening a band the next day', () => {
+      // As a plain minute count "25:00" was unreachable and harmless. As an arc
+      // it would open a real band on the following day, repricing a window
+      // nobody wrote. 2026-08-18 is a Tuesday, which is where 25:00 would land.
+      const corrupt: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['25:00-26:00'], days: [] }],
+      };
+      expect(
+        computeTokenCost({ ...base, pricing: corrupt, at: new Date('2026-08-18T01:30:00Z') }),
+      ).toBeCloseTo(0.22 + 0.66, 10);
+    });
+
+    it('ignores a minute outside 00-59', () => {
+      const corrupt: PricingEntry = {
+        ...peakPricing,
+        time_tiers: [{ ...peakPricing.time_tiers![0], windows: ['01:75-02:00'], days: [] }],
+      };
+      expect(
+        computeTokenCost({ ...base, pricing: corrupt, at: new Date('2026-08-18T01:50:00Z') }),
       ).toBeCloseTo(0.22 + 0.66, 10);
     });
 

--- a/packages/backend/src/common/utils/cost-calculator.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.spec.ts
@@ -348,6 +348,106 @@ describe('computeTokenCost', () => {
     expect(result).toBeCloseTo(0.0075, 10);
   });
 
+  describe('cost source precedence', () => {
+    const catalogPricing: PricingEntry = {
+      model_name: 'deepseek-v4-pro',
+      provider: 'DeepSeek',
+      input_price_per_token: 0.66e-6,
+      output_price_per_token: 1.98e-6,
+      display_name: 'DeepSeek V4 Pro',
+    };
+    const base = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      model: 'deepseek-v4-pro',
+      pricing: catalogPricing,
+    };
+
+    it('prefers a provider-reported cost over the catalogue for non-subscription usage', () => {
+      // The gateway said what it charged. That beats any estimate we can make,
+      // and before this it was read only for subscription providers.
+      expect(computeTokenCost({ ...base, reportedCostUsd: 0.42 })).toBe(0.42);
+    });
+
+    it('prefers a reported cost of zero over the catalogue', () => {
+      // Zero is a real answer, not a missing one — a free-tier request.
+      expect(computeTokenCost({ ...base, reportedCostUsd: 0 })).toBe(0);
+    });
+
+    it('ignores a negative reported cost and falls back to the catalogue', () => {
+      expect(computeTokenCost({ ...base, reportedCostUsd: -1 })).toBeCloseTo(0.66 + 1.98, 10);
+    });
+
+    it('prefers a reported cost over a matching peak tier', () => {
+      const tiered: PricingEntry = {
+        ...catalogPricing,
+        time_tiers: [
+          {
+            windows: ['01:00-04:00'],
+            input_price_per_token: 1.32e-6,
+            output_price_per_token: 3.96e-6,
+          },
+        ],
+      };
+      const cost = computeTokenCost({
+        ...base,
+        pricing: tiered,
+        reportedCostUsd: 0.1,
+        at: new Date('2026-08-21T02:00:00Z'),
+      });
+      expect(cost).toBe(0.1);
+    });
+
+    it('still prefers a reported cost for subscription usage', () => {
+      const cost = computeTokenCost({
+        ...base,
+        isSubscription: true,
+        reportedCostUsd: 0.07,
+        perRequestCostUsd: 0.05,
+      });
+      expect(cost).toBe(0.07);
+    });
+
+    it('ignores a reported cost too large for the cost_usd column', () => {
+      // `decimal(10, 6)` tops out at 9999.999999. A bigger number is a
+      // provider reporting credits or a session total, not a request price —
+      // and persisting it would throw and lose the whole telemetry row.
+      const cost = computeTokenCost({ ...base, reportedCostUsd: 25_000 });
+      expect(cost).toBeCloseTo(0.66 + 1.98, 10);
+    });
+
+    it('accepts a reported cost exactly at the column limit', () => {
+      expect(computeTokenCost({ ...base, reportedCostUsd: 9999.999999 })).toBe(9999.999999);
+    });
+
+    it('returns null for an unknown model even when a cost was reported', () => {
+      // "A cost for a model we cannot name" is not a row worth writing.
+      expect(computeTokenCost({ ...base, model: null, reportedCostUsd: 0.42 })).toBeNull();
+    });
+
+    it('records zero for local inference instead of an unknown null', () => {
+      // Ollama, llama.cpp and LM Studio run on the user's own hardware. There
+      // is no bill, and "free" is a different fact from "not known".
+      expect(computeTokenCost({ ...base, pricing: undefined, isLocalProvider: true })).toBe(0);
+    });
+
+    it('records zero for local inference even when no tokens were counted', () => {
+      expect(
+        computeTokenCost({
+          ...base,
+          inputTokens: 0,
+          outputTokens: 0,
+          pricing: undefined,
+          isLocalProvider: true,
+        }),
+      ).toBe(0);
+    });
+
+    it('returns null for a non-local provider with no pricing', () => {
+      expect(computeTokenCost({ ...base, pricing: undefined })).toBeNull();
+    });
+  });
+
   describe('time-of-day pricing tiers', () => {
     // DeepSeek V4 Flash shape: off-peak base, peak windows at double.
     const peakPricing: PricingEntry = {

--- a/packages/backend/src/common/utils/cost-calculator.ts
+++ b/packages/backend/src/common/utils/cost-calculator.ts
@@ -22,11 +22,22 @@ export interface CostInput {
    */
   perRequestCostUsd?: number | null;
   /**
-   * USD cost reported by the upstream provider in the response usage block.
-   * Used for subscription providers that debit a quota/balance per request
-   * (for example NousResearch Portal) instead of being flat-fee unlimited.
+   * USD cost reported by the upstream provider in its response usage block
+   * (`usage.cost`, as OpenRouter and other gateways emit).
+   *
+   * This is what the provider says it charged, so it outranks every catalogue
+   * estimate — no seller lookup, no stale rate. It is believed from any
+   * upstream that reports it, which includes user-defined OpenAI-compatible
+   * endpoints; the parser accepts only a non-negative finite number, and that
+   * is the whole of the validation.
    */
   reportedCostUsd?: number | null;
+  /**
+   * True when the model ran on the user's own hardware (Ollama, llama.cpp,
+   * LM Studio — `localOnly` in the provider registry). Local inference has no
+   * per-token bill, so the cost is a known `0` rather than an unknown `null`.
+   */
+  isLocalProvider?: boolean;
   /**
    * Billing timestamp used to resolve time-of-day pricing tiers (peak/off-peak
    * providers like DeepSeek V4). Pass the request start when available;
@@ -70,29 +81,54 @@ function resolveTimeTier(pricing: PricingEntry, at: Date): PricingTimeTier | und
 }
 
 /**
+ * Widest value `agent_messages.cost_usd` can hold — `decimal(10, 6)`.
+ *
+ * A larger number is not an expensive request, it is a provider reporting
+ * something other than per-request USD (credits, cents, a running session
+ * total). Storing it is not an option: PostgreSQL raises `numeric field
+ * overflow`, the insert throws, and the recorder swallows it — costing the
+ * whole telemetry row, not just its price. Ignoring the report and estimating
+ * from the catalogue keeps the request visible.
+ */
+const MAX_RECORDABLE_COST_USD = 9999.999999;
+
+/** True when a provider-reported cost is usable and will survive the column. */
+function isRecordableReportedCost(reported: number | null | undefined): boolean {
+  return reported != null && reported >= 0 && reported <= MAX_RECORDABLE_COST_USD;
+}
+
+/**
  * Computes the USD cost for a set of tokens given a pricing entry.
  *
- * Returns:
- * - `reportedCostUsd` when subscription usage includes a provider-reported
- *   non-negative USD cost (NousResearch Portal pattern)
- * - `perRequestCostUsd` when the usage is subscription-based AND a positive
- *   per-request rate is provided (OpenCode Go pattern)
- * - `0` when the usage is subscription-based with no per-request rate
- *   (flat-fee subscriptions: Claude Max, ChatGPT Plus, GLM Coding, etc.)
- * - `null` when the model is unknown, tokens are zero, or pricing is unavailable
- * - the computed cost otherwise
+ * Sources are tried most-accurate first, because they are not equally good
+ * answers to "what did this request cost":
+ *
+ * 1. `reportedCostUsd` — what the provider says it charged. Exact, so it wins
+ *    outright, for any provider that reports it. Ignored above
+ *    `MAX_RECORDABLE_COST_USD`, which is not a real per-request price.
+ * 2. `perRequestCostUsd` — a published per-request rate on a subscription
+ *    (OpenCode Go pattern); `0` for a flat-fee plan with no such rate
+ *    (Claude Max, ChatGPT Plus, GLM Coding).
+ * 3. `0` for local inference — free, and known to be free.
+ * 4. The token maths below, from the caller's `pricing` entry. An estimate:
+ *    it is only as right as the catalogue, and the catalogue only holds the
+ *    correct seller's rates when the caller looked them up by provider.
+ *
+ * Returns `null` when the model is unknown, tokens are zero, or no pricing is
+ * available — meaning "not known", which is not the same as free.
  */
 export function computeTokenCost(input: CostInput): number | null {
   if (!input.model) return null;
+  if (isRecordableReportedCost(input.reportedCostUsd)) {
+    return input.reportedCostUsd as number;
+  }
   if (input.isSubscription) {
-    if (input.reportedCostUsd != null && input.reportedCostUsd >= 0) {
-      return input.reportedCostUsd;
-    }
     if (input.perRequestCostUsd != null && input.perRequestCostUsd > 0) {
       return input.perRequestCostUsd;
     }
     return 0;
   }
+  if (input.isLocalProvider) return 0;
   if (input.inputTokens === 0 && input.outputTokens === 0) return null;
 
   const pricing = input.pricing;

--- a/packages/backend/src/common/utils/cost-calculator.ts
+++ b/packages/backend/src/common/utils/cost-calculator.ts
@@ -26,10 +26,10 @@ export interface CostInput {
    * (`usage.cost`, as OpenRouter and other gateways emit).
    *
    * This is what the provider says it charged, so it outranks every catalogue
-   * estimate — no seller lookup, no stale rate. It is believed from any
-   * upstream that reports it, which includes user-defined OpenAI-compatible
-   * endpoints; the parser accepts only a non-negative finite number, and that
-   * is the whole of the validation.
+   * estimate — no seller lookup, no peak-hour arithmetic, no stale rate. It is
+   * believed from any upstream that reports it, which includes user-defined
+   * OpenAI-compatible endpoints; the parser accepts only a non-negative finite
+   * number, and that is the whole of the validation.
    */
   reportedCostUsd?: number | null;
   /**
@@ -50,34 +50,73 @@ export interface CostInput {
 /**
  * Minutes since UTC midnight for a "HH:MM" string, or null when malformed.
  * Tier windows are validated upstream, so null only guards corrupted data.
+ *
+ * The range check earns its place under the week-circle matching below. An
+ * out-of-range hour used to be harmless — "25:00" was simply a minute count no
+ * clock reached — but as an arc it opens a real band on the following day, so
+ * corrupt input would silently reprice a window nobody wrote.
  */
 function toUtcMinutes(time: string | undefined): number | null {
   if (!time) return null;
   const [hours, minutes] = time.split(':').map(Number);
-  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null;
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
   return hours * 60 + minutes;
 }
 
-/** True when `minutes` falls inside a "HH:MM-HH:MM" window (end exclusive, wraps midnight). */
-function windowMatches(window: string, minutes: number): boolean {
-  const [start, end] = window.split('-').map(toUtcMinutes);
-  if (start == null || end == null) return false;
-  // A zero-length window matches nothing. Without this, start === end falls
-  // into the wrap branch and matches the whole day, letting a malformed
-  // upstream band override the base rate around the clock.
-  if (start === end) return false;
-  return start < end ? minutes >= start && minutes < end : minutes >= start || minutes < end;
+const MINUTES_PER_DAY = 24 * 60;
+const MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
+/** ISO weekdays, used when a tier names no `days` of its own. */
+const EVERY_DAY: readonly number[] = [1, 2, 3, 4, 5, 6, 7];
+
+/** Minutes since Monday 00:00 UTC (0 … 10079). */
+function weekMinutes(at: Date): number {
+  // getUTCDay() is 0-based on Sunday; ISO counts Monday as day 1.
+  const isoDay = (at.getUTCDay() + 6) % 7;
+  return isoDay * MINUTES_PER_DAY + at.getUTCHours() * 60 + at.getUTCMinutes();
 }
 
 /**
- * The time tier whose windows contain `at`, if any. A matching tier replaces
- * the base prices outright (tiers never compose with the base cost).
+ * True when `at` falls in one of the tier's windows.
+ *
+ * A window is an arc on the 10 080-minute week circle: it opens on each of the
+ * tier's `days` at the window's start minute and runs for its length. Framing
+ * it that way makes the two awkward cases definitional rather than special —
+ * a window whose end precedes its start simply runs past midnight into the
+ * next day, and it stays attributed to the day it opened on, so a Friday
+ * 23:00-02:00 band still bills at 00:30 on Saturday. A zero-length window is
+ * a zero-length arc, which contains nothing.
+ */
+function tierCovers(tier: PricingTimeTier, at: Date): boolean {
+  const now = weekMinutes(at);
+  const days = tier.days?.length ? tier.days : EVERY_DAY;
+  for (const window of tier.windows) {
+    const [start, end] = window.split('-').map(toUtcMinutes);
+    if (start == null || end == null) continue;
+    const length = (end - start + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+    for (const day of days) {
+      const opensAt = ((day - 1) * MINUTES_PER_DAY + start) % MINUTES_PER_WEEK;
+      // Distance travelled around the circle since the window opened; inside
+      // the window exactly while that distance is short of its length, which
+      // makes the start inclusive and the end exclusive.
+      if ((now - opensAt + MINUTES_PER_WEEK) % MINUTES_PER_WEEK < length) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The time tier covering `at`, if any. A matching tier replaces the base
+ * prices outright (tiers never compose with the base cost).
+ *
+ * A tier may narrow its windows to specific ISO weekdays (`days`, 1 = Monday
+ * … 7 = Sunday) — DeepSeek's peak hours are Monday through Friday, so the
+ * weekend is off-peak end to end. An absent or empty list means every day.
  */
 function resolveTimeTier(pricing: PricingEntry, at: Date): PricingTimeTier | undefined {
   const tiers = pricing.time_tiers;
   if (!tiers || tiers.length === 0) return undefined;
-  const minutes = at.getUTCHours() * 60 + at.getUTCMinutes();
-  return tiers.find((tier) => tier.windows.some((window) => windowMatches(window, minutes)));
+  return tiers.find((tier) => tierCovers(tier, at));
 }
 
 /**

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1108,6 +1108,7 @@ describe('ModelsDevSyncService', () => {
       expect(model!.timeTiers).toEqual([
         {
           windows: ['01:00-04:00', '06:00-10:00'],
+          days: null,
           inputPricePerToken: 2.0 / 1_000_000,
           outputPricePerToken: 4.0 / 1_000_000,
           cacheReadPricePerToken: 0.2 / 1_000_000,
@@ -1180,6 +1181,7 @@ describe('ModelsDevSyncService', () => {
       expect(service.lookupModel('openai', 'mixed-windows')!.timeTiers).toEqual([
         {
           windows: ['01:00-04:00'],
+          days: null,
           inputPricePerToken: 2.0 / 1_000_000,
           outputPricePerToken: null,
           cacheReadPricePerToken: null,
@@ -1225,6 +1227,7 @@ describe('ModelsDevSyncService', () => {
       expect(flash!.timeTiers).toEqual([
         {
           windows: ['01:00-04:00', '06:00-10:00'],
+          days: [1, 2, 3, 4, 5],
           inputPricePerToken: 0.44 / 1_000_000,
           outputPricePerToken: 1.32 / 1_000_000,
           cacheReadPricePerToken: 0.014 / 1_000_000,
@@ -1235,6 +1238,107 @@ describe('ModelsDevSyncService', () => {
       const chat = service.lookupModel('deepseek', 'deepseek-chat');
       expect(chat!.inputPricePerToken).toBe(0.14 / 1_000_000);
       expect(chat!.timeTiers).toBeNull();
+    });
+
+    it('seeds the vision preview on the Flash card', async () => {
+      const response = {
+        deepseek: {
+          id: 'deepseek',
+          name: 'DeepSeek',
+          models: {
+            'deepseek-v4-flash-vision-exp': {
+              id: 'deepseek-v4-flash-vision-exp',
+              name: 'DeepSeek V4 Flash Vision',
+              cost: { input: 0.14, output: 0.28, cache_read: 0.0028 },
+              modalities: { input: ['text', 'image'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const vision = service.lookupModel('deepseek', 'deepseek-v4-flash-vision-exp');
+      expect(vision!.inputPricePerToken).toBe(0.22 / 1_000_000);
+      expect(vision!.outputPricePerToken).toBe(0.66 / 1_000_000);
+      expect(vision!.timeTiers![0].days).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('carries a catalog day list through to the tier', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'weekday-model': {
+              id: 'weekday-model',
+              name: 'Weekday',
+              cost: {
+                input: 1.0,
+                output: 2.0,
+                tiers: [
+                  {
+                    tier: { type: 'time', windows: ['01:00-04:00'], days: [1, 2, 3, 4, 5] },
+                    input: 2.0,
+                    output: 4.0,
+                  },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'weekday-model')!.timeTiers![0].days).toEqual([
+        1, 2, 3, 4, 5,
+      ]);
+    });
+
+    it.each([
+      ['a non-array', 'weekdays'],
+      ['an out-of-range weekday', [1, 2, 3, 4, 5, 8]],
+      ['a non-integer weekday', [1, 2.5]],
+      ['a non-numeric entry', [1, 2, 3, 4, 5, '6']],
+      ['an empty list', []],
+    ])('drops %s day list whole rather than salvaging part of it', async (_label, days) => {
+      // Filtering [1,2,3,4,5,'6'] down to [1..5] would read as a clean weekday
+      // rule and quietly discount a day the provider charges peak for.
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'bad-days': {
+              id: 'bad-days',
+              name: 'Bad Days',
+              cost: {
+                input: 1.0,
+                output: 2.0,
+                tiers: [
+                  {
+                    tier: { type: 'time', windows: ['01:00-04:00'], days },
+                    input: 2.0,
+                    output: 4.0,
+                  },
+                ],
+              },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const tiers = service.lookupModel('openai', 'bad-days')!.timeTiers;
+      expect(tiers).toHaveLength(1);
+      expect(tiers![0].days).toBeNull();
     });
 
     it('prefers catalog time tiers over the DeepSeek seed once models.dev has them', async () => {
@@ -1267,6 +1371,7 @@ describe('ModelsDevSyncService', () => {
       expect(flash!.timeTiers).toEqual([
         {
           windows: ['02:00-05:00'],
+          days: null,
           inputPricePerToken: 0.5 / 1_000_000,
           outputPricePerToken: 1.4 / 1_000_000,
           cacheReadPricePerToken: null,

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -86,6 +86,12 @@ function resolveProviderId(providerId: string): string {
  */
 export interface ModelsDevTimeTier {
   windows: readonly string[];
+  /**
+   * ISO weekdays (1 = Monday … 7 = Sunday) the windows apply on. Null means
+   * every day — a tier with no schedule is unrestricted, as it was before this
+   * field existed.
+   */
+  days: readonly number[] | null;
   inputPricePerToken: number | null;
   outputPricePerToken: number | null;
   cacheReadPricePerToken: number | null;
@@ -112,7 +118,7 @@ export interface ModelsDevModelEntry {
 }
 
 interface RawModelsDevCostTier {
-  tier?: { type?: string; size?: number; windows?: string[] };
+  tier?: { type?: string; size?: number; windows?: string[]; days?: unknown };
   input?: number;
   output?: number;
   cache_read?: number;
@@ -153,8 +159,9 @@ const TIME_WINDOW_RE = /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/;
 
 /**
  * DeepSeek V4 moved to peak/off-peak billing on 2026-08-16: peak hours are
- * 01:00-04:00 and 06:00-10:00 UTC, every other hour is off-peak at half the
- * peak rate. models.dev cannot express time-of-day pricing yet
+ * 01:00-04:00 and 06:00-10:00 UTC **Monday through Friday**, and every other
+ * hour — including all 48 weekend hours — is off-peak at half the peak rate.
+ * models.dev cannot express time-of-day pricing yet
  * (anomalyco/models.dev#4892 adds `cost.tiers[].tier.type = "time"`; #4891
  * corrects the flat numbers in the meantime), so until the catalog carries a
  * time tier for these models this seed replaces whatever flat rate the sync
@@ -166,6 +173,8 @@ const TIME_WINDOW_RE = /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/;
  * https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17).
  */
 const DEEPSEEK_PEAK_WINDOWS: readonly string[] = ['01:00-04:00', '06:00-10:00'];
+/** Monday–Friday: DeepSeek's peak schedule does not run on weekends. */
+const DEEPSEEK_PEAK_DAYS: readonly number[] = [1, 2, 3, 4, 5];
 const DEEPSEEK_V4_PEAK_SEED: ReadonlyMap<
   string,
   {
@@ -191,6 +200,16 @@ const DEEPSEEK_V4_PEAK_SEED: ReadonlyMap<
       output: 1.98,
       cacheRead: 0.022,
       peak: { input: 1.32, output: 3.96, cacheRead: 0.044 },
+    },
+  ],
+  // The vision preview is billed on the Flash card, not a card of its own.
+  [
+    'deepseek-v4-flash-vision-exp',
+    {
+      input: 0.22,
+      output: 0.66,
+      cacheRead: 0.007,
+      peak: { input: 0.44, output: 1.32, cacheRead: 0.014 },
     },
   ],
 ]);
@@ -637,6 +656,23 @@ export class ModelsDevSyncService implements OnModuleInit {
   }
 
   /**
+   * ISO weekdays a time tier is restricted to, or null for "every day".
+   *
+   * A malformed list is dropped **whole**, never filtered entry by entry:
+   * salvaging `[1,2,3,4,5,'6']` down to `[1..5]` would read as a clean weekday
+   * rule and quietly discount a day the provider charges peak for. Dropping it
+   * falls back to the unrestricted tier, which is what the catalog meant
+   * before the field existed and never bills below the published rate.
+   */
+  private parseTierDays(days: unknown): readonly number[] | null {
+    if (!Array.isArray(days) || days.length === 0) return null;
+    const valid = days.every(
+      (day) => typeof day === 'number' && Number.isInteger(day) && day >= 1 && day <= 7,
+    );
+    return valid ? (days as number[]) : null;
+  }
+
+  /**
    * Extract time-of-day pricing tiers from a raw models.dev cost block.
    * Context-size tiers (`tier.type = "context"`) are ignored — Manifest does
    * not price by context band. Returns null when no valid time tier exists.
@@ -660,6 +696,7 @@ export class ModelsDevSyncService implements OnModuleInit {
       if (windows.length === 0) continue;
       parsed.push({
         windows,
+        days: this.parseTierDays(tier.tier.days),
         inputPricePerToken: tier.input != null ? tier.input / 1_000_000 : null,
         outputPricePerToken: tier.output != null ? tier.output / 1_000_000 : null,
         cacheReadPricePerToken: tier.cache_read != null ? tier.cache_read / 1_000_000 : null,
@@ -696,6 +733,7 @@ export class ModelsDevSyncService implements OnModuleInit {
         timeTiers = [
           {
             windows: DEEPSEEK_PEAK_WINDOWS,
+            days: DEEPSEEK_PEAK_DAYS,
             inputPricePerToken: seed.peak.input / 1_000_000,
             outputPricePerToken: seed.peak.output / 1_000_000,
             cacheReadPricePerToken: seed.peak.cacheRead / 1_000_000,

--- a/packages/backend/src/model-prices/model-pricing-cache.provider-scope.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.provider-scope.spec.ts
@@ -17,6 +17,7 @@ import { normalizeProviderName } from 'manifest-shared';
 
 const DEEPSEEK_TIME_TIER = {
   windows: ['01:00-04:00', '06:00-10:00'],
+  days: [1, 2, 3, 4, 5],
   inputPricePerToken: 1.32 / 1_000_000,
   outputPricePerToken: 3.96 / 1_000_000,
   cacheReadPricePerToken: 0.044 / 1_000_000,
@@ -113,12 +114,12 @@ describe('ModelPricingCacheService — pricing scoped to the provider that serve
     expect(entry!.output_price_per_token).toBe(1.98 / 1_000_000);
   });
 
-  it("carries DeepSeek's peak-hour schedule on the scoped entry", async () => {
+  it("carries DeepSeek's weekday peak schedule on the scoped entry", async () => {
     await service.reload();
 
-    // The schedule belongs to the seller. Losing the entry loses the schedule.
     const tiers = service.getByModel('deepseek-v4-pro', 'deepseek')!.time_tiers;
     expect(tiers).toHaveLength(1);
+    expect(tiers![0].days).toEqual([1, 2, 3, 4, 5]);
     expect(tiers![0].input_price_per_token).toBe(1.32 / 1_000_000);
   });
 

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -29,6 +29,11 @@ const CUSTOM_PROVIDER_LABEL = 'Custom';
  */
 export interface PricingTimeTier {
   windows: readonly string[];
+  /**
+   * ISO weekdays (1 = Monday … 7 = Sunday) the windows apply on. Absent or
+   * empty means every day. DeepSeek's peak hours are Monday through Friday.
+   */
+  days?: readonly number[] | null;
   input_price_per_token: number | null;
   output_price_per_token: number | null;
   cache_read_price_per_token?: number | null;
@@ -349,6 +354,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
           cache_write_price_per_token: model.cacheWritePricePerToken ?? null,
           time_tiers: model.timeTiers?.map((tier) => ({
             windows: tier.windows,
+            days: tier.days ?? null,
             input_price_per_token: tier.inputPricePerToken,
             output_price_per_token: tier.outputPricePerToken,
             cache_read_price_per_token: tier.cacheReadPricePerToken,

--- a/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
@@ -14,6 +14,7 @@ import { ProviderModelRegistryService } from '../model-discovery/provider-model-
 
 const DEEPSEEK_TIME_TIER = {
   windows: ['01:00-04:00', '06:00-10:00'],
+  days: [1, 2, 3, 4, 5],
   inputPricePerToken: 0.44 / 1_000_000,
   outputPricePerToken: 1.32 / 1_000_000,
   cacheReadPricePerToken: 0.014 / 1_000_000,
@@ -80,6 +81,7 @@ describe('ModelPricingCacheService — time-of-day pricing tiers', () => {
     expect(entry!.time_tiers).toEqual([
       {
         windows: ['01:00-04:00', '06:00-10:00'],
+        days: [1, 2, 3, 4, 5],
         input_price_per_token: 0.44 / 1_000_000,
         output_price_per_token: 1.32 / 1_000_000,
         cache_read_price_per_token: 0.014 / 1_000_000,

--- a/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.time-tiers.spec.ts
@@ -97,6 +97,31 @@ describe('ModelPricingCacheService — time-of-day pricing tiers', () => {
     expect(service.getByModel('deepseek-chat')!.time_tiers).toBeUndefined();
   });
 
+  it('carries a schedule with no weekdays through as null, meaning every day', async () => {
+    // `days` is optional upstream and an absent list means the windows apply
+    // on all seven days. That has to survive the mapping as an explicit null
+    // rather than vanishing, because the cost calculator reads the field to
+    // decide whether to narrow the window at all.
+    mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) =>
+      providerId === 'deepseek'
+        ? [
+            {
+              id: 'deepseek-v4-flash',
+              name: 'DeepSeek V4 Flash',
+              inputPricePerToken: 0.22 / 1_000_000,
+              outputPricePerToken: 0.66 / 1_000_000,
+              cacheReadPricePerToken: 0.007 / 1_000_000,
+              timeTiers: [{ ...DEEPSEEK_TIME_TIER, days: null }],
+            },
+          ]
+        : [],
+    );
+
+    await service.reload();
+
+    expect(service.getByModel('deepseek-v4-flash')!.time_tiers![0].days).toBeNull();
+  });
+
   it('keeps the OpenRouter entry on the prefixed key and only drops the tiers', async () => {
     // OpenRouter also lists the model, so the prefixed key pre-exists. Pricing
     // follows transport: the OR entry keeps OR's own flat rate — the overlay

--- a/packages/backend/src/playground/playground.module.ts
+++ b/packages/backend/src/playground/playground.module.ts
@@ -11,6 +11,8 @@ import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { RoutingCoreModule } from '../routing/routing-core/routing-core.module';
 import { ProxyModule } from '../routing/proxy/proxy.module';
 import { OAuthModule } from '../routing/oauth/oauth.module';
+import { ModelDiscoveryModule } from '../model-discovery/model-discovery.module';
+import { CustomProviderModule } from '../routing/custom-provider/custom-provider.module';
 import { PlaygroundController } from './playground.controller';
 import { PlaygroundService } from './playground.service';
 import { PlaygroundHistoryService } from './playground-history.service';
@@ -31,6 +33,8 @@ import { PlaygroundAgentService } from './playground-agent.service';
     RoutingCoreModule,
     ProxyModule,
     OAuthModule,
+    ModelDiscoveryModule,
+    CustomProviderModule,
   ],
   controllers: [PlaygroundController],
   providers: [PlaygroundService, PlaygroundHistoryService, PlaygroundAgentService],

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -620,6 +620,135 @@ describe('PlaygroundService.runStream', () => {
     expect((done.metrics as Record<string, unknown>).cost).toBe(0);
   });
 
+  it('completes the run when the custom-provider lookup fails after the answer streamed', async () => {
+    // By this point the client already has its answer. A metadata lookup that
+    // throws must not retro-actively turn a delivered run into an error one;
+    // it only costs the local/subscription refinement, so the run falls back
+    // to the raw provider name and prices from the catalogue as usual.
+    const { service, mocks } = buildService();
+    mocks.customProviders.canonicalizeAgentMessageKeys.mockRejectedValue(new Error('db down'));
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(CTX, makeDto({ provider: 'custom:cp-llamacpp' }), asRes(res));
+
+    const events = parseSse(res);
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    const done = events.find((e) => e.type === 'done') as Record<string, unknown>;
+    expect((done.metrics as Record<string, unknown>).cost).toBeCloseTo(0.000008, 10);
+  });
+
+  it('falls back to the request provider when canonicalization resolves no name', async () => {
+    // `canonicalizeAgentMessageKeys` returns a null provider for a row it
+    // cannot attribute. Passing that null on as the local check would read as
+    // "not local" by accident rather than by lookup, so the raw name stands in.
+    const { service, mocks } = buildService();
+    mocks.customProviders.canonicalizeAgentMessageKeys.mockResolvedValue({
+      provider: null,
+      model: null,
+    });
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(CTX, makeDto({ provider: 'openai' }), asRes(res));
+
+    const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
+    expect((done.metrics as Record<string, unknown>).cost).toBeCloseTo(0.000008, 10);
+  });
+
+  it('resolves a tenant-less run against no tenant instead of crashing', async () => {
+    // A fresh account has no tenant until its first agent exists, and the
+    // Playground is reachable before that. There are no custom providers to
+    // resolve, so the lookup degrades to the raw name.
+    const { service, mocks } = buildService();
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      { tenantId: null, userId: 'user-1' } as TenantContext,
+      makeDto({ provider: 'openai' }),
+      asRes(res),
+    );
+
+    expect(mocks.customProviders.canonicalizeAgentMessageKeys).toHaveBeenCalledWith(
+      '',
+      'openai',
+      expect.any(String),
+    );
+    expect(parseSse(res).some((e) => e.type === 'error')).toBe(false);
+  });
+
+  it('bills a run that leaves a peak window mid-stream at the rate it started on', async () => {
+    // Only Date is faked: the stream reader still needs real timers to drain.
+    // The run opens at 09:59 UTC inside the peak band and closes at 10:01
+    // outside it. The proxy recorder bills such a run from its start, so
+    // pricing the Playground from the completion time would put two different
+    // numbers on the same request.
+    jest.useFakeTimers({
+      doNotFake: [
+        'setTimeout',
+        'setInterval',
+        'setImmediate',
+        'clearTimeout',
+        'clearInterval',
+        'clearImmediate',
+        'nextTick',
+        'queueMicrotask',
+        'performance',
+      ],
+    });
+    try {
+      // 2026-08-21 is a Friday, so the weekday-only band applies.
+      jest.setSystemTime(new Date('2026-08-21T09:59:00Z'));
+      const { service, mocks } = buildService();
+      mocks.pricingCache.getByModel.mockReturnValue({
+        input_price_per_token: 0.000001,
+        output_price_per_token: 0.000002,
+        time_tiers: [
+          {
+            windows: ['09:00-10:00'],
+            days: [1, 2, 3, 4, 5],
+            input_price_per_token: 0.00001,
+            output_price_per_token: 0.00002,
+            cache_read_price_per_token: null,
+            cache_write_price_per_token: null,
+          },
+        ],
+      });
+      mocks.providerClient.forward.mockImplementation(async () => {
+        jest.setSystemTime(new Date('2026-08-21T10:01:00Z'));
+        return okStream([
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+          'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+        ]);
+      });
+      const res = mockRes();
+
+      await service.runStream(CTX, makeDto({ provider: 'deepseek' }), asRes(res));
+
+      const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
+      // Peak: 4 x $0.00001 + 2 x $0.00002. Off-peak would be $0.000008.
+      expect((done.metrics as Record<string, unknown>).cost).toBeCloseTo(0.00008, 10);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('unwraps OpenAI OAuth blobs before forwarding subscription Playground requests', async () => {
     const oauthBlob = JSON.stringify({
       t: 'stored-access-token',

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -1,6 +1,8 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import type { Response as ExpressResponse } from 'express';
 import { PlaygroundService } from './playground.service';
+import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
 import type { ProviderClient } from '../routing/proxy/provider-client';
 import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
 import type { PlaygroundAgentService } from './playground-agent.service';
@@ -160,6 +162,8 @@ function errorForward(status: number, bodyText: string) {
 }
 
 interface Mocks {
+  customProviders: { canonicalizeAgentMessageKeys: jest.Mock };
+  opencodeGoCatalog: { resolveCostPerRequest: jest.Mock };
   playgroundAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
@@ -222,6 +226,14 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     history: { saveColumn: jest.fn().mockResolvedValue('col-1') },
     messageRepo: { insert: jest.fn().mockResolvedValue(undefined) },
     customProviderRepo: { findOne: jest.fn().mockResolvedValue(null) },
+    customProviders: {
+      canonicalizeAgentMessageKeys: jest
+        .fn()
+        .mockImplementation((_t: string, provider: string | null, model: string | null) =>
+          Promise.resolve({ provider, model }),
+        ),
+    },
+    opencodeGoCatalog: { resolveCostPerRequest: jest.fn().mockResolvedValue(null) },
     ...mocks,
   };
   const service = new PlaygroundService(
@@ -239,6 +251,8 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     full.history as unknown as PlaygroundHistoryService,
     full.messageRepo as unknown as Repository<AgentMessage>,
     full.customProviderRepo as unknown as Repository<CustomProvider>,
+    full.customProviders as unknown as CustomProviderService,
+    full.opencodeGoCatalog as unknown as OpencodeGoCatalogService,
   );
   return { service, mocks: full };
 }
@@ -554,6 +568,56 @@ describe('PlaygroundService.runStream', () => {
     const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
     expect((done.metrics as Record<string, unknown>).cost).toBe(0);
     expect(mocks.messageRepo.insert.mock.calls[0][0].auth_type).toBe('subscription');
+  });
+
+  it('bills an OpenCode Go subscription run at its per-request rate, not $0', async () => {
+    // The recorder resolves this rate from the OpenCode Go catalogue. Without
+    // the same lookup here the playground records $0 for a run that really
+    // costs money, and the two cost writers disagree about the same provider.
+    const { service, mocks } = buildService();
+    mocks.providerKeyService.getAuthType.mockResolvedValue('subscription');
+    mocks.opencodeGoCatalog.resolveCostPerRequest.mockResolvedValue(0.04);
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      CTX,
+      makeDto({ provider: 'opencode-go', authType: 'subscription' }),
+      asRes(res),
+    );
+
+    const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
+    expect((done.metrics as Record<string, unknown>).cost).toBe(0.04);
+  });
+
+  it('records a known $0 for a tile-connected local runtime', async () => {
+    // llama.cpp reaches us as `custom:<uuid>`; only the canonical provider
+    // says it is local. Checking the raw name records `null` — "not known" —
+    // for inference that is free by construction, while the proxy recorder
+    // records 0 for the very same run.
+    const { service, mocks } = buildService();
+    mocks.customProviders.canonicalizeAgentMessageKeys.mockResolvedValue({
+      provider: 'llamacpp',
+      model: 'llamacpp/qwen2.5-0.5b-q4.gguf',
+    });
+    mocks.pricingCache.getByModel.mockReturnValue(undefined);
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(CTX, makeDto({ provider: 'custom:cp-llamacpp' }), asRes(res));
+
+    const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
+    expect((done.metrics as Record<string, unknown>).cost).toBe(0);
   });
 
   it('unwraps OpenAI OAuth blobs before forwarding subscription Playground requests', async () => {

--- a/packages/backend/src/playground/playground.service.truncation.spec.ts
+++ b/packages/backend/src/playground/playground.service.truncation.spec.ts
@@ -1,5 +1,7 @@
 import type { Response as ExpressResponse } from 'express';
 import { PlaygroundService } from './playground.service';
+import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
 import type { ProviderClient } from '../routing/proxy/provider-client';
 import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
 import type { PlaygroundAgentService } from './playground-agent.service';
@@ -85,6 +87,8 @@ function mockRes(): MockRes {
 const asRes = (r: MockRes): ExpressResponse => r as unknown as ExpressResponse;
 
 interface Mocks {
+  customProviders: { canonicalizeAgentMessageKeys: jest.Mock };
+  opencodeGoCatalog: { resolveCostPerRequest: jest.Mock };
   playgroundAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
@@ -144,6 +148,14 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     history: { saveColumn: jest.fn().mockResolvedValue('col-1') },
     messageRepo: { insert: jest.fn().mockResolvedValue(undefined) },
     customProviderRepo: { findOne: jest.fn().mockResolvedValue(null) },
+    customProviders: {
+      canonicalizeAgentMessageKeys: jest
+        .fn()
+        .mockImplementation((_t: string, provider: string | null, model: string | null) =>
+          Promise.resolve({ provider, model }),
+        ),
+    },
+    opencodeGoCatalog: { resolveCostPerRequest: jest.fn().mockResolvedValue(null) },
     ...mocks,
   };
   const service = new PlaygroundService(
@@ -161,6 +173,8 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     full.history as unknown as PlaygroundHistoryService,
     full.messageRepo as unknown as Repository<AgentMessage>,
     full.customProviderRepo as unknown as Repository<CustomProvider>,
+    full.customProviders as unknown as CustomProviderService,
+    full.opencodeGoCatalog as unknown as OpencodeGoCatalogService,
   );
   return { service, mocks: full };
 }

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -332,15 +332,18 @@ export class PlaygroundService {
       const outputTokens = usage?.completion_tokens ?? 0;
       const cacheReadTokens = usage?.cache_read_tokens ?? 0;
       const cacheCreationTokens = usage?.cache_creation_tokens ?? 0;
-      const { provider: canonicalProvider } =
-        // Tile-connected local runtimes arrive as `custom:<uuid>`; only the
-        // canonical provider says whether one is local. A tenant-less context
-        // has no custom providers to resolve, so it degrades to the raw name.
-        await this.customProviders.canonicalizeAgentMessageKeys(
-          ctx.tenantId ?? '',
-          dto.provider,
-          dto.model,
-        );
+      // Tile-connected local runtimes arrive as `custom:<uuid>`; only the
+      // canonical provider says whether one is local. A tenant-less context
+      // has no custom providers to resolve, so it degrades to the raw name.
+      //
+      // Best-effort by design: the answer has already been streamed to the
+      // client, so a metadata lookup that fails must not turn a delivered run
+      // into an error one. It only refines the cost inputs below, and the raw
+      // name is where the lookup starts from anyway.
+      const canonicalProvider = await this.customProviders
+        .canonicalizeAgentMessageKeys(ctx.tenantId ?? '', dto.provider, dto.model)
+        .then(({ provider }) => provider ?? dto.provider)
+        .catch(() => dto.provider);
       const cost = computeTokenCost({
         inputTokens,
         outputTokens,
@@ -355,14 +358,19 @@ export class PlaygroundService {
         // resolves it — the local check on the canonical provider, because a
         // tile-connected llama.cpp arrives as `custom:<uuid>`, and the
         // per-request rate from the OpenCode Go catalogue.
-        isLocalProvider: isLocalOnlyProvider(canonicalProvider ?? dto.provider),
+        isLocalProvider: isLocalOnlyProvider(canonicalProvider),
         perRequestCostUsd:
           authType === 'subscription' &&
-          PROVIDER_BY_ID_OR_ALIAS.get((canonicalProvider ?? dto.provider).toLowerCase())?.id ===
-            'opencode-go'
+          PROVIDER_BY_ID_OR_ALIAS.get(canonicalProvider.toLowerCase())?.id === 'opencode-go'
             ? await this.opencodeGoCatalog.resolveCostPerRequest(dto.model)
             : null,
         reportedCostUsd: usage?.reported_cost_usd,
+        // The request start, not the completion time. A stream that opens at
+        // 09:59 UTC and closes at 10:01 crossed out of a DeepSeek peak window
+        // mid-answer; the proxy recorder bills such a run from `startedAt`, so
+        // billing the playground from `Date.now()` would price the same run
+        // two different ways.
+        at: new Date(startedAt),
       });
       const tokensPerSec = outputTokens > 0 ? outputTokens / (Math.max(totalMs, 1) / 1000) : null;
 

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -15,6 +15,9 @@ import {
   resolveApiKey,
 } from '../routing/proxy/oauth-credentials';
 import { ProviderKeyService } from '../routing/routing-core/provider-key.service';
+import { isLocalOnlyProvider } from '../common/utils/provider-availability';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
+import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 import { PlaygroundAgentService } from './playground-agent.service';
 import { OpenaiOauthService } from '../routing/oauth/openai/openai-oauth.service';
 import { MinimaxOauthService } from '../routing/oauth/minimax/minimax-oauth.service';
@@ -57,6 +60,8 @@ export class PlaygroundService {
     private readonly messageRepo: Repository<AgentMessage>,
     @InjectRepository(CustomProvider)
     private readonly customProviderRepo: Repository<CustomProvider>,
+    private readonly customProviders: CustomProviderService,
+    private readonly opencodeGoCatalog: OpencodeGoCatalogService,
   ) {}
 
   /**
@@ -327,6 +332,15 @@ export class PlaygroundService {
       const outputTokens = usage?.completion_tokens ?? 0;
       const cacheReadTokens = usage?.cache_read_tokens ?? 0;
       const cacheCreationTokens = usage?.cache_creation_tokens ?? 0;
+      const { provider: canonicalProvider } =
+        // Tile-connected local runtimes arrive as `custom:<uuid>`; only the
+        // canonical provider says whether one is local. A tenant-less context
+        // has no custom providers to resolve, so it degrades to the raw name.
+        await this.customProviders.canonicalizeAgentMessageKeys(
+          ctx.tenantId ?? '',
+          dto.provider,
+          dto.model,
+        );
       const cost = computeTokenCost({
         inputTokens,
         outputTokens,
@@ -335,6 +349,20 @@ export class PlaygroundService {
         model: dto.model,
         pricing: this.pricingCache.getByModel(dto.model, dto.provider),
         isSubscription: authType === 'subscription',
+        // Same source order as the proxy recorder: a playground run against
+        // the same provider must not report a different cost. That parity is
+        // the whole point, so each input is resolved the way the recorder
+        // resolves it — the local check on the canonical provider, because a
+        // tile-connected llama.cpp arrives as `custom:<uuid>`, and the
+        // per-request rate from the OpenCode Go catalogue.
+        isLocalProvider: isLocalOnlyProvider(canonicalProvider ?? dto.provider),
+        perRequestCostUsd:
+          authType === 'subscription' &&
+          PROVIDER_BY_ID_OR_ALIAS.get((canonicalProvider ?? dto.provider).toLowerCase())?.id ===
+            'opencode-go'
+            ? await this.opencodeGoCatalog.resolveCostPerRequest(dto.model)
+            : null,
+        reportedCostUsd: usage?.reported_cost_usd,
       });
       const tokensPerSec = outputTokens > 0 ? outputTokens / (Math.max(totalMs, 1) / 1000) : null;
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -2272,6 +2272,34 @@ describe('ProxyMessageRecorder with real CustomProviderService', () => {
     }
   });
 
+  it('costs a tile-connected llama.cpp run at a known zero, not an unknown null', async () => {
+    // llama.cpp and LM Studio are `tileOnly`, so they reach the recorder as
+    // `custom:<uuid>` and only become `llamacpp` after canonicalization. A
+    // local-provider check run on the raw string misses them entirely and the
+    // row falls through to `null` — "we don't know" for inference that is
+    // free by construction.
+    const { recorder, insertMock } = wire({
+      id: 'cp-llamacpp',
+      name: 'llama.cpp',
+      agent_id: 'agent-1',
+    });
+    try {
+      await recorder.recordSuccessMessage(
+        ctx,
+        'custom:cp-llamacpp/qwen2.5-0.5b-q4.gguf',
+        'default',
+        'test',
+        { prompt_tokens: 1000, completion_tokens: 500 } as never,
+        { provider: 'custom:cp-llamacpp' },
+      );
+
+      expect(insertMock).toHaveBeenCalled();
+      expect(insertMock.mock.calls[0][0]).toMatchObject({ cost_usd: 0 });
+    } finally {
+      recorder.onModuleDestroy();
+    }
+  });
+
   it('leaves a user-defined custom provider unchanged (no tileOnly match)', async () => {
     const { recorder, insertMock } = wire({
       id: 'cp-my-groq',

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -25,6 +25,7 @@ import type { ProviderAttemptRef, ProviderAttemptStart, ProxyApiMode } from './p
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
+import { isLocalOnlyProvider } from '../../common/utils/provider-availability';
 import { extractManifestErrorCode, type ManifestErrorCode } from '../../common/errors/error-codes';
 import {
   MANIFEST_CODE_TO_REASON,
@@ -1060,14 +1061,23 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     const inputTokens = usage?.prompt_tokens ?? 0;
     const outputTokens = usage?.completion_tokens ?? 0;
 
+    const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
+      ctx.tenantId,
+      provider,
+      model,
+    );
+
     const costUsd = computeTokenCost({
       inputTokens,
       outputTokens,
       cacheReadTokens: usage?.cache_read_tokens ?? 0,
       cacheCreationTokens: usage?.cache_creation_tokens ?? 0,
       model,
+      // Priced on the raw keys: a custom provider's rates are stored under
+      // `custom:<uuid>/<model>`, which is exactly what canonicalization strips.
       pricing: usage ? this.pricingCache.getByModel(model, provider) : undefined,
       isSubscription: authType === 'subscription',
+      isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
       perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
       reportedCostUsd: usage?.reported_cost_usd,
       // Bill the hour the provider attempt actually ran: `timestamp` is the
@@ -1076,11 +1086,6 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       at: attempt ? new Date(attempt.startedAt) : timestamp ? new Date(timestamp) : undefined,
     });
 
-    const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.tenantId,
-      provider,
-      model,
-    );
     const canonicalFallbackFrom = await this.customProviders.canonicalizeAgentMessageKeys(
       ctx.tenantId,
       null,
@@ -1151,18 +1156,6 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     } = opts ?? {};
     const requestId = providedRequestId ?? uuid();
 
-    const costUsd = computeTokenCost({
-      inputTokens: usage.prompt_tokens,
-      outputTokens: usage.completion_tokens,
-      cacheReadTokens: usage.cache_read_tokens ?? 0,
-      cacheCreationTokens: usage.cache_creation_tokens ?? 0,
-      model,
-      pricing: this.pricingCache.getByModel(model, provider),
-      isSubscription: authType === 'subscription',
-      perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
-      reportedCostUsd: usage.reported_cost_usd,
-    });
-
     // `model` is a required string, so the overload on
     // `canonicalizeAgentMessageKeys` keeps `canonical.model` non-null.
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
@@ -1170,6 +1163,22 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       provider,
       model,
     );
+
+    const costUsd = computeTokenCost({
+      inputTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      cacheReadTokens: usage.cache_read_tokens ?? 0,
+      cacheCreationTokens: usage.cache_creation_tokens ?? 0,
+      model,
+      // Priced on the raw keys: a custom provider's rates are stored under
+      // `custom:<uuid>/<model>`, which is exactly what canonicalization strips.
+      pricing: this.pricingCache.getByModel(model, provider),
+      isSubscription: authType === 'subscription',
+      isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
+      perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
+      reportedCostUsd: usage.reported_cost_usd,
+    });
+
     const canonicalModel = canonical.model;
     const canonicalProvider = canonical.provider;
 

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -1177,6 +1177,11 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
       perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
       reportedCostUsd: usage.reported_cost_usd,
+      // Bill a peak/off-peak model on when the attempt started, not on when
+      // this row is written: a long stream that opens at 09:59 and records at
+      // 10:01 is a peak request, and the fallback path already reads it this
+      // way. Falls back to now when the caller tracked no attempt.
+      at: attempt ? new Date(attempt.startedAt) : undefined,
     });
 
     const canonicalModel = canonical.model;


### PR DESCRIPTION
Re-lands two commits that were merged into branches that had already stopped leading to `main`.

## What happened

The three-PR stack merged out of order. #2759 squash-merged into `main` at 17:21:08, which retired `fix/provider-scoped-pricing` as a base. #2760 then merged *into* that retired branch at 17:23:29, and #2761 into `fix/cost-source-precedence` at 17:23:42. Both carry a green "Merged" badge; neither reached `main`.

| PR | Head → Base | Landed on `main`? |
|---|---|---|
| #2759 | `fix/provider-scoped-pricing` → `main` | yes (`fe8677ef`) |
| #2760 | `fix/cost-source-precedence` → `fix/provider-scoped-pricing` | no |
| #2761 | `fix/deepseek-weekday-peak` → `fix/cost-source-precedence` | no |

So `main` still has the hour-only `resolveTimeTier` that #2755 reported: a `deepseek-v4-pro` request at Saturday 02:00 UTC is billed $1.32/$3.96 against DeepSeek's $0.66/$1.98, for 14 of every 168 hours. It also lacks #2760's cost-source precedence.

## What this PR does

Nothing new. `78e709592` (the stack's unsquashed copy of #2759) has the same tree as `main`'s `fe8677ef`, so both commits cherry-picked clean with no conflict and no edit — the diff is byte-identical to what CI already passed on #2760 and #2761. Their changesets came along.

Landing only the DeepSeek commit would strand #2760 the same way, so both ride together.

## Verification

- `cost-calculator`, `models-dev-sync`, `model-prices`, `proxy-message-recorder` — 438 passed, 10 suites
- `tsc --noEmit` clean

The issue's discriminating vectors are pinned in `cost-calculator.spec.ts`: `2026-08-21T02:00Z` (Friday) bills peak, `2026-08-22T02:00Z` (Saturday) bills base — same clock time, so only the day rule can separate them. Alongside them: ISO Sunday as 7 rather than `getUTCDay()`'s 0, a `23:00-02:00` band staying attributed to the Friday it opened on, and the Monday 00:00 seam.

Closes #2755.
