### PR TITLE
feat: configure proxy concurrency limit

### DIFF
--- a/.changeset/configurable-concurrency-limit.md
+++ b/.changeset/configurable-concurrency-limit.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Allow deployments to configure the per-tenant concurrent request limit with `MANIFEST_CONCURRENCY_MAX`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,7 @@ See `packages/backend/.env.example` for all variables. Key ones:
 - `PROVIDER_TIMEOUT_MS` — Per-attempt timeout (ms) for upstream provider requests. Default: `180000`
 - `STREAM_WARMUP_MS` — Timeout (ms) to wait for the first chunk of a streaming response before trying a fallback. Default: `15000`
 - `CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS` — Timeout (ms) to wait for deliverable ChatGPT Codex text or tool output. Default: `60000`
+- `MANIFEST_CONCURRENCY_MAX` — Per-tenant concurrent in-flight request limit for each backend process. Accepts a plain positive integer; invalid values fall back to `10`.
 - `EMAIL_PROVIDER` — Unified email provider: `resend` (recommended), `mailgun`, or `sendgrid`. Used for Better Auth transactional emails and threshold alerts.
 - `EMAIL_API_KEY` — API key for the configured `EMAIL_PROVIDER`.
 - `EMAIL_DOMAIN` — Sending domain (required for Mailgun).

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -78,6 +78,9 @@ BETTER_AUTH_SECRET=
 # Timeout (ms) to wait for deliverable text or tool output from ChatGPT Codex.
 # CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS=60000
 
+# Per-tenant concurrent in-flight request limit for each backend process.
+# MANIFEST_CONCURRENCY_MAX=10
+
 # Managed free providers (optional). A master key enables automatic
 # virtual-key provisioning; users can otherwise paste a key obtained through
 # the provider's "Get API key" link.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       - PROVIDER_TIMEOUT_MS=${PROVIDER_TIMEOUT_MS:-180000}
       - STREAM_WARMUP_MS=${STREAM_WARMUP_MS:-15000}
       - CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS=${CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS:-60000}
+      # Per-tenant concurrent in-flight request limit for this backend process.
+      - MANIFEST_CONCURRENCY_MAX=${MANIFEST_CONCURRENCY_MAX:-10}
       # Both are deliberately hardcoded, not `${VAR:-default}`. The image is a
       # production artifact: NODE_ENV=production is what makes it one, and the
       # seeder refuses to run under it anyway (database-seeder.service.ts logs

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -57,6 +57,8 @@ BETTER_AUTH_URL=http://localhost:3001
 # STREAM_IDLE_TIMEOUT_MS=180000
 # Timeout (ms) to wait for deliverable text or tool output from ChatGPT Codex.
 # CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS=60000
+# Per-tenant concurrent in-flight request limit for each backend process.
+# MANIFEST_CONCURRENCY_MAX=10
 
 # ── Managed free providers (optional) ───────────────
 # Managed gateway used by providers such as Gemini Free. A master key enables

