### PR TITLE
fix: Anthropic server tools get parameters when forwarded to chat-completions providers

### DIFF
--- a/.changeset/anthropic-server-tool-parameters.md
+++ b/.changeset/anthropic-server-tool-parameters.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix Anthropic server tools (web_search, bash, computer, etc.) being forwarded to non-Anthropic providers with no `parameters` field, which some providers reject with a 400.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -231,10 +231,11 @@ describe('Anthropic Messages adapter', () => {
     });
 
     it('exposes Anthropic server tools to the scorer by function.name (issue #1886)', () => {
-      // chatBody is only consumed by the routing/scoring layer in messages
-      // mode — the wire body goes through applyAnthropicMessagesMutations
-      // direct from the inbound body, so server-tool `type` tags are
-      // preserved upstream. Scoring just needs tool count + function.name.
+      // chatBody is consumed by the routing/scoring layer in messages mode —
+      // the scorer reads tool count + function.name. When the resolved
+      // provider is Anthropic, the wire body goes through
+      // applyAnthropicMessagesMutations direct from the inbound body instead
+      // of this translation, so server-tool `type` tags are preserved there.
       const result = messagesToChatCompletionsRequest({
         messages: [{ role: 'user', content: 'x' }],
         tools: [
@@ -256,6 +257,48 @@ describe('Anthropic Messages adapter', () => {
         'mcp',
         'my_custom',
         'explicit_custom',
+      ]);
+    });
+
+    it('gives Anthropic server tools a safe empty schema so strict chat-completions providers accept them (issue #2754)', () => {
+      // chatBody.tools is also the literal wire payload forwarded to
+      // non-Anthropic providers reached via the chat-completions wire format
+      // (ProviderClient.forward's needsChatBody path). Anthropic server
+      // tools (web_search, bash, computer, etc.) carry no `input_schema`;
+      // some strict providers (e.g. MiniMax) reject any function tool with
+      // no `parameters` field at all, so omitting it 400s the request even
+      // though Manifest itself never executes the tool.
+      const result = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [
+          { type: 'web_search_20250305', name: 'web_search' },
+          { type: 'bash_20250124', name: 'bash' },
+          { type: 'mcp_toolset', name: 'mcp' },
+        ],
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'web_search',
+            parameters: { type: 'object', properties: {}, additionalProperties: false },
+          },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'bash',
+            parameters: { type: 'object', properties: {}, additionalProperties: false },
+          },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'mcp',
+            parameters: { type: 'object', properties: {}, additionalProperties: false },
+          },
+        },
       ]);
     });
 

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -21,28 +21,8 @@ const DEFAULT_CUSTOM_TOOL_INPUT_SCHEMA = {
   additionalProperties: false,
 } as const;
 
