### PR TITLE
fix: enforce hard limits across replicas

### DIFF
--- a/.changeset/fix-hard-limit-consistency.md
+++ b/.changeset/fix-hard-limit-consistency.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Apply hard-limit rule and usage changes immediately across backend replicas.

--- a/packages/backend/src/notifications/notifications.controller.email-validation.spec.ts
+++ b/packages/backend/src/notifications/notifications.controller.email-validation.spec.ts
@@ -7,7 +7,6 @@ import { NotificationRulesService } from './services/notification-rules.service'
 import { NotificationLogService } from './services/notification-log.service';
 import { EmailProviderConfigService } from './services/email-provider-config.service';
 import { NotificationCronService } from './services/notification-cron.service';
-import { LimitCheckService } from './services/limit-check.service';
 import { TenantCacheService } from '../common/services/tenant-cache.service';
 
 const ctx = { tenantId: 'tenant-1', userId: 'user-1' };
@@ -45,7 +44,6 @@ describe('NotificationsController setNotificationEmail validation', () => {
         { provide: NotificationLogService, useValue: { getLogsForAgent: jest.fn() } },
         { provide: EmailProviderConfigService, useValue: mockEmailProviderConfigService },
         { provide: NotificationCronService, useValue: { checkThresholds: jest.fn() } },
-        { provide: LimitCheckService, useValue: { invalidateCache: jest.fn() } },
       ],
     }).compile();
 

--- a/packages/backend/src/notifications/notifications.controller.spec.ts
+++ b/packages/backend/src/notifications/notifications.controller.spec.ts
@@ -4,7 +4,6 @@ import { NotificationRulesService } from './services/notification-rules.service'
 import { NotificationLogService } from './services/notification-log.service';
 import { EmailProviderConfigService } from './services/email-provider-config.service';
 import { NotificationCronService } from './services/notification-cron.service';
-import { LimitCheckService } from './services/limit-check.service';
 
 const mockCtx = { tenantId: 't-1', userId: 'user-1' } as never;
 
@@ -58,10 +57,6 @@ describe('NotificationsController', () => {
       checkThresholds: jest.fn().mockResolvedValue(2),
     };
 
-    const mockLimitCheck = {
-      invalidateCache: jest.fn(),
-    };
-
     const mockNotificationLog = {
       getLogsForAgent: jest.fn().mockResolvedValue([]),
     };
@@ -73,7 +68,6 @@ describe('NotificationsController', () => {
         { provide: NotificationLogService, useValue: mockNotificationLog },
         { provide: EmailProviderConfigService, useValue: mockEmailProviderConfigService },
         { provide: NotificationCronService, useValue: mockCronService },
-        { provide: LimitCheckService, useValue: mockLimitCheck },
       ],
     }).compile();
 
@@ -229,85 +223,5 @@ describe('NotificationsController', () => {
     const result = await controller.testSavedEmailProvider(mockCtx, { to: 'test@test.com' });
     expect(emailProviderConfigService.testSavedConfig).toHaveBeenCalledWith('t-1', 'test@test.com');
     expect(result).toEqual({ success: true });
-  });
-
-  describe('block rule cache invalidation', () => {
-    let limitCheck: jest.Mocked<LimitCheckService>;
-
-    beforeEach(() => {
-      limitCheck = module.get(LimitCheckService);
-    });
-
-    it('invalidates cache when creating a block rule', async () => {
-      const blockRule = { ...mockRule, action: 'block' as const };
-      rulesService.createRule.mockResolvedValue(blockRule);
-
-      const dto = {
-        agent_name: 'my-agent',
-        metric_type: 'tokens' as const,
-        threshold: 100000,
-        period: 'day' as const,
-        action: 'block' as const,
-      };
-      await controller.createRule(dto, mockCtx);
-
-      expect(limitCheck.invalidateCache).toHaveBeenCalledWith('t-1', 'my-agent');
-    });
-
-    it('does not invalidate cache when creating a notify rule', async () => {
-      const notifyRule = { ...mockRule, action: 'notify' as const };
-      rulesService.createRule.mockResolvedValue(notifyRule);
-
-      const dto = {
-        agent_name: 'my-agent',
-        metric_type: 'tokens' as const,
-        threshold: 100000,
-        period: 'day' as const,
-        action: 'notify' as const,
-      };
-      await controller.createRule(dto, mockCtx);
-
-      expect(limitCheck.invalidateCache).not.toHaveBeenCalled();
-    });
-
-    it('invalidates cache when creating a both rule', async () => {
-      const bothRule = { ...mockRule, action: 'both' as const };
-      rulesService.createRule.mockResolvedValue(bothRule);
-
-      const dto = {
-        agent_name: 'my-agent',
-        metric_type: 'tokens' as const,
-        threshold: 100000,
-        period: 'day' as const,
-        action: 'both' as const,
-      };
-      await controller.createRule(dto, mockCtx);
-
-      expect(limitCheck.invalidateCache).toHaveBeenCalledWith('t-1', 'my-agent');
-    });
-
-    it('always invalidates cache on update', async () => {
-      rulesService.updateRule.mockResolvedValue({ ...mockRule, threshold: 200 });
-
-      await controller.updateRule('rule-1', { threshold: 200 }, mockCtx);
-
-      expect(limitCheck.invalidateCache).toHaveBeenCalledWith('t-1', 'my-agent');
-    });
-
-    it('invalidates cache on delete when rule exists', async () => {
-      rulesService.getOwnedRule.mockResolvedValue(mockRule);
-
-      await controller.deleteRule('rule-1', mockCtx);
-
-      expect(limitCheck.invalidateCache).toHaveBeenCalledWith('t-1', 'my-agent');
-    });
-
-    it('does not invalidate cache on delete when rule not found', async () => {
-      rulesService.getOwnedRule.mockResolvedValue(undefined);
-
-      await controller.deleteRule('rule-missing', mockCtx);
-
-      expect(limitCheck.invalidateCache).not.toHaveBeenCalled();
-    });
   });
 });

