### PR TITLE
feat: add custom route model aliases

### DIFF
--- a/.changeset/custom-route-model-aliases.md
+++ b/.changeset/custom-route-model-aliases.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Let custom routing tiers expose stable `manifest/<alias>` model IDs. Model aliases are available through `/v1/models`, work across all proxy APIs, outrank conflicting header rules, and fail with `M302` instead of falling through when unavailable.

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -159,6 +159,7 @@ import { MakeAutofixEnabledNullable1799000300000 } from './migrations/1799000300
 import { AddAutofixAccessGrant1799000400000 } from './migrations/1799000400000-AddAutofixAccessGrant';
 import { AddRequestsAndProviderAttempts1801000000000 } from './migrations/1801000000000-AddRequestsAndProviderAttempts';
 import { AddProviderAttemptOrdering1801100000000 } from './migrations/1801100000000-AddProviderAttemptOrdering';
+import { AddHeaderTierModelAliases1802100000000 } from './migrations/1802100000000-AddHeaderTierModelAliases';
 
 export const entities = [
   AgentMessage,
@@ -320,4 +321,5 @@ export const migrations = [
   AddRequestApiMode1801720000000,
   AddAutofixConsentToInstallMetadata1801900000000,
   SlimTenantAgentModelIndex1802000000000,
+  AddHeaderTierModelAliases1802100000000,
 ];

--- a/packages/backend/src/database/migrations/1802100000000-AddHeaderTierModelAliases.spec.ts
+++ b/packages/backend/src/database/migrations/1802100000000-AddHeaderTierModelAliases.spec.ts
@@ -1,0 +1,29 @@
+import { AddHeaderTierModelAliases1802100000000 } from './1802100000000-AddHeaderTierModelAliases';
+
+describe('AddHeaderTierModelAliases1802100000000', () => {
+  const migration = new AddHeaderTierModelAliases1802100000000();
+  const queryRunner = { query: jest.fn().mockResolvedValue(undefined) } as never;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('adds a constrained, agent-scoped model alias', async () => {
+    await migration.up(queryRunner);
+
+    const queries = (queryRunner as { query: jest.Mock }).query.mock.calls.map(([sql]) => sql);
+    expect(queries[0]).toContain('ADD COLUMN "model_alias" varchar(48) DEFAULT NULL');
+    expect(queries[1]).toContain('"model_alias" <> \'auto\'');
+    expect(queries[1]).toContain("'^[a-z0-9]+(-[a-z0-9]+)*$'");
+    expect(queries[2]).toContain('CREATE UNIQUE INDEX "IDX_header_tiers_agent_model_alias"');
+    expect(queries[2]).toContain('("agent_id", "model_alias")');
+    expect(queries[2]).toContain('WHERE "model_alias" IS NOT NULL');
+  });
+
+  it('removes the index, constraint, and column on rollback', async () => {
+    await migration.down(queryRunner);
+
+    const queries = (queryRunner as { query: jest.Mock }).query.mock.calls.map(([sql]) => sql);
+    expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_header_tiers_agent_model_alias"');
+    expect(queries[1]).toContain('DROP CONSTRAINT IF EXISTS "CHK_header_tiers_model_alias"');
+    expect(queries[2]).toContain('DROP COLUMN "model_alias"');
+  });
+});

--- a/packages/backend/src/database/migrations/1802100000000-AddHeaderTierModelAliases.ts
+++ b/packages/backend/src/database/migrations/1802100000000-AddHeaderTierModelAliases.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddHeaderTierModelAliases1802100000000 implements MigrationInterface {
+  name = 'AddHeaderTierModelAliases1802100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "header_tiers" ADD COLUMN "model_alias" varchar(48) DEFAULT NULL`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "header_tiers"
+      ADD CONSTRAINT "CHK_header_tiers_model_alias"
+      CHECK (
+        "model_alias" IS NULL OR (
+          "model_alias" <> 'auto'
+          AND "model_alias" ~ '^[a-z0-9]+(-[a-z0-9]+)*$'
+        )
+      )
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_header_tiers_agent_model_alias"
+      ON "header_tiers" ("agent_id", "model_alias")
+      WHERE "model_alias" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_header_tiers_agent_model_alias"`);
+    await queryRunner.query(
+      `ALTER TABLE "header_tiers" DROP CONSTRAINT IF EXISTS "CHK_header_tiers_model_alias"`,
+    );
+    await queryRunner.query(`ALTER TABLE "header_tiers" DROP COLUMN "model_alias"`);
+  }
+}

--- a/packages/backend/src/entities/header-tier.entity.ts
+++ b/packages/backend/src/entities/header-tier.entity.ts
@@ -20,6 +20,9 @@ export class HeaderTier {
   @Column('varchar')
   name!: string;
 
+  @Column('varchar', { length: 48, nullable: true })
+  model_alias!: string | null;
+
   @Column('varchar')
   header_key!: string;
 

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -154,6 +154,12 @@ describe('HeaderTierService', () => {
       ).rejects.toThrow(/48 characters/);
     });
 
