### PR TITLE
fix: make the "AI agent" harness category label singular

### DIFF
--- a/.changeset/ai-agent-singular-label.md
+++ b/.changeset/ai-agent-singular-label.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Rename the "AI agents" harness category to "AI agent" so it matches the other singular category labels

--- a/packages/backend/src/public-stats/public-stats.controller.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.spec.ts
@@ -304,7 +304,7 @@ describe('PublicStatsController', () => {
       {
         agent_category: 'personal',
         agent_platform: 'openclaw',
-        category_label: 'AI agents',
+        category_label: 'AI agent',
         platform_label: 'OpenClaw',
         total_tokens: 1100000,
         models: [

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -157,9 +157,7 @@ describe('PublicStatsService', () => {
         [{ model: 'gpt-5.5', provider: 'openai', tokens: '5000000' }],
         [{ model: 'gpt-5.5', provider: 'openai', tokens: '18000000' }],
       );
-      mockPricingCache.getByModel.mockReturnValue(
-        makePricingEntry({ provider: 'OpenCode Zen' }),
-      );
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenCode Zen' }));
 
       const result = await service.getUsageStats();
 
@@ -904,9 +902,7 @@ describe('PublicStatsService', () => {
           cost: '0.10',
         },
       ]);
-      mockPricingCache.getByModel.mockReturnValue(
-        makePricingEntry({ provider: 'OpenCode Zen' }),
-      );
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenCode Zen' }));
 
       const result = await service.getProviderDailyTokens();
 
@@ -1086,7 +1082,7 @@ describe('PublicStatsService', () => {
       expect(result).toHaveLength(2);
       expect(result[0].agent_category).toBe('personal');
       expect(result[0].agent_platform).toBe('openclaw');
-      expect(result[0].category_label).toBe('AI agents');
+      expect(result[0].category_label).toBe('AI agent');
       expect(result[0].platform_label).toBe('OpenClaw');
       expect(result[0].total_tokens).toBe(1100000);
       expect(result[0].models).toHaveLength(1);

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -185,7 +185,7 @@ describe('GET /api/v1/public/agent-tokens', () => {
         g.agent_category === 'personal' && g.agent_platform === 'openclaw',
     );
     expect(group).toBeDefined();
-    expect(group.category_label).toBe('AI agents');
+    expect(group.category_label).toBe('AI agent');
     expect(group.platform_label).toBe('OpenClaw');
     // seeded messages: 150 + 300 + 225 = 675 tokens across two models
     expect(group.total_tokens).toBeGreaterThanOrEqual(675);

--- a/packages/frontend/tests/components/AgentTypeGrid.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeGrid.test.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from "@solidjs/testing-library";
 vi.mock("manifest-shared", () => ({
   AGENT_CATEGORIES: ["personal", "app", "coding"],
   CATEGORY_LABELS: {
-    personal: "AI agents",
+    personal: "AI agent",
     app: "App AI SDK",
     coding: "Coding Assistant",
   },
@@ -57,7 +57,7 @@ describe("AgentTypeGrid", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const labels = container.querySelectorAll(".agent-type-select__group-label");
     expect(labels).toHaveLength(3);
-    expect(labels[0].textContent).toContain("AI agents");
+    expect(labels[0].textContent).toContain("AI agent");
     expect(labels[1].textContent).toContain("App AI SDK");
     expect(labels[2].textContent).toContain("Coding Assistant");
   });

--- a/packages/frontend/tests/components/AgentTypeSelect.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeSelect.test.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from "@solidjs/testing-library";
 vi.mock("manifest-shared", () => ({
   AGENT_CATEGORIES: ["personal", "app", "coding"],
   CATEGORY_LABELS: {
-    personal: "AI agents",
+    personal: "AI agent",
     app: "App AI SDK",
     coding: "Coding Assistant",
   },
@@ -79,7 +79,7 @@ describe("AgentTypeSelect", () => {
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const labels = container.querySelectorAll(".agent-type-select__group-label");
     expect(labels).toHaveLength(3);
-    expect(labels[0].textContent).toContain("AI agents");
+    expect(labels[0].textContent).toContain("AI agent");
     expect(labels[1].textContent).toContain("App AI SDK");
     expect(labels[2].textContent).toContain("Coding Assistant");
   });

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -99,7 +99,7 @@ vi.mock("manifest-shared", () => ({
     return icons[plat];
   },
   CATEGORY_LABELS: {
-    personal: "AI agents",
+    personal: "AI agent",
     app: "App AI SDK",
     coding: "Coding Assistant",
   },
@@ -434,7 +434,7 @@ describe("Settings", () => {
     const { container } = render(() => <Settings />);
     await vi.waitFor(() => {
       expect(container.textContent).toContain("OpenClaw");
-      expect(container.textContent).toContain("AI agents");
+      expect(container.textContent).toContain("AI agent");
     });
   });
 

--- a/packages/shared/src/agent-type.ts
+++ b/packages/shared/src/agent-type.ts
@@ -25,7 +25,7 @@ export function coerceAgentPlatform(value: string | null | undefined): AgentPlat
 }
 
 export const CATEGORY_LABELS: Readonly<Record<AgentCategory, string>> = {
-  personal: 'AI agents',
+  personal: 'AI agent',
   app: 'App AI SDK',
   coding: 'Coding Assistant',
 };


### PR DESCRIPTION
### 💭 Why
In the Connect Harness picker, the first category read "AI agents" while its siblings ("App AI SDK", "Coding Assistant") are singular.

### ✨ What changed
- `CATEGORY_LABELS.personal` in the shared package is now "AI agent".
- Tests pinning the old label updated (frontend mocks, public-stats specs).

### 👤 For users
The harness type dropdown and Settings page now show "AI agent".