### PR TITLE
fix: reconcile stale subscription context windows in cached models

### DIFF
--- a/.changeset/calm-codex-context.md
+++ b/.changeset/calm-codex-context.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Tag cached models with context-window provenance and reconcile stale configured subscription context windows at read time, without overriding provider-native limits.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -172,7 +172,7 @@ describe('ModelDiscoveryService', () => {
     });
 
     it('should decrypt key, fetch, enrich, and cache models', async () => {
-      const models = [makeModel({ id: 'gpt-4' })];
+      const models = [makeModel({ id: 'gpt-4', contextWindowSource: 'provider' })];
       fetcher.fetch.mockResolvedValue(models);
 
       const provider = makeProvider();
@@ -183,6 +183,7 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key', undefined);
       expect(result).toHaveLength(1);
       expect(provider.cached_models).toEqual(result);
+      expect(result[0]).toMatchObject({ contextWindowSource: 'provider' });
       expect(provider.models_fetched_at).toBeDefined();
       expect(providerRepo.save).toHaveBeenCalledWith(provider);
     });
@@ -793,6 +794,61 @@ describe('ModelDiscoveryService', () => {
       expect(result[1].id).toBe('custom:cp-1/custom-llm');
       expect(result[1].provider).toBe('custom:cp-1');
       expect(result[1].displayName).toBe('custom-llm');
+    });
+
+    it('should reconcile a legacy supplemented subscription context window', async () => {
+      providerRepo.find.mockResolvedValue([
+        makeProvider({
+          provider: 'openai',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({
+              id: 'gpt-5.6-sol',
+              displayName: 'gpt-5.6-sol',
+              provider: 'openai',
+              authType: 'subscription',
+              contextWindow: 272_000,
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            }),
+          ],
+        }),
+      ]);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('tenant-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].contextWindow).toBe(1_050_000);
+      expect(result[0].contextWindowSource).toBe('subscription_config');
+    });
+
+    it('should preserve a provider-native subscription context window', async () => {
+      providerRepo.find.mockResolvedValue([
+        makeProvider({
+          provider: 'openai',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({
+              id: 'gpt-5.6-sol',
+              displayName: 'gpt-5.6-sol',
+              provider: 'openai',
+              authType: 'subscription',
+              contextWindow: 640_000,
+              contextWindowSource: 'provider',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            }),
+          ],
+        }),
+      ]);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('tenant-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].contextWindow).toBe(640_000);
+      expect(result[0].contextWindowSource).toBe('provider');
     });
 
     it('should filter stale unsupported OpenAI subscription cached models', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -38,6 +38,7 @@ import {
   buildFallbackModels,
   buildModelsDevFallback,
   buildSubscriptionFallbackModels,
+  reconcileCachedSubscriptionContextWindow,
   supplementWithKnownModels,
 } from './model-fallback';
 import { lookupKnownPrice } from './known-model-prices';
@@ -551,7 +552,11 @@ export class ModelDiscoveryService {
       const providerId = p.provider.toLowerCase();
       const filterKey = nonChatFilterKey(providerId, providerAuthType);
       const cached = filterNonChatModels(rawCached, filterKey);
-      for (const m of cached) {
+      for (const cachedModel of cached) {
+        const m =
+          providerAuthType === 'subscription'
+            ? reconcileCachedSubscriptionContextWindow(cachedModel, p.provider)
+            : cachedModel;
         const effectiveAuthType = m.authType ?? providerAuthType;
         // Deduplicate by the routable tuple, not just model ID. Multiple
         // providers can expose the same native model name, and the picker must

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -426,6 +426,21 @@ describe('reconcileCachedSubscriptionContextWindow', () => {
     );
   });
 
+  it('does not infer legacy provenance for provider-fetched rows whose display name fell back to the id', () => {
+    // A pre-provenance row from the Codex models API whose display_name was
+    // absent looks id-named and zero-priced, exactly like a supplemented row -
+    // but the fetch parser marks capabilityCode true, the supplement path false.
+    const providerFetchedModel = {
+      ...cachedModel,
+      contextWindow: 640000,
+      capabilityCode: true,
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(providerFetchedModel, 'openai')).toBe(
+      providerFetchedModel,
+    );
+  });
+
   it('does not infer legacy provenance for other subscription providers', () => {
     const ambiguousMoonshotModel = {
       ...cachedModel,

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -2,6 +2,7 @@ import {
   buildFallbackModels,
   buildModelsDevFallback,
   buildSubscriptionFallbackModels,
+  reconcileCachedSubscriptionContextWindow,
   supplementWithKnownModels,
   findOpenRouterPrefix,
   lookupWithVariants,
@@ -353,9 +354,130 @@ describe('buildSubscriptionFallbackModels', () => {
       'MiniMax-M2',
     ]);
   });
+
+  it('uses the route-specific configured context windows for GPT-5.6 subscriptions', () => {
+    const models = buildSubscriptionFallbackModels('openai');
+
+    expect(
+      models
+        .filter((candidate) => candidate.id.startsWith('gpt-5.6-'))
+        .map((candidate) => [candidate.id, candidate.contextWindow]),
+    ).toEqual([
+      ['gpt-5.6-sol', 1050000],
+      ['gpt-5.6-terra', 1050000],
+      ['gpt-5.6-luna', 1050000],
+    ]);
+  });
+});
+
+describe('reconcileCachedSubscriptionContextWindow', () => {
+  // A stale curated row as a 272K-era refresh would have persisted it; the
+  // current configuration restores the documented 1.05M window.
+  const cachedModel = {
+    id: 'gpt-5.6-sol',
+    displayName: 'gpt-5.6-sol',
+    provider: 'openai',
+    contextWindow: 272000,
+    inputPricePerToken: 0,
+    outputPricePerToken: 0,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 3,
+  };
+
+  it('corrects a legacy curated model using the current subscription configuration', () => {
+    expect(reconcileCachedSubscriptionContextWindow(cachedModel, 'openai')).toMatchObject({
+      contextWindow: 1050000,
+      contextWindowSource: 'subscription_config',
+    });
+  });
+
+  it('preserves provider-native context metadata', () => {
+    const providerModel = {
+      ...cachedModel,
+      contextWindow: 640000,
+      contextWindowSource: 'provider' as const,
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(providerModel, 'openai')).toBe(providerModel);
+  });
+
+  it('preserves models for providers without a curated catalog', () => {
+    expect(reconcileCachedSubscriptionContextWindow(cachedModel, 'unknown-provider')).toBe(
+      cachedModel,
+    );
+  });
+
+  it('preserves models outside the curated catalog', () => {
+    const unknownModel = { ...cachedModel, id: 'unlisted-model', displayName: 'unlisted-model' };
+
+    expect(reconcileCachedSubscriptionContextWindow(unknownModel, 'openai')).toBe(unknownModel);
+  });
+
+  it('does not infer provenance for provider-shaped legacy rows', () => {
+    const providerShapedModel = {
+      ...cachedModel,
+      contextWindow: 640000,
+      displayName: 'GPT-5.6 Sol',
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(providerShapedModel, 'openai')).toBe(
+      providerShapedModel,
+    );
+  });
+
+  it('does not infer legacy provenance for other subscription providers', () => {
+    const ambiguousMoonshotModel = {
+      ...cachedModel,
+      id: 'k3',
+      displayName: 'k3',
+      provider: 'moonshot',
+      contextWindow: 640000,
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(ambiguousMoonshotModel, 'moonshot')).toBe(
+      ambiguousMoonshotModel,
+    );
+  });
+
+  it('reconciles explicitly tagged subscription configuration for other providers', () => {
+    const configuredMoonshotModel = {
+      ...cachedModel,
+      id: 'k3',
+      displayName: 'k3',
+      provider: 'moonshot',
+      contextWindow: 640000,
+      contextWindowSource: 'subscription_config' as const,
+    };
+
+    expect(
+      reconcileCachedSubscriptionContextWindow(configuredMoonshotModel, 'moonshot'),
+    ).toMatchObject({
+      contextWindow: 1048576,
+      contextWindowSource: 'subscription_config',
+    });
+  });
+
+  it('keeps an already-current configured row unchanged', () => {
+    const currentModel = {
+      ...cachedModel,
+      contextWindow: 1050000,
+      contextWindowSource: 'subscription_config' as const,
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(currentModel, 'openai')).toBe(currentModel);
+  });
 });
 
 describe('supplementWithKnownModels', () => {
+  it('tags supplemented models with subscription configuration provenance', () => {
+    const result = supplementWithKnownModels([], 'openai');
+
+    expect(result.find((model) => model.id === 'gpt-5.6-sol')).toMatchObject({
+      contextWindowSource: 'subscription_config',
+    });
+  });
+
   it('should return raw list unchanged for providers with no known models', () => {
     const raw = [
       {

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -346,6 +346,7 @@ export function reconcileCachedSubscriptionContextWindow(
     model.contextWindowSource === undefined &&
     hasExplicitContextWindow &&
     model.displayName === model.id &&
+    model.capabilityCode === false &&
     model.inputPricePerToken === 0 &&
     model.outputPricePerToken === 0;
 

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -296,6 +296,7 @@ export function buildSubscriptionFallbackModels(providerId: string): DiscoveredM
     displayName: modelId,
     provider: providerId,
     contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
+    contextWindowSource: 'subscription_config',
     inputPricePerToken: 0,
     outputPricePerToken: 0,
     capabilityReasoning: false,
@@ -305,9 +306,64 @@ export function buildSubscriptionFallbackModels(providerId: string): DiscoveredM
 }
 
 /**
- * Supplement discovered models with knownModels from subscription-capabilities.
- * Ensures subscription users always have the known models available as selectable options,
- * even if the live provider API did not return them.
+ * Reconcile persisted subscription-config context windows without overriding
+ * context metadata returned by the provider's native model catalog.
+ */
+export function reconcileCachedSubscriptionContextWindow(
+  model: DiscoveredModel,
+  providerId: string,
+): DiscoveredModel {
+  if (model.contextWindowSource === 'provider') return model;
+
+  const knownModels = getSubscriptionKnownModels(providerId);
+  if (!knownModels) return model;
+  const matchMode = getSubscriptionKnownModelsMatch(providerId);
+  const normalizedModelId = model.id.toLowerCase();
+  const isKnownModel = knownModels.some((knownModel) => {
+    const normalizedKnownModel = knownModel.toLowerCase();
+    if (normalizedKnownModel === normalizedModelId) return true;
+    return matchMode !== 'exact' && normalizedModelId.startsWith(`${normalizedKnownModel}-`);
+  });
+  if (!isKnownModel) return model;
+
+  const capabilities = getSubscriptionCapabilities(providerId);
+  const hasExplicitContextWindow = Object.keys(capabilities?.modelContextWindows ?? {}).some(
+    (configuredModelId) => {
+      const normalizedConfiguredModelId = configuredModelId.toLowerCase();
+      return (
+        normalizedModelId === normalizedConfiguredModelId ||
+        normalizedModelId.startsWith(`${normalizedConfiguredModelId}-`)
+      );
+    },
+  );
+  const expectedContextWindow = resolveSubscriptionContextWindow(
+    model.id,
+    capabilities?.maxContextWindow ?? 200000,
+    capabilities,
+  );
+  const isLegacySupplementedModel =
+    providerId.toLowerCase() === 'openai' &&
+    model.contextWindowSource === undefined &&
+    hasExplicitContextWindow &&
+    model.displayName === model.id &&
+    model.inputPricePerToken === 0 &&
+    model.outputPricePerToken === 0;
+
+  if (model.contextWindowSource !== 'subscription_config' && !isLegacySupplementedModel) {
+    return model;
+  }
+  if (model.contextWindow === expectedContextWindow) return model;
+
+  return {
+    ...model,
+    contextWindow: expectedContextWindow,
+    contextWindowSource: 'subscription_config',
+  };
+}
+
+/**
+ * Supplement discovered models with knownModels from subscription capabilities.
+ * Ensures subscription users can select known models omitted by the live provider API.
  */
 export function supplementWithKnownModels(
   raw: DiscoveredModel[],
@@ -335,6 +391,7 @@ export function supplementWithKnownModels(
       displayName: modelId,
       provider: providerId,
       contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
+      contextWindowSource: 'subscription_config',
       inputPricePerToken: 0,
       outputPricePerToken: 0,
       capabilityReasoning: false,

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -28,6 +28,8 @@ export interface DiscoveredModel {
   displayName: string;
   provider: string;
   contextWindow: number;
+  /** Origin of the context limit, retained in cached_models for safe reconciliation. */
+  contextWindowSource?: 'provider' | 'subscription_config';
   inputPricePerToken: number | null;
   outputPricePerToken: number | null;
   cacheReadPricePerToken?: number;

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2474,6 +2474,31 @@ describe('ProviderModelFetcherService', () => {
       expect(result[1].id).toBe('gpt-5.4');
     });
 
+    it('does not tag the parser context-window fallback as provider-native', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          models: [
+            {
+              slug: 'gpt-5.5',
+              display_name: 'GPT-5.5',
+              visibility: 'list',
+              supported_in_api: true,
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'oauth-token', 'subscription');
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          id: 'gpt-5.5',
+          contextWindow: 200000,
+          contextWindowSource: 'subscription_config',
+        }),
+      );
+    });
+
     it('should filter ChatGPT-account unsupported Codex models from the models response', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2464,6 +2464,7 @@ describe('ProviderModelFetcherService', () => {
           displayName: 'GPT-5.5',
           provider: 'openai',
           contextWindow: 192000,
+          contextWindowSource: 'provider',
           inputPricePerToken: 0,
           outputPricePerToken: 0,
           capabilityCode: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -70,6 +70,7 @@ interface ModelParserConfig<T> {
   getId: (entry: T) => string;
   getDisplayName: (entry: T, id: string) => string;
   contextWindow?: number | ((entry: T) => number);
+  contextWindowSource?: DiscoveredModel['contextWindowSource'];
   inputPricePerToken?: number | null;
   outputPricePerToken?: number | null;
   capabilityReasoning?: boolean;
@@ -98,6 +99,9 @@ function createModelParser<T>(
           displayName: config.getDisplayName(entry, id),
           provider,
           contextWindow: typeof ctxVal === 'function' ? ctxVal(entry) : ctxVal,
+          ...(config.contextWindowSource
+            ? { contextWindowSource: config.contextWindowSource }
+            : {}),
           inputPricePerToken: config.inputPricePerToken ?? null,
           outputPricePerToken: config.outputPricePerToken ?? null,
           capabilityReasoning: config.capabilityReasoning ?? false,
@@ -736,6 +740,7 @@ const parseOpenaiSubscription = createModelParser<OpenAISubscriptionModelEntry>(
   getId: (entry) => entry.slug,
   getDisplayName: (entry, id) => entry.display_name || id,
   contextWindow: (entry) => entry.context_window ?? 200000,
+  contextWindowSource: 'provider',
   inputPricePerToken: 0,
   outputPricePerToken: 0,
   capabilityCode: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -70,7 +70,8 @@ interface ModelParserConfig<T> {
   getId: (entry: T) => string;
   getDisplayName: (entry: T, id: string) => string;
   contextWindow?: number | ((entry: T) => number);
-  contextWindowSource?: DiscoveredModel['contextWindowSource'];
+  contextWindowSource?:
+    DiscoveredModel['contextWindowSource'] | ((entry: T) => DiscoveredModel['contextWindowSource']);
   inputPricePerToken?: number | null;
   outputPricePerToken?: number | null;
   capabilityReasoning?: boolean;
@@ -93,15 +94,17 @@ function createModelParser<T>(
         const entry = m as T;
         const id = config.getId(entry);
         const ctxVal = config.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+        const contextWindowSource =
+          typeof config.contextWindowSource === 'function'
+            ? config.contextWindowSource(entry)
+            : config.contextWindowSource;
         const supportedEndpoints = config.supportedEndpoints?.(entry);
         return {
           id,
           displayName: config.getDisplayName(entry, id),
           provider,
           contextWindow: typeof ctxVal === 'function' ? ctxVal(entry) : ctxVal,
-          ...(config.contextWindowSource
-            ? { contextWindowSource: config.contextWindowSource }
-            : {}),
+          ...(contextWindowSource ? { contextWindowSource } : {}),
           inputPricePerToken: config.inputPricePerToken ?? null,
           outputPricePerToken: config.outputPricePerToken ?? null,
           capabilityReasoning: config.capabilityReasoning ?? false,
@@ -740,7 +743,11 @@ const parseOpenaiSubscription = createModelParser<OpenAISubscriptionModelEntry>(
   getId: (entry) => entry.slug,
   getDisplayName: (entry, id) => entry.display_name || id,
   contextWindow: (entry) => entry.context_window ?? 200000,
-  contextWindowSource: 'provider',
+  // The 200000 above is a parser fallback, not provider metadata: only an
+  // actually reported window is provider-native; the fallback stays owned by
+  // (and reconcilable from) the subscription configuration.
+  contextWindowSource: (entry) =>
+    typeof entry.context_window === 'number' ? 'provider' : 'subscription_config',
   inputPricePerToken: 0,
   outputPricePerToken: 0,
   capabilityCode: true,


### PR DESCRIPTION
## Problem

`tenant_providers.cached_models` rows persist a `contextWindow` with no record of where the value came from. When a curated subscription configuration value is corrected (as happened with the GPT-5.6 subscription windows), rows cached before the correction keep serving the stale limit until a manual model refresh — and there is no safe way to heal them automatically, because blindly rewriting cached rows would also clobber provider-native metadata.

## Change

- **Provenance tagging**: `DiscoveredModel` gains an optional `contextWindowSource: 'provider' | 'subscription_config'`. The OpenAI subscription parser tags models whose window came from the provider's own API as `'provider'`; `supplementWithKnownModels` tags curated-catalog supplements as `'subscription_config'`. The tag is persisted in `cached_models`, so future rows are self-describing.
- **Read-time reconciliation**: `reconcileCachedSubscriptionContextWindow` (wired into `ModelDiscoveryService` for subscription-auth providers only) updates a cached row's context window to the current curated value when the row is attributable to the subscription catalog. Rows tagged `'provider'`, rows outside the curated catalog, providers without a catalog, and legacy untagged rows that look provider-shaped are all returned unchanged — provider-native metadata is never overridden, and ambiguous rows are deliberately left alone rather than guessed at.

The net effect: a stale configured context window heals itself on the next read, while everything the provider actually reported stays untouched.

## Tests

- `model-fallback.spec.ts`: full matrix for the reconciler — legacy curated row corrected, provider-tagged row preserved, unknown provider/model preserved, provider-shaped legacy row not inferred, other-subscription-provider ambiguity not inferred, explicitly tagged rows reconciled, already-current rows returned by reference.
- `model-discovery.service.spec.ts`: reconciliation applied on the subscription read path, not on API-key providers.
- `provider-model-fetcher.service.spec.ts`: subscription parser tags `'provider'` provenance.

`npx jest --runInBand src/model-discovery`: 12 suites, 566 tests passing; changed lines fully covered.

## Changeset

Patch changeset targeting `manifest` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale subscription context windows in cached models so a corrected curated limit heals on the next read instead of serving the old value until a manual model refresh. Provider-native context metadata is never overridden, and ambiguous legacy rows are left untouched.

- Tags `DiscoveredModel` with `contextWindowSource` ('provider' or 'subscription_config') and persists it in `cached_models`; provider-native only when the Codex API actually reported a window, so the parser's fallback stays reconcilable.
- Reconciles cached rows against the current curated catalog at read time for subscription-auth providers only, touching legacy untagged rows only when supplement-path markers (including `capabilityCode === false`) make provenance unambiguous.
- Adds a patch changeset targeting `manifest`.

<sup>Written for commit ece0d6b1607c8ea82732919b1aa78c0931e17170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

