### PR TITLE
feat: add grok-4.6 to Grok subscription models

### DIFF
--- a/.changeset/xai-subscription-grok-4.6.md
+++ b/.changeset/xai-subscription-grok-4.6.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add grok-4.6 to the Grok subscription known-models list so xAI subscription connections can select it.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -245,6 +245,7 @@ describe('getSubscriptionProviderConfig', () => {
   it('publishes the curated xai subscription models', () => {
     const config = getSubscriptionProviderConfig('xai');
     expect(config?.knownModels).toEqual([
+      'grok-4.6',
       'grok-4.5',
       'grok-4.3',
       'grok-4.20-0309-reasoning',
@@ -440,6 +441,7 @@ describe('getSubscriptionKnownModels', () => {
   it('returns known models for xai', () => {
     const models = getSubscriptionKnownModels('xai');
     expect(models).toEqual([
+      'grok-4.6',
       'grok-4.5',
       'grok-4.3',
       'grok-4.20-0309-reasoning',

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -277,6 +277,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'Grok subscription',
     subscriptionAuthMode: 'popup_oauth' as const,
     knownModels: Object.freeze([
+      'grok-4.6',
       'grok-4.5',
       'grok-4.3',
       'grok-4.20-0309-reasoning',


### PR DESCRIPTION
### ✨ What changed
- Add `grok-4.6` to the xAI Grok subscription known-models list.

### 💭 Why
Grok 4.6 is live on xAI (including Grok Build) but Manifest still advertised only through `grok-4.5` for Grok subscription connections.

### 👤 For users
Grok subscription connections can select `grok-4.6` in the model picker, including when live `/models` omits it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `grok-4.6` to the Grok subscription known-models list so xAI subscription connections can pick it in the model selector, even when the live `/models` response omits it.

<sup>Written for commit 4e6d3b02f5db9685f16d752c40267ea84a0b5fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

