### PR TITLE
fix(routing/proxy): emit finish_reason: tool_calls when tool call pre…

### DIFF
--- a/packages/backend/src/routing/proxy/chatgpt-adapter.streaming.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.streaming.spec.ts
@@ -277,12 +277,11 @@ describe('chatgpt-adapter streaming: finish_reason with empty response.completed
   });
 
   it('keeps finish_reason tool_calls when completed payload still contains the function call', () => {
-    // Pre-existing behavior (completed WITH output listing the function_call)
-    // must not regress.
+    // Isolate the completed-payload path: without a preceding streamed tool
+    // call, this assertion specifically guards hasFunctionCalls.
     const stream = createChatGptStreamTransformer('gpt-5');
     const seen: string[] = [];
     for (const chunk of [
-      'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c1","name":"foo"}}',
       'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
     ]) {
       const out = stream(chunk);

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.streaming.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.streaming.spec.ts
@@ -10,7 +10,11 @@
  * Split out of chatgpt-adapter.spec.ts to keep each file under 300 lines.
  */
 
-import { collectChatGptSseResponse, transformResponsesStreamChunk } from './chatgpt-adapter';
+import {
+  collectChatGptSseResponse,
+  createChatGptStreamTransformer,
+  transformResponsesStreamChunk,
+} from './chatgpt-adapter';
 
 function parseFrame(frame: string | null): Record<string, unknown> | null {
   if (!frame) return null;
@@ -233,3 +237,59 @@ describe('chatgpt-adapter streaming: truncated tool-call argument JSON', () => {
     });
   });
 });
+
+describe('chatgpt-adapter streaming: finish_reason with empty response.completed output', () => {
+  it('emits finish_reason tool_calls when the tool call streamed before completed (output: [])', () => {
+    // GPT/Codex Responses streams frequently emit response.completed with an
+    // empty output array — the tool call was already streamed earlier via
+    // response.output_item.added + response.function_call_arguments.delta.
+    // Inspecting only the completed payload mislabels this as "stop", which
+    // makes OpenAI Chat Completions clients end the turn without executing
+    // the tool. The transformer tracks tool calls across the whole stream.
+    const stream = createChatGptStreamTransformer('gpt-5');
+    const seen: string[] = [];
+    for (const chunk of [
+      'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c1","name":"read_file"}}',
+      'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"path\\":\\"/tmp/test.txt\\"}"}',
+      'event: response.completed\ndata: {"response":{"output":[]}}',
+    ]) {
+      const out = stream(chunk);
+      if (out) seen.push(out);
+    }
+    const final = seen[seen.length - 1];
+    expect(final).toContain('"finish_reason":"tool_calls"');
+  });
+
+  it('still emits finish_reason stop for a plain text completion', () => {
+    // Guard against the fix leaking: a stream that produced only text must
+    // keep finishing as "stop".
+    const stream = createChatGptStreamTransformer('gpt-5');
+    const seen: string[] = [];
+    for (const chunk of [
+      'event: response.output_text.delta\ndata: {"delta":"hello"}',
+      'event: response.completed\ndata: {"response":{"output":[{"type":"output_text","text":"hello"}]}}',
+    ]) {
+      const out = stream(chunk);
+      if (out) seen.push(out);
+    }
+    const final = seen[seen.length - 1];
+    expect(final).toContain('"finish_reason":"stop"');
+  });
+
+  it('keeps finish_reason tool_calls when completed payload still contains the function call', () => {
+    // Pre-existing behavior (completed WITH output listing the function_call)
+    // must not regress.
+    const stream = createChatGptStreamTransformer('gpt-5');
+    const seen: string[] = [];
+    for (const chunk of [
+      'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c1","name":"foo"}}',
+      'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+    ]) {
+      const out = stream(chunk);
+      if (out) seen.push(out);
+    }
+    const final = seen[seen.length - 1];
+    expect(final).toContain('"finish_reason":"tool_calls"');
+  });
+});
+

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -195,6 +195,8 @@ function reasoningDeltaText(data: Record<string, unknown>): string {
 /** Tracks whether reasoning summary text was already streamed to the client. */
 interface ReasoningStreamState {
   streamed: boolean;
+  /** True once the stream has emitted any function_call output item / delta. */
+  sawToolCall: boolean;
 }
 
 /**
@@ -301,7 +303,7 @@ export function fromResponsesResponse(
  * summaries that never streamed as recognizable deltas.
  */
 export function createChatGptStreamTransformer(model: string): (chunk: string) => string | null {
-  const state: ReasoningStreamState = { streamed: false };
+  const state: ReasoningStreamState = { streamed: false, sawToolCall: false };
   return (chunk) => transformResponsesStreamChunk(chunk, model, state);
 }
 
@@ -370,6 +372,7 @@ export function transformResponsesStreamChunk(
     if (!data) return null;
     const item = isObjectRecord(data.item) ? data.item : undefined;
     if (item?.type !== 'function_call') return null;
+    if (state) state.sawToolCall = true;
     return formatSSE(
       {
         delta: {
@@ -412,8 +415,9 @@ function handleCompletedEvent(
   const response = isObjectRecord(data?.response) ? data.response : undefined;
   const responseOutput = responseOutputItems(response);
   const hasFunctionCalls = responseOutput.some((item) => item.type === 'function_call');
+  const sawToolCall = state?.sawToolCall ?? false;
   const finish = formatSSE(
-    { delta: {}, finish_reason: hasFunctionCalls ? 'tool_calls' : 'stop' },
+    { delta: {}, finish_reason: hasFunctionCalls || sawToolCall ? 'tool_calls' : 'stop' },
     model,
     extractResponseUsage(response),
   );


### PR DESCRIPTION
…cedes empty completion

GPT/Codex streaming can emit `response.output_item.added` with a `function_call` before `response.completed`, whose `output` array is empty. Previously the adapter only checked `output` for function_call items, producing `finish_reason: stop` and causing the client to end the turn prematurely.

- Track `sawToolCall` in `ReasoningStreamState`
- Set `sawToolCall = true` on `response.output_item.added` function_call
- In `handleCompletedEvent`, use `hasFunctionCalls || sawToolCall` to decide `finish_reason`
- Add regression tests for empty-completion + tool-call, text-only completion, and normal function-call completion

Fixes the "GPT no-respond / stops after one tool call" symptom in streaming mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ChatGPT/Codex streaming adapter emitting `finish_reason: stop` when a tool call precedes an empty `response.completed` output, which made clients end the turn before running the tool. The adapter now emits `finish_reason: tool_calls` when any `function_call` was streamed, even if the completed event's output is empty.

- Tracks tool-call presence in the stream transformer state on `response.output_item.added` events.
- Uses the tracked state, alongside existing output inspection, to decide `finish_reason`.
- Adds regression tests for empty-completion tool calls, text-only completions, and normal function-call completions.

<sup>Written for commit f2a798f8e0ec46407b3bc1db4d74894fc23db10f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