--- a/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
@@ -3,13 +3,20 @@ import { ProxyRateLimiter } from '../proxy-rate-limiter';
 
 describe('ProxyRateLimiter', () => {
   let limiter: ProxyRateLimiter;
+  const originalConcurrencyMax = process.env.MANIFEST_CONCURRENCY_MAX;
 
   beforeEach(() => {
+    delete process.env.MANIFEST_CONCURRENCY_MAX;
     limiter = new ProxyRateLimiter();
   });
 
   afterEach(() => {
     limiter.onModuleDestroy();
+    if (originalConcurrencyMax === undefined) {
+      delete process.env.MANIFEST_CONCURRENCY_MAX;
+    } else {
+      process.env.MANIFEST_CONCURRENCY_MAX = originalConcurrencyMax;
+    }
   });
 
   describe('checkLimit', () => {
@@ -263,6 +270,39 @@ describe('ProxyRateLimiter', () => {
   });
 
   describe('acquireSlot / releaseSlot', () => {
+    it('uses MANIFEST_CONCURRENCY_MAX when it is a positive integer', () => {
+      limiter.onModuleDestroy();
+      process.env.MANIFEST_CONCURRENCY_MAX = '40';
+      limiter = new ProxyRateLimiter();
+
+      for (let i = 0; i < 40; i++) {
+        expect(() => limiter.acquireSlot('tenant-1')).not.toThrow();
+      }
+      expect(() => limiter.acquireSlot('tenant-1')).toThrow(HttpException);
+    });
+
+    it.each([
+      '',
+      '0',
+      '-1',
+      '1.5',
+      'not-a-number',
+      '9007199254740992',
+      '0x10',
+      '0b101',
+      '2e1',
+      ' 40 ',
+    ])('falls back to 10 when MANIFEST_CONCURRENCY_MAX is %p', (configuredValue) => {
+      limiter.onModuleDestroy();
+      process.env.MANIFEST_CONCURRENCY_MAX = configuredValue;
+      limiter = new ProxyRateLimiter();
+
+      for (let i = 0; i < 10; i++) {
+        expect(() => limiter.acquireSlot('tenant-1')).not.toThrow();
+      }
+      expect(() => limiter.acquireSlot('tenant-1')).toThrow(HttpException);
+    });
+
     it('allows up to 10 concurrent slots', () => {
       for (let i = 0; i < 10; i++) {
         expect(() => limiter.acquireSlot('user-1')).not.toThrow();

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -1,11 +1,12 @@
 import { Injectable, OnModuleDestroy, HttpStatus } from '@nestjs/common';
 import { ManifestError } from '../../common/errors/manifest-error';
+import { optionalPositiveInteger } from '../../config/env.util';
 
 const RATE_WINDOW_MS = 60_000;
 const RATE_MAX_REQUESTS = 200;
 const IP_RATE_MAX_REQUESTS = 500;
 const MAX_RATE_ENTRIES = 50_000;
-const CONCURRENCY_MAX = 10;
+const DEFAULT_CONCURRENCY_MAX = 10;
 const CLEANUP_INTERVAL_MS = 60_000;
 
 interface RateEntry {
@@ -18,6 +19,8 @@ export class ProxyRateLimiter implements OnModuleDestroy {
   private readonly rates = new Map<string, RateEntry>();
   private readonly ipRates = new Map<string, RateEntry>();
   private readonly concurrency = new Map<string, number>();
+  private readonly concurrencyMax =
+    optionalPositiveInteger(process.env.MANIFEST_CONCURRENCY_MAX) ?? DEFAULT_CONCURRENCY_MAX;
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
 
   constructor() {
@@ -81,7 +84,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
 
   acquireSlot(tenantId: string): void {
     const current = this.concurrency.get(tenantId) ?? 0;
-    if (current >= CONCURRENCY_MAX) {
+    if (current >= this.concurrencyMax) {
       throw new ManifestError('M203', HttpStatus.TOO_MANY_REQUESTS);
     }
     this.concurrency.set(tenantId, current + 1);


### PR DESCRIPTION
### ✨ What changed
- Add `MANIFEST_CONCURRENCY_MAX` with a default of 10.
- Validate the value with the shared positive-integer parser.
- Document local and Compose configuration.

### 💭 Why
Deployments need to tune per-tenant concurrency without changing source.

### 🔧 For operators
Set `MANIFEST_CONCURRENCY_MAX` before starting the backend. The limit applies per tenant in each backend process, so replicas enforce it independently.

### 📝 Notes
Supersedes #2786.
Thanks @daragao3 for the original proposal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the proxy's per-tenant concurrency limit configurable via `MANIFEST_CONCURRENCY_MAX` instead of being hardcoded to 10.

- Defaults to 10; invalid values (non–positive integers) fall back to the default.
- The limit applies per tenant in each backend process, so replicas enforce it independently.
- Operators set `MANIFEST_CONCURRENCY_MAX` before starting the backend; Compose and `.env.example` files document the option.

<sup>Written for commit 7c0cc51f719f8e5b1a6ca9f860568635a4aa14b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

