### PR TITLE
refactor(proxy): leave conditional fixes to Autofix

### DIFF
--- a/.changeset/calm-otters-heal.md
+++ b/.changeset/calm-otters-heal.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Leave provider- and model-specific request corrections to Autofix.

--- a/.changeset/calm-otters-heal.md
+++ b/.changeset/calm-otters-heal.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Leave provider- and model-specific request corrections to Autofix.
+Leave conditional provider corrections to Autofix while preserving protocol translations.

--- a/.changeset/calm-otters-heal.md
+++ b/.changeset/calm-otters-heal.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Leave conditional provider corrections to Autofix while preserving protocol translations.
+Leave model-specific provider corrections to Autofix. Keep provider-level protocol strips (OpenAI-only fields, OpenRouter and Ollama dialect fields) so traffic does not regress when Autofix is off.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -154,15 +154,19 @@ describe('Anthropic Adapter', () => {
       expect(result.stop_sequences).toEqual(['STOP', 'END']);
     });
 
-    it('strips adaptive thinking when routing to Claude Haiku 4.5', () => {
+    it('preserves adaptive thinking for model-specific Autofix', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
         thinking: { type: 'adaptive' },
       };
 
-      expect(toAnthropicRequest(body, 'claude-haiku-4-5-20251001').thinking).toBeUndefined();
-      expect(toAnthropicRequest(body, 'anthropic/claude-haiku-4.5').thinking).toBeUndefined();
-      expect(toAnthropicRequest(body, 'claude-haiku-4').thinking).toBeUndefined();
+      expect(toAnthropicRequest(body, 'claude-haiku-4-5-20251001').thinking).toEqual({
+        type: 'adaptive',
+      });
+      expect(toAnthropicRequest(body, 'anthropic/claude-haiku-4.5').thinking).toEqual({
+        type: 'adaptive',
+      });
+      expect(toAnthropicRequest(body, 'claude-haiku-4').thinking).toEqual({ type: 'adaptive' });
     });
 
     it('preserves extended thinking for Claude Haiku 4.5', () => {
@@ -189,7 +193,7 @@ describe('Anthropic Adapter', () => {
       });
     });
 
