### PR TITLE
fix: match Grok subscription catalog to Grok Build

### DIFF
--- a/.changeset/xai-subscription-grok-build-models.md
+++ b/.changeset/xai-subscription-grok-build-models.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Limit the Grok subscription catalog to grok-4.6 and grok-4.5, the models Grok Build actually offers, and advertise their 500k context window.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -244,14 +244,7 @@ describe('getSubscriptionProviderConfig', () => {
 
   it('publishes the curated xai subscription models', () => {
     const config = getSubscriptionProviderConfig('xai');
-    expect(config?.knownModels).toEqual([
-      'grok-4.6',
-      'grok-4.5',
-      'grok-4.3',
-      'grok-4.20-0309-reasoning',
-      'grok-4.20-0309-non-reasoning',
-      'grok-build-0.1',
-    ]);
+    expect(config?.knownModels).toEqual(['grok-4.6', 'grok-4.5']);
   });
 
   it('returns config for gemini', () => {
@@ -440,14 +433,7 @@ describe('getSubscriptionKnownModels', () => {
 
   it('returns known models for xai', () => {
     const models = getSubscriptionKnownModels('xai');
-    expect(models).toEqual([
-      'grok-4.6',
-      'grok-4.5',
-      'grok-4.3',
-      'grok-4.20-0309-reasoning',
-      'grok-4.20-0309-non-reasoning',
-      'grok-build-0.1',
-    ]);
+    expect(models).toEqual(['grok-4.6', 'grok-4.5']);
   });
 
   it('returns null for unsupported providers', () => {
@@ -615,7 +601,7 @@ describe('getSubscriptionCapabilities', () => {
   it('returns capabilities for xai', () => {
     const caps = getSubscriptionCapabilities('xai');
     expect(caps).toMatchObject({
-      maxContextWindow: 128000,
+      maxContextWindow: 500000,
       supportsPromptCaching: true,
       supportsBatching: false,
     });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -276,16 +276,9 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     supportsSubscription: true as const,
     subscriptionLabel: 'Grok subscription',
     subscriptionAuthMode: 'popup_oauth' as const,
-    knownModels: Object.freeze([
-      'grok-4.6',
-      'grok-4.5',
-      'grok-4.3',
-      'grok-4.20-0309-reasoning',
-      'grok-4.20-0309-non-reasoning',
-      'grok-build-0.1',
-    ]),
+    knownModels: Object.freeze(['grok-4.6', 'grok-4.5']),
     subscriptionCapabilities: Object.freeze({
-      maxContextWindow: 128000,
+      maxContextWindow: 500000,
       supportsPromptCaching: true,
       supportsBatching: false,
     }),


### PR DESCRIPTION
### ✨ What changed
- Keep only `grok-4.6` and `grok-4.5` on the Grok subscription known-models list.
- Set the Grok subscription context window to 500k.

### 💭 Why
Grok Build currently offers those two models. The previous list also advertised API-key-only ids (`grok-4.3`, `grok-4.20-*`, `grok-build-0.1`) and capped context at 128k.

### 👤 For users
Grok subscription connections pick `grok-4.6` or `grok-4.5` with the 500k window xAI publishes.

### 📝 Notes
https://docs.x.ai/developers/models/grok-4.6
https://docs.x.ai/developers/models/grok-4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Grok subscription catalog with what Grok Build offers by keeping only `grok-4.6` and `grok-4.5` and advertising their 500k context window. The old list advertised API-key-only models (`grok-4.3`, `grok-4.20-*`, `grok-build-0.1`) and capped context at 128k.

<sup>Written for commit 1fd4ec0a774d1671c2cfc7599d1f039c2d652762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

