### PR TITLE
fix: preserve subscription context limits

### DIFF
--- a/.changeset/subscription-context-windows.md
+++ b/.changeset/subscription-context-windows.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve configured subscription context windows after live model discovery.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1696,6 +1696,48 @@ describe('ModelDiscoveryService', () => {
       );
     });
 
+    it('should apply provider and model-specific context windows to live subscription models', async () => {
+      mockDecrypt.mockReturnValue(
+        JSON.stringify({ t: 'access-token-123', r: 'refresh-tok', e: Date.now() + 60000 }),
+      );
+      mockComputeScore.mockImplementation(({ context_window: contextWindow }) =>
+        contextWindow === 200000 ? 2 : 5,
+      );
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ id: 'gpt-5.5', contextWindow: 1050000 }),
+        makeModel({ id: 'gpt-5.6-sol', contextWindow: 1050000 }),
+        makeModel({ id: 'gpt-5.6-terra', contextWindow: 1050000 }),
+        makeModel({ id: 'gpt-5.6-luna', contextWindow: 1050000 }),
+      ]);
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        name: 'GPT-5.6',
+        inputPricePerToken: 0,
+        outputPricePerToken: 0,
+        contextWindow: 1050000,
+      });
+
+      const result = await service.discoverModels(
+        makeProvider({ provider: 'openai', auth_type: 'subscription' }),
+      );
+
+      expect(result.find((model) => model.id === 'gpt-5.5')).toMatchObject({
+        contextWindow: 200000,
+        qualityScore: 2,
+      });
+      expect(result.find((model) => model.id === 'gpt-5.6-sol')).toMatchObject({
+        contextWindow: 1050000,
+        qualityScore: 5,
+      });
+      expect(result.find((model) => model.id === 'gpt-5.6-terra')).toMatchObject({
+        contextWindow: 1050000,
+        qualityScore: 5,
+      });
+      expect(result.find((model) => model.id === 'gpt-5.6-luna')).toMatchObject({
+        contextWindow: 1050000,
+        qualityScore: 5,
+      });
+    });
+
     it('should use raw key when OpenAI subscription blob has no t field', async () => {
       const blob = JSON.stringify({ r: 'refresh-tok', e: Date.now() + 60000 });
       mockDecrypt.mockReturnValue(blob);

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -38,6 +38,7 @@ import {
   buildFallbackModels,
   buildModelsDevFallback,
   buildSubscriptionFallbackModels,
+  applySubscriptionContextWindows,
   supplementWithKnownModels,
 } from './model-fallback';
 import { lookupKnownPrice } from './known-model-prices';
@@ -313,10 +314,15 @@ export class ModelDiscoveryService {
     // narrowing to the two legacy values would drop the 'local' tag that the
     // frontend uses to render the house badge and the Local tab.
     const authType: AuthType = provider.auth_type;
-    const enriched = raw.map((model) => ({
+    let enriched = raw.map((model) => ({
       ...this.enrichModel(model, provider.provider),
       authType,
     }));
+    if (provider.auth_type === 'subscription') {
+      enriched = applySubscriptionContextWindows(enriched, provider.provider).map((model) =>
+        this.computeScore(model),
+      );
+    }
 
     // Filter out models confirmed to lack tool support (models.dev toolCall === false).
     // AI agents (OpenClaw, Hermes, SDK-based agents) almost always
@@ -777,7 +783,7 @@ export class ModelDiscoveryService {
     };
   }
 
-  private computeScore(model: DiscoveredModel): DiscoveredModel {
+  private computeScore<T extends DiscoveredModel>(model: T): T {
     const score = computeQualityScore({
       model_name: model.id,
       input_price_per_token: model.inputPricePerToken,

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -304,6 +304,18 @@ export function buildSubscriptionFallbackModels(providerId: string): DiscoveredM
   }));
 }
 
+export function applySubscriptionContextWindows<T extends DiscoveredModel>(
+  models: T[],
+  providerId: string,
+): T[] {
+  const capabilities = getSubscriptionCapabilities(providerId);
+  if (!capabilities) return models;
+  return models.map((model) => ({
+    ...model,
+    contextWindow: resolveSubscriptionContextWindow(model.id, model.contextWindow, capabilities),
+  }));
+}
+
 /**
  * Supplement discovered models with knownModels from subscription-capabilities.
  * Ensures subscription users always have the known models available as selectable options,


### PR DESCRIPTION
### ✨ What changed
- Reapply configured subscription context windows after discovery enrichment.
- Recompute quality scores from the final context window.

### 💭 Why
Catalog enrichment could replace provider or model-specific subscription limits.

### 👤 For users
Subscription models report route-specific limits. GPT-5.6 models remain at 1.05M.

### 📝 Notes
Split from #2786 so the concurrency PR stays focused.
OpenAI model reference: https://developers.openai.com/api/docs/models/gpt-5.6-sol