### PR TITLE
fix: translate Anthropic user metadata

### DIFF
--- a/.changeset/quiet-pandas-route.md
+++ b/.changeset/quiet-pandas-route.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Translate Anthropic user metadata when routing Messages requests to OpenAI.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1099,6 +1099,65 @@ describe('ProviderClient', () => {
       expect(resolveChatBody).toHaveBeenCalledTimes(1);
     });
 
+    it.each([
+      ['keeps a short identifier', 'user-123', 'user-123'],
+      [
+        'hashes an identifier longer than OpenAI allows',
+        'anthropic-user-id-that-is-longer-than-the-openai-sixty-four-character-limit',
+        '6415270ed2d8147603f504ee756f5d658dfdb277685889ddd9c09d5a64579699',
+      ],
+    ])('%s when translating Anthropic metadata to OpenAI', async (_label, userId, expected) => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const resolveChatBody = jest.fn().mockResolvedValue({
+        messages: [{ role: 'user', content: 'hi' }],
+        metadata: { user_id: userId },
+      });
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: {
+          model: 'gpt-4o',
+          messages: [{ role: 'user', content: 'hi' }],
+          metadata: { user_id: userId },
+        },
+        resolveChatBody,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.safety_identifier).toBe(expected);
+      expect(sentBody.metadata).toBeUndefined();
+      expect(sentBody.store).toBeUndefined();
+    });
+
+    it('drops Anthropic metadata that has no usable OpenAI safety identifier', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: {
+          model: 'gpt-4o',
+          messages: [{ role: 'user', content: 'hi' }],
+          metadata: { user_id: '' },
+        },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'hi' }],
+          metadata: { user_id: '' },
+        }),
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.metadata).toBeUndefined();
+      expect(sentBody.safety_identifier).toBeUndefined();
+    });
+
     it('forwards Anthropic-Messages inbound to an Anthropic upstream without OpenAI translation (issue #1886)', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
@@ -1112,6 +1171,7 @@ describe('ProviderClient', () => {
           { name: 'my_custom', input_schema: { type: 'object' } },
         ],
         top_k: 40,
+        metadata: { user_id: 'anthropic-user' },
       };
       // This is what the routing layer would derive. Pass it as a resolver to
       // prove the native wire path never asks for it.
@@ -1151,6 +1211,7 @@ describe('ProviderClient', () => {
       expect(sent.tools[1].cache_control).toEqual({ type: 'ephemeral' });
       // Anthropic-only fields survive verbatim.
       expect(sent.top_k).toBe(40);
+      expect(sent.metadata).toEqual({ user_id: 'anthropic-user' });
       // System was promoted to a block array and got the cache_control breakpoint.
       expect(sent.system).toEqual([
         { type: 'text', text: 'Be concise.', cache_control: { type: 'ephemeral' } },
@@ -4582,6 +4643,7 @@ describe('ProviderClient', () => {
       expect(sentBody.store).toBe(false);
       expect(sentBody.max_completion_tokens).toBe(8192);
       expect(sentBody.metadata).toEqual({ user: 'test' });
+      expect(sentBody.safety_identifier).toBeUndefined();
     });
 
     it('preserves all fields for OpenRouter', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1137,7 +1137,10 @@ describe('ProviderClient', () => {
       expect(sentBody.store).toBeUndefined();
     });
 
-    it('drops Anthropic metadata that has no usable OpenAI safety identifier', async () => {
+    it.each([
+      ['an empty user ID', { user_id: '' }],
+      ['no metadata object', undefined],
+    ])('drops Anthropic metadata with %s', async (_label, metadata) => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
@@ -1147,11 +1150,11 @@ describe('ProviderClient', () => {
         body: {
           model: 'gpt-4o',
           messages: [{ role: 'user', content: 'hi' }],
-          metadata: { user_id: '' },
+          metadata,
         },
         resolveChatBody: async () => ({
           messages: [{ role: 'user', content: 'hi' }],
-          metadata: { user_id: '' },
+          metadata,
         }),
         stream: false,
         apiMode: 'messages',

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1073,6 +1073,7 @@ describe('ProviderClient', () => {
           { role: 'user', content: 'hi' },
         ],
         model: 'o1-pro',
+        metadata: { user_id: 'anthropic-responses-user' },
       });
 
       await client.forward({
@@ -1085,6 +1086,7 @@ describe('ProviderClient', () => {
           model: 'o1-pro',
           system: 'be brief',
           messages: [{ role: 'user', content: 'hi' }],
+          metadata: { user_id: 'anthropic-responses-user' },
         },
         resolveChatBody,
         stream: false,
@@ -1096,6 +1098,8 @@ describe('ProviderClient', () => {
       // messages, proving the lazy conversion, not the raw Anthropic body, was forwarded.
       expect(sentBody.instructions).toBe('be brief');
       expect(sentBody.system).toBeUndefined();
+      expect(sentBody.metadata).toBeUndefined();
+      expect(sentBody.safety_identifier).toBe('anthropic-responses-user');
       expect(resolveChatBody).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -235,8 +235,11 @@ function applyHashedPromptCacheKey(
 
 // Anthropic metadata.user_id identifies the caller. OpenAI metadata instead
 // annotates stored completions, so the equivalent OpenAI field is safety_identifier.
-function applyAnthropicUserIdForOpenAi(body: Record<string, unknown>): void {
-  const metadata = isRecord(body.metadata) ? body.metadata : undefined;
+function applyAnthropicUserIdForOpenAi(
+  body: Record<string, unknown>,
+  source: Record<string, unknown> = body,
+): void {
+  const metadata = isRecord(source.metadata) ? source.metadata : undefined;
   delete body.metadata;
 
   const userId = metadata?.user_id;
@@ -746,6 +749,9 @@ export class ProviderClient {
             });
       if (endpointKey === 'xai-responses') {
         applyHashedPromptCacheKey(requestBody, ctx.providerCacheKey);
+      }
+      if (endpointKey === 'openai-responses' && ctx.apiMode === 'messages') {
+        applyAnthropicUserIdForOpenAi(requestBody, requestSource);
       }
       if (endpointKey === 'openai-responses' || endpointKey === 'openai-subscription') {
         applyHashedPromptCacheKey(requestBody, ctx.providerCacheKey);

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -233,6 +233,19 @@ function applyHashedPromptCacheKey(
   body.prompt_cache_key = buildPromptCacheKey(trimmedCacheKey);
 }
 
+// Anthropic metadata.user_id identifies the caller. OpenAI metadata instead
+// annotates stored completions, so the equivalent OpenAI field is safety_identifier.
+function applyAnthropicUserIdForOpenAi(body: Record<string, unknown>): void {
+  const metadata = isRecord(body.metadata) ? body.metadata : undefined;
+  delete body.metadata;
+
+  const userId = metadata?.user_id;
+  if (typeof userId !== 'string' || !userId) return;
+
+  body.safety_identifier =
+    userId.length <= 64 ? userId : createHash('sha256').update(userId).digest('hex');
+}
+
 function openRouterCacheMode(model: string): 'anthropic' | 'message' | null {
   const normalized = model.toLowerCase().replace(/^~/, '');
   if (normalized.startsWith('anthropic/')) return 'anthropic';
@@ -767,6 +780,7 @@ export class ProviderClient {
     }
     const requestBody = { ...sanitized, model: bareModel, stream };
     if (endpointKey === 'openai') {
+      if (ctx.apiMode === 'messages') applyAnthropicUserIdForOpenAi(requestBody);
       applyHashedPromptCacheKey(requestBody, ctx.providerCacheKey);
     }
     if (endpointKey === 'mistral') {


### PR DESCRIPTION
### ✨ What changed

- Map Anthropic `metadata.user_id` to OpenAI `safety_identifier`.
- Hash identifiers longer than OpenAI's 64-character limit.
- Preserve metadata on native OpenAI and Anthropic routes.

### 💭 Why

Anthropic user metadata identifies the caller. OpenAI completion metadata has different storage semantics.

### 👤 For users

Anthropic Messages requests routed to OpenAI no longer fail on incompatible metadata.

### 📝 Notes

This translation does not enable storage. Prompt caching remains independent.
This PR intentionally excludes the broader request-boundary changes from #2782.