--- a/packages/backend/src/notifications/notifications.controller.ts
+++ b/packages/backend/src/notifications/notifications.controller.ts
@@ -4,7 +4,6 @@ import { NotificationRulesService } from './services/notification-rules.service'
 import { NotificationLogService } from './services/notification-log.service';
 import { EmailProviderConfigService } from './services/email-provider-config.service';
 import { NotificationCronService } from './services/notification-cron.service';
-import { LimitCheckService } from './services/limit-check.service';
 import { CreateNotificationRuleDto, UpdateNotificationRuleDto } from './dto/notification-rule.dto';
 import {
   SetEmailProviderDto,
@@ -22,7 +21,6 @@ export class NotificationsController {
     private readonly notificationLog: NotificationLogService,
     private readonly emailProviderConfigService: EmailProviderConfigService,
     private readonly cronService: NotificationCronService,
-    private readonly limitCheck: LimitCheckService,
   ) {}
 
   @Get('email-provider')
@@ -92,11 +90,7 @@ export class NotificationsController {
 
   @Post()
   async createRule(@Body() dto: CreateNotificationRuleDto, @TenantCtx() ctx: TenantContext) {
-    const rule = await this.rulesService.createRule(ctx.tenantId, dto);
-    if (rule.action === 'block' || rule.action === 'both') {
-      this.limitCheck.invalidateCache(rule.tenant_id, rule.agent_name);
-    }
-    return rule;
+    return this.rulesService.createRule(ctx.tenantId, dto);
   }
 
   @Patch(':id')
@@ -105,20 +99,12 @@ export class NotificationsController {
     @Body() dto: UpdateNotificationRuleDto,
     @TenantCtx() ctx: TenantContext,
   ) {
-    const rule = await this.rulesService.updateRule(ctx.tenantId, id, dto);
-    if (rule) {
-      this.limitCheck.invalidateCache(rule.tenant_id, rule.agent_name);
-    }
-    return rule;
+    return this.rulesService.updateRule(ctx.tenantId, id, dto);
   }
 
   @Delete(':id')
   async deleteRule(@Param('id') id: string, @TenantCtx() ctx: TenantContext) {
-    const rule = await this.rulesService.getOwnedRule(ctx.tenantId, id);
     await this.rulesService.deleteRule(ctx.tenantId, id);
-    if (rule) {
-      this.limitCheck.invalidateCache(rule.tenant_id, rule.agent_name);
-    }
     return { deleted: true };
   }
 }

--- a/packages/backend/src/notifications/services/alert-scenarios.spec.ts
+++ b/packages/backend/src/notifications/services/alert-scenarios.spec.ts
@@ -8,7 +8,6 @@
  * 4. Token alert + block (both) → email sent once + proxy blocked with message
  * 5. No alert defined → no email, no block
  */
-import { Subject } from 'rxjs';
 import { HttpException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotificationCronService } from './notification-cron.service';
@@ -17,7 +16,6 @@ import { NotificationRulesService } from './notification-rules.service';
 import { NotificationEmailService } from './notification-email.service';
 import { EmailProviderConfigService } from './email-provider-config.service';
 import { NotificationLogService } from './notification-log.service';
-import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { ManifestRuntimeService } from '../../common/services/manifest-runtime.service';
 
 /* ── Shared helpers ──────────────────────────────── */
@@ -186,7 +184,6 @@ describe('Alert scenarios — email + block (both)', () => {
   let mockHasAlreadySent: jest.Mock;
   let mockInsertLog: jest.Mock;
   let mockResolveRecipientEmail: jest.Mock;
-  let ingestSubject: Subject<string>;
 
   beforeEach(() => {
     mockGetActiveBlockRules = jest.fn().mockResolvedValue([]);
@@ -195,8 +192,6 @@ describe('Alert scenarios — email + block (both)', () => {
     mockHasAlreadySent = jest.fn().mockResolvedValue(false);
     mockInsertLog = jest.fn().mockResolvedValue(undefined);
     mockResolveRecipientEmail = jest.fn().mockResolvedValue(EMAIL);
-
-    ingestSubject = new Subject<string>();
 
     limitCheckService = new LimitCheckService(
       {
@@ -209,7 +204,6 @@ describe('Alert scenarios — email + block (both)', () => {
       {
         getFullConfig: jest.fn().mockResolvedValue(null),
       } as unknown as EmailProviderConfigService,
-      { all: () => ingestSubject.asObservable() } as unknown as IngestEventBusService,
       {
         getAuthBaseUrl: jest.fn().mockReturnValue('http://localhost:3001'),
       } as unknown as ManifestRuntimeService,
@@ -219,12 +213,6 @@ describe('Alert scenarios — email + block (both)', () => {
         resolveRecipientEmail: mockResolveRecipientEmail,
       } as unknown as NotificationLogService,
     );
-    limitCheckService.onModuleInit();
-  });
-
-  afterEach(() => {
-    limitCheckService.onModuleDestroy();
-    ingestSubject.complete();
   });
 
   it('cost alert + block — sends email, blocks agent, returns formatted message', async () => {
@@ -283,7 +271,6 @@ describe('Alert scenarios — email + block (both)', () => {
 
     // Second check — already sent
     mockHasAlreadySent.mockResolvedValue(true);
-    limitCheckService.invalidateCache(TENANT, AGENT);
     const exceeded2 = await limitCheckService.checkLimits(TENANT, AGENT);
     await new Promise((r) => setTimeout(r, 50));
 
@@ -347,7 +334,6 @@ describe('Alert scenarios — email + block (both)', () => {
     expect(mockSendThresholdAlert).toHaveBeenCalledTimes(1);
 
     mockHasAlreadySent.mockResolvedValue(true);
-    limitCheckService.invalidateCache(TENANT, AGENT);
     const exceeded2 = await limitCheckService.checkLimits(TENANT, AGENT);
     await new Promise((r) => setTimeout(r, 50));
 
@@ -364,7 +350,6 @@ describe('Alert scenarios — email + block (both)', () => {
     expect(first).not.toBeNull();
 
     // Agent tries again — still blocked (consumption hasn't reset)
-    limitCheckService.invalidateCache(TENANT, AGENT);
     const second = await limitCheckService.checkLimits(TENANT, AGENT);
     expect(second).not.toBeNull();
     expect(second!.ruleId).toBe('rule-1');
@@ -379,13 +364,11 @@ describe('Alert scenarios — no rules defined', () => {
   let mockGetAllActiveRules: jest.Mock;
   let mockGetActiveBlockRules: jest.Mock;
   let mockSendThresholdAlert: jest.Mock;
-  let ingestSubject: Subject<string>;
 
   beforeEach(async () => {
     mockGetAllActiveRules = jest.fn().mockResolvedValue([]);
     mockGetActiveBlockRules = jest.fn().mockResolvedValue([]);
     mockSendThresholdAlert = jest.fn().mockResolvedValue(true);
-    ingestSubject = new Subject<string>();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -436,7 +419,6 @@ describe('Alert scenarios — no rules defined', () => {
       {
         getFullConfig: jest.fn().mockResolvedValue(null),
       } as unknown as EmailProviderConfigService,
-      { all: () => ingestSubject.asObservable() } as unknown as IngestEventBusService,
       {
         getAuthBaseUrl: jest.fn().mockReturnValue('http://localhost:3001'),
       } as unknown as ManifestRuntimeService,
@@ -446,12 +428,6 @@ describe('Alert scenarios — no rules defined', () => {
         resolveRecipientEmail: jest.fn().mockResolvedValue(EMAIL),
       } as unknown as NotificationLogService,
     );
-    limitCheckService.onModuleInit();
-  });
-
-  afterEach(() => {
-    limitCheckService.onModuleDestroy();
-    ingestSubject.complete();
   });
 
   it('no email is sent when no rules are defined', async () => {

--- a/packages/backend/src/notifications/services/limit-check.service.edge-cases.spec.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.edge-cases.spec.ts
@@ -9,13 +9,11 @@
  *
  * Split out from limit-check.service.spec.ts to keep each file under the 300-line cap.
  */
-import { Subject } from 'rxjs';
 import { LimitCheckService } from './limit-check.service';
 import { NotificationRulesService } from './notification-rules.service';
 import { NotificationEmailService } from './notification-email.service';
 import { EmailProviderConfigService } from './email-provider-config.service';
 import { NotificationLogService } from './notification-log.service';
-import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { ManifestRuntimeService } from '../../common/services/manifest-runtime.service';
 
 const TENANT = 'tenant-1';
@@ -39,7 +37,6 @@ describe('LimitCheckService — edge cases', () => {
   let mockHasAlreadySent: jest.Mock;
   let mockInsertLog: jest.Mock;
   let mockResolveRecipientEmail: jest.Mock;
-  let ingestSubject: Subject<string>;
 
   beforeEach(() => {
     mockGetActiveBlockRules = jest.fn().mockResolvedValue([BLOCK_RULE]);
@@ -64,11 +61,6 @@ describe('LimitCheckService — edge cases', () => {
       getAuthBaseUrl: jest.fn().mockReturnValue('http://localhost:3001'),
     } as unknown as ManifestRuntimeService;
 
-    ingestSubject = new Subject<string>();
-    const ingestBus = {
-      all: () => ingestSubject.asObservable(),
-    } as unknown as IngestEventBusService;
-
     mockHasAlreadySent = jest.fn().mockResolvedValue(false);
     mockInsertLog = jest.fn().mockResolvedValue(undefined);
     mockResolveRecipientEmail = jest.fn().mockResolvedValue(null);
@@ -82,16 +74,12 @@ describe('LimitCheckService — edge cases', () => {
       rulesService,
       emailService,
       emailProviderConfig,
-      ingestBus,
       runtime,
       notificationLog,
     );
-    service.onModuleInit();
   });
 
   afterEach(() => {
-    service.onModuleDestroy();
-    ingestSubject.complete();
     jest.restoreAllMocks();
   });
 

--- a/packages/backend/src/notifications/services/limit-check.service.spec.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.spec.ts
@@ -1,10 +1,8 @@
-import { Subject } from 'rxjs';
 import { LimitCheckService } from './limit-check.service';
 import { NotificationRulesService } from './notification-rules.service';
 import { NotificationEmailService } from './notification-email.service';
 import { EmailProviderConfigService } from './email-provider-config.service';
 import { NotificationLogService } from './notification-log.service';
-import { IngestEventBusService, IngestEvent } from '../../common/services/ingest-event-bus.service';
 import { ManifestRuntimeService } from '../../common/services/manifest-runtime.service';
 
 describe('LimitCheckService', () => {
@@ -16,7 +14,6 @@ describe('LimitCheckService', () => {
   let mockHasAlreadySent: jest.Mock;
   let mockInsertLog: jest.Mock;
   let mockResolveRecipientEmail: jest.Mock;
-  let ingestSubject: Subject<IngestEvent>;
   let mockRuntime: { getAuthBaseUrl: jest.Mock };
 
   beforeEach(() => {
@@ -41,11 +38,6 @@ describe('LimitCheckService', () => {
       getAuthBaseUrl: jest.fn().mockReturnValue('http://localhost:3001'),
     };
 
-    ingestSubject = new Subject<IngestEvent>();
-    const ingestBus = {
-      all: () => ingestSubject.asObservable(),
-    } as unknown as IngestEventBusService;
-
     mockHasAlreadySent = jest.fn().mockResolvedValue(false);
     mockInsertLog = jest.fn().mockResolvedValue(undefined);
     mockResolveRecipientEmail = jest.fn().mockResolvedValue(null);
@@ -59,16 +51,9 @@ describe('LimitCheckService', () => {
       rulesService,
       emailService,
       emailProviderConfig,
-      ingestBus,
       mockRuntime as unknown as ManifestRuntimeService,
       notificationLog,
     );
-    service.onModuleInit();
-  });
-
-  afterEach(() => {
-    service.onModuleDestroy();
-    ingestSubject.complete();
   });
 
   it('returns null when no block rules exist', async () => {
@@ -161,345 +146,45 @@ describe('LimitCheckService', () => {
     expect(result!.ruleId).toBe('r2');
   });
 
-  it('caches rules for 60s', async () => {
-    mockGetActiveBlockRules.mockResolvedValue([]);
+  it('enforces a block rule created through another replica on the next request', async () => {
+    await expect(service.checkLimits('tenant-1', 'my-agent')).resolves.toBeNull();
 
-    await service.checkLimits('tenant-1', 'my-agent');
-    await service.checkLimits('tenant-1', 'my-agent');
-
-    expect(mockGetActiveBlockRules).toHaveBeenCalledTimes(1);
-  });
-
-  it('caches consumption values for 60s', async () => {
     mockGetActiveBlockRules.mockResolvedValue([
       {
-        id: 'r1',
+        id: 'new-rule',
         tenant_id: 'tenant-1',
         agent_name: 'my-agent',
         metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-    ]);
-    mockGetConsumption.mockResolvedValue(5000);
-
-    await service.checkLimits('tenant-1', 'my-agent');
-    await service.checkLimits('tenant-1', 'my-agent');
-
-    expect(mockGetConsumption).toHaveBeenCalledTimes(1);
-  });
-
-  it('invalidateCache clears rules and consumption for tenant+agent', async () => {
-    mockGetActiveBlockRules.mockResolvedValue([
-      {
-        id: 'r1',
-        tenant_id: 'tenant-1',
-        agent_name: 'my-agent',
-        metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-    ]);
-    mockGetConsumption.mockResolvedValue(5000);
-
-    await service.checkLimits('tenant-1', 'my-agent');
-    expect(mockGetActiveBlockRules).toHaveBeenCalledTimes(1);
-
-    service.invalidateCache('tenant-1', 'my-agent');
-
-    await service.checkLimits('tenant-1', 'my-agent');
-    expect(mockGetActiveBlockRules).toHaveBeenCalledTimes(2);
-    expect(mockGetConsumption).toHaveBeenCalledTimes(2);
-  });
-
-  it('evicts the writing tenant consumption cache when ingest event fires', async () => {
-    mockGetActiveBlockRules.mockResolvedValue([
-      {
-        id: 'r1',
-        tenant_id: 'tenant-1',
-        agent_name: 'my-agent',
-        metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-    ]);
-    mockGetConsumption.mockResolvedValue(5000);
-
-    await service.checkLimits('tenant-1', 'my-agent');
-    expect(mockGetConsumption).toHaveBeenCalledTimes(1);
-
-    // Simulate OTLP ingest event for the same tenant that owns the rule.
-    ingestSubject.next({ tenantId: 'tenant-1', kind: 'message' });
-
-    await service.checkLimits('tenant-1', 'my-agent');
-    expect(mockGetConsumption).toHaveBeenCalledTimes(2);
-  });
-
-  it('ingest event for one tenant does NOT evict another tenant consumption cache', async () => {
-    // Two distinct tenants, each with its own block rule.
-    mockGetActiveBlockRules.mockImplementation((tenantId: string) =>
-      Promise.resolve([
-        {
-          id: `r-${tenantId}`,
-          tenant_id: tenantId,
-          agent_name: 'my-agent',
-          metric_type: 'tokens',
-          threshold: 100000,
-          period: 'day',
-        },
-      ]),
-    );
-    mockGetConsumption.mockResolvedValue(5000);
-
-    await service.checkLimits('tenant-A', 'my-agent');
-    await service.checkLimits('tenant-B', 'my-agent');
-    expect(mockGetConsumption).toHaveBeenCalledTimes(2);
-
-    // Ingest event for tenant-A only.
-    ingestSubject.next({ tenantId: 'tenant-A', kind: 'message' });
-
-    await service.checkLimits('tenant-A', 'my-agent'); // re-fetched (evicted)
-    await service.checkLimits('tenant-B', 'my-agent'); // still cached
-    expect(mockGetConsumption).toHaveBeenCalledTimes(3);
-  });
-
-  it('consumption cache entries expire after the TTL even without an ingest event', async () => {
-    mockGetActiveBlockRules.mockResolvedValue([
-      {
-        id: 'r1',
-        tenant_id: 'tenant-1',
-        agent_name: 'my-agent',
-        metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-    ]);
-    mockGetConsumption.mockResolvedValue(5000);
-
-    const nowSpy = jest.spyOn(Date, 'now');
-    nowSpy.mockReturnValue(1_000_000);
-    await service.checkLimits('tenant-1', 'my-agent');
-    expect(mockGetConsumption).toHaveBeenCalledTimes(1);
-
-    // Advance past the 60s TTL — the cached entry is now stale.
-    nowSpy.mockReturnValue(1_000_000 + 61_000);
-    await service.checkLimits('tenant-1', 'my-agent');
-    expect(mockGetConsumption).toHaveBeenCalledTimes(2);
-
-    nowSpy.mockRestore();
-  });
-
-  it('invalidateCache does not affect other tenant+agent pairs', async () => {
-    mockGetActiveBlockRules.mockResolvedValue([]);
-
-    await service.checkLimits('tenant-1', 'agent-a');
-    await service.checkLimits('tenant-2', 'agent-b');
-    expect(mockGetActiveBlockRules).toHaveBeenCalledTimes(2);
-
-    service.invalidateCache('tenant-1', 'agent-a');
-
-    await service.checkLimits('tenant-1', 'agent-a');
-    await service.checkLimits('tenant-2', 'agent-b');
-    // tenant-1/agent-a re-fetched, tenant-2/agent-b cached
-    expect(mockGetActiveBlockRules).toHaveBeenCalledTimes(3);
-  });
-
-  it('reuses an existing tenant bucket for a second metric/period entry', async () => {
-    // One rule with a long period and one with a short period → two distinct
-    // inner keys under the same tenant bucket. The second insert must reuse the
-    // already-created bucket rather than overwrite it.
-    mockGetActiveBlockRules.mockResolvedValue([
-      {
-        id: 'r1',
-        tenant_id: 'tenant-1',
-        agent_name: 'my-agent',
-        metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-      {
-        id: 'r2',
-        tenant_id: 'tenant-1',
-        agent_name: 'my-agent',
-        metric_type: 'cost',
         threshold: 100,
-        period: 'month',
+        period: 'day',
       },
     ]);
-    mockGetConsumption.mockResolvedValue(0);
+    mockGetConsumption.mockResolvedValue(100);
 
-    await service.checkLimits('tenant-1', 'my-agent');
-
-    const consumptionCache = (service as any).consumptionCache as Map<string, Map<string, unknown>>;
-    // Both rules' consumption entries live in the single 'tenant-1' bucket.
-    expect(consumptionCache.size).toBe(1);
-    expect(consumptionCache.get('tenant-1')!.size).toBe(2);
+    await expect(service.checkLimits('tenant-1', 'my-agent')).resolves.toEqual(
+      expect.objectContaining({ ruleId: 'new-rule', actual: 100 }),
+    );
+    expect(mockGetActiveBlockRules).toHaveBeenCalledTimes(2);
   });
 
-  it('drops a tenant bucket whose entries have all expired on the next lookup', async () => {
-    const consumptionCache = (service as any).consumptionCache as Map<string, Map<string, unknown>>;
-    const nowSpy = jest.spyOn(Date, 'now');
-    nowSpy.mockReturnValue(1_000_000);
-
-    // Seed a stale bucket for an unrelated tenant that will be swept on lookup.
-    const staleBucket = new Map<string, unknown>();
-    staleBucket.set('agent-x:tokens:2026-01-01', {
-      data: 1,
-      expiresAt: 1_000_000 + 10,
-    });
-    consumptionCache.set('tenant-stale', staleBucket);
-
+  it('uses current consumption on every request', async () => {
     mockGetActiveBlockRules.mockResolvedValue([
       {
         id: 'r1',
         tenant_id: 'tenant-1',
         agent_name: 'my-agent',
         metric_type: 'tokens',
-        threshold: 100000,
+        threshold: 100,
         period: 'day',
       },
     ]);
-    mockGetConsumption.mockResolvedValue(0);
+    mockGetConsumption.mockResolvedValueOnce(99).mockResolvedValueOnce(100);
 
-    // Jump past the stale bucket's TTL so evictExpiredConsumption drops it.
-    nowSpy.mockReturnValue(1_000_000 + 999_999);
-    await service.checkLimits('tenant-1', 'my-agent');
-
-    expect(consumptionCache.has('tenant-stale')).toBe(false);
-    nowSpy.mockRestore();
-  });
-
-  it('invalidateCache deletes only matching inner entries and keeps the bucket', () => {
-    const consumptionCache = (service as any).consumptionCache as Map<
-      string,
-      Map<string, { data: number; expiresAt: number }>
-    >;
-    const now = Date.now();
-    const bucket = new Map<string, { data: number; expiresAt: number }>();
-    // One entry scoped to the agent we invalidate, one to a different agent.
-    bucket.set('agent-a:tokens:2026-01-01', { data: 1, expiresAt: now + 999_999 });
-    bucket.set('agent-b:tokens:2026-01-01', { data: 2, expiresAt: now + 999_999 });
-    consumptionCache.set('tenant-1', bucket);
-
-    service.invalidateCache('tenant-1', 'agent-a');
-
-    // The agent-a entry is gone, agent-b survives, and the bucket is retained.
-    expect(bucket.has('agent-a:tokens:2026-01-01')).toBe(false);
-    expect(bucket.has('agent-b:tokens:2026-01-01')).toBe(true);
-    expect(consumptionCache.has('tenant-1')).toBe(true);
-  });
-
-  it('invalidateCache drops an emptied tenant bucket', async () => {
-    mockGetActiveBlockRules.mockResolvedValue([
-      {
-        id: 'r1',
-        tenant_id: 'tenant-1',
-        agent_name: 'my-agent',
-        metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-    ]);
-    mockGetConsumption.mockResolvedValue(5000);
-
-    await service.checkLimits('tenant-1', 'my-agent');
-    const consumptionCache = (service as any).consumptionCache as Map<string, unknown>;
-    expect(consumptionCache.has('tenant-1')).toBe(true);
-
-    service.invalidateCache('tenant-1', 'my-agent');
-
-    // The single entry was removed, so the now-empty 'tenant-1' bucket is dropped.
-    expect(consumptionCache.has('tenant-1')).toBe(false);
-  });
-
-  it('evicts oldest rules cache entry when MAX_CACHE_SIZE is reached', async () => {
-    const rulesCache = (service as any).rulesCache as Map<string, unknown>;
-    const now = Date.now();
-
-    // Fill to exactly MAX_CACHE_SIZE so the next insert triggers eviction
-    for (let i = 0; i < 10_000; i++) {
-      rulesCache.set(`t-${i}:a-${i}`, { data: [], expiresAt: now + 999_999 });
-    }
-    expect(rulesCache.size).toBe(10_000);
-
-    mockGetActiveBlockRules.mockResolvedValue([]);
-    await service.checkLimits('tenant-new', 'agent-new');
-
-    // The first filler entry should have been evicted
-    expect(rulesCache.has('t-0:a-0')).toBe(false);
-    // The new entry should be present
-    expect(rulesCache.has('tenant-new:agent-new')).toBe(true);
-  });
-
-  it('evicts oldest consumption cache entry when MAX_CACHE_SIZE is reached', async () => {
-    const consumptionCache = (service as any).consumptionCache as Map<string, Map<string, unknown>>;
-    const now = Date.now();
-
-    // Fill the oldest tenant bucket to exactly MAX_CACHE_SIZE so the next insert
-    // (under a new tenant) trips the total-size guard and evicts from the oldest.
-    const oldestBucket = new Map<string, unknown>();
-    for (let i = 0; i < 10_000; i++) {
-      oldestBucket.set(`a-${i}:tokens:2026-01-01`, {
-        data: 0,
-        expiresAt: now + 999_999,
-      });
-    }
-    consumptionCache.set('tenant-old', oldestBucket);
-    expect(oldestBucket.size).toBe(10_000);
-
-    mockGetActiveBlockRules.mockResolvedValue([
-      {
-        id: 'r1',
-        tenant_id: 'tenant-new',
-        agent_name: 'agent-new',
-        metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-    ]);
-    mockGetConsumption.mockResolvedValue(0);
-
-    await service.checkLimits('tenant-new', 'agent-new');
-
-    // The first filler entry in the oldest bucket should have been evicted.
-    expect(oldestBucket.has('a-0:tokens:2026-01-01')).toBe(false);
-    // The new tenant's consumption was still cached under its own bucket.
-    expect(consumptionCache.has('tenant-new')).toBe(true);
-    expect(consumptionCache.get('tenant-new')!.size).toBe(1);
-  });
-
-  it('drops an emptied tenant bucket when its last entry is evicted by size', async () => {
-    const consumptionCache = (service as any).consumptionCache as Map<string, Map<string, unknown>>;
-    const now = Date.now();
-
-    // Oldest bucket holds a single entry; total still reaches MAX via a second
-    // bucket so the size guard fires and empties the oldest bucket entirely.
-    const oldestBucket = new Map<string, unknown>();
-    oldestBucket.set('a-old:tokens:2026-01-01', { data: 0, expiresAt: now + 999_999 });
-    consumptionCache.set('tenant-old', oldestBucket);
-
-    const fillerBucket = new Map<string, unknown>();
-    for (let i = 0; i < 9_999; i++) {
-      fillerBucket.set(`a-${i}:tokens:2026-01-01`, { data: 0, expiresAt: now + 999_999 });
-    }
-    consumptionCache.set('tenant-filler', fillerBucket);
-
-    mockGetActiveBlockRules.mockResolvedValue([
-      {
-        id: 'r1',
-        tenant_id: 'tenant-new',
-        agent_name: 'agent-new',
-        metric_type: 'tokens',
-        threshold: 100000,
-        period: 'day',
-      },
-    ]);
-    mockGetConsumption.mockResolvedValue(0);
-
-    await service.checkLimits('tenant-new', 'agent-new');
-
-    // The oldest bucket had its only entry evicted and was removed.
-    expect(consumptionCache.has('tenant-old')).toBe(false);
+    await expect(service.checkLimits('tenant-1', 'my-agent')).resolves.toBeNull();
+    await expect(service.checkLimits('tenant-1', 'my-agent')).resolves.toEqual(
+      expect.objectContaining({ ruleId: 'r1', actual: 100 }),
+    );
+    expect(mockGetConsumption).toHaveBeenCalledTimes(2);
   });
 
   describe('email notification on block', () => {

--- a/packages/backend/src/notifications/services/limit-check.service.spec.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.spec.ts
@@ -146,6 +146,33 @@ describe('LimitCheckService', () => {
     expect(result!.ruleId).toBe('r2');
   });
 
+  it('reuses consumption for rules with the same metric and period within one request', async () => {
+    mockGetActiveBlockRules.mockResolvedValue([
+      {
+        id: 'r1',
+        tenant_id: 't',
+        agent_name: 'a',
+        metric_type: 'tokens',
+        threshold: 100000,
+        period: 'day',
+      },
+      {
+        id: 'r2',
+        tenant_id: 't',
+        agent_name: 'a',
+        metric_type: 'tokens',
+        threshold: 50000,
+        period: 'day',
+      },
+    ]);
+    mockGetConsumption.mockResolvedValue(75000);
+
+    await expect(service.checkLimits('t', 'a')).resolves.toEqual(
+      expect.objectContaining({ ruleId: 'r2', actual: 75000 }),
+    );
+    expect(mockGetConsumption).toHaveBeenCalledTimes(1);
+  });
+
   it('enforces a block rule created through another replica on the next request', async () => {
     await expect(service.checkLimits('tenant-1', 'my-agent')).resolves.toBeNull();
 

--- a/packages/backend/src/notifications/services/limit-check.service.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.ts
@@ -42,15 +42,21 @@ export class LimitCheckService {
     const rules = await this.rulesService.getActiveBlockRules(tenantId, agentName);
     if (rules.length === 0) return null;
 
+    const consumptionByMetricAndPeriod = new Map<string, number>();
     for (const rule of rules) {
       const { periodStart, periodEnd } = computePeriodBoundaries(rule.period);
-      const actual = await this.rulesService.getConsumption(
-        tenantId,
-        agentName,
-        rule.metric_type,
-        periodStart,
-        periodEnd,
-      );
+      const consumptionKey = `${rule.metric_type}:${periodStart}:${periodEnd}`;
+      let actual = consumptionByMetricAndPeriod.get(consumptionKey);
+      if (actual === undefined) {
+        actual = await this.rulesService.getConsumption(
+          tenantId,
+          agentName,
+          rule.metric_type,
+          periodStart,
+          periodEnd,
+        );
+        consumptionByMetricAndPeriod.set(consumptionKey, actual);
+      }
 
       if (actual >= rule.threshold) {
         this.notifyLimitExceeded(rule, actual, periodStart, periodEnd).catch((err) => {

--- a/packages/backend/src/notifications/services/limit-check.service.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.ts
@@ -1,10 +1,8 @@
-import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { Subscription } from 'rxjs';
+import { Injectable, Logger } from '@nestjs/common';
 import { NotificationRulesService } from './notification-rules.service';
 import { NotificationEmailService } from './notification-email.service';
 import { EmailProviderConfigService } from './email-provider-config.service';
 import { NotificationLogService, formatNotificationTimestamp } from './notification-log.service';
-import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { ManifestRuntimeService } from '../../common/services/manifest-runtime.service';
 import { computePeriodBoundaries, computePeriodResetDate } from '../../common/utils/period.util';
 
@@ -25,53 +23,28 @@ export interface LimitExceeded {
   period: string;
 }
 
-interface CacheEntry<T> {
-  data: T;
-  expiresAt: number;
-}
-
-const CACHE_TTL_MS = 60_000;
-const MAX_CACHE_SIZE = 10_000;
-
 @Injectable()
-export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
+export class LimitCheckService {
   private readonly logger = new Logger(LimitCheckService.name);
-  private readonly rulesCache = new Map<string, CacheEntry<BlockRule[]>>();
-  // Consumption is cached per-tenant (outer key) so an ingest event — which
-  // carries the tenantId of the agent that just wrote a message — can evict
-  // just that tenant's buckets instead of nuking every tenant's cached
-  // consumption. The inner key keeps the agent/metric/period granularity.
-  private readonly consumptionCache = new Map<string, Map<string, CacheEntry<number>>>();
-  private ingestSub?: Subscription;
 
   constructor(
     private readonly rulesService: NotificationRulesService,
     private readonly emailService: NotificationEmailService,
     private readonly emailProviderConfig: EmailProviderConfigService,
-    private readonly ingestBus: IngestEventBusService,
     private readonly runtime: ManifestRuntimeService,
     private readonly notificationLog: NotificationLogService,
   ) {}
 
-  onModuleInit(): void {
-    this.ingestSub = this.ingestBus.all().subscribe((event) => {
-      // Surgical eviction: only the writing tenant's consumption is now stale.
-      // Other tenants' cached entries keep serving from cache for the TTL.
-      this.consumptionCache.delete(event.tenantId);
-    });
-  }
-
-  onModuleDestroy(): void {
-    this.ingestSub?.unsubscribe();
-  }
-
   async checkLimits(tenantId: string, agentName: string): Promise<LimitExceeded | null> {
-    const rules = await this.getCachedRules(tenantId, agentName);
+    // Hard limits are an enforcement boundary. Read both the rules and their
+    // current consumption for every provider request so changes made through a
+    // different backend replica take effect on the next request.
+    const rules = await this.rulesService.getActiveBlockRules(tenantId, agentName);
     if (rules.length === 0) return null;
 
     for (const rule of rules) {
       const { periodStart, periodEnd } = computePeriodBoundaries(rule.period);
-      const actual = await this.getCachedConsumption(
+      const actual = await this.rulesService.getConsumption(
         tenantId,
         agentName,
         rule.metric_type,
@@ -95,18 +68,6 @@ export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
     }
 
     return null;
-  }
-
-  invalidateCache(tenantId: string, agentName: string): void {
-    this.rulesCache.delete(`${tenantId}:${agentName}`);
-    // Drop only this agent's inner entries from the tenant's bucket.
-    const inner = this.consumptionCache.get(tenantId);
-    if (!inner) return;
-    const innerPrefix = `${agentName}:`;
-    for (const innerKey of inner.keys()) {
-      if (innerKey.startsWith(innerPrefix)) inner.delete(innerKey);
-    }
-    if (inner.size === 0) this.consumptionCache.delete(tenantId);
   }
 
   private async notifyLimitExceeded(
@@ -151,85 +112,5 @@ export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
         providerConfig ?? undefined,
       );
     }
-  }
-
-  private async getCachedRules(tenantId: string, agentName: string): Promise<BlockRule[]> {
-    const key = `${tenantId}:${agentName}`;
-    const now = Date.now();
-    const cached = this.rulesCache.get(key);
-    if (cached && cached.expiresAt > now) return cached.data;
-
-    this.evictExpired(this.rulesCache, now);
-    this.evictOldestIfFull(this.rulesCache);
-    const rules = await this.rulesService.getActiveBlockRules(tenantId, agentName);
-    this.rulesCache.set(key, { data: rules, expiresAt: now + CACHE_TTL_MS });
-    return rules;
-  }
-
-  private async getCachedConsumption(
-    tenantId: string,
-    agentName: string,
-    metricType: 'tokens' | 'cost',
-    periodStart: string,
-    periodEnd: string,
-  ): Promise<number> {
-    const innerKey = `${agentName}:${metricType}:${periodStart}`;
-    const now = Date.now();
-    const cached = this.consumptionCache.get(tenantId)?.get(innerKey);
-    if (cached && cached.expiresAt > now) return cached.data;
-
-    this.evictExpiredConsumption(now);
-    this.evictOldestConsumptionIfFull();
-    const actual = await this.rulesService.getConsumption(
-      tenantId,
-      agentName,
-      metricType,
-      periodStart,
-      periodEnd,
-    );
-    let bucket = this.consumptionCache.get(tenantId);
-    if (!bucket) {
-      bucket = new Map<string, CacheEntry<number>>();
-      this.consumptionCache.set(tenantId, bucket);
-    }
-    bucket.set(innerKey, { data: actual, expiresAt: now + CACHE_TTL_MS });
-    return actual;
-  }
-
-  private evictExpired<T>(cache: Map<string, CacheEntry<T>>, now: number): void {
-    for (const [k, v] of cache) {
-      if (v.expiresAt <= now) cache.delete(k);
-    }
-  }
-
-  private evictOldestIfFull<T>(cache: Map<string, CacheEntry<T>>): void {
-    if (cache.size >= MAX_CACHE_SIZE) {
-      const firstKey = cache.keys().next().value;
-      if (firstKey) cache.delete(firstKey);
-    }
-  }
-
-  private evictExpiredConsumption(now: number): void {
-    for (const [tenantId, inner] of this.consumptionCache) {
-      this.evictExpired(inner, now);
-      if (inner.size === 0) this.consumptionCache.delete(tenantId);
-    }
-  }
-
-  private evictOldestConsumptionIfFull(): void {
-    let total = 0;
-    for (const inner of this.consumptionCache.values()) total += inner.size;
-    if (total < MAX_CACHE_SIZE) return;
-
-    // total >= MAX_CACHE_SIZE guarantees the first bucket exists and is
-    // non-empty (empty buckets are dropped eagerly elsewhere). Evict its oldest
-    // inner entry, removing the bucket if that was its last entry.
-    const [tenantId, inner] = this.consumptionCache.entries().next().value as [
-      string,
-      Map<string, CacheEntry<number>>,
-    ];
-    const firstInnerKey = inner.keys().next().value as string;
-    inner.delete(firstInnerKey);
-    if (inner.size === 0) this.consumptionCache.delete(tenantId);
   }
 }


### PR DESCRIPTION
### What changed

- Read active hard-limit rules on every provider request.
- Read current consumption before enforcing each active rule.
- Remove replica-local limit caches and mutation invalidation.

### Why

Rules and consumption were cached for 60 seconds. A different backend replica could miss a new or updated rule, keep enforcing a deleted rule, or use stale consumption.

### User impact

Hard-limit changes and new usage now apply on the next request across backend replicas.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hard-limit enforcement so rule and usage changes apply on the next request across backend replicas.

Previously, rules and consumption were cached for 60 seconds, causing replicas to enforce stale limits. Now each request reads active rules and current consumption directly, with consumption read once per metric and period when multiple rules share it.

<sup>Written for commit 24007d9ef181e1250b4d67d8caa9189d983bdf17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