-const ANTHROPIC_SERVER_TOOL_PREFIXES = [
-  'bash_',
-  'code_execution_',
-  'computer_',
-  'memory_',
-  'text_editor_',
-  'tool_search_tool_',
-  'web_fetch_',
-  'web_search_',
-] as const;
-
-const ANTHROPIC_SERVER_TOOL_TYPES = ['mcp_toolset'] as const;
-
 function isRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isAnthropicServerToolType(type: string): boolean {
-  return (
-    ANTHROPIC_SERVER_TOOL_TYPES.includes(type as (typeof ANTHROPIC_SERVER_TOOL_TYPES)[number]) ||
-    ANTHROPIC_SERVER_TOOL_PREFIXES.some((prefix) => type.startsWith(prefix))
-  );
 }
 
 function normalizeOpenAiFunctionSchema(schema: unknown): unknown {
@@ -191,7 +171,19 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
 // and array length, nothing else. The Anthropic wire body is emitted by
 // `applyAnthropicMessagesMutations` directly from the inbound body, so this
 // translation can lose Anthropic-only tool fields (e.g. server-tool `type`
-// tags, omitted input_schema) without affecting upstream behavior.
+// tags, omitted input_schema) without affecting upstream behavior *when the
+// resolved provider is Anthropic*.
+//
+// But `chatBody.tools` is also the literal wire payload forwarded to
+// non-Anthropic providers reached via the chat-completions wire format (see
+// `ProviderClient.forward`'s `needsChatBody` path) — those providers never
+// see the native Anthropic body. Anthropic server tools (`web_search_*`,
+// `bash_*`, `computer_*`, etc.) have no `input_schema`, and some strict
+// chat-completions providers (e.g. MiniMax) reject any function tool whose
+// `parameters` field is missing entirely — even though the tool itself can't
+// run there regardless. Emitting the same safe empty-object schema used for
+// unrecognized tool types (issue #1897) keeps the request well-formed
+// without pretending the schema is meaningful (fixes #2754).
 function toChatTools(tools: unknown[]): JsonRecord[] {
   return tools.filter(isRecord).map((tool) => ({
     type: 'function',
@@ -200,9 +192,7 @@ function toChatTools(tools: unknown[]): JsonRecord[] {
       ...(typeof tool.description === 'string' && { description: tool.description }),
       ...(tool.input_schema !== undefined
         ? { parameters: normalizeOpenAiFunctionSchema(tool.input_schema) }
-        : typeof tool.type === 'string' &&
-            tool.type !== 'custom' &&
-            !isAnthropicServerToolType(tool.type)
+        : typeof tool.type === 'string' && tool.type !== 'custom'
           ? { parameters: DEFAULT_CUSTOM_TOOL_INPUT_SCHEMA }
           : {}),
     },


### PR DESCRIPTION
## Summary

Fixes #2754.

`toChatTools()` in `packages/backend/src/routing/proxy/anthropic-messages-adapter.ts` converts an inbound Anthropic Messages request into Manifest's internal chat-completions shape. For Anthropic server tools (`web_search`, `bash`, `computer`, `text_editor`, `mcp_toolset`, etc.) it omitted the `parameters` field on the converted tool entirely, since these tools have no `input_schema` in the Anthropic wire format.

That converted body isn't only used for routing/scoring — it's the literal wire payload forwarded to non-Anthropic providers reached through the chat-completions format (`ProviderClient.forward`'s `needsChatBody` path, used e.g. for MiniMax). Some of those providers reject any function tool whose `parameters` field is missing outright, so a request containing a server tool 400s before the model even runs — exactly the repro in the issue (MiniMax: `invalid params, function parameters is empty (2013)`).

## Fix

This ships the smaller of the two options the issue proposes: server tools now get the same safe empty-object schema (`{ type: 'object', properties: {}, additionalProperties: false }`) already used for unrecognized tool types (issue #1897), rather than omitting `parameters` entirely. The schema content is never meaningful to a provider that can't execute an Anthropic-internal tool anyway — the fix is just making sure the field exists.

Requests actually routed to a real Anthropic provider are unaffected: per the existing comment in the file (and issue #1886's test), the wire body sent there is built by `applyAnthropicMessagesMutations` directly from the inbound Anthropic body, not from this chat-completions translation.

I deliberately did not also implement the issue's option 2 (dropping server tools entirely for non-Anthropic providers) — at the point `toChatTools` runs, the target provider hasn't been resolved yet (it runs before provider/model resolution, feeding both the scorer and, for chat-completions-format providers, the forwarded wire body), so doing that safely would need a larger restructuring of where tool translation happens relative to provider resolution. Happy to discuss if maintainers would rather see that approach.

Also removed the now-unused `ANTHROPIC_SERVER_TOOL_PREFIXES` / `ANTHROPIC_SERVER_TOOL_TYPES` / `isAnthropicServerToolType` helpers, since server tools no longer need special-casing in this function.

## Test plan

- [x] Updated the existing `anthropic-messages-adapter.spec.ts` test (issue #1886) that documented the old parameters-omitted behavior for server tools
- [x] Added a new regression test reproducing #2754 directly, asserting `web_search`, `bash`, and `mcp_toolset` tools all get the safe empty schema
- [x] `npx jest routing/proxy` — 2287/2287 passing
- [x] `npx jest` (full backend suite) — 8509/8511 passing; the 2 failures (`public-stats.service.spec.ts`, `notification-cron.service.edge-cases.spec.ts`) are pre-existing and reproduce identically on unmodified `main` — unrelated to this change (timezone/environment-dependent)
- [x] `npx eslint` on the changed files — clean
- [x] `npx tsc --noEmit` — clean
- [x] Added a changeset (`manifest`, patch)

## AI assistance disclosure

This PR was prepared with the assistance of Claude Code (Anthropic), including root-cause investigation, the code change, and the regression tests. I reviewed the diff and verified all checks above myself before opening this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2754: Anthropic server tools no longer get forwarded to non-Anthropic chat-completions providers without a `parameters` field. `toChatTools()` previously omitted it for these tools, and strict providers like MiniMax reject any function tool missing `parameters` with a 400 before the model runs.

- Server tools now get the same safe empty-object schema already used for unrecognized tool types.
- Requests routed to real Anthropic providers are unaffected; their wire body comes from `applyAnthropicMessagesMutations` directly.
- Removed the now-unused `ANTHROPIC_SERVER_TOOL_PREFIXES`, `ANTHROPIC_SERVER_TOOL_TYPES`, and `isAnthropicServerToolType` helpers.
- Added regression tests covering `web_search`, `bash`, and `mcp_toolset`.

<sup>Written for commit deda5170c6291740e4d33ca9a66da606bf294e58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