+    it('rejects non-string model aliases', async () => {
+      await expect(
+        svc.create('agent-1', 'tenant-1', validInput({ model_alias: 42 as never })),
+      ).rejects.toThrow('Model alias must be a string');
+    });
+
     it('rejects a model alias used by a sibling tier', async () => {
       repo.find.mockResolvedValue([
         {

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -101,6 +101,7 @@ describe('HeaderTierService', () => {
       expect(repo.insert).toHaveBeenCalledTimes(1);
       expect(result.sort_order).toBe(0);
       expect(result.name).toBe('Premium');
+      expect(result.model_alias).toBeNull();
       expect(result.header_key).toBe('x-tier');
       expect(result.header_value).toBe('premium');
       expect(result.badge_color).toBe('red');
@@ -127,6 +128,46 @@ describe('HeaderTierService', () => {
       await expect(
         svc.create('agent-1', 'tenant-1', validInput({ name: 'a'.repeat(33) })),
       ).rejects.toThrow(/32 characters/);
+    });
+
+    it('stores a valid model alias', async () => {
+      const result = await svc.create(
+        'agent-1',
+        'tenant-1',
+        validInput({ model_alias: 'premium-fast' }),
+      );
+      expect(result.model_alias).toBe('premium-fast');
+    });
+
+    it.each(['auto', 'Premium', 'premium_fast', 'premium--fast', 'manifest/premium'])(
+      'rejects the invalid or reserved model alias %s',
+      async (model_alias) => {
+        await expect(
+          svc.create('agent-1', 'tenant-1', validInput({ model_alias })),
+        ).rejects.toThrow(/model alias/i);
+      },
+    );
+
+    it('rejects oversized model aliases', async () => {
+      await expect(
+        svc.create('agent-1', 'tenant-1', validInput({ model_alias: 'a'.repeat(49) })),
+      ).rejects.toThrow(/48 characters/);
+    });
+
+    it('rejects a model alias used by a sibling tier', async () => {
+      repo.find.mockResolvedValue([
+        {
+          id: 'h1',
+          name: 'Other',
+          model_alias: 'premium',
+          header_key: 'x',
+          header_value: 'a',
+          sort_order: 0,
+        } as HeaderTier,
+      ]);
+      await expect(
+        svc.create('agent-1', 'tenant-1', validInput({ model_alias: 'premium' })),
+      ).rejects.toThrow(/already uses this model alias/);
     });
 
     it('rejects header keys with disallowed characters', async () => {
@@ -254,6 +295,52 @@ describe('HeaderTierService', () => {
       expect(result.header_key).toBe('x-band');
       expect(result.header_value).toBe('gold');
       expect(result.badge_color).toBe('blue');
+    });
+
+    it('sets and clears a model alias without changing the display name', async () => {
+      const row = {
+        id: 'h1',
+        agent_id: 'agent-1',
+        name: 'Premium',
+        model_alias: null,
+        header_key: 'x-tier',
+        header_value: 'old',
+        badge_color: 'red' as TierColor,
+      } as HeaderTier;
+      repo.findOne.mockResolvedValue(row);
+      repo.find.mockResolvedValue([row]);
+
+      const withAlias = await svc.update('agent-1', 'h1', { model_alias: 'premium' });
+      expect(withAlias.model_alias).toBe('premium');
+      expect(withAlias.name).toBe('Premium');
+
+      const withoutAlias = await svc.update('agent-1', 'h1', { model_alias: null });
+      expect(withoutAlias.model_alias).toBeNull();
+    });
+
+    it('rejects changing a model alias to a sibling alias', async () => {
+      const row = {
+        id: 'h1',
+        agent_id: 'agent-1',
+        name: 'A',
+        model_alias: 'a',
+        header_key: 'x-tier',
+        header_value: 'a',
+      } as HeaderTier;
+      const sibling = {
+        id: 'h2',
+        agent_id: 'agent-1',
+        name: 'B',
+        model_alias: 'b',
+        header_key: 'x-tier',
+        header_value: 'b',
+      } as HeaderTier;
+      repo.findOne.mockResolvedValue(row);
+      repo.find.mockResolvedValue([row, sibling]);
+
+      await expect(svc.update('agent-1', 'h1', { model_alias: 'b' })).rejects.toThrow(
+        /already uses this model alias/,
+      );
     });
 
     it('rejects renaming to a sibling name', async () => {

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
@@ -81,6 +81,7 @@ describe('HeaderTierController', () => {
     const { controller, service } = makeController({ tenant_id: 't1' });
     const body = {
       name: 'Premium',
+      model_alias: 'premium',
       header_key: 'x',
       header_value: 'y',
       badge_color: 'indigo' as const,
@@ -92,8 +93,14 @@ describe('HeaderTierController', () => {
 
   it('update calls service.update with the patch', async () => {
     const { controller, service } = makeController();
-    await controller.update(ctx, 'my-agent', 'ht-1', { name: 'Updated' });
-    expect(service.update).toHaveBeenCalledWith('agent-1', 'ht-1', { name: 'Updated' });
+    await controller.update(ctx, 'my-agent', 'ht-1', {
+      name: 'Updated',
+      model_alias: 'updated',
+    });
+    expect(service.update).toHaveBeenCalledWith('agent-1', 'ht-1', {
+      name: 'Updated',
+      model_alias: 'updated',
+    });
   });
 
   it('delete returns ok and calls service.delete', async () => {

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.ts
@@ -33,6 +33,7 @@ import { AUTH_TYPES, type TierColor } from 'manifest-shared';
 
 interface CreateHeaderTierBody {
   name: string;
+  model_alias?: string | null;
   header_key: string;
   header_value: string;
   badge_color: TierColor;
@@ -40,6 +41,7 @@ interface CreateHeaderTierBody {
 
 interface UpdateHeaderTierBody {
   name?: string;
+  model_alias?: string | null;
   header_key?: string;
   header_value?: string;
   badge_color?: TierColor;

--- a/packages/backend/src/routing/header-tiers/header-tier.service.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.service.ts
@@ -29,11 +29,14 @@ export const RESERVED_HEADER_KEYS = new Set<string>([
 ]);
 
 const HEADER_KEY_RE = /^[a-z0-9-]+$/;
+export const MODEL_ALIAS_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const MAX_NAME_LEN = 32;
+export const MAX_MODEL_ALIAS_LEN = 48;
 const MAX_HEADER_VALUE_LEN = 128;
 
 export interface CreateHeaderTierInput {
   name: string;
+  model_alias?: string | null;
   header_key: string;
   header_value: string;
   badge_color: TierColor;
@@ -41,6 +44,7 @@ export interface CreateHeaderTierInput {
 
 export interface UpdateHeaderTierInput {
   name?: string;
+  model_alias?: string | null;
   header_key?: string;
   header_value?: string;
   badge_color?: TierColor;
@@ -72,12 +76,14 @@ export class HeaderTierService {
     input: CreateHeaderTierInput,
   ): Promise<HeaderTier> {
     const name = this.validateName(input.name);
+    const modelAlias = this.validateModelAlias(input.model_alias);
     const headerKey = this.validateHeaderKey(input.header_key);
     const headerValue = this.validateHeaderValue(input.header_value);
     const badgeColor = this.validateColor(input.badge_color);
 
     const existing = await this.repo.find({ where: { agent_id: agentId } });
     this.assertNameAvailable(existing, name);
+    this.assertModelAliasAvailable(existing, modelAlias);
     this.assertRuleAvailable(existing, headerKey, headerValue);
 
     const nextOrder =
@@ -89,6 +95,7 @@ export class HeaderTierService {
       tenant_id: tenantId,
       agent_id: agentId,
       name,
+      model_alias: modelAlias,
       header_key: headerKey,
       header_value: headerValue,
       badge_color: badgeColor,
@@ -116,6 +123,9 @@ export class HeaderTierService {
       this.assertNameAvailable(siblings, next);
       row.name = next;
     }
+    if (patch.model_alias !== undefined) {
+      row.model_alias = this.validateModelAlias(patch.model_alias);
+    }
     if (patch.header_key !== undefined) {
       row.header_key = this.validateHeaderKey(patch.header_key);
     }
@@ -125,6 +135,7 @@ export class HeaderTierService {
     if (patch.badge_color !== undefined) {
       row.badge_color = this.validateColor(patch.badge_color);
     }
+    this.assertModelAliasAvailable(siblings, row.model_alias);
     this.assertRuleAvailable(siblings, row.header_key, row.header_value);
     row.updated_at = new Date().toISOString();
     await this.repo.save(row);
@@ -351,6 +362,25 @@ export class HeaderTierService {
     return name;
   }
 
+  private validateModelAlias(raw: string | null | undefined): string | null {
+    const alias = (raw ?? '').trim();
+    if (!alias) return null;
+    if (alias.length > MAX_MODEL_ALIAS_LEN) {
+      throw new BadRequestException(
+        `Model alias must be ${MAX_MODEL_ALIAS_LEN} characters or fewer`,
+      );
+    }
+    if (alias === 'auto') {
+      throw new BadRequestException('The model alias "auto" is reserved by Manifest');
+    }
+    if (!MODEL_ALIAS_RE.test(alias)) {
+      throw new BadRequestException(
+        'Model alias can only contain lowercase letters, numbers, and single hyphens',
+      );
+    }
+    return alias;
+  }
+
   private validateHeaderKey(raw: string): string {
     const key = (raw ?? '').trim().toLowerCase();
     if (!key) throw new BadRequestException('Header key is required');
@@ -389,6 +419,12 @@ export class HeaderTierService {
     const lower = name.toLowerCase();
     if (existing.some((t) => t.name.toLowerCase() === lower)) {
       throw new BadRequestException('A tier with this name already exists');
+    }
+  }
+
+  private assertModelAliasAvailable(existing: HeaderTier[], alias: string | null): void {
+    if (alias && existing.some((t) => t.model_alias === alias)) {
+      throw new BadRequestException('Another tier already uses this model alias');
     }
   }
 

--- a/packages/backend/src/routing/header-tiers/header-tier.service.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.service.ts
@@ -362,7 +362,10 @@ export class HeaderTierService {
     return name;
   }
 
-  private validateModelAlias(raw: string | null | undefined): string | null {
+  private validateModelAlias(raw: unknown): string | null {
+    if (raw !== null && raw !== undefined && typeof raw !== 'string') {
+      throw new BadRequestException('Model alias must be a string');
+    }
     const alias = (raw ?? '').trim();
     if (!alias) return null;
     if (alias.length > MAX_MODEL_ALIAS_LEN) {

--- a/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
@@ -1,6 +1,8 @@
 import type { DiscoveredModel } from '../../../model-discovery/model-fetcher';
 import {
   explicitModelRouteCandidate,
+  manifestModelId,
+  modelAliasFromManifestId,
   openAiModelId,
   routeForOpenAiModelId,
 } from '../openai-model-id';
@@ -22,6 +24,13 @@ function model(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
 }
 
 describe('OpenAI model ids', () => {
+  it('formats and parses Manifest custom-route ids', () => {
+    expect(manifestModelId('free')).toBe('manifest/free');
+    expect(modelAliasFromManifestId('manifest/free')).toBe('free');
+    expect(modelAliasFromManifestId('manifest/')).toBeNull();
+    expect(modelAliasFromManifestId('openai/gpt-4o')).toBeNull();
+  });
+
   it('formats provider-qualified API-key model ids', () => {
     expect(openAiModelId(model({ id: 'gpt-4o-mini', provider: 'openai' }))).toBe(
       'openai/gpt-4o-mini',

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -143,6 +143,7 @@ describe('ProxyController', () => {
   };
   let mockPricingCache: { getByModel: jest.Mock };
   let modelDiscovery: { getModelsForAgent: jest.Mock };
+  let headerTierService: { list: jest.Mock };
   let providerParamSpecs: { getCapabilities: jest.Mock };
   let modelsDevSync: { lookupModelCapabilities: jest.Mock };
   let recorder: ProxyMessageRecorder;
@@ -187,6 +188,7 @@ describe('ProxyController', () => {
     modelDiscovery = {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
+    headerTierService = { list: jest.fn().mockResolvedValue([]) };
     providerParamSpecs = { getCapabilities: jest.fn().mockResolvedValue(null) };
     modelsDevSync = { lookupModelCapabilities: jest.fn().mockReturnValue(null) };
     observationReporter = { report: jest.fn() };
@@ -224,6 +226,7 @@ describe('ProxyController', () => {
       new ThinkingBlockCache(),
       new ReasoningContentCache(),
       modelDiscovery as never,
+      headerTierService as never,
       planService as never,
       observationReporter as never,
       providerParamSpecs as never,
@@ -250,6 +253,34 @@ describe('ProxyController', () => {
       ],
     });
     expect(modelDiscovery.getModelsForAgent).toHaveBeenCalledWith('tenant-1', 'agent-1');
+    expect(headerTierService.list).toHaveBeenCalledWith('agent-1');
+  });
+
+  it('should include enabled custom-tier aliases with a configured primary route', async () => {
+    headerTierService.list.mockResolvedValue([
+      {
+        model_alias: 'free',
+        enabled: true,
+        override_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o-mini' },
+        fallback_routes: null,
+      },
+      {
+        model_alias: 'fallback-only',
+        enabled: true,
+        override_route: null,
+        fallback_routes: [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o-mini' }],
+      },
+      { model_alias: 'disabled', enabled: false, override_route: {}, fallback_routes: null },
+      { model_alias: null, enabled: true, override_route: {}, fallback_routes: null },
+      { model_alias: 'empty', enabled: true, override_route: null, fallback_routes: null },
+    ]);
+
+    const result = await controller.models(mockRequest({}) as never);
+
+    expect(result.data).toEqual([
+      { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+      { id: 'manifest/free', object: 'model', created: 0, owned_by: 'manifest' },
+    ]);
   });
 
   it('should include authenticated agent models using provider-qualified ids', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -144,7 +144,7 @@ describe('ProxyController', () => {
   let mockPricingCache: { getByModel: jest.Mock };
   let modelDiscovery: { getModelsForAgent: jest.Mock };
   let headerTierService: { list: jest.Mock };
-  let resolveService: { resolveModelAlias: jest.Mock };
+  let resolveService: { isCustomTierRoutable: jest.Mock };
   let providerParamSpecs: { getCapabilities: jest.Mock };
   let modelsDevSync: { lookupModelCapabilities: jest.Mock };
   let recorder: ProxyMessageRecorder;
@@ -190,7 +190,7 @@ describe('ProxyController', () => {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
     headerTierService = { list: jest.fn().mockResolvedValue([]) };
-    resolveService = { resolveModelAlias: jest.fn().mockResolvedValue({}) };
+    resolveService = { isCustomTierRoutable: jest.fn().mockResolvedValue(true) };
     providerParamSpecs = { getCapabilities: jest.fn().mockResolvedValue(null) };
     modelsDevSync = { lookupModelCapabilities: jest.fn().mockReturnValue(null) };
     observationReporter = { report: jest.fn() };
@@ -260,9 +260,9 @@ describe('ProxyController', () => {
   });
 
   it('should include enabled custom-tier aliases with a configured primary route', async () => {
-    resolveService.resolveModelAlias.mockImplementation(
-      async (_agentId: string, _tenantId: string, alias: string) =>
-        alias === 'free' ? { model: 'gpt-4o-mini' } : null,
+    resolveService.isCustomTierRoutable.mockImplementation(
+      async (_agentId: string, _tenantId: string, tier: { model_alias: string }) =>
+        tier.model_alias === 'free',
     );
     headerTierService.list.mockResolvedValue([
       {
@@ -294,11 +294,11 @@ describe('ProxyController', () => {
       { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
       { id: 'manifest/free', object: 'model', created: 0, owned_by: 'manifest' },
     ]);
-    expect(resolveService.resolveModelAlias).toHaveBeenCalledWith('agent-1', 'tenant-1', 'free');
-    expect(resolveService.resolveModelAlias).toHaveBeenCalledWith(
+    expect(resolveService.isCustomTierRoutable).toHaveBeenCalledTimes(4);
+    expect(resolveService.isCustomTierRoutable).toHaveBeenCalledWith(
       'agent-1',
       'tenant-1',
-      'unavailable',
+      expect.objectContaining({ model_alias: 'free' }),
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -144,6 +144,7 @@ describe('ProxyController', () => {
   let mockPricingCache: { getByModel: jest.Mock };
   let modelDiscovery: { getModelsForAgent: jest.Mock };
   let headerTierService: { list: jest.Mock };
+  let resolveService: { resolveModelAlias: jest.Mock };
   let providerParamSpecs: { getCapabilities: jest.Mock };
   let modelsDevSync: { lookupModelCapabilities: jest.Mock };
   let recorder: ProxyMessageRecorder;
@@ -189,6 +190,7 @@ describe('ProxyController', () => {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
     headerTierService = { list: jest.fn().mockResolvedValue([]) };
+    resolveService = { resolveModelAlias: jest.fn().mockResolvedValue({}) };
     providerParamSpecs = { getCapabilities: jest.fn().mockResolvedValue(null) };
     modelsDevSync = { lookupModelCapabilities: jest.fn().mockReturnValue(null) };
     observationReporter = { report: jest.fn() };
@@ -227,6 +229,7 @@ describe('ProxyController', () => {
       new ReasoningContentCache(),
       modelDiscovery as never,
       headerTierService as never,
+      resolveService as never,
       planService as never,
       observationReporter as never,
       providerParamSpecs as never,
@@ -257,11 +260,21 @@ describe('ProxyController', () => {
   });
 
   it('should include enabled custom-tier aliases with a configured primary route', async () => {
+    resolveService.resolveModelAlias.mockImplementation(
+      async (_agentId: string, _tenantId: string, alias: string) =>
+        alias === 'free' ? { model: 'gpt-4o-mini' } : null,
+    );
     headerTierService.list.mockResolvedValue([
       {
         model_alias: 'free',
         enabled: true,
         override_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o-mini' },
+        fallback_routes: null,
+      },
+      {
+        model_alias: 'unavailable',
+        enabled: true,
+        override_route: { provider: 'openai', authType: 'api_key', model: 'missing' },
         fallback_routes: null,
       },
       {
@@ -281,6 +294,12 @@ describe('ProxyController', () => {
       { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
       { id: 'manifest/free', object: 'model', created: 0, owned_by: 'manifest' },
     ]);
+    expect(resolveService.resolveModelAlias).toHaveBeenCalledWith('agent-1', 'tenant-1', 'free');
+    expect(resolveService.resolveModelAlias).toHaveBeenCalledWith(
+      'agent-1',
+      'tenant-1',
+      'unavailable',
+    );
   });
 
   it('should include authenticated agent models using provider-qualified ids', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -130,6 +130,7 @@ describe('ProxyController streaming abort', () => {
       new ReasoningContentCache(),
       modelDiscovery as never,
       { list: jest.fn().mockResolvedValue([]) } as never,
+      { resolveModelAlias: jest.fn().mockResolvedValue(null) } as never,
       { assertWithinRequestLimit: jest.fn().mockResolvedValue(undefined) } as never,
       { report: jest.fn() } as never,
       { getCapabilities: jest.fn().mockResolvedValue(null) } as never,

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -130,7 +130,7 @@ describe('ProxyController streaming abort', () => {
       new ReasoningContentCache(),
       modelDiscovery as never,
       { list: jest.fn().mockResolvedValue([]) } as never,
-      { resolveModelAlias: jest.fn().mockResolvedValue(null) } as never,
+      { isCustomTierRoutable: jest.fn().mockResolvedValue(false) } as never,
       { assertWithinRequestLimit: jest.fn().mockResolvedValue(undefined) } as never,
       { report: jest.fn() } as never,
       { getCapabilities: jest.fn().mockResolvedValue(null) } as never,

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -129,6 +129,7 @@ describe('ProxyController streaming abort', () => {
       new ThinkingBlockCache(),
       new ReasoningContentCache(),
       modelDiscovery as never,
+      { list: jest.fn().mockResolvedValue([]) } as never,
       { assertWithinRequestLimit: jest.fn().mockResolvedValue(undefined) } as never,
       { report: jest.fn() } as never,
       { getCapabilities: jest.fn().mockResolvedValue(null) } as never,

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -86,7 +86,12 @@ describe('ProxyService — orchestration', () => {
   let resolveService: jest.Mocked<
     Pick<
       ResolveService,
-      'resolve' | 'resolveLazy' | 'resolveForTier' | 'resolveHeaderTier' | 'pinRouteKeyLabel'
+      | 'resolve'
+      | 'resolveLazy'
+      | 'resolveForTier'
+      | 'resolveHeaderTier'
+      | 'resolveModelAlias'
+      | 'pinRouteKeyLabel'
     >
   >;
   let providerKeyService: jest.Mocked<
@@ -144,6 +149,7 @@ describe('ProxyService — orchestration', () => {
       }),
       resolveForTier: jest.fn(),
       resolveHeaderTier: jest.fn().mockResolvedValue(null),
+      resolveModelAlias: jest.fn().mockResolvedValue(null),
       // Default: no connection pin configured — the route passes through.
       // Tests that exercise pinning override this per case.
       pinRouteKeyLabel: jest.fn(async (_agentId, _tenantId, route: ModelRoute) => route),
@@ -1260,6 +1266,54 @@ describe('ProxyService — orchestration', () => {
         }),
       );
     });
+
+    it('routes a custom model alias ahead of a conflicting header rule', async () => {
+      resolveService.resolveModelAlias.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o-mini'),
+        fallback_routes: [route('anthropic', 'api_key', 'claude-haiku-4-5')],
+        confidence: 1,
+        score: 0,
+        reason: 'model-alias',
+        header_tier_id: 'ht-free',
+        header_tier_name: 'Free',
+      });
+
+      const result = await svc.proxyRequest(
+        baseOpts({
+          body: { model: 'manifest/free', messages: [{ role: 'user', content: 'hi' }] },
+          headers: { 'x-manifest-tier': 'premium' },
+        }),
+      );
+
+      expect(resolveService.resolveModelAlias).toHaveBeenCalledWith('agent-1', 'tenant-1', 'free');
+      expect(resolveService.resolveHeaderTier).not.toHaveBeenCalled();
+      expect(modelDiscovery.getModelsForAgent).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openai', model: 'gpt-4o-mini' }),
+      );
+      expect(result.meta).toMatchObject({
+        tier: 'standard',
+        reason: 'model-alias',
+        header_tier_id: 'ht-free',
+      });
+    });
+
+    it.each(['manifest/missing', 'manifest/auto', 'manifest/'])(
+      'returns model-not-available for the unknown or reserved alias %s',
+      async (model) => {
+        const result = await svc.proxyRequest(
+          baseOpts({ body: { model, messages: [{ role: 'user', content: 'hi' }] } }),
+        );
+        const responseBody = await result.forward.response.text();
+
+        expect(responseBody).toContain('M302');
+        expect(responseBody).toContain(model);
+        expect(modelDiscovery.getModelsForAgent).not.toHaveBeenCalled();
+        expect(providerKeyService.hasRouteCredentials).not.toHaveBeenCalled();
+        expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      },
+    );
 
     it('routes a bare provider-native model name to the one connection carrying it', async () => {
       modelDiscovery.getModelsForAgent.mockResolvedValue([

--- a/packages/backend/src/routing/proxy/openai-model-id.ts
+++ b/packages/backend/src/routing/proxy/openai-model-id.ts
@@ -3,6 +3,7 @@ import type { DiscoveredModel } from '../../model-discovery/model-fetcher';
 import { unambiguousRoute } from '../routing-core/route-helpers';
 
 export const OPENAI_MODEL_ID_AUTO = 'auto';
+export const MANIFEST_MODEL_ID_PREFIX = 'manifest/';
 export const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
 
 export interface ExplicitModelRouteCandidate {
@@ -21,6 +22,16 @@ export function openAiModelId(model: DiscoveredModel): string {
     return routeId;
   }
   return `${routeId}${SUBSCRIPTION_MODEL_SUFFIX}`;
+}
+
+export function manifestModelId(alias: string): string {
+  return `${MANIFEST_MODEL_ID_PREFIX}${alias}`;
+}
+
+export function modelAliasFromManifestId(modelId: string): string | null {
+  if (!modelId.startsWith(MANIFEST_MODEL_ID_PREFIX)) return null;
+  const alias = modelId.slice(MANIFEST_MODEL_ID_PREFIX.length);
+  return alias || null;
 }
 
 /**

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -175,15 +175,20 @@ export class ProxyController {
     ];
     const seen = new Set(data.map((model) => model.id));
 
-    for (const tier of customTiers) {
-      if (!tier.enabled || !tier.model_alias || tier.override_route === null) continue;
-      const resolved = await this.resolveService.resolveModelAlias(
-        req.ingestionContext.agentId,
-        req.ingestionContext.tenantId,
-        tier.model_alias,
-      );
-      if (!resolved) continue;
-      const id = manifestModelId(tier.model_alias);
+    const aliasTiers = customTiers.filter((tier) => tier.enabled && tier.model_alias);
+    const routableAliases = await Promise.all(
+      aliasTiers.map((tier) =>
+        this.resolveService.isCustomTierRoutable(
+          req.ingestionContext.agentId,
+          req.ingestionContext.tenantId,
+          tier,
+        ),
+      ),
+    );
+    for (const [index, tier] of aliasTiers.entries()) {
+      const alias = tier.model_alias;
+      if (!alias || !routableAliases[index]) continue;
+      const id = manifestModelId(alias);
       if (seen.has(id)) continue;
       seen.add(id);
       data.push({

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -27,6 +27,7 @@ import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { HeaderTierService } from '../header-tiers/header-tier.service';
+import { ResolveService } from '../resolve/resolve.service';
 import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
 import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { resolveModelCapabilityMetadata } from '../../model-discovery/model-capabilities';
@@ -136,6 +137,7 @@ export class ProxyController {
     private readonly reasoningCache: ReasoningContentCache,
     private readonly modelDiscovery: ModelDiscoveryService,
     private readonly headerTierService: HeaderTierService,
+    private readonly resolveService: ResolveService,
     private readonly planService: PlanService,
     private readonly observationReporter: ObservationReporter,
     private readonly providerParamSpecs: ProviderParamSpecService,
@@ -175,6 +177,12 @@ export class ProxyController {
 
     for (const tier of customTiers) {
       if (!tier.enabled || !tier.model_alias || tier.override_route === null) continue;
+      const resolved = await this.resolveService.resolveModelAlias(
+        req.ingestionContext.agentId,
+        req.ingestionContext.tenantId,
+        tier.model_alias,
+      );
+      if (!resolved) continue;
       const id = manifestModelId(tier.model_alias);
       if (seen.has(id)) continue;
       seen.add(id);

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -26,6 +26,7 @@ import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { HeaderTierService } from '../header-tiers/header-tier.service';
 import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
 import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { resolveModelCapabilityMetadata } from '../../model-discovery/model-capabilities';
@@ -61,7 +62,7 @@ import type {
 } from './proxy-types';
 import { ResponsesSseError } from './chatgpt-adapter';
 import { redactInlineImageDataUrls } from './inline-image-redaction';
-import { openAiModelId } from './openai-model-id';
+import { manifestModelId, openAiModelId } from './openai-model-id';
 import { openAiModelCapabilities, type OpenAiModelCapabilities } from './openai-model-capabilities';
 import { PlanService } from '../../billing/plan.service';
 import { StreamFailure } from './stream-writer';
@@ -134,6 +135,7 @@ export class ProxyController {
     private readonly thinkingCache: ThinkingBlockCache,
     private readonly reasoningCache: ReasoningContentCache,
     private readonly modelDiscovery: ModelDiscoveryService,
+    private readonly headerTierService: HeaderTierService,
     private readonly planService: PlanService,
     private readonly observationReporter: ObservationReporter,
     private readonly providerParamSpecs: ProviderParamSpecService,
@@ -152,10 +154,13 @@ export class ProxyController {
   ): Promise<OpenAiModelList> {
     const includeCapabilities = capabilities === 'true';
     const includeCost = cost === 'true';
-    const models = await this.modelDiscovery.getModelsForAgent(
-      req.ingestionContext.tenantId,
-      req.ingestionContext.agentId,
-    );
+    const [models, customTiers] = await Promise.all([
+      this.modelDiscovery.getModelsForAgent(
+        req.ingestionContext.tenantId,
+        req.ingestionContext.agentId,
+      ),
+      this.headerTierService.list(req.ingestionContext.agentId),
+    ]);
     // The synthetic `auto` route never carries metadata — it resolves to a
     // different concrete model per request, so any claim would be wrong.
     const data: OpenAiModelObject[] = [
@@ -167,6 +172,19 @@ export class ProxyController {
       },
     ];
     const seen = new Set(data.map((model) => model.id));
+
+    for (const tier of customTiers) {
+      if (!tier.enabled || !tier.model_alias || tier.override_route === null) continue;
+      const id = manifestModelId(tier.model_alias);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      data.push({
+        id,
+        object: 'model',
+        created: MODEL_CREATED_UNKNOWN,
+        owned_by: 'manifest',
+      });
+    }
 
     for (const model of models) {
       const id = openAiModelId(model);

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -64,6 +64,8 @@ import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
 import { effectiveRoutesForResponseMode } from '../routing-core/response-mode-guard';
 import {
   explicitModelRouteCandidate,
+  MANIFEST_MODEL_ID_PREFIX,
+  modelAliasFromManifestId,
   OPENAI_MODEL_ID_AUTO,
   routeForOpenAiModelId,
   SUBSCRIPTION_MODEL_SUFFIX,
@@ -897,22 +899,24 @@ export class ProxyService {
     apiMode: ProxyApiMode,
   ): Promise<ResolvedRouting> {
     const requestedModel = typeof body.model === 'string' ? body.model : undefined;
+    // `manifest/*` is a reserved routing namespace. Resolve it before header
+    // rules and provider-qualified IDs so explicit route intent wins, and an
+    // unknown alias cannot be mistaken for a provider named "manifest".
+    if (requestedModel?.startsWith(MANIFEST_MODEL_ID_PREFIX)) {
+      const alias = modelAliasFromManifestId(requestedModel);
+      const customRoute = alias
+        ? await this.resolveService.resolveModelAlias(agentId, tenantId, alias)
+        : null;
+      if (customRoute?.route) return customRoute;
+      return this.unavailableExplicitModel(requestedModel);
+    }
     // Every public proxy surface treats a concrete model as an explicit route.
     // The resolver accepts both provider-qualified /v1/models IDs and the
     // unambiguous provider-native IDs required by Anthropic clients.
     if (requestedModel && requestedModel !== OPENAI_MODEL_ID_AUTO) {
       const explicit = await this.resolveExplicitModel(agentId, tenantId, requestedModel, headers);
       if (explicit) return explicit;
-      return {
-        tier: 'default' as const,
-        route: null,
-        fallback_routes: null,
-        response_mode: DEFAULT_RESPONSE_MODE,
-        confidence: 0,
-        score: 0,
-        reason: 'default' as const,
-        explicit_model_unavailable: requestedModel,
-      };
+      return this.unavailableExplicitModel(requestedModel);
     }
 
     const isHeartbeat = this.detectHeartbeatBody(body, apiMode);
@@ -949,6 +953,19 @@ export class ProxyService {
         ));
 
     return baseResolved;
+  }
+
+  private unavailableExplicitModel(requestedModel: string): ResolvedRouting {
+    return {
+      tier: 'default',
+      route: null,
+      fallback_routes: null,
+      response_mode: DEFAULT_RESPONSE_MODE,
+      confidence: 0,
+      score: 0,
+      reason: 'default',
+      explicit_model_unavailable: requestedModel,
+    };
   }
 
   /**

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -488,6 +488,45 @@ describe('ResolveService', () => {
     });
   });
 
+  describe('isCustomTierRoutable', () => {
+    const primary = route('openai', 'api_key', 'gpt-4o-mini');
+    const fallback = route('anthropic', 'api_key', 'claude-haiku');
+
+    it('returns false without a configured primary route', async () => {
+      const tier = { override_route: null, fallback_routes: [fallback] } as HeaderTier;
+
+      await expect(svc.isCustomTierRoutable('agent-1', 'tenant-1', tier)).resolves.toBe(false);
+      expect(providerKeyService.isRouteAvailable).not.toHaveBeenCalled();
+    });
+
+    it('returns true when the primary route is available', async () => {
+      const tier = { override_route: primary, fallback_routes: [fallback] } as HeaderTier;
+
+      await expect(svc.isCustomTierRoutable('agent-1', 'tenant-1', tier)).resolves.toBe(true);
+      expect(providerKeyService.isRouteAvailable).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks fallbacks until it finds an available route', async () => {
+      const tier = { override_route: primary, fallback_routes: [fallback] } as HeaderTier;
+      providerKeyService.isRouteAvailable.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+      await expect(svc.isCustomTierRoutable('agent-1', 'tenant-1', tier)).resolves.toBe(true);
+      expect(providerKeyService.isRouteAvailable).toHaveBeenNthCalledWith(
+        2,
+        'tenant-1',
+        fallback,
+        'agent-1',
+      );
+    });
+
+    it('returns false when every configured route is unavailable', async () => {
+      const tier = { override_route: primary, fallback_routes: [fallback] } as HeaderTier;
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+
+      await expect(svc.isCustomTierRoutable('agent-1', 'tenant-1', tier)).resolves.toBe(false);
+    });
+  });
+
   describe('resolveProviderForModel paths (via header tier with bare model)', () => {
     // Provider field is empty (falsy) so resolveProviderForModel runs via the
     // `||` short-circuit. authType is a real value so the route can be built

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -442,6 +442,52 @@ describe('ResolveService', () => {
     });
   });
 
+  describe('resolveModelAlias', () => {
+    const aliasTier = {
+      id: 'h1',
+      name: 'Free',
+      model_alias: 'free',
+      header_key: 'x-tier',
+      header_value: 'free',
+      enabled: true,
+      badge_color: 'emerald',
+      override_route: route('openai', 'api_key', 'gpt-4o-mini'),
+      fallback_routes: null,
+    } as unknown as HeaderTier;
+
+    it('returns the enabled custom tier with model-alias attribution', async () => {
+      headerTierService.list.mockResolvedValue([aliasTier]);
+
+      const result = await svc.resolveModelAlias('agent-1', 'tenant-1', 'free');
+
+      expect(result).toMatchObject({
+        reason: 'model-alias',
+        route: route('openai', 'api_key', 'gpt-4o-mini'),
+        header_tier_id: 'h1',
+        header_tier_name: 'Free',
+        header_tier_color: 'emerald',
+      });
+    });
+
+    it('requires an exact, enabled alias', async () => {
+      headerTierService.list.mockResolvedValue([
+        aliasTier,
+        { ...aliasTier, id: 'h2', model_alias: 'disabled', enabled: false },
+      ]);
+
+      await expect(svc.resolveModelAlias('agent-1', 'tenant-1', 'Free')).resolves.toBeNull();
+      await expect(svc.resolveModelAlias('agent-1', 'tenant-1', 'disabled')).resolves.toBeNull();
+      await expect(svc.resolveModelAlias('agent-1', 'tenant-1', 'missing')).resolves.toBeNull();
+    });
+
+    it('returns null when the selected tier has no available route', async () => {
+      headerTierService.list.mockResolvedValue([aliasTier]);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+
+      await expect(svc.resolveModelAlias('agent-1', 'tenant-1', 'free')).resolves.toBeNull();
+    });
+  });
+
   describe('resolveProviderForModel paths (via header tier with bare model)', () => {
     // Provider field is empty (falsy) so resolveProviderForModel runs via the
     // `||` short-circuit. authType is a real value so the route can be built

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -263,10 +263,35 @@ export class ResolveService {
     const match = tiers.find((t) => matchesHeaderRule(headers, t));
     if (!match) return null;
 
+    return this.resolveCustomTier(agentId, tenantId, match, 'header-match', 'header');
+  }
+
+  /** Resolve an explicit `manifest/<alias>` model to its custom tier. */
+  async resolveModelAlias(
+    agentId: string,
+    tenantId: string,
+    alias: string,
+  ): Promise<ResolveResponse | null> {
+    const tiers = await this.headerTierService.list(agentId);
+    const match = tiers.find((tier) => tier.enabled && tier.model_alias === alias);
+    if (!match) return null;
+
+    return this.resolveCustomTier(agentId, tenantId, match, 'model-alias', 'model alias');
+  }
+
+  private async resolveCustomTier(
+    agentId: string,
+    tenantId: string,
+    match: HeaderTier,
+    reason: 'header-match' | 'model-alias',
+    trigger: 'header' | 'model alias',
+  ): Promise<ResolveResponse | null> {
     const overrideRoute = readOverrideRoute(match);
     if (!overrideRoute) {
       this.logger.debug(
-        `Header tier "${match.name}" matched but has no model configured — falling through`,
+        reason === 'header-match'
+          ? `Header tier "${match.name}" matched but has no model configured — falling through`
+          : `Custom tier "${match.name}" selected by ${trigger} but has no model configured`,
       );
       return null;
     }
@@ -283,8 +308,11 @@ export class ResolveService {
       // An explicitly configured tier shouldn't die with its primary: promote
       // the first available fallback instead of abandoning the whole tier.
       this.logger.warn(
-        `Header tier "${match.name}" override ${overrideRoute.model} is unavailable ` +
-          `for agent=${agentId} — trying the tier's fallbacks`,
+        reason === 'header-match'
+          ? `Header tier "${match.name}" override ${overrideRoute.model} is unavailable ` +
+              `for agent=${agentId} — trying the tier's fallbacks`
+          : `Custom tier "${match.name}" override ${overrideRoute.model} is unavailable ` +
+              `for agent=${agentId} — trying the tier's fallbacks`,
       );
       primaryOverride = null;
       const candidates = fallbackRoutes ?? [];
@@ -298,8 +326,11 @@ export class ResolveService {
       }
       if (!primaryOverride) {
         this.logger.warn(
-          `Header tier "${match.name}" has no available route ` +
-            `for agent=${agentId}; falling through to existing routing`,
+          reason === 'header-match'
+            ? `Header tier "${match.name}" has no available route ` +
+                `for agent=${agentId}; falling through to existing routing`
+            : `Custom tier "${match.name}" selected by ${trigger} has no available route ` +
+                `for agent=${agentId}`,
         );
         return null;
       }
@@ -329,7 +360,7 @@ export class ResolveService {
       response_mode: responseMode,
       confidence: 1,
       score: 0,
-      reason: 'header-match',
+      reason,
       header_tier_id: match.id,
       header_tier_name: match.name,
       header_tier_color: match.badge_color,

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -279,6 +279,21 @@ export class ResolveService {
     return this.resolveCustomTier(agentId, tenantId, match, 'model-alias', 'model alias');
   }
 
+  /** Check whether a loaded custom tier has an available primary or fallback route. */
+  async isCustomTierRoutable(
+    agentId: string,
+    tenantId: string,
+    tier: HeaderTier,
+  ): Promise<boolean> {
+    const primary = readOverrideRoute(tier);
+    if (!primary) return false;
+    const routes = [primary, ...(readFallbackRoutes(tier) ?? [])];
+    for (const route of routes) {
+      if (await this.providerKeyService.isRouteAvailable(tenantId, route, agentId)) return true;
+    }
+    return false;
+  }
+
   private async resolveCustomTier(
     agentId: string,
     tenantId: string,

--- a/packages/backend/src/scoring/types.ts
+++ b/packages/backend/src/scoring/types.ts
@@ -47,7 +47,8 @@ export type ScoringReason =
   | 'heartbeat'
   | 'specificity'
   | 'default'
-  | 'header-match';
+  | 'header-match'
+  | 'model-alias';
 
 export interface DimensionScore {
   name: string;

--- a/packages/frontend/src/components/FrameworkSnippets.tsx
+++ b/packages/frontend/src/components/FrameworkSnippets.tsx
@@ -28,6 +28,8 @@ interface Props {
    * Used by the header-tier "How to send this" modal.
    */
   customHeaders?: Record<string, string>;
+  /** Model id rendered in request snippets. Defaults to Manifest's `auto`. */
+  model?: string;
 }
 
 const EyeOpen: Component = () => (
@@ -104,6 +106,7 @@ const FrameworkSnippets: Component<Props> = (props) => {
       openaiLang(),
       props.customHeaders,
       openaiApi(),
+      props.model,
     );
   const snippetForCopy = () =>
     getSnippetForToolkit(
@@ -113,6 +116,7 @@ const FrameworkSnippets: Component<Props> = (props) => {
       openaiLang(),
       props.customHeaders,
       openaiApi(),
+      props.model,
     );
   const language = () => getLangForToolkit(activeTab(), openaiLang());
 
@@ -243,8 +247,8 @@ const FrameworkSnippets: Component<Props> = (props) => {
         <div class="setup-onboard-fields__row" role="listitem">
           <span class="setup-onboard-fields__label">Model</span>
           <span class="setup-onboard-fields__value">
-            <code>auto</code>
-            <CopyButton text="auto" />
+            <code>{props.model ?? 'auto'}</code>
+            <CopyButton text={props.model ?? 'auto'} />
           </span>
         </div>
         <For each={headerEntries()}>

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -310,7 +310,7 @@ const HeaderTierCard: Component<Props> = (props) => {
                     setSnippetOpen(true);
                   }}
                 >
-                  Send this header
+                  How to route
                 </button>
                 <Show when={props.onEdit}>
                   <button
@@ -372,12 +372,21 @@ const HeaderTierCard: Component<Props> = (props) => {
         </Show>
       </div>
 
-      <code
-        class="header-tier-card__rule"
-        title={`${props.tier.header_key}: ${props.tier.header_value}`}
-      >
-        {props.tier.header_key}: {props.tier.header_value}
-      </code>
+      <div class="header-tier-card__rules">
+        <Show when={props.tier.model_alias}>
+          {(alias) => (
+            <code class="header-tier-card__rule" title={`model: manifest/${alias()}`}>
+              model: manifest/{alias()}
+            </code>
+          )}
+        </Show>
+        <code
+          class="header-tier-card__rule"
+          title={`${props.tier.header_key}: ${props.tier.header_value}`}
+        >
+          {props.tier.header_key}: {props.tier.header_value}
+        </code>
+      </div>
 
       <div class="routing-card__body">
         <Show when={currentModel()}>

--- a/packages/frontend/src/components/HeaderTierModal.tsx
+++ b/packages/frontend/src/components/HeaderTierModal.tsx
@@ -304,7 +304,13 @@ const HeaderTierModal: Component<Props> = (props) => {
           onInput={(e) => {
             const nextName = e.currentTarget.value;
             setName(nextName);
-            if (!modelAliasTouched()) setModelAlias(suggestedModelAlias(nextName));
+            if (!modelAliasTouched()) {
+              const suggestion = suggestedModelAlias(nextName);
+              const unavailable =
+                suggestion === 'auto' ||
+                otherTiers().some((tier) => tier.model_alias === suggestion);
+              setModelAlias(unavailable ? '' : suggestion);
+            }
           }}
         />
         <Show when={nameError()}>

--- a/packages/frontend/src/components/HeaderTierModal.tsx
+++ b/packages/frontend/src/components/HeaderTierModal.tsx
@@ -20,8 +20,21 @@ const RESERVED_KEYS = new Set([
   'x-api-key',
 ]);
 const HEADER_KEY_RE = /^[a-z0-9-]+$/;
+const MODEL_ALIAS_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const MAX_NAME_LEN = 32;
+const MAX_MODEL_ALIAS_LEN = 48;
 const MAX_HEADER_VALUE_LEN = 128;
+
+function suggestedModelAlias(name: string): string {
+  return name
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_MODEL_ALIAS_LEN)
+    .replace(/-+$/g, '');
+}
 
 interface Props {
   agentName: string;
@@ -42,6 +55,8 @@ const HeaderTierModal: Component<Props> = (props) => {
   const editingTier = props.editing;
 
   const [name, setName] = createSignal(editingTier?.name ?? '');
+  const [modelAlias, setModelAlias] = createSignal(editingTier?.model_alias ?? '');
+  const [modelAliasTouched, setModelAliasTouched] = createSignal(editingTier !== undefined);
   const [headerKey, setHeaderKey] = createSignal(editingTier?.header_key ?? '');
   const [headerValue, setHeaderValue] = createSignal(editingTier?.header_value ?? '');
   const [badgeColor, setBadgeColor] = createSignal<TierColor>(
@@ -130,6 +145,22 @@ const HeaderTierModal: Component<Props> = (props) => {
     return undefined;
   };
 
+  const validateModelAlias = (raw: string): string | undefined => {
+    const alias = raw.trim();
+    if (!alias) return undefined;
+    if (alias.length > MAX_MODEL_ALIAS_LEN) {
+      return `Model alias must be ${MAX_MODEL_ALIAS_LEN} characters or fewer`;
+    }
+    if (alias === 'auto') return 'The model alias "auto" is reserved by Manifest';
+    if (!MODEL_ALIAS_RE.test(alias)) {
+      return 'Use lowercase letters, numbers, and single hyphens only';
+    }
+    if (otherTiers().some((tier) => tier.model_alias === alias)) {
+      return 'Another tier already uses this model alias';
+    }
+    return undefined;
+  };
+
   const validateValue = (rawValue: string, rawKey: string): string | undefined => {
     const v = rawValue.trim();
     if (!v) return 'Header value is required';
@@ -150,12 +181,15 @@ const HeaderTierModal: Component<Props> = (props) => {
   };
 
   const nameError = (): string | undefined => (triedSubmit() ? validateName(name()) : undefined);
+  const modelAliasError = (): string | undefined =>
+    triedSubmit() ? validateModelAlias(modelAlias()) : undefined;
   const keyError = (): string | undefined => (triedSubmit() ? validateKey(headerKey()) : undefined);
   const valueError = (): string | undefined =>
     triedSubmit() ? validateValue(headerValue(), headerKey()) : undefined;
 
   const isValid = (): boolean =>
     validateName(name()) === undefined &&
+    validateModelAlias(modelAlias()) === undefined &&
     validateKey(headerKey()) === undefined &&
     validateValue(headerValue(), headerKey()) === undefined;
 
@@ -166,6 +200,7 @@ const HeaderTierModal: Component<Props> = (props) => {
     try {
       const payload = {
         name: name().trim(),
+        model_alias: modelAlias().trim() || null,
         header_key: headerKey().trim().toLowerCase(),
         header_value: headerValue().trim(),
         badge_color: badgeColor(),
@@ -190,8 +225,8 @@ const HeaderTierModal: Component<Props> = (props) => {
 
   const titleText = editingTier ? 'Edit custom tier' : 'Create custom tier';
   const descText = editingTier
-    ? 'Update the header rule, name, or color for this tier. Model and fallbacks are managed on the card.'
-    : 'Custom routing lets you identify requests based on their headers and assign specific models to them.';
+    ? 'Update the model alias, header rule, name, or color for this tier. Model and fallbacks are managed on the card.'
+    : 'Custom routing lets you select a model chain with a stable model alias or a matching request header.';
   const submitLabel = (): string => {
     if (editingTier) return submitting() ? 'Saving…' : 'Save changes';
     return submitting() ? 'Creating…' : 'Create tier';
@@ -266,11 +301,45 @@ const HeaderTierModal: Component<Props> = (props) => {
           value={name()}
           placeholder="My custom tier"
           maxlength={MAX_NAME_LEN}
-          onInput={(e) => setName(e.currentTarget.value)}
+          onInput={(e) => {
+            const nextName = e.currentTarget.value;
+            setName(nextName);
+            if (!modelAliasTouched()) setModelAlias(suggestedModelAlias(nextName));
+          }}
         />
         <Show when={nameError()}>
           <div class="header-tier-modal__error">{nameError()}</div>
         </Show>
+
+        <label class="modal-card__field-label" for="header-tier-model-alias">
+          Model alias <span class="header-tier-modal__optional">Optional</span>
+        </label>
+        <input
+          id="header-tier-model-alias"
+          class="modal-card__input"
+          classList={{ 'modal-card__input--error': modelAliasError() !== undefined }}
+          type="text"
+          value={modelAlias()}
+          placeholder="free"
+          maxlength={MAX_MODEL_ALIAS_LEN}
+          onInput={(e) => {
+            setModelAliasTouched(true);
+            setModelAlias(e.currentTarget.value);
+          }}
+        />
+        <Show when={modelAliasError()}>
+          <div class="header-tier-modal__error">{modelAliasError()}</div>
+        </Show>
+        <p class="header-tier-modal__hint">
+          {modelAlias().trim() ? (
+            <>
+              Clients can select this tier with <code>model: "manifest/{modelAlias().trim()}"</code>
+              .
+            </>
+          ) : (
+            'Add an alias to select this tier through the request model field.'
+          )}
+        </p>
 
         <label class="modal-card__field-label" for="header-tier-key">
           Header key

--- a/packages/frontend/src/components/HeaderTierSnippetModal.tsx
+++ b/packages/frontend/src/components/HeaderTierSnippetModal.tsx
@@ -1,4 +1,4 @@
-import { type Component, createResource } from 'solid-js';
+import { type Component, createResource, Show } from 'solid-js';
 import FrameworkSnippets from './FrameworkSnippets.jsx';
 import { getAgentKey } from '../services/api.js';
 import type { HeaderTier } from '../services/api/header-tiers.js';
@@ -10,9 +10,9 @@ interface Props {
 }
 
 /**
- * Modal that shows SDK-specific code snippets for sending the tier's matching
- * header. Reuses {@link FrameworkSnippets} (the same tabbed UI used in the
- * onboarding wizard) with `customHeaders` filled from the tier's rule.
+ * Modal that shows SDK-specific code snippets for selecting a custom tier.
+ * Model aliases are preferred when configured; existing header-only tiers keep
+ * their original snippets.
  */
 const HeaderTierSnippetModal: Component<Props> = (props) => {
   const [keyData] = createResource(
@@ -26,9 +26,15 @@ const HeaderTierSnippetModal: Component<Props> = (props) => {
     return `${window.location.origin}/v1`;
   };
 
-  const customHeaders = (): Record<string, string> => ({
-    [props.tier.header_key]: props.tier.header_value,
-  });
+  const modelAlias = (): string | null =>
+    props.tier.model_alias ? `manifest/${props.tier.model_alias}` : null;
+
+  const customHeaders = (): Record<string, string> | undefined =>
+    modelAlias()
+      ? undefined
+      : {
+          [props.tier.header_key]: props.tier.header_value,
+        };
 
   const modelText = (): string =>
     props.tier.override_route?.model ?? 'no model assigned (falls back to default routing)';
@@ -55,7 +61,7 @@ const HeaderTierSnippetModal: Component<Props> = (props) => {
             id="header-tier-snippet-title"
             style="margin: 0; font-size: var(--font-size-lg); font-weight: 600;"
           >
-            Send the “{props.tier.name}” header
+            Route to “{props.tier.name}”
           </h2>
           <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
             <svg
@@ -71,7 +77,20 @@ const HeaderTierSnippetModal: Component<Props> = (props) => {
           </button>
         </div>
         <p class="modal-card__desc" style="margin-top: 0;">
-          Add this header to any request and it'll route to <code>{modelText()}</code>.
+          <Show
+            when={modelAlias()}
+            fallback={
+              <>
+                Add this header to any request and it will route to <code>{modelText()}</code>.
+              </>
+            }
+          >
+            {(alias) => (
+              <>
+                Use <code>{alias()}</code> as the request model. It selects this tier's model chain.
+              </>
+            )}
+          </Show>
         </p>
 
         <FrameworkSnippets
@@ -79,6 +98,7 @@ const HeaderTierSnippetModal: Component<Props> = (props) => {
           keyPrefix={keyData()?.keyPrefix ?? null}
           baseUrl={baseUrl()}
           customHeaders={customHeaders()}
+          model={modelAlias() ?? 'auto'}
         />
 
         <div style="display: flex; justify-content: flex-end; margin-top: 16px;">

--- a/packages/frontend/src/components/RoutingPipelineCard.tsx
+++ b/packages/frontend/src/components/RoutingPipelineCard.tsx
@@ -21,7 +21,7 @@ export function buildPipelineHelp(
     steps.push({
       num: n++,
       name: 'Custom routing',
-      desc: 'If a request header matches a custom tier rule, it is routed to the corresponding model.',
+      desc: 'A Manifest model alias or matching request header selects the corresponding custom model chain.',
     });
   }
 

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -363,7 +363,8 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
           <div class="routing-section__empty">
             <div class="routing-section__empty-title">No custom tiers activated</div>
             <div class="routing-section__empty-desc">
-              Create or activate custom tiers to route matching requests to the models you choose.
+              Create or activate custom tiers to route model aliases or matching request headers to
+              the models you choose.
             </div>
             <button type="button" class="btn btn--primary btn--sm" onClick={openCreateOrManage}>
               {tiers().length > 0 ? 'Manage custom routing' : 'Create custom tier'}

--- a/packages/frontend/src/services/api/header-tiers.ts
+++ b/packages/frontend/src/services/api/header-tiers.ts
@@ -6,6 +6,7 @@ export interface HeaderTier {
   id: string;
   agent_id: string;
   name: string;
+  model_alias: string | null;
   header_key: string;
   header_value: string;
   badge_color: TierColor;
@@ -28,6 +29,7 @@ export interface SeenHeader {
 
 export interface CreateHeaderTierInput {
   name: string;
+  model_alias?: string | null;
   header_key: string;
   header_value: string;
   badge_color: TierColor;

--- a/packages/frontend/src/services/framework-snippets.ts
+++ b/packages/frontend/src/services/framework-snippets.ts
@@ -433,16 +433,17 @@ export function getSnippetsForFramework(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet[] {
   switch (id) {
     case 'python':
-      return getPythonSnippets(baseUrl, apiKey, customHeaders);
+      return getPythonSnippets(baseUrl, apiKey, customHeaders, model);
     case 'typescript':
-      return getTypeScriptSnippets(baseUrl, apiKey, customHeaders);
+      return getTypeScriptSnippets(baseUrl, apiKey, customHeaders, model);
     case 'openclaw':
       return [{ title: 'OpenClaw CLI', code: getOpenClawSnippet(baseUrl, apiKey) }];
     case 'curl':
-      return getCurlSnippet(baseUrl, apiKey, customHeaders);
+      return getCurlSnippet(baseUrl, apiKey, customHeaders, model);
   }
 }
 

--- a/packages/frontend/src/services/framework-snippets.ts
+++ b/packages/frontend/src/services/framework-snippets.ts
@@ -119,8 +119,10 @@ function getOpenAIChatPythonSnippet(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet {
   const openaiHeaders = headerLine(customHeaders, 'py-kwarg', 'default_headers');
+  const modelId = JSON.stringify(model);
   return {
     title: 'Chat Completions',
     code: `from openai import OpenAI
@@ -131,7 +133,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="auto",
+    model=${modelId},
     messages=[{"role": "user", "content": "Hello"}],
 )`,
   };
@@ -141,8 +143,10 @@ function getOpenAIChatTypeScriptSnippet(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet {
   const openaiHeaders = headerLine(customHeaders, 'ts-prop', 'defaultHeaders');
+  const modelId = JSON.stringify(model);
   return {
     title: 'Chat Completions',
     code: `import OpenAI from "openai";
@@ -153,7 +157,7 @@ const client = new OpenAI({
 });
 
 const response = await client.chat.completions.create({
-  model: "auto",
+  model: ${modelId},
   messages: [{ role: "user", content: "Hello" }],
 });`,
   };
@@ -173,9 +177,11 @@ function getAnthropicPythonSnippet(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet {
   const headersLine = headerLine(customHeaders, 'py-kwarg', 'default_headers');
   const url = stripV1Suffix(baseUrl);
+  const modelId = JSON.stringify(model);
   return {
     title: 'Anthropic Python SDK',
     code: `from anthropic import Anthropic
@@ -186,7 +192,7 @@ client = Anthropic(
 )
 
 message = client.messages.create(
-    model="auto",
+    model=${modelId},
     max_tokens=1024,
     messages=[{"role": "user", "content": "Hello"}],
 )`,
@@ -197,9 +203,11 @@ function getAnthropicTypeScriptSnippet(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet {
   const headersLine = headerLine(customHeaders, 'ts-prop', 'defaultHeaders');
   const url = stripV1Suffix(baseUrl);
+  const modelId = JSON.stringify(model);
   return {
     title: 'Anthropic TypeScript SDK',
     code: `import Anthropic from "@anthropic-ai/sdk";
@@ -210,7 +218,7 @@ const client = new Anthropic({
 });
 
 const message = await client.messages.create({
-  model: "auto",
+  model: ${modelId},
   max_tokens: 1024,
   messages: [{ role: "user", content: "Hello" }],
 });`,
@@ -221,9 +229,11 @@ export function getPythonSnippets(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet[] {
   const langchainHeaders = headerLine(customHeaders, 'py-kwarg', 'default_headers');
   const openaiHeaders = headerLine(customHeaders, 'py-kwarg', 'default_headers');
+  const modelId = JSON.stringify(model);
   return [
     {
       title: 'LangChain',
@@ -232,7 +242,7 @@ export function getPythonSnippets(
 llm = ChatOpenAI(
     base_url="${baseUrl}",
     api_key="${apiKey}",
-    model="auto",${langchainHeaders}
+    model=${modelId},${langchainHeaders}
 )`,
     },
     {
@@ -245,7 +255,7 @@ client = OpenAI(
 )
 
 response = client.responses.create(
-    model="auto",
+    model=${modelId},
     input="Hello",
     store=False,
 )`,
@@ -257,8 +267,10 @@ export function getVercelPythonSnippet(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet {
   const headersLine = headerLine(customHeaders, 'py-kwarg', 'default_headers');
+  const modelId = JSON.stringify(model);
   return {
     title: 'Vercel AI SDK (Python)',
     code: `# pip install ai-sdk
@@ -270,7 +282,7 @@ client = AIClient(
 )
 
 response = client.generate_text(
-    model="auto",
+    model=${modelId},
     prompt="Hello",
 )`,
   };
@@ -280,9 +292,11 @@ export function getTypeScriptSnippets(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet[] {
   const vercelHeaders = headerLine(customHeaders, 'ts-prop', 'headers');
   const openaiHeaders = headerLine(customHeaders, 'ts-prop', 'defaultHeaders');
+  const modelId = JSON.stringify(model);
   return [
     {
       title: 'Vercel AI SDK',
@@ -295,7 +309,7 @@ const manifest = createOpenAI({
 });
 
 const { text } = await generateText({
-  model: manifest("auto"),
+  model: manifest(${modelId}),
   prompt: "Hello",
 });`,
     },
@@ -309,7 +323,7 @@ const client = new OpenAI({
 });
 
 const response = await client.responses.create({
-  model: "auto",
+  model: ${modelId},
   input: "Hello",
   store: false,
 });`,
@@ -388,7 +402,9 @@ export function getCurlSnippet(
   baseUrl: string,
   apiKey: string,
   customHeaders?: CustomHeaders,
+  model = 'auto',
 ): Snippet[] {
+  const modelId = JSON.stringify(model);
   // Wrap each header arg in single quotes so embedded double-quotes (already
   // rejected at input validation but defended against here too) can't break
   // out of the shell string.
@@ -404,7 +420,7 @@ export function getCurlSnippet(
   -H "Authorization: Bearer ${apiKey}" \\
   -H "Content-Type: application/json" \\
 ${extraHeaders}  -d '{
-    "model": "auto",
+    "model": ${modelId},
     "input": "Hello",
     "store": false
   }'`,
@@ -473,29 +489,30 @@ export function getSnippetForToolkit(
   openaiLang: OpenAILangId = 'python',
   customHeaders?: CustomHeaders,
   openaiApi: OpenAIApiId = 'responses',
+  model = 'auto',
 ): Snippet {
   switch (id) {
     case 'openai-sdk':
       if (openaiApi === 'chat-completions') {
         return openaiLang === 'python'
-          ? getOpenAIChatPythonSnippet(baseUrl, apiKey, customHeaders)
-          : getOpenAIChatTypeScriptSnippet(baseUrl, apiKey, customHeaders);
+          ? getOpenAIChatPythonSnippet(baseUrl, apiKey, customHeaders, model)
+          : getOpenAIChatTypeScriptSnippet(baseUrl, apiKey, customHeaders, model);
       }
       return openaiLang === 'python'
-        ? getPythonSnippets(baseUrl, apiKey, customHeaders)[1]!
-        : getTypeScriptSnippets(baseUrl, apiKey, customHeaders)[1]!;
+        ? getPythonSnippets(baseUrl, apiKey, customHeaders, model)[1]!
+        : getTypeScriptSnippets(baseUrl, apiKey, customHeaders, model)[1]!;
     case 'anthropic-sdk':
       return openaiLang === 'python'
-        ? getAnthropicPythonSnippet(baseUrl, apiKey, customHeaders)
-        : getAnthropicTypeScriptSnippet(baseUrl, apiKey, customHeaders);
+        ? getAnthropicPythonSnippet(baseUrl, apiKey, customHeaders, model)
+        : getAnthropicTypeScriptSnippet(baseUrl, apiKey, customHeaders, model);
     case 'vercel-ai-sdk':
       return openaiLang === 'python'
-        ? getVercelPythonSnippet(baseUrl, apiKey, customHeaders)
-        : getTypeScriptSnippets(baseUrl, apiKey, customHeaders)[0]!;
+        ? getVercelPythonSnippet(baseUrl, apiKey, customHeaders, model)
+        : getTypeScriptSnippets(baseUrl, apiKey, customHeaders, model)[0]!;
     case 'langchain':
-      return getPythonSnippets(baseUrl, apiKey, customHeaders)[0]!;
+      return getPythonSnippets(baseUrl, apiKey, customHeaders, model)[0]!;
     case 'curl':
-      return getCurlSnippet(baseUrl, apiKey, customHeaders)[0]!;
+      return getCurlSnippet(baseUrl, apiKey, customHeaders, model)[0]!;
   }
 }
 

--- a/packages/frontend/src/styles/routing-header-tiers.css
+++ b/packages/frontend/src/styles/routing-header-tiers.css
@@ -141,8 +141,17 @@
   flex-shrink: 0;
 }
 
-/* Header rule chip (key:value), shown under the title row so the title row
+/* Model alias and header rule, shown under the title row so the title row
    can stay tidy in narrow card widths. */
+.header-tier-card__rules {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-bottom: 8px;
+  max-width: 100%;
+  align-self: flex-start;
+}
+
 .header-tier-card__rule {
   display: inline-block;
   font-family: var(--font-mono);
@@ -150,7 +159,7 @@
   color: hsl(var(--muted-foreground));
   background: none;
   padding: 0;
-  margin-bottom: 8px;
+  margin: 0;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -288,6 +297,19 @@
   font-size: var(--font-size-xs);
   color: hsl(var(--destructive));
   margin-top: 4px;
+}
+
+.header-tier-modal__optional {
+  color: hsl(var(--muted-foreground));
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.header-tier-modal__hint {
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+  margin: 5px 0 0;
 }
 
 /* ── Color swatches ───────────────────────────────── */

--- a/packages/frontend/tests/components/FrameworkSnippets.test.tsx
+++ b/packages/frontend/tests/components/FrameworkSnippets.test.tsx
@@ -410,6 +410,14 @@ describe("FrameworkSnippets", () => {
     expect(container.textContent).not.toContain("Header x-");
   });
 
+  it("renders a custom model in the snippet and connection details", () => {
+    const { container } = render(() => (
+      <FrameworkSnippets {...defaultProps} model="manifest/free" />
+    ));
+    expect(container.textContent).toContain('model="manifest/free"');
+    expect(container.textContent).toContain("manifest/free");
+  });
+
   it("weaves customHeaders into the snippet code (defaultHeaders for OpenAI TS)", () => {
     const { container } = render(() => (
       <FrameworkSnippets

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -209,6 +209,7 @@ const baseTier: HeaderTier = {
   id: 'ht-1',
   agent_id: 'agent-1',
   name: 'Premium',
+  model_alias: 'premium',
   header_key: 'x-manifest-tier',
   header_value: 'premium',
   badge_color: 'indigo',
@@ -308,6 +309,7 @@ describe('HeaderTierCard', () => {
     expect(container.textContent).toContain('Premium');
     expect(container.textContent).toContain('x-manifest-tier');
     expect(container.textContent).toContain('premium');
+    expect(container.textContent).toContain('manifest/premium');
   });
 
   it('renders the override_route.model display label', () => {
@@ -632,10 +634,10 @@ describe('HeaderTierCard', () => {
     fireEvent.click(kebab);
     expect(container.querySelector('.header-tier-card__menu')).not.toBeNull();
     const items = Array.from(container.querySelectorAll('.header-tier-card__menu-item'));
-    expect(items.map((b) => b.textContent)).toEqual(['Send this header', 'Edit tier', 'Disable']);
+    expect(items.map((b) => b.textContent)).toEqual(['How to route', 'Edit tier', 'Disable']);
   });
 
-  it('opens the snippet modal when Send this header is clicked', () => {
+  it('opens the snippet modal when How to route is clicked', () => {
     const { container, queryByTestId } = render(() => (
       <HeaderTierCard
         agentName="demo"
@@ -650,7 +652,7 @@ describe('HeaderTierCard', () => {
     fireEvent.click(container.querySelector('.header-tier-card__icon-btn') as HTMLButtonElement);
     fireEvent.click(
       Array.from(container.querySelectorAll('.header-tier-card__menu-item')).find((b) =>
-        b.textContent?.includes('Send this header'),
+        b.textContent?.includes('How to route'),
       ) as HTMLButtonElement,
     );
     expect(queryByTestId('snippet-modal')).not.toBeNull();

--- a/packages/frontend/tests/components/HeaderTierModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierModal.test.tsx
@@ -60,6 +60,7 @@ const existingTier: HeaderTier = {
   id: "ht-1",
   agent_id: "agent-1",
   name: "Premium",
+  model_alias: "premium",
   header_key: "x-manifest-tier",
   header_value: "premium",
   badge_color: "indigo",
@@ -95,7 +96,9 @@ describe("HeaderTierModal", () => {
       expect(container.querySelector("#header-tier-modal-title")?.textContent).toBe(
         "Create custom tier",
       );
-      expect(container.textContent).toContain("Custom routing lets you identify");
+      expect(container.textContent).toContain(
+        "Custom routing lets you select a model chain with a stable model alias",
+      );
     });
 
     it("renders the close button when no onBack handler is provided", () => {
@@ -213,6 +216,7 @@ describe("HeaderTierModal", () => {
       await waitFor(() => {
         expect(mockCreateHeaderTier).toHaveBeenCalledWith("demo", {
           name: "Premium",
+          model_alias: "premium",
           header_key: "x-manifest-tier",
           header_value: "premium",
           badge_color: "indigo",
@@ -220,6 +224,68 @@ describe("HeaderTierModal", () => {
       });
       expect(onSaved).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
+    });
+
+    it("suggests a stable model alias from the tier name", () => {
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[]}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+
+      fireEvent.input(container.querySelector("#header-tier-name") as HTMLInputElement, {
+        target: { value: "Crème brûlée Fast" },
+      });
+
+      expect(
+        (container.querySelector("#header-tier-model-alias") as HTMLInputElement).value,
+      ).toBe("creme-brulee-fast");
+    });
+
+    it("rejects reserved and duplicate model aliases", async () => {
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[existingTier]}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      fireEvent.input(container.querySelector("#header-tier-name") as HTMLInputElement, {
+        target: { value: "Other" },
+      });
+      fireEvent.input(container.querySelector("#header-tier-model-alias") as HTMLInputElement, {
+        target: { value: "auto" },
+      });
+      fireEvent.input(container.querySelector("#header-tier-key") as HTMLInputElement, {
+        target: { value: "x-other" },
+      });
+      fireEvent.input(container.querySelector("#header-tier-value") as HTMLInputElement, {
+        target: { value: "other" },
+      });
+      const submit = () =>
+        fireEvent.click(
+          Array.from(container.querySelectorAll("button")).find((button) =>
+            button.textContent?.includes("Create tier"),
+          ) as HTMLButtonElement,
+        );
+
+      submit();
+      await waitFor(() => {
+        expect(container.textContent).toContain('The model alias "auto" is reserved');
+      });
+
+      fireEvent.input(container.querySelector("#header-tier-model-alias") as HTMLInputElement, {
+        target: { value: "premium" },
+      });
+      submit();
+      await waitFor(() => {
+        expect(container.textContent).toContain("Another tier already uses this model alias");
+      });
+      expect(mockCreateHeaderTier).not.toHaveBeenCalled();
     });
 
     it("shows a name error when the name is empty after a submission attempt", async () => {
@@ -482,10 +548,39 @@ describe("HeaderTierModal", () => {
       await waitFor(() => {
         expect(mockUpdateHeaderTier).toHaveBeenCalledWith("demo", existingTier.id, {
           name: "Premium",
+          model_alias: "premium",
           header_key: "x-manifest-tier",
           header_value: "premium",
           badge_color: "indigo",
         });
+      });
+    });
+
+    it("does not change the stable model alias when the display name changes", async () => {
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[existingTier]}
+          editing={existingTier}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      fireEvent.input(container.querySelector("#header-tier-name") as HTMLInputElement, {
+        target: { value: "Renamed tier" },
+      });
+      fireEvent.click(
+        Array.from(container.querySelectorAll("button")).find((button) =>
+          button.textContent?.includes("Save changes"),
+        ) as HTMLButtonElement,
+      );
+
+      await waitFor(() => {
+        expect(mockUpdateHeaderTier).toHaveBeenCalledWith(
+          "demo",
+          existingTier.id,
+          expect.objectContaining({ name: "Renamed tier", model_alias: "premium" }),
+        );
       });
     });
 

--- a/packages/frontend/tests/components/HeaderTierModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierModal.test.tsx
@@ -245,6 +245,28 @@ describe("HeaderTierModal", () => {
       ).toBe("creme-brulee-fast");
     });
 
+    it.each([
+      ["Auto", []],
+      ["Premium", [existingTier]],
+    ] as const)("does not suggest an unavailable alias for %s", (tierName, existingTiers) => {
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[...existingTiers]}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+
+      fireEvent.input(container.querySelector("#header-tier-name") as HTMLInputElement, {
+        target: { value: tierName },
+      });
+
+      expect(
+        (container.querySelector("#header-tier-model-alias") as HTMLInputElement).value,
+      ).toBe("");
+    });
+
     it("rejects reserved and duplicate model aliases", async () => {
       const { container } = render(() => (
         <HeaderTierModal

--- a/packages/frontend/tests/components/HeaderTierSnippetModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierSnippetModal.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../src/components/FrameworkSnippets.jsx", () => ({
     baseUrl: string;
     apiKey?: string | null;
     keyPrefix?: string | null;
+    model?: string;
   }) => (
     <div data-testid="framework-snippets">
       <div data-testid="snippets-base-url">{props.baseUrl}</div>
@@ -20,6 +21,7 @@ vi.mock("../../src/components/FrameworkSnippets.jsx", () => ({
       </div>
       <div data-testid="snippets-api-key">{props.apiKey ?? "null"}</div>
       <div data-testid="snippets-key-prefix">{props.keyPrefix ?? "null"}</div>
+      <div data-testid="snippets-model">{props.model ?? "auto"}</div>
     </div>
   ),
 }));
@@ -31,6 +33,7 @@ const baseTier: HeaderTier = {
   id: "ht-1",
   agent_id: "agent-1",
   name: "Premium",
+  model_alias: null,
   header_key: "x-manifest-tier",
   header_value: "premium",
   badge_color: "indigo",
@@ -86,6 +89,19 @@ describe("HeaderTierSnippetModal", () => {
       string
     >;
     expect(headers).toEqual({ "x-manifest-tier": "premium" });
+  });
+
+  it("uses the stable model alias instead of a custom header when configured", () => {
+    const tier = { ...baseTier, model_alias: "premium" };
+    const { getByTestId, container } = render(() => (
+      <HeaderTierSnippetModal agentName="demo" tier={tier} onClose={vi.fn()} />
+    ));
+
+    expect(getByTestId("snippets-model").textContent).toBe("manifest/premium");
+    expect(getByTestId("snippets-custom-headers").textContent).toBe("null");
+    expect(container.querySelector(".modal-card__desc")?.textContent).toContain(
+      "manifest/premium",
+    );
   });
 
   it("uses window.location.origin + /v1 as the base URL on non-app.manifest.build hosts", () => {

--- a/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
@@ -165,6 +165,7 @@ const tier1: HeaderTier = {
   id: 'ht-1',
   agent_id: 'a',
   name: 'Premium',
+  model_alias: 'premium',
   header_key: 'x-tier',
   header_value: 'premium',
   badge_color: 'indigo',
@@ -179,6 +180,7 @@ const tier2: HeaderTier = {
   ...tier1,
   id: 'ht-2',
   name: 'Free',
+  model_alias: null,
   header_value: 'free',
   enabled: false,
 };

--- a/packages/frontend/tests/services/framework-snippets.test.ts
+++ b/packages/frontend/tests/services/framework-snippets.test.ts
@@ -397,6 +397,20 @@ describe("getSnippetsForFramework", () => {
     expect(result).toHaveLength(1);
     expect(result[0].title).toBe("cURL");
   });
+
+  it.each(["python", "typescript", "curl"] as const)(
+    "forwards the selected model to %s snippets",
+    (framework) => {
+      const result = getSnippetsForFramework(
+        framework,
+        "http://x/v1",
+        "key",
+        undefined,
+        "manifest/free",
+      );
+      expect(result.every((snippet) => snippet.code.includes("manifest/free"))).toBe(true);
+    },
+  );
 });
 
 describe("getSnippetForToolkit", () => {

--- a/packages/frontend/tests/services/framework-snippets.test.ts
+++ b/packages/frontend/tests/services/framework-snippets.test.ts
@@ -668,4 +668,20 @@ describe("customHeaders weaving", () => {
     const s = getSnippetForToolkit("curl", "https://api.local/v1", "k", "python", headers);
     expect(s.code).toContain("-H 'x-manifest-tier: premium'");
   });
+
+  it.each(["openai-sdk", "anthropic-sdk", "vercel-ai-sdk", "langchain", "curl"] as const)(
+    "getSnippetForToolkit renders a custom model id for %s",
+    (toolkit) => {
+      const s = getSnippetForToolkit(
+        toolkit,
+        "https://api.local/v1",
+        "k",
+        "python",
+        undefined,
+        "responses",
+        "manifest/free",
+      );
+      expect(s.code).toContain('"manifest/free"');
+    },
+  );
 });


### PR DESCRIPTION
### ✨ What changed
- Add stable `manifest/<alias>` IDs to custom routing tiers.
- Reserve the namespace and reject unavailable aliases with `M302`.
- List enabled aliases in `/v1/models` and dashboard snippets.

### 💭 Why
SDKs require a model value, so custom routes depended on extra request headers.

### 👤 For users
Custom tiers can now be selected through the model field without removing header rules.

### 🔧 For operators
The deployment adds a nullable `header_tiers.model_alias` column and scoped unique index.

### 📝 Notes
Closes #2091
