### PR TITLE
fix: open Anthropic OAuth popup before request

### DIFF
--- a/.changeset/anthropic-popup-timing.md
+++ b/.changeset/anthropic-popup-timing.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Open Anthropic subscription popups before the OAuth request so adding another account is not blocked by the browser.

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -95,7 +95,7 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
     try {
       const { url, state: authState } = await startAnthropicOAuth(props.agentName);
       setState(authState);
-      popup.location.replace(url);
+      if (!popup.closed) popup.location.replace(url);
     } catch {
       popup.close();
       if (props.connected()) setAddingAccount(false);

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -78,20 +78,26 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
   });
 
   const handleSignIn = async () => {
-    props.setBusy(true);
     setError(null);
+    // Open synchronously while the click still has user activation. Browsers
+    // can block a window opened after the OAuth start request completes.
+    const popup = window.open('about:blank', '_blank');
+    if (!popup) {
+      toast.error('Popup was blocked by your browser. Allow popups for this site, then try again.');
+      if (props.connected()) setAddingAccount(false);
+      return;
+    }
+    // The blank page is same-origin, so remove its access to the dashboard
+    // before navigating it to Anthropic.
+    popup.opener = null;
+
+    props.setBusy(true);
     try {
       const { url, state: authState } = await startAnthropicOAuth(props.agentName);
       setState(authState);
-      const opened = window.open(url, 'manifest-anthropic-oauth', 'noopener,noreferrer');
-      if (!opened) {
-        toast.error(
-          'Popup was blocked by your browser. Allow popups for this site, then try again.',
-        );
-        setState(null);
-        if (props.connected()) setAddingAccount(false);
-      }
+      popup.location.replace(url);
     } catch {
+      popup.close();
       if (props.connected()) setAddingAccount(false);
       // error toast from fetchMutate
     } finally {

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -70,6 +70,19 @@ function renderView(connectedValue = false) {
 
 const OAUTH_PAYLOAD = 'auth-code-123#state-xyz';
 
+function mockOpenPopup() {
+  const replace = vi.fn();
+  const close = vi.fn();
+  const popup = {
+    closed: false,
+    opener: window,
+    close,
+    location: { replace },
+  } as unknown as Window;
+  const openSpy = vi.spyOn(window, 'open').mockReturnValue(popup);
+  return { popup, openSpy, replace, close };
+}
+
 describe('AnthropicOAuthDetailView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -82,8 +95,7 @@ describe('AnthropicOAuthDetailView', () => {
     expect(screen.getByLabelText('Anthropic authorization code')).toBeDefined();
   });
 
-  it('shows a toast and clears state when the popup is blocked', async () => {
-    mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
+  it('shows a toast without starting OAuth when the popup is blocked', async () => {
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
 
     renderView();
@@ -92,14 +104,13 @@ describe('AnthropicOAuthDetailView', () => {
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith(expect.stringMatching(/Popup was blocked/));
     });
+    expect(mockStartAnthropicOAuth).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });
 
   it('starts the OAuth flow and opens a popup', async () => {
     mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
-    const openSpy = vi
-      .spyOn(window, 'open')
-      .mockReturnValue({ closed: false } as unknown as Window);
+    const { popup, openSpy, replace } = mockOpenPopup();
 
     renderView();
     fireEvent.click(screen.getByText('Sign in with Claude'));
@@ -107,18 +118,16 @@ describe('AnthropicOAuthDetailView', () => {
     await waitFor(() => {
       expect(mockStartAnthropicOAuth).toHaveBeenCalledWith('test-agent');
     });
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://x',
-      'manifest-anthropic-oauth',
-      'noopener,noreferrer',
-    );
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+    expect(popup.opener).toBeNull();
+    expect(replace).toHaveBeenCalledWith('https://x');
     openSpy.mockRestore();
   });
 
   it('exchanges a pasted authorization code', async () => {
     mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'state-xyz' });
     mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
-    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+    mockOpenPopup();
 
     const { onClose, onUpdate } = renderView();
     fireEvent.click(screen.getByText('Sign in with Claude'));
@@ -223,7 +232,7 @@ describe('AnthropicOAuthDetailView', () => {
   it('shows an error if the OAuth exchange fails', async () => {
     mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 's1' });
     mockSubmitAnthropicOAuth.mockRejectedValue(new Error('boom'));
-    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+    mockOpenPopup();
 
     renderView();
     fireEvent.click(screen.getByText('Sign in with Claude'));
@@ -241,7 +250,7 @@ describe('AnthropicOAuthDetailView', () => {
   it('shows the generic exchange error when the failure is not an Error object', async () => {
     mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 's1' });
     mockSubmitAnthropicOAuth.mockRejectedValue('boom');
-    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+    mockOpenPopup();
 
     renderView();
     fireEvent.click(screen.getByText('Sign in with Claude'));
@@ -354,9 +363,11 @@ describe('AnthropicOAuthDetailView', () => {
 
   it('swallows errors thrown by startAnthropicOAuth', async () => {
     mockStartAnthropicOAuth.mockRejectedValue(new Error('network'));
+    const { close } = mockOpenPopup();
     renderView();
     fireEvent.click(screen.getByText('Sign in with Claude'));
     await waitFor(() => expect(mockStartAnthropicOAuth).toHaveBeenCalled());
+    expect(close).toHaveBeenCalled();
     expect(screen.getByText('Sign in with Claude')).toBeDefined();
   });
 });
@@ -562,7 +573,7 @@ describe('AnthropicOAuthDetailView — addKeyOpen effect', () => {
 
   it('auto-launches handleSignIn when addKeyOpen is true and connected', async () => {
     mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
-    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+    mockOpenPopup();
 
     renderViewWithAddKeyOpen();
 
@@ -572,9 +583,34 @@ describe('AnthropicOAuthDetailView — addKeyOpen effect', () => {
     expect(screen.getByLabelText('Anthropic authorization code')).toBeDefined();
   });
 
+  it('opens the add-account popup before the OAuth start request resolves', async () => {
+    let resolveStart: (value: { url: string; state: string }) => void = () => {};
+    mockStartAnthropicOAuth.mockReturnValue(
+      new Promise<{ url: string; state: string }>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const { popup, openSpy, replace } = mockOpenPopup();
+
+    renderViewWithAddKeyOpen();
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+    });
+    expect(mockStartAnthropicOAuth).toHaveBeenCalledWith('test-agent');
+    expect(popup.opener).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+
+    resolveStart({ url: 'https://x', state: 'abc' });
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('https://x');
+    });
+  });
+
   it('cancels a connected add-account Claude OAuth flow', async () => {
     mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
-    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+    mockOpenPopup();
 
     renderViewWithAddKeyOpen();
 

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -608,6 +608,31 @@ describe('AnthropicOAuthDetailView — addKeyOpen effect', () => {
     });
   });
 
+  it('does not navigate a popup closed while the OAuth start request is pending', async () => {
+    let resolveStart: (value: { url: string; state: string }) => void = () => {};
+    mockStartAnthropicOAuth.mockReturnValue(
+      new Promise<{ url: string; state: string }>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const { popup, replace, close } = mockOpenPopup();
+
+    renderViewWithAddKeyOpen();
+    await waitFor(() => {
+      expect(mockStartAnthropicOAuth).toHaveBeenCalledWith('test-agent');
+    });
+
+    Object.defineProperty(popup, 'closed', { value: true });
+    resolveStart({ url: 'https://x', state: 'abc' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign in with Claude')).toBeDefined();
+    });
+    expect(replace).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Anthropic authorization code')).toBeDefined();
+  });
+
   it('cancels a connected add-account Claude OAuth flow', async () => {
     mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
     mockOpenPopup();

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -646,9 +646,12 @@ describe('ProviderSelectModal', () => {
         url: 'https://claude.ai/oauth/authorize?state=abc',
         state: 'abc',
       });
-      const windowOpenSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue({ closed: false } as unknown as Window);
+      const windowOpenSpy = vi.spyOn(window, 'open').mockReturnValue({
+        closed: false,
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+      } as unknown as Window);
 
       openSubscription('anthropic');
       fireEvent.click(screen.getByText('Sign in with Claude'));
@@ -668,9 +671,12 @@ describe('ProviderSelectModal', () => {
         state: 'xyz',
       });
       mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
-      const windowOpenSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue({ closed: false } as unknown as Window);
+      const windowOpenSpy = vi.spyOn(window, 'open').mockReturnValue({
+        closed: false,
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+      } as unknown as Window);
 
       openSubscription('anthropic');
       fireEvent.click(screen.getByText('Sign in with Claude'));


### PR DESCRIPTION
### ✨ What changed
- Open Anthropic OAuth popups before the authorization request.
- Navigate the blank popup after startup and close it on failure.
- Cover blocked and second-account popup timing.

### 💭 Why
The API wait removed browser user activation before `window.open`, which blocked second account sign-in.

### 👤 For users
Adding another Claude Pro or Max subscription now opens Anthropic sign-in normally.

### 📝 Notes
Fixes #2493

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2493 by opening the Anthropic OAuth popup before the authorization request, so adding a second Claude account no longer gets blocked by the browser.

- Opens a blank popup synchronously on click, then navigates it to the OAuth URL once the request resolves.
- Closes the popup if the request fails, and shows a toast without starting the request if the popup is blocked.
- Skips navigating the popup if it was closed while the request was pending.

<sup>Written for commit 9130719cd4c839441f0351a78bd0b527c67d4fee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

