### PR TITLE
fix: translate subscription Autofix model IDs

### DIFF
--- a/.changeset/native-subscription-autofix.md
+++ b/.changeset/native-subscription-autofix.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep Phoenix model remaps provider-native while preserving subscription routing and legacy Autofix compatibility.

--- a/packages/backend/src/routing/autofix/__tests__/http-healing-client.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/http-healing-client.spec.ts
@@ -79,9 +79,9 @@ describe('HttpHealingClient', () => {
       expect((err as HealContractError).status).toBe(401);
     });
 
-    it('sends the x-api-key header when an API key is configured', async () => {
+    it('sends the API key and Manifest version when an API key is configured', async () => {
       fetchSpy.mockResolvedValue(fakeResponse(true, 200, { status: 'no_patch', issueId: 'i' }));
-      const client = new HttpHealingClient('http://x', 1000, 'secret-key');
+      const client = new HttpHealingClient('http://x', 1000, 'secret-key', undefined, '6.19.1');
 
       await client.heal(makeHealRequest(), context);
 
@@ -89,6 +89,7 @@ describe('HttpHealingClient', () => {
       expect(init.headers).toEqual({
         'content-type': 'application/json',
         'x-api-key': 'secret-key',
+        'X-Manifest-Version': '6.19.1',
       });
     });
 
@@ -176,6 +177,7 @@ describe('HttpHealingClient', () => {
       expect(fetchSpy.mock.calls[0][1].headers).toEqual({
         'content-type': 'application/json',
         'x-api-key': 'static-key',
+        'X-Manifest-Version': '6.15.1',
       });
     });
 
@@ -228,6 +230,7 @@ describe('HttpHealingClient', () => {
       expect(init.headers).toEqual({
         'content-type': 'application/json',
         'x-api-key': 'secret-key',
+        'X-Manifest-Version': 'unknown',
       });
     });
 
@@ -294,6 +297,7 @@ describe('HttpHealingClient', () => {
       expect(init.headers).toEqual({
         'content-type': 'application/json',
         'x-api-key': 'secret-key',
+        'X-Manifest-Version': 'unknown',
       });
       expect(JSON.parse(init.body)).toEqual({ observations: batch });
     });

--- a/packages/backend/src/routing/autofix/http-healing-client.ts
+++ b/packages/backend/src/routing/autofix/http-healing-client.ts
@@ -112,6 +112,7 @@ export class HttpHealingClient implements HealingClient {
       return this.request(path, init, {
         'content-type': 'application/json',
         'x-api-key': this.apiKey,
+        'X-Manifest-Version': this.manifestVersion ?? 'unknown',
       });
     }
     if (!this.instanceId) {

--- a/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
@@ -3,6 +3,7 @@ import {
   explicitModelRouteCandidate,
   openAiModelId,
   routeForOpenAiModelId,
+  subscriptionOpenAiModelId,
 } from '../openai-model-id';
 
 function model(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
@@ -34,6 +35,16 @@ describe('OpenAI model ids', () => {
     );
     expect(openAiModelId(model({ id: 'gpt-5.5-subscription', authType: 'subscription' }))).toBe(
       'openai/gpt-5.5-subscription',
+    );
+  });
+
+  it('encodes native subscription models idempotently', () => {
+    expect(subscriptionOpenAiModelId('openai', 'gpt-5.5')).toBe('openai/gpt-5.5-subscription');
+    expect(subscriptionOpenAiModelId('openai', 'openai/gpt-5.5-subscription')).toBe(
+      'openai/gpt-5.5-subscription',
+    );
+    expect(subscriptionOpenAiModelId('opencode-go', 'opencode-go/glm-5.1')).toBe(
+      'opencode-go/glm-5.1-subscription',
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
@@ -39,6 +39,7 @@ describe('OpenAI model ids', () => {
   });
 
   it('encodes native subscription models idempotently', () => {
+    expect(subscriptionOpenAiModelId('openai', 'auto')).toBe('auto');
     expect(subscriptionOpenAiModelId('openai', 'gpt-5.5')).toBe('openai/gpt-5.5-subscription');
     expect(subscriptionOpenAiModelId('openai', 'openai/gpt-5.5-subscription')).toBe(
       'openai/gpt-5.5-subscription',

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -321,6 +321,33 @@ describe('ProxyController', () => {
     });
   });
 
+  it('should expose provider-native route metadata when requested', async () => {
+    modelDiscovery.getModelsForAgent.mockResolvedValue([
+      makeDiscoveredModel({
+        id: 'opencode-go/glm-5.1',
+        provider: 'opencode-go',
+        authType: 'subscription',
+      }),
+    ]);
+
+    await expect(
+      controller.models(mockRequest({}) as never, undefined, undefined, 'true'),
+    ).resolves.toEqual({
+      object: 'list',
+      data: [
+        { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+        {
+          id: 'opencode-go/glm-5.1-subscription',
+          object: 'model',
+          created: 0,
+          owned_by: 'opencode-go',
+          provider_model_id: 'opencode-go/glm-5.1',
+          auth_type: 'subscription',
+        },
+      ],
+    });
+  });
+
   it('should expose capability metadata when ?capabilities=true, preserving subscription ids', async () => {
     modelDiscovery.getModelsForAgent.mockResolvedValue([
       makeDiscoveredModel({
@@ -575,6 +602,44 @@ describe('ProxyController', () => {
     expect(headers['X-Manifest-Provider']).toBe('OpenAI');
     expect(headers['X-Manifest-Confidence']).toBe('0.9');
     expect(headers['X-Manifest-Reason']).toBe('scored');
+  });
+
+  it('routes a native Phoenix replay through the requested subscription connection', async () => {
+    const responseBody = { choices: [{ message: { content: 'hello' } }] };
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: {
+        response: new Response(JSON.stringify(responseBody), { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      },
+      meta: {
+        tier: 'direct',
+        model: 'gpt-5.5',
+        provider: 'openai',
+        auth_type: 'subscription',
+        confidence: 1,
+        reason: 'direct',
+      },
+    });
+    const body = { model: 'gpt-5.5', messages: [{ role: 'user', content: 'hi' }] };
+    const req = mockRequest(body, 'user-1', {
+      'x-manifest-provider': 'openai',
+      'x-manifest-auth-type': 'subscription',
+    });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+
+    expect(proxyService.proxyRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body,
+        routingBody: {
+          model: 'openai/gpt-5.5-subscription',
+          messages: [{ role: 'user', content: 'hi' }],
+        },
+      }),
+    );
   });
 
   it.each([

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -577,14 +577,6 @@ describe('ProxyService — orchestration', () => {
       fallbackService.tryForwardToProvider.mockResolvedValueOnce(failed);
       fallbackService.retryWireBody.mockResolvedValueOnce(healed);
       modelDiscovery.getModelsForAgent.mockResolvedValue([]);
-      resolveService.resolve.mockResolvedValue({
-        tier: 'standard',
-        route: null,
-        fallback_routes: null,
-        confidence: 0.9,
-        score: 5,
-        reason: 'scored',
-      });
       resolveService.resolve.mockResolvedValueOnce({
         tier: 'standard',
         route: route('openai', 'subscription', 'gpt-5.4'),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -533,6 +533,125 @@ describe('ProxyService — orchestration', () => {
       expect(reforwardOpts.provider).toBe('openai');
     });
 
+    it('routes a native Autofix remap through the original subscription auth type', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.4'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      const healed = fwd(200, { model: 'gpt-5.5' });
+      fallbackService.tryForwardToProvider
+        .mockResolvedValueOnce(fwd(400, { model: 'gpt-5.4' }))
+        .mockResolvedValueOnce(healed);
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-5.5', provider: 'openai', authType: 'api_key' }),
+        discoveredModel({ id: 'gpt-5.5', provider: 'openai', authType: 'subscription' }),
+      ]);
+      autofixService.maybeHeal.mockImplementation(
+        async (params: { reforward: (b: Record<string, unknown>) => Promise<unknown> }) => ({
+          forward: await params.reforward({ model: 'gpt-5.5', max_output_tokens: 5 }),
+          record: { outcome: 'healed', attempts: 1, original_http_status: 400, chain: [] },
+        }),
+      );
+
+      const result = await svc.proxyRequest(baseOpts());
+
+      expect(result.forward).toBe(healed);
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledTimes(2);
+      expect(fallbackService.tryForwardToProvider.mock.calls[1][0]).toEqual(
+        expect.objectContaining({
+          provider: 'openai',
+          authType: 'subscription',
+          model: 'gpt-5.5',
+          body: expect.objectContaining({ model: 'gpt-5.5' }),
+        }),
+      );
+    });
+
+    it('keeps a native remap body on the original subscription transport when discovery is stale', async () => {
+      const failed = fwd(400, { model: 'gpt-5.4' });
+      const healed = fwd(200, { model: 'gpt-5.5' });
+      fallbackService.tryForwardToProvider.mockResolvedValueOnce(failed);
+      fallbackService.retryWireBody.mockResolvedValueOnce(healed);
+      modelDiscovery.getModelsForAgent.mockResolvedValue([]);
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: null,
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      resolveService.resolve.mockResolvedValueOnce({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.4'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      autofixService.maybeHeal.mockImplementation(
+        async (params: { reforward: (b: Record<string, unknown>) => Promise<unknown> }) => ({
+          forward: await params.reforward({ model: 'gpt-5.5', max_output_tokens: 5 }),
+          record: { outcome: 'healed', attempts: 1, original_http_status: 400, chain: [] },
+        }),
+      );
+
+      const result = await svc.proxyRequest(baseOpts());
+
+      expect(result.forward).toBe(healed);
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledTimes(1);
+      expect(fallbackService.retryWireBody).toHaveBeenCalledWith(
+        failed,
+        { model: 'gpt-5.5', max_output_tokens: 5 },
+        expect.objectContaining({
+          provider: 'openai',
+          model: 'gpt-5.5',
+          authType: 'subscription',
+        }),
+      );
+    });
+
+    it('keeps legacy suffixed Autofix remaps idempotent', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.4'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      const healed = fwd(200, { model: 'gpt-5.5' });
+      fallbackService.tryForwardToProvider
+        .mockResolvedValueOnce(fwd(400, { model: 'gpt-5.4' }))
+        .mockResolvedValueOnce(healed);
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-5.5', provider: 'openai', authType: 'subscription' }),
+      ]);
+      autofixService.maybeHeal.mockImplementation(
+        async (params: { reforward: (b: Record<string, unknown>) => Promise<unknown> }) => ({
+          forward: await params.reforward({
+            model: 'openai/gpt-5.5-subscription',
+            max_output_tokens: 5,
+          }),
+          record: { outcome: 'healed', attempts: 1, original_http_status: 400, chain: [] },
+        }),
+      );
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(fallbackService.tryForwardToProvider.mock.calls[1][0]).toEqual(
+        expect.objectContaining({
+          authType: 'subscription',
+          model: 'gpt-5.5',
+          body: expect.objectContaining({ model: 'openai/gpt-5.5-subscription' }),
+        }),
+      );
+    });
+
     it('re-resolves an uncatalogued healed model through connected-provider passthrough', async () => {
       routableResolve();
       const healed = fwd(200, { model: 'gpt-new' });

--- a/packages/backend/src/routing/proxy/openai-model-id.ts
+++ b/packages/backend/src/routing/proxy/openai-model-id.ts
@@ -11,16 +11,29 @@ export interface ExplicitModelRouteCandidate {
   providerQualified: boolean;
 }
 
+/** Encode a provider-native model for Manifest's public subscription route. */
+export function subscriptionOpenAiModelId(provider: string, modelId: string): string {
+  const normalizedProvider = provider.toLowerCase();
+  if (normalizedProvider.startsWith('custom:')) return modelId;
+
+  const prefix = `${normalizedProvider}/`;
+  const routeId = modelId.toLowerCase().startsWith(prefix)
+    ? modelId
+    : `${normalizedProvider}/${modelId}`;
+  return routeId.endsWith(SUBSCRIPTION_MODEL_SUFFIX)
+    ? routeId
+    : `${routeId}${SUBSCRIPTION_MODEL_SUFFIX}`;
+}
+
 export function openAiModelId(model: DiscoveredModel): string {
   const provider = model.provider.toLowerCase();
   if (provider.startsWith('custom:')) return model.id;
 
   const prefix = `${provider}/`;
   const routeId = model.id.toLowerCase().startsWith(prefix) ? model.id : `${provider}/${model.id}`;
-  if (model.authType !== 'subscription' || routeId.endsWith(SUBSCRIPTION_MODEL_SUFFIX)) {
-    return routeId;
-  }
-  return `${routeId}${SUBSCRIPTION_MODEL_SUFFIX}`;
+  return model.authType === 'subscription'
+    ? subscriptionOpenAiModelId(provider, model.id)
+    : routeId;
 }
 
 /**

--- a/packages/backend/src/routing/proxy/openai-model-id.ts
+++ b/packages/backend/src/routing/proxy/openai-model-id.ts
@@ -14,7 +14,7 @@ export interface ExplicitModelRouteCandidate {
 /** Encode a provider-native model for Manifest's public subscription route. */
 export function subscriptionOpenAiModelId(provider: string, modelId: string): string {
   const normalizedProvider = provider.toLowerCase();
-  if (normalizedProvider.startsWith('custom:')) return modelId;
+  if (modelId === OPENAI_MODEL_ID_AUTO || normalizedProvider.startsWith('custom:')) return modelId;
 
   const prefix = `${normalizedProvider}/`;
   const routeId = modelId.toLowerCase().startsWith(prefix)

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -61,7 +61,7 @@ import type {
 } from './proxy-types';
 import { ResponsesSseError } from './chatgpt-adapter';
 import { redactInlineImageDataUrls } from './inline-image-redaction';
-import { openAiModelId } from './openai-model-id';
+import { openAiModelId, subscriptionOpenAiModelId } from './openai-model-id';
 import { openAiModelCapabilities, type OpenAiModelCapabilities } from './openai-model-capabilities';
 import { PlanService } from '../../billing/plan.service';
 import { StreamFailure } from './stream-writer';
@@ -81,6 +81,8 @@ interface OpenAiModelObject {
   object: 'model';
   created: number;
   owned_by: string;
+  provider_model_id?: string;
+  auth_type?: string;
   capabilities?: OpenAiModelCapabilities;
   cost?: OpenAiModelCost;
 }
@@ -149,9 +151,11 @@ export class ProxyController {
     @Req() req: Request & { ingestionContext: IngestionContext },
     @Query('capabilities') capabilities?: string,
     @Query('cost') cost?: string,
+    @Query('route_metadata') routeMetadata?: string,
   ): Promise<OpenAiModelList> {
     const includeCapabilities = capabilities === 'true';
     const includeCost = cost === 'true';
+    const includeRouteMetadata = routeMetadata === 'true';
     const models = await this.modelDiscovery.getModelsForAgent(
       req.ingestionContext.tenantId,
       req.ingestionContext.agentId,
@@ -178,6 +182,10 @@ export class ProxyController {
         created: MODEL_CREATED_UNKNOWN,
         owned_by: model.provider,
       };
+      if (includeRouteMetadata) {
+        entry.provider_model_id = model.id;
+        entry.auth_type = model.authType;
+      }
       if (includeCapabilities) {
         // Same resolution as the dashboard's model picker, so agents and the
         // routing UI report identical capability facts.
@@ -379,7 +387,7 @@ export class ProxyController {
       this.rateLimiter.checkIpLimit(req.ip ?? '');
       this.rateLimiter.acquireSlot(tenantId);
       slotAcquired = true;
-      routingBody = redactInlineImageDataUrls(body);
+      routingBody = redactInlineImageDataUrls(this.routingBody(body, req));
       const specificityOverride = req.headers['x-manifest-specificity'] as string | undefined;
       const { forward, meta, failedFallbacks, autofix } = await this.proxyService.proxyRequest({
         agentId: req.ingestionContext.agentId,
@@ -574,6 +582,24 @@ export class ProxyController {
     } finally {
       if (slotAcquired) this.rateLimiter.releaseSlot(tenantId);
     }
+  }
+
+  /**
+   * Phoenix replays a provider-native model while naming the original route in
+   * headers. Keep Manifest's public `-subscription` syntax inside Manifest: the
+   * original body remains provider-native and only the routing view is encoded.
+   */
+  private routingBody(
+    body: Record<string, unknown>,
+    req: Request & { ingestionContext: IngestionContext },
+  ): Record<string, unknown> {
+    const provider = req.headers['x-manifest-provider'];
+    const authType = req.headers['x-manifest-auth-type'];
+    const model = body.model;
+    if (typeof provider !== 'string' || authType !== 'subscription' || typeof model !== 'string') {
+      return body;
+    }
+    return { ...body, model: subscriptionOpenAiModelId(provider, model) };
   }
 
   /**

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -67,6 +67,7 @@ import {
   OPENAI_MODEL_ID_AUTO,
   routeForOpenAiModelId,
   SUBSCRIPTION_MODEL_SUFFIX,
+  subscriptionOpenAiModelId,
 } from './openai-model-id';
 import { AutofixService } from '../autofix/autofix.service';
 import type { AutofixRecord } from '../autofix/autofix.types';
@@ -715,7 +716,18 @@ export class ProxyService {
     const originalModel = originalForward.wireRequestBody?.model;
     const healedModel = typeof healedBody.model === 'string' ? healedBody.model : undefined;
     if (healedModel && healedModel !== originalModel) {
-      return this.forwardResolvedHealed(healedBody, originalForward, ctx);
+      // Phoenix speaks in provider-native model ids. Manifest owns the public
+      // `-subscription` route syntax, so add it only while resolving the healed
+      // retry. The helper is idempotent for older Phoenix patches that already
+      // carry the legacy route id.
+      const routingBody =
+        ctx.authType === 'subscription'
+          ? {
+              ...healedBody,
+              model: subscriptionOpenAiModelId(ctx.provider, healedModel),
+            }
+          : healedBody;
+      return this.forwardResolvedHealed(routingBody, healedBody, originalForward, ctx);
     }
     return this.fallbackService.retryWireBody(originalForward, healedBody, {
       provider: ctx.provider,
@@ -729,16 +741,21 @@ export class ProxyService {
   }
 
   private async forwardResolvedHealed(
+    routingBody: Record<string, unknown>,
     healedBody: Record<string, unknown>,
     originalForward: ForwardResult,
     ctx: HealedReforwardContext,
   ): Promise<ForwardResult> {
     const resolveChatBody = this.createChatBodyResolver(ctx.apiMode, healedBody);
+    const resolveRoutingChatBody =
+      routingBody === healedBody
+        ? resolveChatBody
+        : this.createChatBodyResolver(ctx.apiMode, routingBody);
     const resolved = await this.resolveRouting(
       ctx.agentId,
       ctx.tenantId,
-      healedBody,
-      resolveChatBody,
+      routingBody,
+      resolveRoutingChatBody,
       ctx.sessionMomentumKey,
       ctx.specificityOverride,
       ctx.headers,


### PR DESCRIPTION
### ✨ What changed
- Translate Phoenix-native remaps into Manifest subscription routes.
- Send the Manifest version for Phoenix response compatibility.
- Publish native model metadata for Phoenix discovery.

### 💭 Why
Manifest owns subscription routing syntax. Phoenix should store provider-native model IDs.

### 👤 For users
Subscription Autofix retries work across current and legacy Manifest versions.

### 📝 Notes
Local deployment E2E passed with Manifest 6.19.1 and 6.17.1.

Companion: https://github.com/mnfst/phoenix/pull/284

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subscription Autofix retries by translating provider-native model IDs into Manifest's subscription route syntax only for routing, so Phoenix can keep storing provider-native IDs.

- Sends the `X-Manifest-Version` header to Phoenix so it knows which subscription routing syntax is in use.
- Exposes `provider_model_id` and `auth_type` in model listings when `?route_metadata=true` so Phoenix publishes native model metadata.
- Encodes provider-native replay bodies into subscription routes when Phoenix supplies the provider and auth type in headers, preserving `auto` routing.
- Keeps legacy `-subscription`-suffixed model IDs idempotent during translation.

<sup>Written for commit c9ad39d6f4130ae758fc52f165fc8934ec7abfd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