-    it('drops the manual budget when forwarding adaptive thinking', () => {
+    it('preserves the manual budget for adaptive-thinking Autofix', () => {
       const thinking = { type: 'adaptive', budget_tokens: 8192, display: 'omitted' };
 
       const result = toAnthropicRequest(
@@ -197,7 +201,7 @@ describe('Anthropic Adapter', () => {
         'claude-opus-4-8',
       );
 
-      expect(result.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+      expect(result.thinking).toBe(thinking);
       expect(thinking).toEqual({
         type: 'adaptive',
         budget_tokens: 8192,
@@ -2220,7 +2224,7 @@ describe('Anthropic Adapter', () => {
   });
 
   describe('applyAnthropicMessagesMutations', () => {
-    it('drops the manual budget from native adaptive thinking without mutating the body', () => {
+    it('preserves the manual budget in native adaptive thinking', () => {
       const inbound = {
         messages: [{ role: 'user', content: 'hi' }],
         thinking: { type: 'adaptive', budget_tokens: 8192, display: 'omitted' },
@@ -2228,7 +2232,7 @@ describe('Anthropic Adapter', () => {
 
       const result = applyAnthropicMessagesMutations(inbound);
 
-      expect(result.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+      expect(result.thinking).toBe(inbound.thinking);
       expect(inbound.thinking).toEqual({
         type: 'adaptive',
         budget_tokens: 8192,
@@ -2782,26 +2786,20 @@ describe('Anthropic Adapter', () => {
       });
     });
 
-    it('downgrades Opus/Fable xhigh effort when Manifest resolves the request to Sonnet', () => {
-      const result = applyAnthropicMessagesMutations(
-        {
-          messages: [{ role: 'user', content: 'hi' }],
-          output_config: { effort: 'xhigh', style: 'unchanged' },
-        },
-        { targetModel: 'claude-sonnet-4-6' },
-      );
+    it('preserves xhigh effort when Manifest resolves the request to Sonnet', () => {
+      const result = applyAnthropicMessagesMutations({
+        messages: [{ role: 'user', content: 'hi' }],
+        output_config: { effort: 'xhigh', style: 'unchanged' },
+      });
 
-      expect(result.output_config).toEqual({ effort: 'high', style: 'unchanged' });
+      expect(result.output_config).toEqual({ effort: 'xhigh', style: 'unchanged' });
     });
 
     it('keeps xhigh effort when the resolved Anthropic model supports it', () => {
-      const result = applyAnthropicMessagesMutations(
-        {
-          messages: [{ role: 'user', content: 'hi' }],
-          output_config: { effort: 'xhigh' },
-        },
-        { targetModel: 'claude-opus-4-8' },
-      );
+      const result = applyAnthropicMessagesMutations({
+        messages: [{ role: 'user', content: 'hi' }],
+        output_config: { effort: 'xhigh' },
+      });
 
       expect(result.output_config).toEqual({ effort: 'xhigh' });
     });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -5,7 +5,7 @@ import {
 
 describe('provider-client-converters', () => {
   describe('sanitizeOpenAiBody', () => {
-    /* ── Top-level field stripping ── */
+    /* ── Top-level field preservation ── */
 
     it('should pass through all fields for openai provider', () => {
       const body = {
@@ -23,7 +23,7 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('stream_options');
     });
 
-    it('should strip OpenAI-only fields for non-passthrough providers', () => {
+    it('should preserve provider-specific fields for Autofix', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
         model: 'mistral-large',
@@ -40,14 +40,14 @@ describe('provider-client-converters', () => {
 
       const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large');
 
-      expect(result).not.toHaveProperty('store');
-      expect(result).not.toHaveProperty('metadata');
-      expect(result).not.toHaveProperty('service_tier');
-      expect(result).not.toHaveProperty('stream_options');
-      expect(result).not.toHaveProperty('modalities');
-      expect(result).not.toHaveProperty('audio');
-      expect(result).not.toHaveProperty('prediction');
-      expect(result).not.toHaveProperty('reasoning_effort');
+      expect(result).toHaveProperty('store', true);
+      expect(result).toHaveProperty('metadata', {});
+      expect(result).toHaveProperty('service_tier', 'auto');
+      expect(result).toHaveProperty('stream_options', {});
+      expect(result).toHaveProperty('modalities', ['text']);
+      expect(result).toHaveProperty('audio', {});
+      expect(result).toHaveProperty('prediction', {});
+      expect(result).toHaveProperty('reasoning_effort', 'medium');
       expect(result).toHaveProperty('temperature', 0.5);
     });
 
@@ -137,7 +137,7 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('metadata');
     });
 
-    it('should strip Anthropic-style thinking params for Ollama endpoints', () => {
+    it('should preserve Anthropic-style thinking params for Ollama Autofix', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
         thinking: { type: 'enabled' },
@@ -148,7 +148,7 @@ describe('provider-client-converters', () => {
       for (const endpointKey of ['ollama', 'ollama-cloud', 'Ollama']) {
         const result = sanitizeOpenAiBody(body, endpointKey, 'qwen3.5:9b-q4_K_M');
 
-        expect(result).not.toHaveProperty('thinking');
+        expect(result).toHaveProperty('thinking', { type: 'enabled' });
         expect(result).toHaveProperty('max_tokens', 4096);
         expect(result).toHaveProperty('temperature', 0.5);
       }
@@ -165,67 +165,21 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('thinking', { type: 'enabled' });
     });
 
-    /* ── DeepSeek max_tokens normalization ── */
+    it('should preserve DeepSeek max_tokens for an evidence-based clamp', () => {
+      for (const maxTokens of [16000, 5000.7, 0, -100, '4096', 'not-a-number']) {
+        const result = sanitizeOpenAiBody(
+          { messages: [], max_tokens: maxTokens },
+          'deepseek',
+          'deepseek-chat',
+        );
 
-    it('should cap max_tokens at 8192 for deepseek provider', () => {
-      const body = { messages: [], max_tokens: 16000 };
-
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat');
-
-      expect(result.max_tokens).toBe(8192);
+        expect(result.max_tokens).toBe(maxTokens);
+      }
     });
 
-    it('should truncate fractional max_tokens for deepseek', () => {
-      const body = { messages: [], max_tokens: 5000.7 };
+    /* ── Message field preservation ── */
 
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat');
-
-      expect(result.max_tokens).toBe(5000);
-    });
-
-    it('should delete max_tokens when 0 for deepseek', () => {
-      const body = { messages: [], max_tokens: 0 };
-
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat');
-
-      expect(result).not.toHaveProperty('max_tokens');
-    });
-
-    it('should delete max_tokens when negative for deepseek', () => {
-      const body = { messages: [], max_tokens: -100 };
-
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat');
-
-      expect(result).not.toHaveProperty('max_tokens');
-    });
-
-    it('should handle string max_tokens for deepseek', () => {
-      const body = { messages: [], max_tokens: '4096' as unknown };
-
-      const result = sanitizeOpenAiBody(body as any, 'deepseek', 'deepseek-chat');
-
-      expect(result.max_tokens).toBe(4096);
-    });
-
-    it('should delete non-finite max_tokens for deepseek', () => {
-      const body = { messages: [], max_tokens: 'not-a-number' as unknown };
-
-      const result = sanitizeOpenAiBody(body as any, 'deepseek', 'deepseek-chat');
-
-      expect(result).not.toHaveProperty('max_tokens');
-    });
-
-    it('should delete max_tokens that truncates to 0 for deepseek', () => {
-      const body = { messages: [], max_tokens: 0.5 };
-
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat');
-
-      expect(result).not.toHaveProperty('max_tokens');
-    });
-
-    /* ── Message sanitization: reasoning_content ── */
-
-    it('should strip reasoning_content for non-deepseek providers', () => {
+    it('should preserve reasoning_content for provider-specific Autofix', () => {
       const body = {
         messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'I thought...' }],
       };
@@ -233,7 +187,7 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'anthropic', 'claude-3');
       const messages = result.messages as any[];
 
-      expect(messages[0]).not.toHaveProperty('reasoning_content');
+      expect(messages[0]).toHaveProperty('reasoning_content', 'I thought...');
     });
 
     it('should preserve reasoning_content for deepseek provider', () => {
@@ -291,7 +245,7 @@ describe('provider-client-converters', () => {
       expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
     });
 
-    it('should strip reasoning_content for non-deepseek openrouter models', () => {
+    it('should preserve reasoning_content for non-deepseek openrouter models', () => {
       const body = {
         messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
       };
@@ -299,7 +253,7 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'openrouter', 'openai/gpt-4o');
       const messages = result.messages as any[];
 
-      expect(messages[0]).not.toHaveProperty('reasoning_content');
+      expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
     });
 
     it('should preserve reasoning_content for opencode-go deepseek models (issue #1862)', () => {
@@ -354,7 +308,7 @@ describe('provider-client-converters', () => {
       }
     });
 
-    it('should strip reasoning_content for unknown opencode-go model families', () => {
+    it('should preserve reasoning_content for unknown opencode-go model families', () => {
       const body = {
         messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
       };
@@ -362,7 +316,7 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'opencode-go', 'opencode-go/claude-sonnet-4');
       const messages = result.messages as any[];
 
-      expect(messages[0]).not.toHaveProperty('reasoning_content');
+      expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
     });
 
     it('should preserve reasoning_content for custom providers proxying DeepSeek', () => {
@@ -390,18 +344,14 @@ describe('provider-client-converters', () => {
       expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
     });
 
-    it('should strip reasoning_content for deepseek-derived slugs on strict OpenAI endpoints', () => {
-      // Community distillations carry the DeepSeek name but are hosted by
-      // providers that may not implement DeepSeek's echo contract and may
-      // reject unknown message fields. The endpoint allowlist excludes
-      // them — substring-match alone is not enough.
+    it('should preserve reasoning_content for deepseek-derived slugs on strict endpoints', () => {
       for (const endpointKey of ['mistral', 'anthropic', 'openai']) {
         const body = {
           messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
         };
         const result = sanitizeOpenAiBody(body, endpointKey, 'deepseek-r1-distill-llama-70b');
         const messages = result.messages as any[];
-        expect(messages[0]).not.toHaveProperty('reasoning_content');
+        expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
       }
     });
 
@@ -446,8 +396,8 @@ describe('provider-client-converters', () => {
       const messages = result.messages as any[];
 
       expect(messages[0]).not.toHaveProperty('reasoning_content');
-      expect(messages[0]).not.toHaveProperty('reasoning');
-      expect(messages[0]).not.toHaveProperty('reasoning_text');
+      expect(messages[0]).toHaveProperty('reasoning', 'plain provider reasoning');
+      expect(messages[0]).toHaveProperty('reasoning_text', 'provider reasoning');
     });
 
     it('does not flatten reasoning_details to reasoning_content for compatible tool-call messages', () => {
@@ -473,7 +423,7 @@ describe('provider-client-converters', () => {
       const messages = result.messages as any[];
 
       expect(messages[0]).not.toHaveProperty('reasoning_content');
-      expect(messages[0]).not.toHaveProperty('reasoning_details');
+      expect(messages[0]).toHaveProperty('reasoning_details', body.messages[0].reasoning_details);
     });
 
     it('does not add reasoning_content to strict providers', () => {
@@ -493,7 +443,7 @@ describe('provider-client-converters', () => {
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
-    it('strips reasoning_text for strict providers', () => {
+    it('preserves reasoning aliases for strict-provider Autofix', () => {
       const body = {
         messages: [
           {
@@ -509,8 +459,8 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large');
       const messages = result.messages as any[];
 
-      expect(messages[0]).not.toHaveProperty('reasoning_text');
-      expect(messages[0]).not.toHaveProperty('reasoning');
+      expect(messages[0]).toHaveProperty('reasoning_text', 'provider reasoning');
+      expect(messages[0]).toHaveProperty('reasoning', 'plain provider reasoning');
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
@@ -532,9 +482,9 @@ describe('provider-client-converters', () => {
       expect(messages[0]).toHaveProperty('reasoning_content', 'client reasoning');
     });
 
-    /* ── Message sanitization: reasoning_details ── */
+    /* ── Message shape edge cases ── */
 
-    it('should strip reasoning_details for non-openrouter providers', () => {
+    it('should preserve reasoning_details for non-openrouter providers', () => {
       const body = {
         messages: [
           {
@@ -548,10 +498,10 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'mistral', 'ministral-3b-2512');
       const messages = result.messages as any[];
 
-      expect(messages[0]).not.toHaveProperty('reasoning_details');
+      expect(messages[0]).toHaveProperty('reasoning_details', body.messages[0].reasoning_details);
     });
 
-    it('should strip reasoning_details for native openai targets', () => {
+    it('should preserve reasoning_details for native openai targets', () => {
       const body = {
         messages: [
           {
@@ -565,7 +515,7 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'openai', 'gpt-4o');
       const messages = result.messages as any[];
 
-      expect(messages[0]).not.toHaveProperty('reasoning_details');
+      expect(messages[0]).toHaveProperty('reasoning_details', body.messages[0].reasoning_details);
     });
 
     it('should preserve reasoning_details for openrouter targets', () => {
@@ -1052,7 +1002,7 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
-    it('should still strip OPENAI_ONLY_FIELDS for Copilot GPT-5', () => {
+    it('should preserve provider-specific fields for Copilot GPT-5 Autofix', () => {
       const body = {
         messages: [],
         max_tokens: 4096,
@@ -1063,8 +1013,8 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5');
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
-      expect(result).not.toHaveProperty('store');
-      expect(result).not.toHaveProperty('service_tier');
+      expect(result).toHaveProperty('store', true);
+      expect(result).toHaveProperty('service_tier', 'auto');
     });
   });
 
@@ -1298,11 +1248,6 @@ describe('provider-client-converters', () => {
 });
 
 describe('sanitizeOpenAiBody reasoning dialect', () => {
-  const zenCatalog = {
-    isReasoningModel: (_endpointKey: string, model: string) =>
-      model.toLowerCase().endsWith('big-pickle') ? true : undefined,
-  };
-
   const bodyWithReasoning = () => ({
     messages: [
       {
@@ -1314,27 +1259,25 @@ describe('sanitizeOpenAiBody reasoning dialect', () => {
     ],
   });
 
-  it('keeps reasoning_content for a Zen model the catalog marks as reasoning', () => {
+  it('keeps reasoning_content without consulting model capabilities', () => {
     const result = sanitizeOpenAiBody(
       bodyWithReasoning(),
       'opencode-zen',
       'opencode-zen/big-pickle',
-      zenCatalog,
     );
 
     const messages = result.messages as Array<Record<string, unknown>>;
     expect(messages[0].reasoning_content).toBe('upstream thinking');
   });
 
-  it('still strips reasoning_content for a Zen slug nothing vouches for', () => {
+  it('keeps reasoning_content when the catalog has no provider capability entry', () => {
     const result = sanitizeOpenAiBody(
       bodyWithReasoning(),
       'opencode-zen',
       'opencode-zen/mystery-slug',
-      zenCatalog,
     );
 
     const messages = result.messages as Array<Record<string, unknown>>;
-    expect(messages[0].reasoning_content).toBeUndefined();
+    expect(messages[0].reasoning_content).toBe('upstream thinking');
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -1247,7 +1247,7 @@ describe('provider-client-converters', () => {
   });
 });
 
-describe('sanitizeOpenAiBody reasoning dialect', () => {
+describe('sanitizeOpenAiBody provider-specific fields', () => {
   const bodyWithReasoning = () => ({
     messages: [
       {
@@ -1259,22 +1259,11 @@ describe('sanitizeOpenAiBody reasoning dialect', () => {
     ],
   });
 
-  it('keeps reasoning_content without consulting model capabilities', () => {
+  it('keeps reasoning_content without model capability checks', () => {
     const result = sanitizeOpenAiBody(
       bodyWithReasoning(),
       'opencode-zen',
       'opencode-zen/big-pickle',
-    );
-
-    const messages = result.messages as Array<Record<string, unknown>>;
-    expect(messages[0].reasoning_content).toBe('upstream thinking');
-  });
-
-  it('keeps reasoning_content when the catalog has no provider capability entry', () => {
-    const result = sanitizeOpenAiBody(
-      bodyWithReasoning(),
-      'opencode-zen',
-      'opencode-zen/mystery-slug',
     );
 
     const messages = result.messages as Array<Record<string, unknown>>;

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -23,7 +23,7 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('stream_options');
     });
 
-    it('should preserve provider-specific fields for Autofix', () => {
+    it('should strip OpenAI-only fields for non-passthrough providers', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
         model: 'mistral-large',
@@ -40,14 +40,14 @@ describe('provider-client-converters', () => {
 
       const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large');
 
-      expect(result).toHaveProperty('store', true);
-      expect(result).toHaveProperty('metadata', {});
-      expect(result).toHaveProperty('service_tier', 'auto');
-      expect(result).toHaveProperty('stream_options', {});
-      expect(result).toHaveProperty('modalities', ['text']);
-      expect(result).toHaveProperty('audio', {});
-      expect(result).toHaveProperty('prediction', {});
-      expect(result).toHaveProperty('reasoning_effort', 'medium');
+      expect(result).not.toHaveProperty('store');
+      expect(result).not.toHaveProperty('metadata');
+      expect(result).not.toHaveProperty('service_tier');
+      expect(result).not.toHaveProperty('stream_options');
+      expect(result).not.toHaveProperty('modalities');
+      expect(result).not.toHaveProperty('audio');
+      expect(result).not.toHaveProperty('prediction');
+      expect(result).not.toHaveProperty('reasoning_effort');
       expect(result).toHaveProperty('temperature', 0.5);
     });
 
@@ -137,7 +137,7 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('metadata');
     });
 
-    it('should preserve Anthropic-style thinking params for Ollama Autofix', () => {
+    it('should strip Anthropic-style thinking params for Ollama endpoints', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
         thinking: { type: 'enabled' },
@@ -148,7 +148,7 @@ describe('provider-client-converters', () => {
       for (const endpointKey of ['ollama', 'ollama-cloud', 'Ollama']) {
         const result = sanitizeOpenAiBody(body, endpointKey, 'qwen3.5:9b-q4_K_M');
 
-        expect(result).toHaveProperty('thinking', { type: 'enabled' });
+        expect(result).not.toHaveProperty('thinking');
         expect(result).toHaveProperty('max_tokens', 4096);
         expect(result).toHaveProperty('temperature', 0.5);
       }
@@ -396,8 +396,8 @@ describe('provider-client-converters', () => {
       const messages = result.messages as any[];
 
       expect(messages[0]).not.toHaveProperty('reasoning_content');
-      expect(messages[0]).toHaveProperty('reasoning', 'plain provider reasoning');
-      expect(messages[0]).toHaveProperty('reasoning_text', 'provider reasoning');
+      expect(messages[0]).not.toHaveProperty('reasoning');
+      expect(messages[0]).not.toHaveProperty('reasoning_text');
     });
 
     it('does not flatten reasoning_details to reasoning_content for compatible tool-call messages', () => {
@@ -423,7 +423,7 @@ describe('provider-client-converters', () => {
       const messages = result.messages as any[];
 
       expect(messages[0]).not.toHaveProperty('reasoning_content');
-      expect(messages[0]).toHaveProperty('reasoning_details', body.messages[0].reasoning_details);
+      expect(messages[0]).not.toHaveProperty('reasoning_details');
     });
 
     it('does not add reasoning_content to strict providers', () => {
@@ -443,7 +443,7 @@ describe('provider-client-converters', () => {
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
-    it('preserves reasoning aliases for strict-provider Autofix', () => {
+    it('strips reasoning aliases for strict providers', () => {
       const body = {
         messages: [
           {
@@ -459,8 +459,8 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large');
       const messages = result.messages as any[];
 
-      expect(messages[0]).toHaveProperty('reasoning_text', 'provider reasoning');
-      expect(messages[0]).toHaveProperty('reasoning', 'plain provider reasoning');
+      expect(messages[0]).not.toHaveProperty('reasoning_text');
+      expect(messages[0]).not.toHaveProperty('reasoning');
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
@@ -484,7 +484,7 @@ describe('provider-client-converters', () => {
 
     /* ── Message shape edge cases ── */
 
-    it('should preserve reasoning_details for non-openrouter providers', () => {
+    it('should strip reasoning_details for non-openrouter providers', () => {
       const body = {
         messages: [
           {
@@ -498,10 +498,10 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'mistral', 'ministral-3b-2512');
       const messages = result.messages as any[];
 
-      expect(messages[0]).toHaveProperty('reasoning_details', body.messages[0].reasoning_details);
+      expect(messages[0]).not.toHaveProperty('reasoning_details');
     });
 
-    it('should preserve reasoning_details for native openai targets', () => {
+    it('should strip reasoning_details for native openai targets', () => {
       const body = {
         messages: [
           {
@@ -515,7 +515,7 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'openai', 'gpt-4o');
       const messages = result.messages as any[];
 
-      expect(messages[0]).toHaveProperty('reasoning_details', body.messages[0].reasoning_details);
+      expect(messages[0]).not.toHaveProperty('reasoning_details');
     });
 
     it('should preserve reasoning_details for openrouter targets', () => {
@@ -1002,7 +1002,7 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
-    it('should preserve provider-specific fields for Copilot GPT-5 Autofix', () => {
+    it('should still strip OPENAI_ONLY_FIELDS for Copilot GPT-5', () => {
       const body = {
         messages: [],
         max_tokens: 4096,
@@ -1013,8 +1013,8 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5');
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
-      expect(result).toHaveProperty('store', true);
-      expect(result).toHaveProperty('service_tier', 'auto');
+      expect(result).not.toHaveProperty('store');
+      expect(result).not.toHaveProperty('service_tier');
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -4136,7 +4136,7 @@ describe('ProviderClient', () => {
     });
   });
 
-  describe('Body sanitization for non-OpenAI providers', () => {
+  describe('Body wire normalization for non-OpenAI providers', () => {
     const bodyWithOpenAiFields = {
       messages: [{ role: 'user', content: 'Hello' }],
       temperature: 0.7,
@@ -4169,7 +4169,7 @@ describe('ProviderClient', () => {
       temperature: 0.7,
     });
 
-    it('strips OpenAI-only fields for Mistral', async () => {
+    it('preserves provider-specific fields for Mistral Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({
         provider: 'mistral',
@@ -4180,10 +4180,10 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.store).toBeUndefined();
-      expect(sentBody.metadata).toBeUndefined();
-      expect(sentBody.service_tier).toBeUndefined();
-      expect(sentBody.stream_options).toBeUndefined();
+      expect(sentBody.store).toBe(false);
+      expect(sentBody.metadata).toEqual({ user: 'test' });
+      expect(sentBody.service_tier).toBe('default');
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
       expect(sentBody.messages).toEqual(bodyWithOpenAiFields.messages);
       expect(sentBody.temperature).toBe(0.7);
     });
@@ -4219,7 +4219,7 @@ describe('ProviderClient', () => {
       expect(sentBody.max_completion_tokens).toBeUndefined();
     });
 
-    it('strips OpenAI-only fields for DeepSeek', async () => {
+    it('preserves provider-specific fields for DeepSeek Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({
         provider: 'deepseek',
@@ -4230,8 +4230,8 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.store).toBeUndefined();
-      expect(sentBody.service_tier).toBeUndefined();
+      expect(sentBody.store).toBe(false);
+      expect(sentBody.service_tier).toBe('default');
     });
 
     it('preserves DeepSeek reasoning_effort in the provider-facing request', async () => {
@@ -4258,7 +4258,7 @@ describe('ProviderClient', () => {
       expect(result.wireRequestBody).toEqual(sentBody);
     });
 
-    it('caps DeepSeek max_tokens at the provider limit', async () => {
+    it('preserves DeepSeek max_tokens above a possible provider limit', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
@@ -4270,10 +4270,10 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.max_tokens).toBe(8192);
+      expect(sentBody.max_tokens).toBe(12000);
     });
 
-    it('drops non-positive DeepSeek max_tokens values', async () => {
+    it('preserves non-positive DeepSeek max_tokens values for Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
@@ -4285,10 +4285,10 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.max_tokens).toBeUndefined();
+      expect(sentBody.max_tokens).toBe(0);
     });
 
-    it('normalizes string DeepSeek max_tokens values', async () => {
+    it('preserves string DeepSeek max_tokens values for Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
@@ -4300,10 +4300,10 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.max_tokens).toBe(8192);
+      expect(sentBody.max_tokens).toBe('9000');
     });
 
-    it('strips reasoning_content for Mistral assistant messages without mutating the input', async () => {
+    it('preserves reasoning_content for Mistral Autofix without mutating the input', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningContent = makeBodyWithReasoningContent();
 
@@ -4316,7 +4316,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
+      expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
       expect(bodyWithReasoningContent.messages[1].reasoning_content).toBe(
         'Detailed internal reasoning',
       );
@@ -4338,7 +4338,7 @@ describe('ProviderClient', () => {
       expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
     });
 
-    it('strips reasoning_content for native OpenAI targets', async () => {
+    it('preserves reasoning_content for native OpenAI Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningContent = makeBodyWithReasoningContent();
 
@@ -4351,10 +4351,10 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
+      expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
     });
 
-    it('strips reasoning_content for non-DeepSeek OpenRouter targets', async () => {
+    it('preserves reasoning_content for non-DeepSeek OpenRouter targets', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningContent = makeBodyWithReasoningContent();
 
@@ -4367,7 +4367,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
+      expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
     });
 
     it('preserves reasoning_content for DeepSeek models on OpenRouter', async () => {
@@ -4386,7 +4386,7 @@ describe('ProviderClient', () => {
       expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
     });
 
-    it('strips reasoning_details for Mistral assistant messages without mutating the input', async () => {
+    it('preserves reasoning_details for Mistral Autofix without mutating the input', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
 
@@ -4399,13 +4399,15 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
+      expect(sentBody.messages[1].reasoning_details).toEqual([
+        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
+      ]);
       expect(bodyWithReasoningDetails.messages[1].reasoning_details).toEqual([
         { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
       ]);
     });
 
-    it('strips reasoning_details for native OpenAI targets', async () => {
+    it('preserves reasoning_details for native OpenAI Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
 
@@ -4418,10 +4420,12 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
+      expect(sentBody.messages[1].reasoning_details).toEqual([
+        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
+      ]);
     });
 
-    it('strips reasoning_details for DeepSeek (does not support reasoning_details)', async () => {
+    it('preserves reasoning_details for DeepSeek Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
 
@@ -4434,7 +4438,9 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
+      expect(sentBody.messages[1].reasoning_details).toEqual([
+        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
+      ]);
     });
 
     it('preserves reasoning_details for OpenRouter targets', async () => {
@@ -4494,7 +4500,7 @@ describe('ProviderClient', () => {
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.messages[0]).toBe('unexpected-entry');
-      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
+      expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
     });
 
     it('normalizes non-compliant tool call ids for Mistral while preserving references', async () => {
@@ -4726,7 +4732,7 @@ describe('ProviderClient', () => {
       expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
-    it('does not forward Anthropic-style thinking params to Ollama endpoints', async () => {
+    it('preserves Anthropic-style thinking params for Ollama Autofix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       for (const provider of ['ollama', 'ollama-cloud']) {
@@ -4744,7 +4750,7 @@ describe('ProviderClient', () => {
         });
 
         const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-        expect(sentBody).not.toHaveProperty('thinking');
+        expect(sentBody).toHaveProperty('thinking', { type: 'enabled' });
         expect(sentBody).toEqual(
           expect.objectContaining({
             model: 'qwen3.5:9b-q4_K_M',
@@ -5283,7 +5289,7 @@ describe('ProviderClient', () => {
   });
 });
 
-describe('ProviderClient reasoning catalog', () => {
+describe('ProviderClient provider-specific message fields', () => {
   const previousMode = process.env['MANIFEST_MODE'];
 
   beforeEach(() => {
@@ -5308,24 +5314,7 @@ describe('ProviderClient reasoning catalog', () => {
     ],
   };
 
-  it('forwards reasoning_content to Zen when the injected catalog vouches for the model', async () => {
-    const catalogClient = new ProviderClient(undefined, undefined, undefined, {
-      isReasoningModel: () => true,
-    });
-
-    await catalogClient.forward({
-      provider: 'opencode-zen',
-      apiKey: 'zen-token',
-      model: 'opencode-zen/big-pickle',
-      body: reasoningBody,
-      stream: false,
-    });
-
-    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(sentBody.messages[0].reasoning_content).toBe('upstream thinking');
-  });
-
-  it('strips reasoning_content for Zen when no catalog is wired', async () => {
+  it('preserves reasoning_content for Zen without consulting model capabilities', async () => {
     const bareClient = new ProviderClient();
 
     await bareClient.forward({
@@ -5337,6 +5326,6 @@ describe('ProviderClient reasoning catalog', () => {
     });
 
     const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(sentBody.messages[0].reasoning_content).toBeUndefined();
+    expect(sentBody.messages[0].reasoning_content).toBe('upstream thinking');
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -4231,7 +4231,9 @@ describe('ProviderClient', () => {
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.store).toBe(false);
+      expect(sentBody.metadata).toEqual({ user: 'test' });
       expect(sentBody.service_tier).toBe('default');
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
     it('preserves DeepSeek reasoning_effort in the provider-facing request', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2,6 +2,7 @@ import { ProviderClient } from '../provider-client';
 import { ManifestError } from '../../../common/errors/manifest-error';
 import { buildCustomEndpoint, buildEndpointOverride } from '../provider-endpoints';
 import { ThinkingBlockCache, type ThinkingBlockRouteContext } from '../thinking-block-cache';
+import { ModelsDevReasoningCatalog } from '../reasoning-model-catalog';
 import type { ProviderModelRegistryService } from '../../../model-discovery/provider-model-registry.service';
 
 const mockFetch = jest.fn();
@@ -1187,14 +1188,17 @@ describe('ProviderClient', () => {
       expect(sentBody).not.toHaveProperty('reasoning_effort');
     });
 
-    it('translates disabled Anthropic thinking to reasoning_effort none', async () => {
+    it('translates disabled Anthropic thinking to reasoning_effort none for a reasoning model', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const reasoningClient = new ProviderClient(undefined, undefined, undefined, {
+        isReasoningModel: () => true,
+      } as unknown as ModelsDevReasoningCatalog);
       const chatBody = {
         messages: [{ role: 'user', content: 'hi' }],
         thinking: { type: 'disabled' },
       };
 
-      await client.forward({
+      await reasoningClient.forward({
         provider: 'openai',
         apiKey: 'sk-test',
         model: 'gpt-5.6-sol',
@@ -1207,6 +1211,28 @@ describe('ProviderClient', () => {
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody).not.toHaveProperty('thinking');
       expect(sentBody.reasoning_effort).toBe('none');
+    });
+
+    it('drops disabled Anthropic thinking without an effort tier for a non-reasoning model', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const chatBody = {
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'disabled' },
+      };
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: { model: 'gpt-4o', ...chatBody },
+        resolveChatBody: async () => chatBody,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).not.toHaveProperty('thinking');
+      expect(sentBody).not.toHaveProperty('reasoning_effort');
     });
 
     it('leaves a caller-sent thinking param alone outside messages mode', async () => {
@@ -2011,6 +2037,60 @@ describe('ProviderClient', () => {
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.reasoning).toEqual({ effort: 'xhigh', summary: 'auto' });
+    });
+
+    it('translates disabled Anthropic thinking to Responses reasoning none', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const reasoningClient = new ProviderClient(undefined, undefined, undefined, {
+        isReasoningModel: () => true,
+      } as unknown as ModelsDevReasoningCatalog);
+      const chatBody = {
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'disabled' },
+      };
+
+      await reasoningClient.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'o1-pro',
+        body: {
+          model: 'o1-pro',
+          messages: [{ role: 'user', content: 'hi' }],
+          thinking: { type: 'disabled' },
+        },
+        resolveChatBody: async () => chatBody,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.reasoning).toEqual({ effort: 'none' });
+      expect(sentBody).not.toHaveProperty('thinking');
+    });
+
+    it('does not translate disabled Anthropic thinking to Responses for a non-reasoning model', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'o1-pro',
+        body: {
+          model: 'o1-pro',
+          messages: [{ role: 'user', content: 'hi' }],
+          thinking: { type: 'disabled' },
+        },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'hi' }],
+          thinking: { type: 'disabled' },
+        }),
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).not.toHaveProperty('reasoning');
+      expect(sentBody).not.toHaveProperty('thinking');
     });
 
     it('sets isChatGpt=false for regular OpenAI api_key auth', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1165,6 +1165,69 @@ describe('ProviderClient', () => {
       expect(sentBody.safety_identifier).toBeUndefined();
     });
 
+    it('translates adaptive Anthropic thinking to the OpenAI default reasoning effort', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const chatBody = {
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'adaptive' },
+      };
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-5.6-sol',
+        body: { model: 'gpt-5.6-sol', ...chatBody },
+        resolveChatBody: async () => chatBody,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).not.toHaveProperty('thinking');
+      expect(sentBody).not.toHaveProperty('reasoning_effort');
+    });
+
+    it('translates disabled Anthropic thinking to reasoning_effort none', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const chatBody = {
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'disabled' },
+      };
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-5.6-sol',
+        body: { model: 'gpt-5.6-sol', ...chatBody },
+        resolveChatBody: async () => chatBody,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).not.toHaveProperty('thinking');
+      expect(sentBody.reasoning_effort).toBe('none');
+    });
+
+    it('leaves a caller-sent thinking param alone outside messages mode', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-5.6-sol',
+        body: {
+          model: 'gpt-5.6-sol',
+          messages: [{ role: 'user', content: 'hi' }],
+          thinking: { type: 'adaptive' },
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.thinking).toEqual({ type: 'adaptive' });
+    });
+
     it('forwards Anthropic-Messages inbound to an Anthropic upstream without OpenAI translation (issue #1886)', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -4232,7 +4232,7 @@ describe('ProviderClient', () => {
       temperature: 0.7,
     });
 
-    it('preserves provider-specific fields for Mistral Autofix', async () => {
+    it('strips OpenAI-only fields for Mistral', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({
         provider: 'mistral',
@@ -4243,10 +4243,10 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.store).toBe(false);
-      expect(sentBody.metadata).toEqual({ user: 'test' });
-      expect(sentBody.service_tier).toBe('default');
-      expect(sentBody.stream_options).toEqual({ include_usage: true });
+      expect(sentBody.store).toBeUndefined();
+      expect(sentBody.metadata).toBeUndefined();
+      expect(sentBody.service_tier).toBeUndefined();
+      expect(sentBody.stream_options).toBeUndefined();
       expect(sentBody.messages).toEqual(bodyWithOpenAiFields.messages);
       expect(sentBody.temperature).toBe(0.7);
     });
@@ -4282,7 +4282,7 @@ describe('ProviderClient', () => {
       expect(sentBody.max_completion_tokens).toBeUndefined();
     });
 
-    it('preserves provider-specific fields for DeepSeek Autofix', async () => {
+    it('strips OpenAI-only fields for DeepSeek', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({
         provider: 'deepseek',
@@ -4293,10 +4293,8 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.store).toBe(false);
-      expect(sentBody.metadata).toEqual({ user: 'test' });
-      expect(sentBody.service_tier).toBe('default');
-      expect(sentBody.stream_options).toEqual({ include_usage: true });
+      expect(sentBody.store).toBeUndefined();
+      expect(sentBody.service_tier).toBeUndefined();
     });
 
     it('preserves DeepSeek reasoning_effort in the provider-facing request', async () => {
@@ -4451,7 +4449,7 @@ describe('ProviderClient', () => {
       expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
     });
 
-    it('preserves reasoning_details for Mistral Autofix without mutating the input', async () => {
+    it('strips reasoning_details for Mistral assistant messages without mutating the input', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
 
@@ -4464,15 +4462,13 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_details).toEqual([
-        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
-      ]);
+      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
       expect(bodyWithReasoningDetails.messages[1].reasoning_details).toEqual([
         { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
       ]);
     });
 
-    it('preserves reasoning_details for native OpenAI Autofix', async () => {
+    it('strips reasoning_details for native OpenAI targets', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
 
@@ -4485,12 +4481,10 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_details).toEqual([
-        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
-      ]);
+      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
     });
 
-    it('preserves reasoning_details for DeepSeek Autofix', async () => {
+    it('strips reasoning_details for DeepSeek (does not support reasoning_details)', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningDetails = makeBodyWithReasoningDetails();
 
@@ -4503,9 +4497,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.messages[1].reasoning_details).toEqual([
-        { type: 'thinking', thinking: 'add them', signature: 'sig-abc' },
-      ]);
+      expect(sentBody.messages[1].reasoning_details).toBeUndefined();
     });
 
     it('preserves reasoning_details for OpenRouter targets', async () => {
@@ -4797,7 +4789,7 @@ describe('ProviderClient', () => {
       expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
-    it('preserves Anthropic-style thinking params for Ollama Autofix', async () => {
+    it('does not forward Anthropic-style thinking params to Ollama endpoints', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       for (const provider of ['ollama', 'ollama-cloud']) {
@@ -4815,7 +4807,7 @@ describe('ProviderClient', () => {
         });
 
         const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-        expect(sentBody).toHaveProperty('thinking', { type: 'enabled' });
+        expect(sentBody).not.toHaveProperty('thinking');
         expect(sentBody).toEqual(
           expect.objectContaining({
             model: 'qwen3.5:9b-q4_K_M',

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
@@ -1,17 +1,15 @@
 import { Test } from '@nestjs/testing';
 import { ModelsDevSyncService } from '../../../database/models-dev-sync.service';
-import { ProviderClient } from '../provider-client';
 import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ModelsDevReasoningCatalog } from '../reasoning-model-catalog';
 import { ProxyModule } from '../proxy.module';
 import { ModelPricesModule } from '../../../model-prices/model-prices.module';
 
 describe('reasoning catalog dependency injection', () => {
-  it('hands the models.dev catalog to the cache and the provider client', async () => {
+  it('hands the models.dev catalog to the reasoning cache', async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
         ReasoningContentCache,
-        ProviderClient,
         ModelsDevReasoningCatalog,
         {
           provide: ModelsDevSyncService,
@@ -22,9 +20,6 @@ describe('reasoning catalog dependency injection', () => {
 
     const catalog = moduleRef.get(ModelsDevReasoningCatalog);
     expect(moduleRef.get(ReasoningContentCache).modelCatalog).toBe(catalog);
-    expect(
-      (moduleRef.get(ProviderClient) as unknown as { reasoningCatalog?: unknown }).reasoningCatalog,
-    ).toBe(catalog);
   });
 });
 

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
@@ -1,15 +1,17 @@
 import { Test } from '@nestjs/testing';
 import { ModelsDevSyncService } from '../../../database/models-dev-sync.service';
+import { ProviderClient } from '../provider-client';
 import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ModelsDevReasoningCatalog } from '../reasoning-model-catalog';
 import { ProxyModule } from '../proxy.module';
 import { ModelPricesModule } from '../../../model-prices/model-prices.module';
 
 describe('reasoning catalog dependency injection', () => {
-  it('hands the models.dev catalog to the reasoning cache', async () => {
+  it('hands the models.dev catalog to the cache and the provider client', async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
         ReasoningContentCache,
+        ProviderClient,
         ModelsDevReasoningCatalog,
         {
           provide: ModelsDevSyncService,
@@ -20,6 +22,9 @@ describe('reasoning catalog dependency injection', () => {
 
     const catalog = moduleRef.get(ModelsDevReasoningCatalog);
     expect(moduleRef.get(ReasoningContentCache).modelCatalog).toBe(catalog);
+    expect(
+      (moduleRef.get(ProviderClient) as unknown as { reasoningCatalog?: unknown }).reasoningCatalog,
+    ).toBe(catalog);
   });
 });
 

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -35,38 +35,7 @@ interface AnthropicTool {
 
 const CACHE = { type: 'ephemeral' } as const;
 const MAX_CACHE_CONTROL_BLOCKS = 4;
-const ANTHROPIC_PREFIX = 'anthropic/';
 const DATA_IMAGE_URL_RE = /^data:([^;,]+)(?:;[^,]*)?;base64,(.*)$/is;
-
-function bareAnthropicModel(model: string): string {
-  return model.startsWith(ANTHROPIC_PREFIX) ? model.slice(ANTHROPIC_PREFIX.length) : model;
-}
-
-function isClaudeHaikuModel(model: string): boolean {
-  const bare = bareAnthropicModel(model).replace(/\./g, '-');
-  return bare.startsWith('claude-haiku-');
-}
-
-function shouldForwardAnthropicThinking(thinking: unknown, model: string): boolean {
-  if (
-    thinking &&
-    typeof thinking === 'object' &&
-    !Array.isArray(thinking) &&
-    (thinking as Record<string, unknown>).type === 'adaptive'
-  ) {
-    return !isClaudeHaikuModel(model);
-  }
-  return true;
-}
-
-function normalizeAnthropicThinking(thinking: unknown): unknown {
-  if (!isObjectRecord(thinking) || thinking.type !== 'adaptive' || !('budget_tokens' in thinking)) {
-    return thinking;
-  }
-  const normalized = { ...thinking };
-  delete normalized.budget_tokens;
-  return normalized;
-}
 
 /**
  * System prompt required by Anthropic's subscription OAuth API to unlock
@@ -128,17 +97,6 @@ export function applyAnthropicAutomaticCacheControl(body: Record<string, unknown
   // explicit cache plan instead of risking a provider-side 400.
   if (hasOneHourCacheControl(body)) return;
   body.cache_control = CACHE;
-}
-
-function isClaudeSonnetModel(model: string | undefined): boolean {
-  if (!model) return false;
-  return bareAnthropicModel(model).replace(/\./g, '-').startsWith('claude-sonnet-');
-}
-
-function normalizeOutputConfigForModel(outputConfig: unknown, model: string | undefined): unknown {
-  if (!isObjectRecord(outputConfig)) return outputConfig;
-  if (outputConfig.effort !== 'xhigh' || !isClaudeSonnetModel(model)) return outputConfig;
-  return { ...outputConfig, effort: 'high' };
 }
 
 function hasReplayableThinkingSignature(block: ContentBlock): boolean {
@@ -351,8 +309,6 @@ export interface AnthropicRequestOptions {
   thinkingLookup?: ThinkingBlockLookup;
   /** Route context for replaying only compatible cached thinking blocks. */
   thinkingRouteContext?: ThinkingBlockRouteContext;
-  /** Resolved Anthropic upstream model, used for model-specific body normalization. */
-  targetModel?: string;
 }
 
 export function toAnthropicRequest(
@@ -396,10 +352,7 @@ export function toAnthropicRequest(
 
   const outputConfig = toAnthropicOutputConfig(body.response_format, body.output_config);
   if (outputConfig) {
-    result.output_config = normalizeOutputConfigForModel(
-      outputConfig,
-      options?.targetModel ?? _model,
-    );
+    result.output_config = outputConfig;
   }
 
   if (body.temperature !== undefined) result.temperature = body.temperature;
@@ -407,9 +360,10 @@ export function toAnthropicRequest(
   if (body.top_k !== undefined) result.top_k = body.top_k;
   // Anthropic-native fields forwarded when the inbound request originated as
   // Anthropic Messages (POST /v1/messages). Chat-completions clients won't
-  // set these, so this is a no-op for the OpenAI-compat path.
-  if (body.thinking !== undefined && shouldForwardAnthropicThinking(body.thinking, _model)) {
-    result.thinking = normalizeAnthropicThinking(body.thinking);
+  // set these, so this is a no-op for the OpenAI-compat path. Model-specific
+  // rejection fixes belong in Autofix, not in this protocol adapter.
+  if (body.thinking !== undefined) {
+    result.thinking = body.thinking;
   }
   // chat_completions `stop` accepts string OR string[]; Anthropic
   // `stop_sequences` is always an array. Wrap a bare string so a single
@@ -473,9 +427,6 @@ export function applyAnthropicMessagesMutations(
   const result: Record<string, unknown> = { ...body };
   result.max_tokens = resolveAnthropicMaxTokens(body);
   delete result.max_completion_tokens;
-  if (body.thinking !== undefined) {
-    result.thinking = normalizeAnthropicThinking(body.thinking);
-  }
   const cacheBudget = {
     remaining: Math.max(0, MAX_CACHE_CONTROL_BLOCKS - countCacheControlBlocks(body)),
   };
@@ -512,13 +463,6 @@ export function applyAnthropicMessagesMutations(
     const tools = (body.tools as Array<Record<string, unknown>>).map((t) => ({ ...t }));
     tryAddCacheControl(tools[tools.length - 1], cacheBudget);
     result.tools = tools;
-  }
-
-  if (result.output_config !== undefined) {
-    result.output_config = normalizeOutputConfigForModel(
-      result.output_config,
-      options?.targetModel,
-    );
   }
 
   const thinkingLookup = options?.thinkingLookup;

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -296,7 +296,9 @@ export function messagesToChatCompletionsRequest(body: JsonRecord): JsonRecord {
   if (body.stop_sequences !== undefined) chatBody.stop = body.stop_sequences;
   // Anthropic-native fields with no chat_completions analogue. Carried on
   // chatBody so toAnthropicRequest can forward them when the resolved
-  // provider is Anthropic; harmlessly ignored by other adapters.
+  // provider is Anthropic. Native OpenAI rejects `thinking` as an unknown
+  // parameter, so the forwarding boundary translates it to reasoning_effort
+  // (see applyAnthropicThinkingForOpenAi in provider-client).
   if (body.thinking !== undefined) chatBody.thinking = body.thinking;
   if (body.top_k !== undefined) chatBody.top_k = body.top_k;
 

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -297,8 +297,11 @@ export function messagesToChatCompletionsRequest(body: JsonRecord): JsonRecord {
   // Anthropic-native fields with no chat_completions analogue. Carried on
   // chatBody so toAnthropicRequest can forward them when the resolved
   // provider is Anthropic. Native OpenAI rejects `thinking` as an unknown
-  // parameter, so the forwarding boundary translates it to reasoning_effort
-  // (see applyAnthropicThinkingForOpenAi in provider-client).
+  // parameter, so the forwarding boundary only preserves the lossless case:
+  // `thinking: {type: disabled}` becomes reasoning_effort `none` (and only on a
+  // model that reasons); every other thinking config is dropped and falls back
+  // to the provider's default reasoning (see applyAnthropicThinkingForOpenAi
+  // in provider-client).
   if (body.thinking !== undefined) chatBody.thinking = body.thinking;
   if (body.top_k !== undefined) chatBody.top_k = body.top_k;
 

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -22,8 +22,6 @@ import {
 import {
   normalizeOpenAiReasoningDelta,
   type OpenAiReasoningStreamFormat,
-  supportsReasoningContent,
-  type ReasoningModelCatalog,
 } from './reasoning-format';
 
 /** Convert a ChatGPT Responses API response to OpenAI format. */
@@ -89,31 +87,17 @@ export type { GoogleStreamChunkResult } from './google-adapter';
 export type { ThinkingBlocksCallback } from './anthropic-adapter';
 export type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
 
-// ─── OpenAI body sanitization (used by ProviderClient.forward) ───────────────
+// ─── OpenAI wire normalization (used by ProviderClient.forward) ─────────────
+
+// Keep this layer limited to unconditional wire-format adaptations. Whether a
+// provider or model accepts a parameter is request-specific and belongs in
+// Autofix, where the provider error can produce a scoped patch.
 
 /**
- * OpenAI-only fields that other providers reject as "extra inputs not permitted".
- * Stripped before forwarding to non-OpenAI, non-OpenRouter providers.
- */
-const OPENAI_ONLY_FIELDS = new Set([
-  'store',
-  'metadata',
-  'service_tier',
-  'stream_options',
-  'modalities',
-  'audio',
-  'prediction',
-  'reasoning_effort',
-]);
-
-/**
- * Providers that accept the full OpenAI top-level request schema without modification.
- * Nested message fields may still need target-aware cleanup.
+ * Providers that use `max_completion_tokens` without a legacy alias rewrite.
  */
 const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
-const OLLAMA_ENDPOINTS = new Set(['ollama', 'ollama-cloud']);
 const MISTRAL_TOOL_CALL_ID_REGEX = /^[A-Za-z0-9]{9}$/;
-const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
 
 /**
  * OpenAI models that require `max_completion_tokens` instead of `max_tokens`.
@@ -200,28 +184,9 @@ export function createReasoningContentStreamTransformer(
   };
 }
 
-/**
- * `reasoning_details` is OpenRouter's structured echo of extended-thinking
- * blocks in assistant messages (array of `{type, thinking, signature}`).
- * Only OpenRouter accepts it as an input field — every other OpenAI-compatible
- * provider (Mistral, native OpenAI, Groq, etc.) rejects unknown message fields
- * with `extra_forbidden` / 422. Strip it before forwarding to those targets so
- * that turn N+1 doesn't fail when routing flips off a reasoning model.
- */
-function supportsReasoningDetails(endpointKey: string): boolean {
-  return endpointKey === 'openrouter';
-}
-
-function sanitizeOpenAiMessages(
-  messages: unknown,
-  endpointKey: string,
-  model: string,
-  catalog?: ReasoningModelCatalog,
-): unknown {
+function normalizeOpenAiMessages(messages: unknown, endpointKey: string): unknown {
   if (!Array.isArray(messages)) return messages;
 
-  const preserveReasoningContent = supportsReasoningContent(endpointKey, model, catalog);
-  const preserveReasoningDetails = supportsReasoningDetails(endpointKey);
   const isMistral = endpointKey === 'mistral';
   const mistralIdMap = new Map<string, string>();
   const reservedMistralIds = new Set<string>();
@@ -284,61 +249,35 @@ function sanitizeOpenAiMessages(
       return message;
     }
 
-    const cleaned = { ...(message as Record<string, unknown>) };
-    if (!preserveReasoningContent) {
-      delete cleaned.reasoning_content;
-    }
-    if (endpointKey !== 'openrouter') {
-      delete cleaned.reasoning;
-    }
-    delete cleaned.reasoning_text;
-    if (!preserveReasoningDetails) {
-      delete cleaned.reasoning_details;
-    }
+    const normalized = { ...(message as Record<string, unknown>) };
 
-    if (isMistral && Array.isArray(cleaned.tool_calls)) {
-      cleaned.tool_calls = cleaned.tool_calls.map((toolCall) => {
+    if (isMistral && Array.isArray(normalized.tool_calls)) {
+      normalized.tool_calls = normalized.tool_calls.map((toolCall) => {
         if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) {
           return toolCall;
         }
-        const cleanedToolCall = { ...(toolCall as Record<string, unknown>) };
-        cleanedToolCall.id = normalizeMistralToolCallId(cleanedToolCall.id);
-        return cleanedToolCall;
+        const normalizedToolCall = { ...(toolCall as Record<string, unknown>) };
+        normalizedToolCall.id = normalizeMistralToolCallId(normalizedToolCall.id);
+        return normalizedToolCall;
       });
     }
 
-    if (isMistral && 'tool_call_id' in cleaned) {
-      cleaned.tool_call_id = normalizeMistralToolCallId(cleaned.tool_call_id);
+    if (isMistral && 'tool_call_id' in normalized) {
+      normalized.tool_call_id = normalizeMistralToolCallId(normalized.tool_call_id);
     }
 
-    return cleaned;
+    return normalized;
   });
 }
 
-function normalizeDeepSeekMaxTokens(body: Record<string, unknown>): void {
-  if (!('max_tokens' in body)) return;
-
-  const raw = body.max_tokens;
-  const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : Number.NaN;
-
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    delete body.max_tokens;
-    return;
-  }
-
-  body.max_tokens = Math.min(Math.trunc(parsed), DEEPSEEK_MAX_TOKENS_LIMIT);
-  if ((body.max_tokens as number) < 1) delete body.max_tokens;
-}
-
 /**
- * Strip OpenAI-specific fields and normalise `max_completion_tokens` -> `max_tokens`
- * for providers that use the OpenAI format but reject unknown fields.
+ * Normalize unconditional OpenAI-compatible wire differences. Provider- and
+ * model-specific parameter corrections are intentionally left to Autofix.
  */
 export function sanitizeOpenAiBody(
   body: Record<string, unknown>,
   endpointKey: string,
   model: string,
-  catalog?: ReasoningModelCatalog,
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
@@ -351,7 +290,7 @@ export function sanitizeOpenAiBody(
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
     if (key === 'messages') {
-      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model, catalog);
+      cleaned[key] = normalizeOpenAiMessages(value, endpointKey);
       continue;
     }
     // Rewrite max_tokens → max_completion_tokens for OpenAI-backed endpoints that
@@ -365,12 +304,6 @@ export function sanitizeOpenAiBody(
       cleaned[key] = value;
       continue;
     }
-    if (key === 'reasoning_effort' && (endpointKey === 'xai' || endpointKey === 'deepseek')) {
-      cleaned[key] = value;
-      continue;
-    }
-    if (OPENAI_ONLY_FIELDS.has(key)) continue;
-    if (key === 'thinking' && OLLAMA_ENDPOINTS.has(endpointKey.toLowerCase())) continue;
     if (key === 'max_completion_tokens') {
       // Preserve max_completion_tokens for endpoints that require it; otherwise
       // downconvert to max_tokens for OpenAI-compatible providers that only know
@@ -384,6 +317,5 @@ export function sanitizeOpenAiBody(
     }
     cleaned[key] = value;
   }
-  if (endpointKey === 'deepseek') normalizeDeepSeekMaxTokens(cleaned);
   return cleaned;
 }

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -89,14 +89,35 @@ export type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
 
 // ─── OpenAI wire normalization (used by ProviderClient.forward) ─────────────
 
-// Keep this layer limited to unconditional wire-format adaptations. Whether a
-// provider or model accepts a parameter is request-specific and belongs in
-// Autofix, where the provider error can produce a scoped patch.
+// This layer keeps unconditional wire-format adaptations: provider-level
+// protocol facts (a field that is simply not part of a given API) and
+// cross-protocol translations. Model- and version-specific corrections — a
+// parameter that some models accept and others reject — stay out of here and
+// belong to Autofix, where the provider error can scope a patch.
 
 /**
  * Providers that use `max_completion_tokens` without a legacy alias rewrite.
  */
 const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
+
+/**
+ * OpenAI-only fields other providers reject as "extra inputs not permitted".
+ * Stripped before forwarding to non-OpenAI, non-OpenRouter providers: these are
+ * not part of those wire protocols, so dropping them cannot remove a parameter
+ * the target would have honoured.
+ */
+const OPENAI_ONLY_FIELDS = new Set([
+  'store',
+  'metadata',
+  'service_tier',
+  'stream_options',
+  'modalities',
+  'audio',
+  'prediction',
+  'reasoning_effort',
+]);
+
+const OLLAMA_ENDPOINTS = new Set(['ollama', 'ollama-cloud']);
 const MISTRAL_TOOL_CALL_ID_REGEX = /^[A-Za-z0-9]{9}$/;
 
 /**
@@ -251,6 +272,17 @@ function normalizeOpenAiMessages(messages: unknown, endpointKey: string): unknow
 
     const normalized = { ...(message as Record<string, unknown>) };
 
+    // OpenRouter dialect fields. Every other OpenAI-compatible host rejects them
+    // as unknown message inputs, so their presence is a wire-protocol fact, not a
+    // model-specific correction. `reasoning_content` is deliberately NOT touched:
+    // it is required by DeepSeek-dialect hosts and rejected by strict hosts
+    // serving the same model, a split only the provider error can settle.
+    if (endpointKey !== 'openrouter') {
+      delete normalized.reasoning;
+      delete normalized.reasoning_details;
+    }
+    delete normalized.reasoning_text;
+
     if (isMistral && Array.isArray(normalized.tool_calls)) {
       normalized.tool_calls = normalized.tool_calls.map((toolCall) => {
         if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) {
@@ -304,6 +336,16 @@ export function sanitizeOpenAiBody(
       cleaned[key] = value;
       continue;
     }
+    // xAI and DeepSeek implement `reasoning_effort`; keep it there. Every other
+    // non-passthrough provider gets the OpenAI-only field stripped below.
+    if (key === 'reasoning_effort' && (endpointKey === 'xai' || endpointKey === 'deepseek')) {
+      cleaned[key] = value;
+      continue;
+    }
+    if (OPENAI_ONLY_FIELDS.has(key)) continue;
+    // Ollama's OpenAI-compatible endpoint does not accept the Anthropic-style
+    // `thinking` block; other non-passthrough providers are left to Autofix.
+    if (key === 'thinking' && OLLAMA_ENDPOINTS.has(endpointKey.toLowerCase())) continue;
     if (key === 'max_completion_tokens') {
       // Preserve max_completion_tokens for endpoints that require it; otherwise
       // downconvert to max_tokens for OpenAI-compatible providers that only know

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { HttpStatus, Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger, Optional } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { XAI_RESPONSES_ONLY_RE } from '../../common/constants/xai-models';
 import {
@@ -12,8 +12,6 @@ import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { resolveSubscriptionEndpointKey } from './provider-hooks';
 import { injectOpenAiMessageCacheControl, injectOpenRouterCacheControl } from './cache-injection';
-import type { ReasoningModelCatalog } from './reasoning-format';
-import { ModelsDevReasoningCatalog } from './reasoning-model-catalog';
 import {
   applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
@@ -301,9 +299,6 @@ export class ProviderClient {
     private readonly modelRegistry?: ProviderModelRegistryService,
     @Optional()
     codexAffinity?: CodexSessionAffinity,
-    @Optional()
-    @Inject(ModelsDevReasoningCatalog)
-    private readonly reasoningCatalog?: ReasoningModelCatalog,
   ) {
     this.codexAffinity = codexAffinity ?? new CodexSessionAffinity();
   }
@@ -686,7 +681,6 @@ export class ProviderClient {
               injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
               thinkingRouteContext,
-              targetModel: bareModel,
             })
           : toAnthropicRequest(requestSource, bareModel, {
               injectSubscriptionIdentity,
@@ -777,12 +771,7 @@ export class ProviderClient {
     }
 
     // OpenAI-compatible path (default)
-    const sanitized = sanitizeOpenAiBody(
-      requestSource,
-      endpointKey,
-      ctx.model,
-      this.reasoningCatalog,
-    );
+    const sanitized = sanitizeOpenAiBody(requestSource, endpointKey, ctx.model);
     if (stream && endpoint.streamUsageReporting === 'openai_stream_options') {
       const existing =
         typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -36,6 +36,7 @@ import {
   type ProviderAttemptRef,
 } from './proxy-types';
 import { CodexSessionAffinity } from './codex-session-affinity';
+import { ModelsDevReasoningCatalog } from './reasoning-model-catalog';
 import { toNativeResponsesRequest } from './responses-adapter';
 import { responsesToolNames, ResponsesToolNames } from './responses-tools';
 import { forwardKiroChat } from './kiro-adapter';
@@ -249,18 +250,33 @@ function applyAnthropicUserIdForOpenAi(
     userId.length <= 64 ? userId : createHash('sha256').update(userId).digest('hex');
 }
 
-// Anthropic thinking configures extended reasoning. OpenAI chat completions
-// reject the field as an unknown parameter and express the same control as
-// reasoning_effort, so translate instead of forwarding. Only `disabled` has a
-// lossless equivalent (`none`); adaptive/enabled budgets map to no single
-// effort tier, so those fall back to the provider's default reasoning.
-function applyAnthropicThinkingForOpenAi(body: Record<string, unknown>): void {
+// Anthropic thinking configures extended reasoning. OpenAI rejects the field
+// as an unknown parameter and expresses the same control as an effort tier, so
+// translate instead of forwarding. Only `disabled` has a lossless equivalent
+// (`reasoning_effort: none`); adaptive/enabled budgets map to no single effort
+// tier and fall back to the provider's default reasoning.
+//
+// The effort tier is emitted only for models that actually reason: a
+// non-reasoning model rejects `reasoning_effort` outright, so for it dropping
+// `thinking` is the whole fix.
+function anthropicThinkingEffort(
+  body: Record<string, unknown>,
+  supportsReasoning: boolean,
+): 'none' | undefined {
+  if (!supportsReasoning) return undefined;
+  return isRecord(body.thinking) && body.thinking.type === 'disabled' ? 'none' : undefined;
+}
+
+function applyAnthropicThinkingForOpenAi(
+  body: Record<string, unknown>,
+  supportsReasoning: boolean,
+): void {
   if (!('thinking' in body)) return;
-  const thinking = isRecord(body.thinking) ? body.thinking : undefined;
+  const effort = anthropicThinkingEffort(body, supportsReasoning);
   delete body.thinking;
 
-  if (thinking?.type === 'disabled' && body.reasoning_effort === undefined) {
-    body.reasoning_effort = 'none';
+  if (effort !== undefined && body.reasoning_effort === undefined) {
+    body.reasoning_effort = effort;
   }
 }
 
@@ -314,8 +330,15 @@ export class ProviderClient {
     private readonly modelRegistry?: ProviderModelRegistryService,
     @Optional()
     codexAffinity?: CodexSessionAffinity,
+    @Optional()
+    private readonly reasoningCatalog?: ModelsDevReasoningCatalog,
   ) {
     this.codexAffinity = codexAffinity ?? new CodexSessionAffinity();
+  }
+
+  /** Whether the target model reasons, so an OpenAI effort tier is meaningful. */
+  private modelSupportsReasoning(endpointKey: string, model: string): boolean {
+    return this.reasoningCatalog?.isReasoningModel(endpointKey, model) === true;
   }
 
   async forward(opts: ForwardOptions): Promise<ForwardResult> {
@@ -768,6 +791,24 @@ export class ProviderClient {
       if (endpointKey === 'openai-responses' && ctx.apiMode === 'messages') {
         applyAnthropicUserIdForOpenAi(requestBody, requestSource);
       }
+      // Anthropic Messages carry `thinking`, which the Responses shape has no
+      // field for. Translate a disabled request to an explicit no-reasoning
+      // effort so the caller's intent survives the cross-protocol route. The
+      // same reasoning-support and endpoint gates as the chat path apply:
+      // only OpenAI infrastructure accepts `reasoning`, and only a reasoning
+      // model accepts the effort tier.
+      if (
+        (endpointKey === 'openai-responses' || endpointKey === 'openai-subscription') &&
+        ctx.apiMode === 'messages'
+      ) {
+        const effort = anthropicThinkingEffort(
+          requestSource,
+          this.modelSupportsReasoning('openai', ctx.model),
+        );
+        if (effort !== undefined && requestBody.reasoning === undefined) {
+          requestBody.reasoning = { effort };
+        }
+      }
       if (endpointKey === 'openai-responses' || endpointKey === 'openai-subscription') {
         applyHashedPromptCacheKey(requestBody, ctx.providerCacheKey);
       }
@@ -798,7 +839,10 @@ export class ProviderClient {
     if (endpointKey === 'openai') {
       if (ctx.apiMode === 'messages') {
         applyAnthropicUserIdForOpenAi(requestBody);
-        applyAnthropicThinkingForOpenAi(requestBody);
+        applyAnthropicThinkingForOpenAi(
+          requestBody,
+          this.modelSupportsReasoning(endpointKey, ctx.model),
+        );
       }
       applyHashedPromptCacheKey(requestBody, ctx.providerCacheKey);
     }

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -249,6 +249,21 @@ function applyAnthropicUserIdForOpenAi(
     userId.length <= 64 ? userId : createHash('sha256').update(userId).digest('hex');
 }
 
+// Anthropic thinking configures extended reasoning. OpenAI chat completions
+// reject the field as an unknown parameter and express the same control as
+// reasoning_effort, so translate instead of forwarding. Only `disabled` has a
+// lossless equivalent (`none`); adaptive/enabled budgets map to no single
+// effort tier, so those fall back to the provider's default reasoning.
+function applyAnthropicThinkingForOpenAi(body: Record<string, unknown>): void {
+  if (!('thinking' in body)) return;
+  const thinking = isRecord(body.thinking) ? body.thinking : undefined;
+  delete body.thinking;
+
+  if (thinking?.type === 'disabled' && body.reasoning_effort === undefined) {
+    body.reasoning_effort = 'none';
+  }
+}
+
 function openRouterCacheMode(model: string): 'anthropic' | 'message' | null {
   const normalized = model.toLowerCase().replace(/^~/, '');
   if (normalized.startsWith('anthropic/')) return 'anthropic';
@@ -781,7 +796,10 @@ export class ProviderClient {
     }
     const requestBody = { ...sanitized, model: bareModel, stream };
     if (endpointKey === 'openai') {
-      if (ctx.apiMode === 'messages') applyAnthropicUserIdForOpenAi(requestBody);
+      if (ctx.apiMode === 'messages') {
+        applyAnthropicUserIdForOpenAi(requestBody);
+        applyAnthropicThinkingForOpenAi(requestBody);
+      }
       applyHashedPromptCacheKey(requestBody, ctx.providerCacheKey);
     }
     if (endpointKey === 'mistral') {


### PR DESCRIPTION
### ✨ What changed

- Leave model- and version-specific corrections to Autofix.
- Keep provider-level protocol strips at the wire boundary: OpenAI-only top-level fields, OpenRouter dialect message fields, and Ollama's rejection of the Anthropic `thinking` block.
- Translate Anthropic `metadata.user_id` to OpenAI `safety_identifier`.
- Translate Anthropic `thinking` to OpenAI `reasoning_effort`.
- Remove hardcoded DeepSeek `max_tokens` clamping and the Anthropic adaptive-thinking / `budget_tokens` / `xhigh` model corrections.

### 💭 Why

Conditional fixes need provider evidence so Autofix can scope them. But a field that is simply not part of a provider's wire protocol is a deterministic protocol fact, not a conditional fix: stripping it cannot remove a parameter the target would have honoured, and removing it would regress every request on installs where Autofix is off (self-hosted default, explicit opt-outs, a heal outage).

`reasoning_content` is deliberately preserved: it is required by DeepSeek-dialect hosts and rejected by strict hosts serving the same model — a split only the provider error can settle. Phoenix now heals that rejection (`remove_unsupported_message_fields`) as well as top-level `extra_forbidden` fields, derived from the error's `loc`.

### 👤 For users

Anthropic Messages requests routed to OpenAI no longer fail because Anthropic metadata was sent as OpenAI completion metadata. Prompt caching remains independent and Manifest does not add `store`. Everyday Mistral, DeepSeek, and Ollama traffic keeps working even when Autofix is unavailable.

### 📝 Notes

Backend typecheck, build, lint, formatting, changeset checks, and all unit tests pass.

Depends on [mnfst/phoenix#314](https://github.com/mnfst/phoenix/pull/314), which teaches Autofix to heal the `reasoning_content` and top-level `extra_forbidden` rejections this PR leaves to it.
