### PR TITLE
feat: self-hosted telemetry now reports request and error counts

### DIFF
--- a/packages/backend/src/telemetry/dto/telemetry-payload.ts
+++ b/packages/backend/src/telemetry/dto/telemetry-payload.ts
@@ -41,6 +41,28 @@ export interface TelemetryPayloadV1 {
    */
   cost_usd_by_provider?: Record<string, number>;
 
+  /**
+   * Caller requests over the 24h window (request-first model: one row per
+   * caller call; provider retries/fallbacks are attempts under it and are
+   * NOT counted here). Optional because older installs predate the field.
+   */
+  requests_total?: number;
+
+  /**
+   * Requests that ended `failed` over the same window. Together with
+   * `errors_by_class` this gives the receiver error visibility for installs
+   * whose failures never reach the Phoenix heal path.
+   */
+  errors_total?: number;
+
+  /**
+   * Per-`error_class` split of `errors_total`, using the shared taxonomy
+   * (`rate_limit`, `auth`, `invalid_request`, ...). Unknown values collapse
+   * to `"other"` and unclassified NULLs to `"unknown"` — same
+   * defense-in-depth as the tier map.
+   */
+  errors_by_class?: Record<string, number>;
+
   // Configuration
   agents_total: number;
   agents_by_platform: Record<string, number>;

--- a/packages/backend/src/telemetry/payload-builder.service.spec.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { ManifestRequest } from '../entities/request.entity';
 import { PayloadBuilderService } from './payload-builder.service';
 
 interface ProviderRow {
@@ -25,6 +26,11 @@ interface TotalsRow {
   cost?: string | null;
 }
 
+interface RequestTotalsRow {
+  total: string;
+  failed: string | null;
+}
+
 interface MockData {
   providers: ProviderRow[];
   tiers: BucketRow[];
@@ -32,6 +38,8 @@ interface MockData {
   totals: TotalsRow | undefined;
   agentPlatforms: CategoryPlatformRow[];
   agentsCount: number;
+  requestTotals: RequestTotalsRow | undefined;
+  errorClasses: BucketRow[];
 }
 
 function defaultData(): MockData {
@@ -42,6 +50,8 @@ function defaultData(): MockData {
     totals: { total: '0', input_tokens: '0', output_tokens: '0' },
     agentPlatforms: [],
     agentsCount: 0,
+    requestTotals: { total: '0', failed: '0' },
+    errorClasses: [],
   };
 }
 
@@ -71,12 +81,18 @@ async function makeServiceWithRepo(partial: Partial<MockData>): Promise<MakeServ
     { row: { count: String(data.agentsCount) }, mode: 'getRawOne' as const },
     { rows: data.agentPlatforms, mode: 'getRawMany' as const },
   ];
+  // requestCounts() uses getRawOne; failedRequestsByClass() uses getRawMany.
+  const requestsQueue = [
+    { row: data.requestTotals, mode: 'getRawOne' as const },
+    { rows: data.errorClasses, mode: 'getRawMany' as const },
+  ];
 
   function makeQb(entry: { rows?: unknown; row?: unknown; mode: 'getRawMany' | 'getRawOne' }) {
     return {
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
       addGroupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue(entry.rows ?? []),
@@ -90,12 +106,16 @@ async function makeServiceWithRepo(partial: Partial<MockData>): Promise<MakeServ
   const agentsRepoMock = {
     createQueryBuilder: jest.fn(() => makeQb(agentsQueue.shift()!)),
   };
+  const requestsRepo = {
+    createQueryBuilder: jest.fn(() => makeQb(requestsQueue.shift()!)),
+  };
 
   const module: TestingModule = await Test.createTestingModule({
     providers: [
       PayloadBuilderService,
       { provide: getRepositoryToken(AgentMessage), useValue: messagesRepo },
       { provide: getRepositoryToken(Agent), useValue: agentsRepoMock },
+      { provide: getRepositoryToken(ManifestRequest), useValue: requestsRepo },
     ],
   }).compile();
 
@@ -190,6 +210,47 @@ describe('PayloadBuilderService', () => {
     expect(payload.messages_total).toBe(0);
     expect(payload.tokens_input_total).toBe(0);
     expect(payload.tokens_output_total).toBe(0);
+  });
+
+  it('emits request-level counters split by error class', async () => {
+    const service = await makeService({
+      requestTotals: { total: '20', failed: '6' },
+      errorClasses: [
+        { bucket: 'rate_limit', count: '4' },
+        { bucket: 'auth', count: '2' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.requests_total).toBe(20);
+    expect(payload.errors_total).toBe(6);
+    expect(payload.errors_by_class).toEqual({ rate_limit: 4, auth: 2 });
+  });
+
+  it('buckets NULL error classes as "unknown" and off-taxonomy strings as "other"', async () => {
+    const service = await makeService({
+      requestTotals: { total: '9', failed: '3' },
+      errorClasses: [
+        { bucket: null, count: '1' },
+        { bucket: 'totally-novel-class', count: '2' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.errors_by_class).toEqual({ unknown: 1, other: 2 });
+  });
+
+  it('treats a NULL failed sum (empty window) and a missing row as zero errors', async () => {
+    const withNullSum = await makeService({ requestTotals: { total: '0', failed: null } });
+    expect((await withNullSum.build('inst', '1.0.0')).errors_total).toBe(0);
+
+    const withNoRow = await makeService({ requestTotals: undefined });
+    const payload = await withNoRow.build('inst', '1.0.0');
+    expect(payload.requests_total).toBe(0);
+    expect(payload.errors_total).toBe(0);
+    expect(payload.errors_by_class).toEqual({});
   });
 
   it('emits cost_usd_total = 0 and cost_usd_by_provider = {} when no cost data', async () => {

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { ALL_TIERS, AUTH_TYPES, TIER_SLOTS } from 'manifest-shared';
+import { ALL_TIERS, AUTH_TYPES, ERROR_CLASSES, FAILED_STATUS, TIER_SLOTS } from 'manifest-shared';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { ManifestRequest } from '../entities/request.entity';
 import type { TelemetryPayloadV1 } from './dto/telemetry-payload';
 import { TELEMETRY_SCHEMA_VERSION } from './telemetry.config';
 
 const TIER_WHITELIST: ReadonlySet<string> = new Set<string>([...TIER_SLOTS, ...ALL_TIERS]);
 const AUTH_TYPE_WHITELIST: ReadonlySet<string> = new Set<string>(AUTH_TYPES);
+const ERROR_CLASS_WHITELIST: ReadonlySet<string> = new Set<string>(ERROR_CLASSES);
 
 interface ProviderAggregateRow {
   provider: string | null;
@@ -41,18 +43,30 @@ export class PayloadBuilderService {
     private readonly messages: Repository<AgentMessage>,
     @InjectRepository(Agent)
     private readonly agents: Repository<Agent>,
+    @InjectRepository(ManifestRequest)
+    private readonly requests: Repository<ManifestRequest>,
   ) {}
 
   async build(installId: string, manifestVersion: string): Promise<TelemetryPayloadV1> {
-    const [providerRows, tierRows, authRows, totals, agentsTotal, agentPlatformRows] =
-      await Promise.all([
-        this.messagesByProvider(),
-        this.messagesByBucket('routing_tier'),
-        this.messagesByBucket('auth_type'),
-        this.totals(),
-        this.userAgentsCount(),
-        this.agentsByPlatform(),
-      ]);
+    const [
+      providerRows,
+      tierRows,
+      authRows,
+      totals,
+      agentsTotal,
+      agentPlatformRows,
+      requestCounts,
+      errorClassRows,
+    ] = await Promise.all([
+      this.messagesByProvider(),
+      this.messagesByBucket('routing_tier'),
+      this.messagesByBucket('auth_type'),
+      this.totals(),
+      this.userAgentsCount(),
+      this.agentsByPlatform(),
+      this.requestCounts(),
+      this.failedRequestsByClass(),
+    ]);
 
     return {
       schema_version: TELEMETRY_SCHEMA_VERSION,
@@ -70,6 +84,11 @@ export class PayloadBuilderService {
       tokens_output_total: Number(totals.output_tokens ?? 0),
       cost_usd_total: roundCents(Number(totals.cost ?? 0)),
       cost_usd_by_provider: this.collapseProviderCosts(providerRows),
+      requests_total: Number(requestCounts.total),
+      errors_total: Number(requestCounts.failed ?? 0),
+      // NULL error_class (unclassified failures) buckets under "unknown";
+      // anything outside the shared taxonomy collapses to "other".
+      errors_by_class: this.bucketsToRecord(errorClassRows, 'unknown', ERROR_CLASS_WHITELIST),
       agents_total: agentsTotal,
       agents_by_platform: this.bucketsToRecord(agentPlatformRows, 'unknown'),
       platform: process.platform,
@@ -140,6 +159,35 @@ export class PayloadBuilderService {
       .where('a.is_playground = false')
       .getRawOne<{ count: string }>();
     return Number(result?.count ?? 0);
+  }
+
+  /**
+   * Request-level counters over the same 24h window. `requests` is the
+   * request-first ledger (one row per caller call), so `total` never counts
+   * provider retries/fallbacks twice, and `failed` is the caller-visible
+   * failure count — including gateway rejections that never produced an
+   * attempt row in `agent_messages`.
+   */
+  private async requestCounts(): Promise<{ total: string; failed: string | null }> {
+    const row = await this.requests
+      .createQueryBuilder('r')
+      .select('COUNT(*)', 'total')
+      .addSelect(`SUM(CASE WHEN r.status = '${FAILED_STATUS}' THEN 1 ELSE 0 END)`, 'failed')
+      .where(`r.timestamp >= NOW() - INTERVAL '24 hours'`)
+      .getRawOne<{ total: string; failed: string | null }>();
+    return row ?? { total: '0', failed: '0' };
+  }
+
+  /** Failed requests grouped by their shared-taxonomy `error_class`. */
+  private async failedRequestsByClass(): Promise<BucketRow[]> {
+    return this.requests
+      .createQueryBuilder('r')
+      .select('r.error_class', 'bucket')
+      .addSelect('COUNT(*)', 'count')
+      .where(`r.timestamp >= NOW() - INTERVAL '24 hours'`)
+      .andWhere(`r.status = '${FAILED_STATUS}'`)
+      .groupBy('r.error_class')
+      .getRawMany<BucketRow>();
   }
 
   private async totals(): Promise<TotalsRow> {

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { ALL_TIERS, AUTH_TYPES, ERROR_CLASSES, FAILED_STATUS, TIER_SLOTS } from 'manifest-shared';
+import { ALL_TIERS, AUTH_TYPES, ERROR_CLASSES, TIER_SLOTS } from 'manifest-shared';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { ManifestRequest } from '../entities/request.entity';
+import { sqlIsFailedStatus } from '../analytics/services/query-helpers';
 import type { TelemetryPayloadV1 } from './dto/telemetry-payload';
 import { TELEMETRY_SCHEMA_VERSION } from './telemetry.config';
 
@@ -172,7 +173,11 @@ export class PayloadBuilderService {
     const row = await this.requests
       .createQueryBuilder('r')
       .select('COUNT(*)', 'total')
-      .addSelect(`SUM(CASE WHEN r.status = '${FAILED_STATUS}' THEN 1 ELSE 0 END)`, 'failed')
+      // Shared legacy-aware predicate: rows written by a not-yet-drained old
+      // replica (or pre-normalization backfill) say `error`/`rate_limited`/…
+      // rather than the canonical `failed`; a bare `= 'failed'` would
+      // undercount them.
+      .addSelect(`SUM(CASE WHEN ${sqlIsFailedStatus('r.status')} THEN 1 ELSE 0 END)`, 'failed')
       .where(`r.timestamp >= NOW() - INTERVAL '24 hours'`)
       .getRawOne<{ total: string; failed: string | null }>();
     return row ?? { total: '0', failed: '0' };
@@ -185,7 +190,7 @@ export class PayloadBuilderService {
       .select('r.error_class', 'bucket')
       .addSelect('COUNT(*)', 'count')
       .where(`r.timestamp >= NOW() - INTERVAL '24 hours'`)
-      .andWhere(`r.status = '${FAILED_STATUS}'`)
+      .andWhere(sqlIsFailedStatus('r.status'))
       .groupBy('r.error_class')
       .getRawMany<BucketRow>();
   }

--- a/packages/backend/src/telemetry/telemetry.module.ts
+++ b/packages/backend/src/telemetry/telemetry.module.ts
@@ -3,12 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { InstallMetadata } from '../entities/install-metadata.entity';
+import { ManifestRequest } from '../entities/request.entity';
 import { InstallIdService } from './install-id.service';
 import { PayloadBuilderService } from './payload-builder.service';
 import { TelemetryService } from './telemetry.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([InstallMetadata, AgentMessage, Agent])],
+  imports: [TypeOrmModule.forFeature([InstallMetadata, AgentMessage, Agent, ManifestRequest])],
   providers: [InstallIdService, PayloadBuilderService, TelemetryService],
   // Autofix announces the same anonymous install id to Phoenix, so the id
   // service is shared rather than duplicated. Telemetry sending stays gated on


### PR DESCRIPTION
### 💭 Why
The daily telemetry aggregate carries zero error signal. A self-hosted install drowning in failures looks identical to a healthy one, and the only failure data we get is the subset that reaches the Phoenix heal path.

### ✨ What changed
- Payload gains optional `requests_total`, `errors_total`, `errors_by_class` (24h window, from the request-first `requests` ledger, so retries are never double-counted and gateway rejections are included).
- `errors_by_class` uses the shared taxonomy; NULL buckets as `unknown`, off-taxonomy values collapse to `other` (same guard as the tier map).
- Additive; `schema_version` stays 1. Receivers feature-detect on presence.

### 🔧 For operators
Deploy order matters: the Peacock ingest whitelists these fields in mnfst/peacock#228. Peacock must deploy first, or upgraded installs get their entire daily report rejected by `forbidNonWhitelisted`.

### 📝 Notes
- Receiver + per-install error dashboards: mnfst/peacock#228.