### PR TITLE
fix: recheck cached agent keys across replicas

### DIFF
--- a/.changeset/fix-agent-key-revocation-consistency.md
+++ b/.changeset/fix-agent-key-revocation-consistency.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop accepting rotated or deleted agent API keys immediately across backend replicas.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,7 +567,7 @@ configuration simply leaves it unset by default.
 - **Better Auth database**: Uses a `pg.Pool` instance passed directly to `betterAuth({ database: pool })`. See `packages/backend/src/auth/auth.instance.ts`.
 - **PostgreSQL container**: `docker run -d --name postgres_db -e POSTGRES_USER=myuser -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=mydatabase -p 5432:5432 postgres:16`
 - **Validation**: Global `ValidationPipe` with `whitelist: true`, `forbidNonWhitelisted: true`. Explicit `@Type()` decorators on numeric DTO fields.
-- **Agent key auth caching**: `AgentKeyAuthGuard` caches valid API keys in-memory for 5 minutes to avoid repeated DB lookups.
+- **Agent key auth caching**: `AgentKeyAuthGuard` caches verified API-key context in-memory for 5 minutes, but checks that the key row is still active on every request so rotation and deletion apply across replicas immediately.
 - **Database migrations**: TypeORM migrations are version-controlled in `src/database/migrations/`. `synchronize` is permanently `false`. Migrations auto-run on boot by default, gated by `RUN_MIGRATIONS_ON_BOOT` (default `true`; disable for multi-replica deploys). `migrationsTransactionMode` is `'each'` (one transaction per migration, not one for the whole run) because some `agent_messages` index migrations run `CONCURRENTLY`, which PostgreSQL forbids inside a shared transaction. The CLI DataSource is at `src/database/datasource.ts`. Better Auth manages its own tables separately via `ctx.runMigrations()`.
 - **SSE**: `SseController` provides `/api/v1/events` for real-time dashboard updates.
 - **Notifications**: Cron-based threshold checking, supports Mailgun + Resend + SendGrid email providers.

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -39,6 +39,7 @@ describe('AgentKeyAuthGuard', () => {
   let mockCreateQueryBuilder: jest.Mock;
   let mockExecute: jest.Mock;
   let mockFindOne: jest.Mock;
+  let mockExistsBy: jest.Mock;
   let mockConfig: ConfigService;
 
   function buildMockRepo() {
@@ -73,9 +74,11 @@ describe('AgentKeyAuthGuard', () => {
       return alias ? mockSelectQb : mockUpdateQb;
     });
     mockFindOne = jest.fn().mockResolvedValue(null);
+    mockExistsBy = jest.fn().mockResolvedValue(true);
     return {
       createQueryBuilder: mockCreateQueryBuilder,
       findOne: mockFindOne,
+      existsBy: mockExistsBy,
     } as never;
   }
 
@@ -242,7 +245,7 @@ describe('AgentKeyAuthGuard', () => {
     await expect(guard.canActivate(ctx)).rejects.toThrow('API key expired');
   });
 
-  it('uses cached result on second call without querying DB again', async () => {
+  it('uses cached context after verifying that the key row is still active', async () => {
     const token = 'mnfst_cached-key-test';
     mockGetMany.mockResolvedValue([
       {
@@ -269,6 +272,32 @@ describe('AgentKeyAuthGuard', () => {
     await guard.canActivate(ctx2);
 
     expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
+    expect(mockExistsBy).toHaveBeenCalledWith({ id: 'key-4', is_active: true });
+  });
+
+  it('rejects a cached key deactivated by another replica', async () => {
+    const token = 'mnfst_cross-replica-revocation';
+    mockGetMany.mockResolvedValue([
+      {
+        id: 'key-revoked',
+        tenant_id: 'tenant-1',
+        agent_id: 'agent-1',
+        key_hash: hashKey(token),
+        expires_at: null,
+        agent: { name: 'test-agent' },
+        tenant: { owner_user_id: 'user-1' },
+      },
+    ]);
+
+    const { ctx: first } = makeContext({ authorization: `Bearer ${token}` });
+    await expect(guard.canActivate(first)).resolves.toBe(true);
+
+    mockExistsBy.mockResolvedValue(false);
+    const { ctx: afterRevocation } = makeContext({ authorization: `Bearer ${token}` });
+    await expect(guard.canActivate(afterRevocation)).rejects.toThrow('Invalid API key');
+
+    const internalCache = (guard as unknown as { cache: Map<string, unknown> }).cache;
+    expect(internalCache.has(testCacheKey(token))).toBe(false);
   });
 
   it('stops authenticating from cache once the key own expiry passes within the cache TTL', async () => {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -300,6 +300,32 @@ describe('AgentKeyAuthGuard', () => {
     expect(internalCache.has(testCacheKey(token))).toBe(false);
   });
 
+  it('fails closed when the cached-key activity recheck cannot reach the database', async () => {
+    const token = 'mnfst_cached-key-db-error';
+    mockGetMany.mockResolvedValue([
+      {
+        id: 'key-db-error',
+        tenant_id: 'tenant-1',
+        agent_id: 'agent-1',
+        key_hash: hashKey(token),
+        expires_at: null,
+        agent: { name: 'test-agent' },
+        tenant: { owner_user_id: 'user-1' },
+      },
+    ]);
+
+    const { ctx: first } = makeContext({ authorization: `Bearer ${token}` });
+    await expect(guard.canActivate(first)).resolves.toBe(true);
+
+    mockExistsBy.mockRejectedValueOnce(new Error('database unavailable'));
+    const { ctx: duringOutage } = makeContext({ authorization: `Bearer ${token}` });
+    await expect(guard.canActivate(duringOutage)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(duringOutage)).resolves.toBe(true);
+
+    expect(mockGetMany).toHaveBeenCalledTimes(1);
+    expect(mockExistsBy).toHaveBeenCalledTimes(2);
+  });
+
   it('stops authenticating from cache once the key own expiry passes within the cache TTL', async () => {
     // A key that expires (or is set to expire) while still cached must not keep
     // authenticating until the 5-min cache TTL lapses. The fast path reads the

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -27,6 +27,7 @@ function cacheKey(token: string): string {
 }
 
 interface CachedKey {
+  keyId: string;
   tenantId: string;
   agentId: string;
   agentName: string;
@@ -46,9 +47,9 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
   private readonly logger = new Logger(AgentKeyAuthGuard.name);
   private cache = new Map<string, CachedKey>();
   private devContext: { context: IngestionContext; expiresAt: number } | null = null;
-  // 5 min TTL keeps revoked-key staleness bounded while still amortizing the
-  // DB lookup across hot ingest bursts. Mutations call invalidateCache()
-  // directly when keys rotate or deactivate.
+  // 5 min TTL amortizes the expensive prefix lookup and hash verification.
+  // Cache hits still verify the key row is active, so rotation and deletion
+  // take effect across replicas without waiting for this TTL.
   private readonly CACHE_TTL_MS = 5 * 60 * 1000;
   private readonly MAX_CACHE_SIZE = 10_000;
   // Maps a rejected token's hash to when its rejection stops being trusted.
@@ -190,6 +191,15 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
     if (cached && cached.keyExpiresAt !== null && cached.keyExpiresAt <= now) {
       this.cache.delete(hashed);
     } else if (cached && cached.expiresAt > now) {
+      const stillActive = await this.keyRepo.existsBy({
+        id: cached.keyId,
+        is_active: true,
+      });
+      if (!stillActive) {
+        this.cache.delete(hashed);
+        this.rememberInvalid(hashed);
+        throw new UnauthorizedException('Invalid API key');
+      }
       // LRU touch — re-insert to move to tail of insertion order
       this.cache.delete(hashed);
       this.cache.set(hashed, cached);
@@ -279,6 +289,7 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
     }
 
     this.cache.set(hashed, {
+      keyId: keyRecord.id,
       tenantId: keyRecord.tenant_id,
       agentId: keyRecord.agent_id,
       agentName: keyRecord.agent.name,

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -191,10 +191,16 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
     if (cached && cached.keyExpiresAt !== null && cached.keyExpiresAt <= now) {
       this.cache.delete(hashed);
     } else if (cached && cached.expiresAt > now) {
-      const stillActive = await this.keyRepo.existsBy({
-        id: cached.keyId,
-        is_active: true,
-      });
+      let stillActive: boolean;
+      try {
+        stillActive = await this.keyRepo.existsBy({
+          id: cached.keyId,
+          is_active: true,
+        });
+      } catch (err) {
+        this.logger.warn(`Agent-key activity recheck failed: ${(err as Error).message}`);
+        throw new UnauthorizedException('Invalid API key');
+      }
       if (!stillActive) {
         this.cache.delete(hashed);
         this.rememberInvalid(hashed);


### PR DESCRIPTION
### What changed

- Verify that a cached agent API key is still active before each authenticated request.
- Keep the expensive prefix, hash, and ingestion-context lookup cached.
- Add a regression test for cross-replica key deactivation.

### Why

Rotating or deleting an agent key only cleared the cache on the replica that handled the change. Other replicas could accept the old key for up to five minutes.

### User impact

Rotated and deleted agent keys stop working on the next request across all replicas.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-replica agent API key revocation so rotated or deleted keys stop working on the next request across all replicas, not just the replica that handled the change.

- Stores the key ID in the cache and checks `is_active` on every cache hit.
- Rejects the request when the key is inactive and fails closed when the recheck can't reach the database.
- Keeps the expensive prefix, hash, and ingestion-context lookup cached.
- Adds regression tests for cross-replica deactivation and recheck database errors.
- Updates the agent-key auth caching docs in `CLAUDE.md`.

<sup>Written for commit 323b9a81f7f10c88d2d5a5c2a93e357561c73a9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

