### PR TITLE
fix: calculate GitHub Copilot token costs

### DIFF
--- a/.changeset/copilot-token-costs.md
+++ b/.changeset/copilot-token-costs.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Calculate GitHub Copilot request costs from live token prices.
+Calculate GitHub Copilot request costs from live token prices, including long-context tiers.

--- a/.changeset/copilot-token-costs.md
+++ b/.changeset/copilot-token-costs.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Calculate GitHub Copilot request costs from live token prices.

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -21,6 +21,8 @@ export interface DiscoveredModel {
   contextWindow: number;
   inputPricePerToken: number | null;
   outputPricePerToken: number | null;
+  cacheReadPricePerToken?: number;
+  cacheWritePricePerToken?: number;
   capabilityReasoning: boolean;
   capabilityCode: boolean;
   capabilities?: readonly ModelCapability[];

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -14,6 +14,15 @@ import type { AuthType, ModelCapability, ModelModality } from 'manifest-shared';
  */
 export const DEFAULT_CONTEXT_WINDOW = 128000;
 
+export interface LongContextPricing {
+  /** Default rates apply through this many prompt tokens; long-context rates apply above it. */
+  thresholdTokens: number;
+  inputPricePerToken: number;
+  outputPricePerToken: number;
+  cacheReadPricePerToken?: number;
+  cacheWritePricePerToken?: number;
+}
+
 export interface DiscoveredModel {
   id: string;
   displayName: string;
@@ -23,6 +32,7 @@ export interface DiscoveredModel {
   outputPricePerToken: number | null;
   cacheReadPricePerToken?: number;
   cacheWritePricePerToken?: number;
+  longContextPricing?: LongContextPricing;
   capabilityReasoning: boolean;
   capabilityCode: boolean;
   capabilities?: readonly ModelCapability[];

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2723,6 +2723,34 @@ describe('ProviderModelFetcherService', () => {
       });
     });
 
+    it('should omit unavailable Copilot cache prices', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'gpt-5-mini',
+              billing: {
+                token_prices: {
+                  batch_size: 1_000_000,
+                  default: { input_price: 25, output_price: 200 },
+                },
+              },
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+
+      expect(result[0]).toMatchObject({
+        inputPricePerToken: 0.25 / 1_000_000,
+        outputPricePerToken: 2 / 1_000_000,
+      });
+      expect(result[0]).not.toHaveProperty('cacheReadPricePerToken');
+      expect(result[0]).not.toHaveProperty('cacheWritePricePerToken');
+    });
+
     it('should keep subscription pricing at zero when Copilot billing is invalid', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
@@ -2733,6 +2761,15 @@ describe('ProviderModelFetcherService', () => {
               billing: {
                 token_prices: {
                   batch_size: 0,
+                  default: { input_price: 100, output_price: 500 },
+                },
+              },
+            },
+            {
+              id: 'gpt-4.1',
+              billing: {
+                token_prices: {
+                  batch_size: 1_000_000,
                   default: { input_price: -1, output_price: Number.POSITIVE_INFINITY },
                 },
               },
@@ -2744,6 +2781,10 @@ describe('ProviderModelFetcherService', () => {
       const result = await service.fetch('copilot', 'tid=token');
 
       expect(result[0]).toMatchObject({
+        inputPricePerToken: 0,
+        outputPricePerToken: 0,
+      });
+      expect(result[1]).toMatchObject({
         inputPricePerToken: 0,
         outputPricePerToken: 0,
       });

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2627,6 +2627,65 @@ describe('ProviderModelFetcherService', () => {
       expect(result[1].id).toBe('copilot/gpt-4o');
     });
 
+    it('should convert Copilot AI-credit prices to USD per token', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'claude-sonnet-4.6',
+              billing: {
+                token_prices: {
+                  batch_size: 1_000_000,
+                  default: {
+                    input_price: 300,
+                    output_price: 1500,
+                    cache_read_price: 30,
+                    cache_write_price: 375,
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+
+      expect(result[0]).toMatchObject({
+        inputPricePerToken: 3 / 1_000_000,
+        outputPricePerToken: 15 / 1_000_000,
+        cacheReadPricePerToken: 0.3 / 1_000_000,
+        cacheWritePricePerToken: 3.75 / 1_000_000,
+      });
+    });
+
+    it('should keep subscription pricing at zero when Copilot billing is invalid', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'gpt-4o',
+              billing: {
+                token_prices: {
+                  batch_size: 0,
+                  default: { input_price: -1, output_price: Number.POSITIVE_INFINITY },
+                },
+              },
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+
+      expect(result[0]).toMatchObject({
+        inputPricePerToken: 0,
+        outputPricePerToken: 0,
+      });
+    });
+
     it('should send correct Copilot headers', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2642,6 +2642,14 @@ describe('ProviderModelFetcherService', () => {
                     output_price: 1500,
                     cache_read_price: 30,
                     cache_write_price: 375,
+                    max_prompt_tokens: 200_000,
+                  },
+                  long_context: {
+                    input_price: 600,
+                    output_price: 2250,
+                    cache_read_price: 60,
+                    cache_write_price: 750,
+                    max_prompt_tokens: 936_000,
                   },
                 },
               },
@@ -2657,6 +2665,61 @@ describe('ProviderModelFetcherService', () => {
         outputPricePerToken: 15 / 1_000_000,
         cacheReadPricePerToken: 0.3 / 1_000_000,
         cacheWritePricePerToken: 3.75 / 1_000_000,
+        longContextPricing: {
+          thresholdTokens: 200_000,
+          inputPricePerToken: 6 / 1_000_000,
+          outputPricePerToken: 22.5 / 1_000_000,
+          cacheReadPricePerToken: 0.6 / 1_000_000,
+          cacheWritePricePerToken: 7.5 / 1_000_000,
+        },
+      });
+    });
+
+    it('should preserve Copilot long-context prices and their prompt threshold', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'gpt-5.6-terra',
+              billing: {
+                token_prices: {
+                  default: {
+                    input_price: 200,
+                    output_price: 1200,
+                    cache_price: 20,
+                    cache_write_price: 250,
+                    context_max: 272_000,
+                  },
+                  long_context: {
+                    input_price: 400,
+                    output_price: 1800,
+                    cache_price: 40,
+                    cache_write_price: 500,
+                    context_max: 936_000,
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+
+      expect(result[0]).toMatchObject({
+        contextWindow: 936_000,
+        inputPricePerToken: 2 / 1_000_000,
+        outputPricePerToken: 12 / 1_000_000,
+        cacheReadPricePerToken: 0.2 / 1_000_000,
+        cacheWritePricePerToken: 2.5 / 1_000_000,
+        longContextPricing: {
+          thresholdTokens: 272_000,
+          inputPricePerToken: 4 / 1_000_000,
+          outputPricePerToken: 18 / 1_000_000,
+          cacheReadPricePerToken: 0.4 / 1_000_000,
+          cacheWritePricePerToken: 5 / 1_000_000,
+        },
       });
     });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -743,24 +743,63 @@ const parseOpenaiSubscription = createModelParser<OpenAISubscriptionModelEntry>(
 
 /* ── GitHub Copilot (subscription-only, OpenAI-compatible /models) ── */
 
+interface CopilotTokenPriceTier {
+  input_price?: unknown;
+  output_price?: unknown;
+  cache_price?: unknown;
+  cache_read_price?: unknown;
+  cache_write_price?: unknown;
+  context_max?: unknown;
+  max_prompt_tokens?: unknown;
+}
+
 interface CopilotModelEntry extends OpenAIModelEntry {
   billing?: {
     token_prices?: {
       batch_size?: unknown;
-      default?: {
-        input_price?: unknown;
-        output_price?: unknown;
-        cache_read_price?: unknown;
-        cache_write_price?: unknown;
-      };
+      default?: CopilotTokenPriceTier;
+      long_context?: CopilotTokenPriceTier;
     };
   };
 }
 
 function copilotUsdPerToken(price: unknown, batchSize: unknown): number | null {
   if (typeof price !== 'number' || !Number.isFinite(price) || price < 0) return null;
-  if (typeof batchSize !== 'number' || !Number.isFinite(batchSize) || batchSize <= 0) return null;
-  return (price * COPILOT_AI_CREDIT_USD) / batchSize;
+  const tokenBatchSize = batchSize ?? 1_000_000;
+  if (
+    typeof tokenBatchSize !== 'number' ||
+    !Number.isFinite(tokenBatchSize) ||
+    tokenBatchSize <= 0
+  ) {
+    return null;
+  }
+  return (price * COPILOT_AI_CREDIT_USD) / tokenBatchSize;
+}
+
+function copilotContextMax(tier: CopilotTokenPriceTier | undefined): number | null {
+  const value = tier?.context_max ?? tier?.max_prompt_tokens;
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+function copilotPriceTier(
+  tier: CopilotTokenPriceTier | undefined,
+  batchSize: unknown,
+): Omit<NonNullable<DiscoveredModel['longContextPricing']>, 'thresholdTokens'> | null {
+  const inputPricePerToken = copilotUsdPerToken(tier?.input_price, batchSize);
+  const outputPricePerToken = copilotUsdPerToken(tier?.output_price, batchSize);
+  if (inputPricePerToken === null || outputPricePerToken === null) return null;
+
+  const cacheReadPricePerToken = copilotUsdPerToken(
+    tier?.cache_read_price ?? tier?.cache_price,
+    batchSize,
+  );
+  const cacheWritePricePerToken = copilotUsdPerToken(tier?.cache_write_price, batchSize);
+  return {
+    inputPricePerToken,
+    outputPricePerToken,
+    ...(cacheReadPricePerToken !== null ? { cacheReadPricePerToken } : {}),
+    ...(cacheWritePricePerToken !== null ? { cacheWritePricePerToken } : {}),
+  };
 }
 
 function parseCopilot(body: unknown, provider: string): DiscoveredModel[] {
@@ -772,23 +811,17 @@ function parseCopilot(body: unknown, provider: string): DiscoveredModel[] {
     if (typeof entry.id !== 'string' || entry.id.length === 0) return [];
 
     const tokenPrices = entry.billing?.token_prices;
-    const inputPrice = copilotUsdPerToken(
-      tokenPrices?.default?.input_price,
-      tokenPrices?.batch_size,
-    );
-    const outputPrice = copilotUsdPerToken(
-      tokenPrices?.default?.output_price,
-      tokenPrices?.batch_size,
-    );
-    const tokenPriced = inputPrice !== null && outputPrice !== null;
-    const cacheReadPrice = copilotUsdPerToken(
-      tokenPrices?.default?.cache_read_price,
-      tokenPrices?.batch_size,
-    );
-    const cacheWritePrice = copilotUsdPerToken(
-      tokenPrices?.default?.cache_write_price,
-      tokenPrices?.batch_size,
-    );
+    const defaultPricing = copilotPriceTier(tokenPrices?.default, tokenPrices?.batch_size);
+    const longContextThreshold = copilotContextMax(tokenPrices?.default);
+    const longContextTier = copilotPriceTier(tokenPrices?.long_context, tokenPrices?.batch_size);
+    const longContextPricing =
+      defaultPricing && longContextTier && longContextThreshold
+        ? { thresholdTokens: longContextThreshold, ...longContextTier }
+        : null;
+    const contextWindow =
+      copilotContextMax(tokenPrices?.long_context) ??
+      longContextThreshold ??
+      DEFAULT_CONTEXT_WINDOW;
     const supportedEndpoints = getStringArray(entry.supported_endpoints);
 
     return [
@@ -796,15 +829,16 @@ function parseCopilot(body: unknown, provider: string): DiscoveredModel[] {
         id: `copilot/${entry.id}`,
         displayName: entry.id,
         provider,
-        contextWindow: DEFAULT_CONTEXT_WINDOW,
-        inputPricePerToken: tokenPriced ? inputPrice : 0,
-        outputPricePerToken: tokenPriced ? outputPrice : 0,
-        ...(tokenPriced && cacheReadPrice !== null
-          ? { cacheReadPricePerToken: cacheReadPrice }
+        contextWindow,
+        inputPricePerToken: defaultPricing?.inputPricePerToken ?? 0,
+        outputPricePerToken: defaultPricing?.outputPricePerToken ?? 0,
+        ...(defaultPricing?.cacheReadPricePerToken !== undefined
+          ? { cacheReadPricePerToken: defaultPricing.cacheReadPricePerToken }
           : {}),
-        ...(tokenPriced && cacheWritePrice !== null
-          ? { cacheWritePricePerToken: cacheWritePrice }
+        ...(defaultPricing?.cacheWritePricePerToken !== undefined
+          ? { cacheWritePricePerToken: defaultPricing.cacheWritePricePerToken }
           : {}),
+        ...(longContextPricing ? { longContextPricing } : {}),
         capabilityReasoning: false,
         capabilityCode: false,
         ...(supportedEndpoints ? { supportedEndpoints } : {}),

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -60,6 +60,7 @@ const OPENCODE_GO_MODELS_URL = 'https://opencode.ai/zen/go/v1/models';
 const PIONEER_MODELS_URL = 'https://api.pioneer.ai/v1/models';
 const PIONEER_BASE_MODELS_URL = 'https://api.pioneer.ai/base-models';
 const META_MODELS_URL = 'https://api.meta.ai/v1/models';
+const COPILOT_AI_CREDIT_USD = 0.01;
 
 /* ── Generic parser factory ── */
 
@@ -742,15 +743,76 @@ const parseOpenaiSubscription = createModelParser<OpenAISubscriptionModelEntry>(
 
 /* ── GitHub Copilot (subscription-only, OpenAI-compatible /models) ── */
 
-const parseCopilot = createModelParser<OpenAIModelEntry>({
-  arrayKey: 'data',
-  filter: (entry) => typeof entry.id === 'string' && entry.id.length > 0,
-  getId: (entry) => `copilot/${entry.id}`,
-  getDisplayName: (entry) => entry.id,
-  inputPricePerToken: 0,
-  outputPricePerToken: 0,
-  supportedEndpoints: (entry) => getStringArray(entry.supported_endpoints),
-});
+interface CopilotModelEntry extends OpenAIModelEntry {
+  billing?: {
+    token_prices?: {
+      batch_size?: unknown;
+      default?: {
+        input_price?: unknown;
+        output_price?: unknown;
+        cache_read_price?: unknown;
+        cache_write_price?: unknown;
+      };
+    };
+  };
+}
+
+function copilotUsdPerToken(price: unknown, batchSize: unknown): number | null {
+  if (typeof price !== 'number' || !Number.isFinite(price) || price < 0) return null;
+  if (typeof batchSize !== 'number' || !Number.isFinite(batchSize) || batchSize <= 0) return null;
+  return (price * COPILOT_AI_CREDIT_USD) / batchSize;
+}
+
+function parseCopilot(body: unknown, provider: string): DiscoveredModel[] {
+  const data = (body as { data?: unknown })?.data;
+  if (!Array.isArray(data)) return [];
+
+  return data.flatMap((raw): DiscoveredModel[] => {
+    const entry = raw as CopilotModelEntry;
+    if (typeof entry.id !== 'string' || entry.id.length === 0) return [];
+
+    const tokenPrices = entry.billing?.token_prices;
+    const inputPrice = copilotUsdPerToken(
+      tokenPrices?.default?.input_price,
+      tokenPrices?.batch_size,
+    );
+    const outputPrice = copilotUsdPerToken(
+      tokenPrices?.default?.output_price,
+      tokenPrices?.batch_size,
+    );
+    const tokenPriced = inputPrice !== null && outputPrice !== null;
+    const cacheReadPrice = copilotUsdPerToken(
+      tokenPrices?.default?.cache_read_price,
+      tokenPrices?.batch_size,
+    );
+    const cacheWritePrice = copilotUsdPerToken(
+      tokenPrices?.default?.cache_write_price,
+      tokenPrices?.batch_size,
+    );
+    const supportedEndpoints = getStringArray(entry.supported_endpoints);
+
+    return [
+      {
+        id: `copilot/${entry.id}`,
+        displayName: entry.id,
+        provider,
+        contextWindow: DEFAULT_CONTEXT_WINDOW,
+        inputPricePerToken: tokenPriced ? inputPrice : 0,
+        outputPricePerToken: tokenPriced ? outputPrice : 0,
+        ...(tokenPriced && cacheReadPrice !== null
+          ? { cacheReadPricePerToken: cacheReadPrice }
+          : {}),
+        ...(tokenPriced && cacheWritePrice !== null
+          ? { cacheWritePricePerToken: cacheWritePrice }
+          : {}),
+        capabilityReasoning: false,
+        capabilityCode: false,
+        ...(supportedEndpoints ? { supportedEndpoints } : {}),
+        qualityScore: 3,
+      },
+    ];
+  });
+}
 
 /* ── OpenCode Zen (aggregator, OpenAI-compatible /models) ── */
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -1653,6 +1653,55 @@ describe('ProxyMessageRecorder', () => {
       expect(insertMock.mock.calls[1][0].cost_usd).toBeCloseTo(0.097802, 10);
     });
 
+    it('falls back to default Copilot prices when its long-context tier is invalid', async () => {
+      getProvidersMock.mockResolvedValue([
+        {
+          id: 'copilot-connection',
+          cached_models: [
+            {
+              id: 'copilot/gpt-5.6-terra',
+              inputPricePerToken: 1 / 1_000_000,
+              outputPricePerToken: 5 / 1_000_000,
+              longContextPricing: {
+                thresholdTokens: 100,
+                inputPricePerToken: 0,
+                outputPricePerToken: 0,
+              },
+            },
+          ],
+        },
+      ]);
+
+      await recorder.recordSuccessMessage(
+        ctx,
+        'copilot/gpt-5.6-terra',
+        'default',
+        'default',
+        { prompt_tokens: 101, completion_tokens: 10 },
+        {
+          provider: 'copilot',
+          authType: 'subscription',
+          tenantProviderId: 'copilot-connection',
+        },
+      );
+
+      expect(insertMock.mock.calls[0][0].cost_usd).toBeCloseTo(0.000151, 10);
+    });
+
+    it('keeps Copilot at zero when no selected connection id is available', async () => {
+      await recorder.recordSuccessMessage(
+        ctx,
+        'copilot/gpt-5-mini',
+        'default',
+        'default',
+        { prompt_tokens: 1000, completion_tokens: 100 },
+        { provider: 'copilot', authType: 'subscription' },
+      );
+
+      expect(insertMock.mock.calls[0][0].cost_usd).toBe(0);
+      expect(getProvidersMock).not.toHaveBeenCalled();
+    });
+
     it('keeps Copilot at zero when its selected connection has no token pricing', async () => {
       getProvidersMock.mockResolvedValue([
         {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -41,12 +41,14 @@ describe('ProxyMessageRecorder', () => {
   let insertMock: jest.Mock;
   let updateMock: jest.Mock;
   let getByModelMock: jest.Mock;
+  let getProvidersMock: jest.Mock;
   let emitMock: jest.Mock;
 
   beforeEach(() => {
     insertMock = jest.fn();
     updateMock = jest.fn();
     getByModelMock = jest.fn().mockReturnValue(undefined);
+    getProvidersMock = jest.fn().mockResolvedValue([]);
     emitMock = jest.fn();
     const repo = {
       insert: insertMock,
@@ -71,12 +73,14 @@ describe('ProxyMessageRecorder', () => {
       getCostPerRequest: jest.fn().mockReturnValue(null),
       resolveCostPerRequest: jest.fn().mockResolvedValue(null),
     } as never;
+    const providerService = { getProviders: getProvidersMock } as never;
     recorder = new ProxyMessageRecorder(
       repo,
       pricingCache,
       eventBus,
       customProviders,
       opencodeGoCatalog,
+      providerService,
     );
   });
 
@@ -1546,6 +1550,89 @@ describe('ProxyMessageRecorder', () => {
         output_tokens: 1,
         cost_usd: 0.00005,
       });
+    });
+
+    it('computes Copilot subscription cost from the selected connection token prices', async () => {
+      getProvidersMock.mockResolvedValue([
+        {
+          id: 'copilot-connection',
+          provider: 'copilot',
+          cached_models: [
+            {
+              id: 'copilot/gpt-5.6-terra',
+              displayName: 'gpt-5.6-terra',
+              inputPricePerToken: 1 / 1_000_000,
+              outputPricePerToken: 5 / 1_000_000,
+              cacheReadPricePerToken: 0.1 / 1_000_000,
+            },
+          ],
+        },
+      ]);
+
+      await recorder.recordSuccessMessage(
+        ctx,
+        'copilot/gpt-5.6-terra',
+        'default',
+        'default',
+        {
+          prompt_tokens: 80_200,
+          completion_tokens: 852,
+          cache_read_tokens: 72_300,
+          reported_cost_usd: 1,
+        },
+        {
+          provider: 'copilot',
+          authType: 'subscription',
+          tenantProviderId: 'copilot-connection',
+        },
+      );
+
+      expect(insertMock.mock.calls[0][0].cost_usd).toBeCloseTo(0.01939, 10);
+      expect(getByModelMock).not.toHaveBeenCalled();
+    });
+
+    it('keeps Copilot at zero when its selected connection has no token pricing', async () => {
+      getProvidersMock.mockResolvedValue([
+        {
+          id: 'copilot-connection',
+          provider: 'copilot',
+          cached_models: [
+            {
+              id: 'copilot/gpt-4o',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            },
+          ],
+        },
+      ]);
+
+      await recorder.recordFallbackSuccess(ctx, 'gpt-4o', 'default', {
+        provider: 'copilot',
+        authType: 'subscription',
+        tenantProviderId: 'copilot-connection',
+        usage: { prompt_tokens: 1000, completion_tokens: 100 },
+      });
+
+      expect(insertMock.mock.calls[0][0].cost_usd).toBe(0);
+    });
+
+    it('keeps Copilot recording available when cached provider lookup fails', async () => {
+      getProvidersMock.mockRejectedValue(new Error('database unavailable'));
+
+      await recorder.recordSuccessMessage(
+        ctx,
+        'copilot/gpt-4o',
+        'default',
+        'default',
+        { prompt_tokens: 1000, completion_tokens: 100 },
+        {
+          provider: 'copilot',
+          authType: 'subscription',
+          tenantProviderId: 'copilot-connection',
+        },
+      );
+
+      expect(insertMock.mock.calls[0][0].cost_usd).toBe(0);
     });
 
     it('records message even when tokens are zero', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -1591,6 +1591,68 @@ describe('ProxyMessageRecorder', () => {
       expect(getByModelMock).not.toHaveBeenCalled();
     });
 
+    it('switches Copilot pricing only above the long-context prompt threshold', async () => {
+      getProvidersMock.mockResolvedValue([
+        {
+          id: 'copilot-connection',
+          provider: 'copilot',
+          cached_models: [
+            {
+              id: 'copilot/gpt-5.6-terra',
+              displayName: 'gpt-5.6-terra',
+              inputPricePerToken: 1 / 1_000_000,
+              outputPricePerToken: 5 / 1_000_000,
+              cacheReadPricePerToken: 0.1 / 1_000_000,
+              cacheWritePricePerToken: 1.25 / 1_000_000,
+              longContextPricing: {
+                thresholdTokens: 100_000,
+                inputPricePerToken: 2 / 1_000_000,
+                outputPricePerToken: 8 / 1_000_000,
+                cacheReadPricePerToken: 0.2 / 1_000_000,
+                cacheWritePricePerToken: 2.5 / 1_000_000,
+              },
+            },
+          ],
+        },
+      ]);
+
+      const options = {
+        provider: 'copilot',
+        authType: 'subscription' as const,
+        tenantProviderId: 'copilot-connection',
+      };
+
+      await recorder.recordSuccessMessage(
+        ctx,
+        'copilot/gpt-5.6-terra',
+        'default',
+        'default',
+        {
+          prompt_tokens: 100_000,
+          completion_tokens: 100,
+          cache_read_tokens: 60_000,
+          cache_creation_tokens: 10_000,
+        },
+        options,
+      );
+      await recorder.recordSuccessMessage(
+        ctx,
+        'copilot/gpt-5.6-terra',
+        'default',
+        'default',
+        {
+          prompt_tokens: 100_001,
+          completion_tokens: 100,
+          cache_read_tokens: 60_000,
+          cache_creation_tokens: 10_000,
+        },
+        options,
+      );
+
+      expect(insertMock.mock.calls[0][0].cost_usd).toBeCloseTo(0.049, 10);
+      expect(insertMock.mock.calls[1][0].cost_usd).toBeCloseTo(0.097802, 10);
+    });
+
     it('keeps Copilot at zero when its selected connection has no token pricing', async () => {
       getProvidersMock.mockResolvedValue([
         {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -1653,6 +1653,43 @@ describe('ProxyMessageRecorder', () => {
       expect(insertMock.mock.calls[1][0].cost_usd).toBeCloseTo(0.097802, 10);
     });
 
+    it('uses billable long-context prices when Copilot default prices are zero', async () => {
+      getProvidersMock.mockResolvedValue([
+        {
+          id: 'copilot-connection',
+          provider: 'copilot',
+          cached_models: [
+            {
+              id: 'copilot/gpt-5.6-terra',
+              displayName: 'gpt-5.6-terra',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+              longContextPricing: {
+                thresholdTokens: 100,
+                inputPricePerToken: 2 / 1_000_000,
+                outputPricePerToken: 8 / 1_000_000,
+              },
+            },
+          ],
+        },
+      ]);
+
+      await recorder.recordSuccessMessage(
+        ctx,
+        'copilot/gpt-5.6-terra',
+        'default',
+        'default',
+        { prompt_tokens: 101, completion_tokens: 10 },
+        {
+          provider: 'copilot',
+          authType: 'subscription',
+          tenantProviderId: 'copilot-connection',
+        },
+      );
+
+      expect(insertMock.mock.calls[0][0].cost_usd).toBeCloseTo(0.000282, 10);
+    });
+
     it('falls back to default Copilot prices when its long-context tier is invalid', async () => {
       getProvidersMock.mockResolvedValue([
         {

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -484,8 +484,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     if (
       !cached ||
       !validPrice(cached.inputPricePerToken) ||
-      !validPrice(cached.outputPricePerToken) ||
-      (cached.inputPricePerToken === 0 && cached.outputPricePerToken === 0)
+      !validPrice(cached.outputPricePerToken)
     ) {
       return undefined;
     }
@@ -500,6 +499,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       validPrice(longContext.outputPricePerToken) &&
       (longContext.inputPricePerToken > 0 || longContext.outputPricePerToken > 0);
     const effective = useLongContext ? longContext : cached;
+    if (effective.inputPricePerToken === 0 && effective.outputPricePerToken === 0) {
+      return undefined;
+    }
 
     return {
       model_name: cached.id,

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -461,6 +461,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     ctx: IngestionContext,
     tenantProviderId: string | null | undefined,
     model: string,
+    promptTokens: number,
   ): Promise<PricingEntry | undefined> {
     if (!tenantProviderId || !this.providerService) return undefined;
 
@@ -489,13 +490,24 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       return undefined;
     }
 
+    const longContext = cached.longContextPricing;
+    const useLongContext =
+      longContext != null &&
+      Number.isSafeInteger(longContext.thresholdTokens) &&
+      longContext.thresholdTokens > 0 &&
+      promptTokens > longContext.thresholdTokens &&
+      validPrice(longContext.inputPricePerToken) &&
+      validPrice(longContext.outputPricePerToken) &&
+      (longContext.inputPricePerToken > 0 || longContext.outputPricePerToken > 0);
+    const effective = useLongContext ? longContext : cached;
+
     return {
       model_name: cached.id,
       provider: connection?.provider ?? 'copilot',
-      input_price_per_token: cached.inputPricePerToken,
-      output_price_per_token: cached.outputPricePerToken,
-      cache_read_price_per_token: cached.cacheReadPricePerToken,
-      cache_write_price_per_token: cached.cacheWritePricePerToken,
+      input_price_per_token: effective.inputPricePerToken,
+      output_price_per_token: effective.outputPricePerToken,
+      cache_read_price_per_token: effective.cacheReadPricePerToken,
+      cache_write_price_per_token: effective.cacheWritePricePerToken,
       display_name: cached.displayName || null,
     };
   }
@@ -512,7 +524,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
   ): Promise<number | null> {
     const isCopilot = this.isCopilotSubscription(provider, authType);
     const copilotPricing =
-      isCopilot && usage ? await this.copilotTokenPricing(ctx, tenantProviderId, model) : undefined;
+      isCopilot && usage
+        ? await this.copilotTokenPricing(ctx, tenantProviderId, model, usage.prompt_tokens)
+        : undefined;
 
     return computeTokenCost({
       inputTokens: usage?.prompt_tokens ?? 0,

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
@@ -13,7 +13,10 @@ import {
 } from 'manifest-shared';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { ManifestRequest } from '../../entities/request.entity';
-import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
+import {
+  ModelPricingCacheService,
+  type PricingEntry,
+} from '../../model-prices/model-pricing-cache.service';
 import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
 import { FailedFallback } from './proxy-fallback.service';
@@ -26,6 +29,7 @@ import { CustomProviderService } from '../custom-provider/custom-provider.servic
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
 import { isLocalOnlyProvider } from '../../common/utils/provider-availability';
+import { ProviderService } from '../routing-core/provider.service';
 import { extractManifestErrorCode, type ManifestErrorCode } from '../../common/errors/error-codes';
 import {
   MANIFEST_CODE_TO_REASON,
@@ -435,6 +439,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     private readonly eventBus: IngestEventBusService,
     private readonly customProviders: CustomProviderService,
     private readonly opencodeGoCatalog: OpencodeGoCatalogService,
+    @Optional()
+    private readonly providerService?: ProviderService,
   ) {
     this.cooldownCleanupTimer = setInterval(() => this.evictExpiredCooldowns(), 60_000);
     if (typeof this.cooldownCleanupTimer === 'object' && 'unref' in this.cooldownCleanupTimer) {
@@ -444,6 +450,90 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
 
   onModuleDestroy(): void {
     clearInterval(this.cooldownCleanupTimer);
+  }
+
+  private isCopilotSubscription(provider?: string, authType?: string): boolean {
+    if (authType !== 'subscription' || !provider) return false;
+    return PROVIDER_BY_ID_OR_ALIAS.get(provider.toLowerCase())?.id === 'copilot';
+  }
+
+  private async copilotTokenPricing(
+    ctx: IngestionContext,
+    tenantProviderId: string | null | undefined,
+    model: string,
+  ): Promise<PricingEntry | undefined> {
+    if (!tenantProviderId || !this.providerService) return undefined;
+
+    let providers;
+    try {
+      providers = await this.providerService.getProviders(ctx.tenantId);
+    } catch {
+      return undefined;
+    }
+
+    const connection = providers.find((candidate) => candidate.id === tenantProviderId);
+    const bareModel = model.toLowerCase().replace(/^copilot\//, '');
+    const cached = Array.isArray(connection?.cached_models)
+      ? connection.cached_models.find(
+          (candidate) => candidate.id.toLowerCase().replace(/^copilot\//, '') === bareModel,
+        )
+      : undefined;
+    const validPrice = (price: number | null): price is number =>
+      typeof price === 'number' && Number.isFinite(price) && price >= 0;
+    if (
+      !cached ||
+      !validPrice(cached.inputPricePerToken) ||
+      !validPrice(cached.outputPricePerToken) ||
+      (cached.inputPricePerToken === 0 && cached.outputPricePerToken === 0)
+    ) {
+      return undefined;
+    }
+
+    return {
+      model_name: cached.id,
+      provider: connection?.provider ?? 'copilot',
+      input_price_per_token: cached.inputPricePerToken,
+      output_price_per_token: cached.outputPricePerToken,
+      cache_read_price_per_token: cached.cacheReadPricePerToken,
+      cache_write_price_per_token: cached.cacheWritePricePerToken,
+      display_name: cached.displayName || null,
+    };
+  }
+
+  private async computeCost(
+    ctx: IngestionContext,
+    model: string,
+    provider: string | undefined,
+    authType: string | undefined,
+    usage: StreamUsage | undefined,
+    tenantProviderId?: string | null,
+    canonicalProvider?: string | null,
+    at?: Date,
+  ): Promise<number | null> {
+    const isCopilot = this.isCopilotSubscription(provider, authType);
+    const copilotPricing =
+      isCopilot && usage ? await this.copilotTokenPricing(ctx, tenantProviderId, model) : undefined;
+
+    return computeTokenCost({
+      inputTokens: usage?.prompt_tokens ?? 0,
+      outputTokens: usage?.completion_tokens ?? 0,
+      cacheReadTokens: usage?.cache_read_tokens ?? 0,
+      cacheCreationTokens: usage?.cache_creation_tokens ?? 0,
+      model,
+      // Priced on the raw keys: a custom provider's rates are stored under
+      // `custom:<uuid>/<model>`, which is exactly what canonicalization strips.
+      pricing:
+        copilotPricing ??
+        (!isCopilot && usage ? this.pricingCache.getByModel(model, provider) : undefined),
+      isSubscription: authType === 'subscription' && !copilotPricing,
+      isLocalProvider: isLocalOnlyProvider(canonicalProvider ?? provider ?? ''),
+      perRequestCostUsd: copilotPricing
+        ? null
+        : await this.perRequestSubscriptionCost(provider, authType, model),
+      // Copilot's usage.cost is a premium-request multiplier, not USD.
+      reportedCostUsd: isCopilot ? undefined : usage?.reported_cost_usd,
+      at,
+    });
   }
 
   /**
@@ -1067,24 +1157,19 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       model,
     );
 
-    const costUsd = computeTokenCost({
-      inputTokens,
-      outputTokens,
-      cacheReadTokens: usage?.cache_read_tokens ?? 0,
-      cacheCreationTokens: usage?.cache_creation_tokens ?? 0,
+    const costUsd = await this.computeCost(
+      ctx,
       model,
-      // Priced on the raw keys: a custom provider's rates are stored under
-      // `custom:<uuid>/<model>`, which is exactly what canonicalization strips.
-      pricing: usage ? this.pricingCache.getByModel(model, provider) : undefined,
-      isSubscription: authType === 'subscription',
-      isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
-      perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
-      reportedCostUsd: usage?.reported_cost_usd,
+      provider,
+      authType,
+      usage,
+      tenantProviderId,
+      canonical.provider,
       // Bill the hour the provider attempt actually ran: `timestamp` is the
       // synthetic ordering stamp from recordFallbackFailures, not the attempt
       // start, so it can cross a peak boundary on delayed writes.
-      at: attempt ? new Date(attempt.startedAt) : timestamp ? new Date(timestamp) : undefined,
-    });
+      attempt ? new Date(attempt.startedAt) : timestamp ? new Date(timestamp) : undefined,
+    );
 
     const canonicalFallbackFrom = await this.customProviders.canonicalizeAgentMessageKeys(
       ctx.tenantId,
@@ -1164,25 +1249,20 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       model,
     );
 
-    const costUsd = computeTokenCost({
-      inputTokens: usage.prompt_tokens,
-      outputTokens: usage.completion_tokens,
-      cacheReadTokens: usage.cache_read_tokens ?? 0,
-      cacheCreationTokens: usage.cache_creation_tokens ?? 0,
+    const costUsd = await this.computeCost(
+      ctx,
       model,
-      // Priced on the raw keys: a custom provider's rates are stored under
-      // `custom:<uuid>/<model>`, which is exactly what canonicalization strips.
-      pricing: this.pricingCache.getByModel(model, provider),
-      isSubscription: authType === 'subscription',
-      isLocalProvider: isLocalOnlyProvider(canonical.provider ?? provider ?? ''),
-      perRequestCostUsd: await this.perRequestSubscriptionCost(provider, authType, model),
-      reportedCostUsd: usage.reported_cost_usd,
+      provider,
+      authType,
+      usage,
+      tenantProviderId,
+      canonical.provider,
       // Bill a peak/off-peak model on when the attempt started, not on when
       // this row is written: a long stream that opens at 09:59 and records at
       // 10:01 is a peak request, and the fallback path already reads it this
       // way. Falls back to now when the caller tracked no attempt.
-      at: attempt ? new Date(attempt.startedAt) : undefined,
-    });
+      attempt ? new Date(attempt.startedAt) : undefined,
+    );
 
     const canonicalModel = canonical.model;
     const canonicalProvider = canonical.provider;


### PR DESCRIPTION
### ✨ What changed\n- Read Copilot token prices from its live model response.\n- Calculate request costs for the selected Copilot connection.\n- Apply long-context rates above each model's prompt threshold.\n- Preserve zero cost when Copilot does not publish token prices.\n\n### 💭 Why\nCopilot subscriptions can continue on usage-based billing after included quota expires. Manifest still recorded those requests as free.\n\n### 👤 For users\nCopilot request costs now reflect default and long-context pricing after model refresh.\n\n### 📝 Notes\nCloses #2699