### PR TITLE
fix: preserve fallback drop slot during drag

### DIFF
--- a/.changeset/calm-fallback-drag.md
+++ b/.changeset/calm-fallback-drag.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix fallback drag-and-drop reordering below the second position.

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -300,9 +300,20 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   };
 
   const handleContainerDragLeave = (e: DragEvent) => {
-    // Only clear when leaving the container entirely
-    const related = e.relatedTarget as Node | null;
-    if (!related || !listRef?.contains(related)) {
+    // DragEvent.relatedTarget can be null while crossing children. Fall back
+    // to the pointer coordinates so an internal transition does not erase the
+    // pending drop slot before the browser dispatches drop.
+    const related = e.relatedTarget;
+    if (related instanceof Node && listRef?.contains(related)) return;
+
+    const bounds = listRef?.getBoundingClientRect();
+    const pointerIsOutside =
+      !bounds ||
+      e.clientX < bounds.left ||
+      e.clientX > bounds.right ||
+      e.clientY < bounds.top ||
+      e.clientY > bounds.bottom;
+    if (related instanceof Node || pointerIsOutside) {
       setDropSlot(null);
     }
   };

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -700,15 +700,41 @@ describe('FallbackList', () => {
       });
     });
 
-    // Create a drop indicator
-    fireEvent.dragOver(list, {
-      clientY: 50,
-      dataTransfer: { dropEffect: '' },
-      preventDefault: vi.fn(),
+    vi.spyOn(list, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 200,
+      width: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
     });
 
-    // DragLeave with relatedTarget outside the list
-    fireEvent.dragLeave(list, { relatedTarget: null });
+    // Create a drop indicator after the final card
+    list.dispatchEvent(
+      new MouseEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 100,
+        clientY: 90,
+      }),
+    );
+
+    expect(
+      container.querySelectorAll('.fallback-list__drop-indicator--active').length,
+    ).toBeGreaterThan(0);
+
+    // DragLeave with no related target and a cursor outside the list
+    list.dispatchEvent(
+      new MouseEvent('dragleave', {
+        bubbles: true,
+        clientX: 100,
+        clientY: 120,
+        relatedTarget: null,
+      }),
+    );
 
     // No active indicators
     const activeIndicators = container.querySelectorAll('.fallback-list__drop-indicator--active');
@@ -745,6 +771,78 @@ describe('FallbackList', () => {
     // Indicator should still be active
     const activeIndicators = container.querySelectorAll('.fallback-list__drop-indicator--active');
     expect(activeIndicators.length).toBeGreaterThan(0);
+  });
+
+  it('reorders the second fallback after a null-related dragLeave inside the list', async () => {
+    mockSetFallbacks.mockResolvedValueOnce(undefined);
+    const onUpdate = vi.fn();
+    const { container } = render(() => (
+      <FallbackList
+        {...defaultProps}
+        fallbacks={['model-a', 'model-b', 'model-c', 'model-d']}
+        onUpdate={onUpdate}
+      />
+    ));
+
+    const list = container.querySelector<HTMLElement>('.fallback-list__items')!;
+    const cards = list.querySelectorAll<HTMLElement>('.fallback-list__card');
+
+    fireEvent.dragStart(cards[1]!, {
+      dataTransfer: { effectAllowed: '', setData: vi.fn() },
+    });
+
+    cards.forEach((card, i) => {
+      vi.spyOn(card, 'getBoundingClientRect').mockReturnValue({
+        top: i * 40,
+        bottom: (i + 1) * 40,
+        height: 40,
+        left: 0,
+        right: 200,
+        width: 200,
+        x: 0,
+        y: i * 40,
+        toJSON: () => {},
+      });
+    });
+    vi.spyOn(list, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      bottom: 160,
+      height: 160,
+      left: 0,
+      right: 200,
+      width: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    list.dispatchEvent(
+      new MouseEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 100,
+        clientY: 110,
+      }),
+    );
+    list.dispatchEvent(
+      new MouseEvent('dragleave', {
+        bubbles: true,
+        clientX: 100,
+        clientY: 110,
+        relatedTarget: null,
+      }),
+    );
+    fireEvent.drop(list, { preventDefault: vi.fn() });
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(['model-a', 'model-c', 'model-b', 'model-d'], null);
+      expect(mockSetFallbacks).toHaveBeenCalledWith(
+        'test-agent',
+        'tier-1',
+        ['model-a', 'model-c', 'model-b', 'model-d'],
+        undefined,
+      );
+    });
   });
 
   it('reorders fallbacks on drop and calls setFallbacks', async () => {


### PR DESCRIPTION
### ✨ What changed
- Keep the active fallback drop slot when an internal drag transition has no related target.
- Add regression coverage for moving the second fallback downward.

### 💭 Why
Browsers can report a null `relatedTarget` while the pointer is still inside the list. Clearing the slot there makes the following drop a no-op.

### 👤 For users
Fallback models can be reordered downward from any position.

### 📝 Notes
- Browser E2E moved the second fallback below the third through a null-related drag leave and verified persistence.
- Closes #2658


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the active fallback drop slot when a `dragleave` event reports a null `relatedTarget` but the pointer is still inside the list. Previously, a null `relatedTarget` cleared the slot, making the following drop a no-op and preventing reordering from the second position downward. Now the slot is only cleared when the pointer coordinates fall outside the list bounds. Closes #2658.

- The drop slot is kept when the pointer is inside the list even if `relatedTarget` is null.
- Adds a regression test that moves the second fallback below the third via a null-related drag leave and verifies persistence.

<sup>Written for commit 2d75ad541ba5c252b8ce287068c19fdd8d8f7648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

