### PR TITLE
fix: preserve tool-result images across routes

### DIFF
--- a/.changeset/calm-codex-image-context.md
+++ b/.changeset/calm-codex-image-context.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop serializing tool_result images as base64 text on OpenAI-compatible routes (a single screenshot inflated to 100K+ input tokens and could overflow the provider context window), and return deterministic ChatGPT Codex context errors as HTTP 400 instead of 502.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -214,6 +214,61 @@ describe('Anthropic Messages adapter', () => {
       ]);
     });
 
+    it('keeps parallel tool results contiguous and emits their images once, after the group', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tu_1',
+                content: [
+                  {
+                    type: 'image',
+                    source: { type: 'base64', media_type: 'image/png', data: 'AAAA' },
+                  },
+                ],
+              },
+              {
+                type: 'tool_result',
+                tool_use_id: 'tu_2',
+                content: [
+                  {
+                    type: 'image',
+                    source: { type: 'base64', media_type: 'image/png', data: 'BBBB' },
+                  },
+                ],
+              },
+              { type: 'text', text: 'both screenshots above' },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'tool',
+          tool_call_id: 'tu_1',
+          content: JSON.stringify([{ type: 'text', text: '[image attached below]' }]),
+        },
+        {
+          role: 'tool',
+          tool_call_id: 'tu_2',
+          content: JSON.stringify([{ type: 'text', text: '[image attached below]' }]),
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Images from the preceding tool result:' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,BBBB' } },
+          ],
+        },
+        { role: 'user', content: 'both screenshots above' },
+      ]);
+    });
+
     it('keeps url-sourced tool_result images and leaves unconvertible image blocks in place', () => {
       const result = messagesToChatCompletionsRequest({
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -173,6 +173,85 @@ describe('Anthropic Messages adapter', () => {
       ]);
     });
 
+    it('extracts tool_result images into a follow-up user message instead of stringified base64', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tu_1',
+                content: [
+                  { type: 'text', text: 'screenshot follows' },
+                  {
+                    type: 'image',
+                    source: { type: 'base64', media_type: 'image/png', data: 'AAAA' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'tool',
+          tool_call_id: 'tu_1',
+          content: JSON.stringify([
+            { type: 'text', text: 'screenshot follows' },
+            { type: 'text', text: '[image attached below]' },
+          ]),
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Images from the preceding tool result:' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+          ],
+        },
+      ]);
+    });
+
+    it('keeps url-sourced tool_result images and leaves unconvertible image blocks in place', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tu_1',
+                content: [
+                  { type: 'image', source: { type: 'url', url: 'https://example.com/a.png' } },
+                  { type: 'image', source: { type: 'unknown' } },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'tool',
+          tool_call_id: 'tu_1',
+          content: JSON.stringify([
+            { type: 'text', text: '[image attached below]' },
+            { type: 'image', source: { type: 'unknown' } },
+          ]),
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Images from the preceding tool result:' },
+            { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+          ],
+        },
+      ]);
+    });
+
     it('falls back to "unknown" for missing tool ids and synthesizes assistant ids', () => {
       const result = messagesToChatCompletionsRequest({
         messages: [
@@ -1200,12 +1279,13 @@ describe('tool-call id sanitation on /v1/messages responses', () => {
 
   it('createMessagesStreamTransformer sanitizes the streamed tool_use id', () => {
     const t = createMessagesStreamTransformer('kimi-k3');
-    const out = [
-      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"Edit:0","function":{"name":"Edit","arguments":""}}]}}]}\n\n',
-      'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
-    ]
-      .map((c) => t.transform(c) ?? '')
-      .join('') + (t.finalize() ?? '');
+    const out =
+      [
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"Edit:0","function":{"name":"Edit","arguments":""}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+      ]
+        .map((c) => t.transform(c) ?? '')
+        .join('') + (t.finalize() ?? '');
     const start = out
       .split('\n\n')
       .find((b) => b.startsWith('event: content_block_start') && b.includes('tool_use'))!;
@@ -1222,7 +1302,9 @@ describe('empty upstream tool_call ids', () => {
           {
             message: {
               content: '',
-              tool_calls: [{ id: '', type: 'function', function: { name: 'Read', arguments: '{}' } }],
+              tool_calls: [
+                { id: '', type: 'function', function: { name: 'Read', arguments: '{}' } },
+              ],
             },
             finish_reason: 'tool_calls',
           },

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -269,6 +269,79 @@ describe('Anthropic Messages adapter', () => {
       ]);
     });
 
+    it('keeps parallel tool results contiguous across consecutive user messages', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'tu_1', name: 'screenshot', input: {} },
+              { type: 'tool_use', id: 'tu_2', name: 'screenshot', input: {} },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tu_1',
+                content: [
+                  {
+                    type: 'image',
+                    source: { type: 'base64', media_type: 'image/png', data: 'AAAA' },
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tu_2',
+                content: [
+                  {
+                    type: 'image',
+                    source: { type: 'base64', media_type: 'image/png', data: 'BBBB' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            { id: 'tu_1', type: 'function', function: { name: 'screenshot', arguments: '{}' } },
+            { id: 'tu_2', type: 'function', function: { name: 'screenshot', arguments: '{}' } },
+          ],
+        },
+        {
+          role: 'tool',
+          tool_call_id: 'tu_1',
+          content: JSON.stringify([{ type: 'text', text: '[image attached below]' }]),
+        },
+        {
+          role: 'tool',
+          tool_call_id: 'tu_2',
+          content: JSON.stringify([{ type: 'text', text: '[image attached below]' }]),
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Images from the preceding tool result:' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,BBBB' } },
+          ],
+        },
+      ]);
+    });
+
     it('keeps url-sourced tool_result images and leaves unconvertible image blocks in place', () => {
       const result = messagesToChatCompletionsRequest({
         messages: [

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -139,6 +139,29 @@ function buildAssistantMessage(content: unknown): OpenAIMessage[] {
   return [message];
 }
 
+function splitToolResultContent(content: unknown): {
+  toolContent: string;
+  imageParts: JsonRecord[];
+} {
+  // Tool messages are text-only in chat_completions, so a nested image block
+  // would otherwise ride inside the stringified tool output as raw base64 —
+  // which downstream providers tokenize as TEXT at roughly 1.5 chars/token
+  // (a single screenshot becomes 100K+ input tokens). Pull images out for a
+  // follow-up user message and leave a short placeholder in the tool output.
+  if (!Array.isArray(content)) {
+    return { toolContent: safeJsonStringify(content), imageParts: [] };
+  }
+  const imageParts: JsonRecord[] = [];
+  const sanitized = content.map((block) => {
+    if (!isRecord(block) || block.type !== 'image') return block;
+    const part = imageBlockToImagePart(block);
+    if (!part) return block;
+    imageParts.push(part);
+    return { type: 'text', text: '[image attached below]' };
+  });
+  return { toolContent: safeJsonStringify(sanitized), imageParts };
+}
+
 function buildUserMessages(content: unknown): OpenAIMessage[] {
   // Walk Anthropic content blocks in input order and emit chat_completions
   // messages without reshuffling. Each `tool_result` becomes a standalone
@@ -170,11 +193,21 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
     if (!isRecord(block)) continue;
     if (block.type === 'tool_result') {
       flushPendingUser();
+      const { toolContent, imageParts } = splitToolResultContent(block.content);
       messages.push({
         role: 'tool',
         tool_call_id: typeof block.tool_use_id === 'string' ? block.tool_use_id : 'unknown',
-        content: safeJsonStringify(block.content),
+        content: toolContent,
       });
+      if (imageParts.length > 0) {
+        messages.push({
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Images from the preceding tool result:' },
+            ...imageParts,
+          ],
+        });
+      }
     } else if (block.type === 'text' && typeof block.text === 'string') {
       pendingParts.push({ type: 'text', text: block.text });
     } else if (block.type === 'image') {

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -176,6 +176,7 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
 
   const messages: OpenAIMessage[] = [];
   let pendingParts: JsonRecord[] = [];
+  let pendingToolImages: JsonRecord[] = [];
 
   const flushPendingUser = () => {
     if (pendingParts.length === 0) return;
@@ -189,6 +190,22 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
     pendingParts = [];
   };
 
+  // Images extracted from tool_results are emitted as ONE user message after
+  // the contiguous tool-message group: every role:tool message must directly
+  // follow the assistant tool_calls turn or a sibling tool message, so a user
+  // message may never be interleaved between parallel tool results.
+  const flushToolImages = () => {
+    if (pendingToolImages.length === 0) return;
+    messages.push({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Images from the preceding tool result:' },
+        ...pendingToolImages,
+      ],
+    });
+    pendingToolImages = [];
+  };
+
   for (const block of content) {
     if (!isRecord(block)) continue;
     if (block.type === 'tool_result') {
@@ -199,22 +216,17 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
         tool_call_id: typeof block.tool_use_id === 'string' ? block.tool_use_id : 'unknown',
         content: toolContent,
       });
-      if (imageParts.length > 0) {
-        messages.push({
-          role: 'user',
-          content: [
-            { type: 'text', text: 'Images from the preceding tool result:' },
-            ...imageParts,
-          ],
-        });
-      }
+      pendingToolImages.push(...imageParts);
     } else if (block.type === 'text' && typeof block.text === 'string') {
+      flushToolImages();
       pendingParts.push({ type: 'text', text: block.text });
     } else if (block.type === 'image') {
+      flushToolImages();
       const part = imageBlockToImagePart(block);
       if (part) pendingParts.push(part);
     }
   }
+  flushToolImages();
   flushPendingUser();
   return messages;
 }

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -162,7 +162,19 @@ function splitToolResultContent(content: unknown): {
   return { toolContent: safeJsonStringify(sanitized), imageParts };
 }
 
-function buildUserMessages(content: unknown): OpenAIMessage[] {
+function flushToolImages(messages: OpenAIMessage[], pendingToolImages: JsonRecord[]): void {
+  if (pendingToolImages.length === 0) return;
+  messages.push({
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Images from the preceding tool result:' },
+      ...pendingToolImages,
+    ],
+  });
+  pendingToolImages.length = 0;
+}
+
+function buildUserMessages(content: unknown, pendingToolImages: JsonRecord[]): OpenAIMessage[] {
   // Walk Anthropic content blocks in input order and emit chat_completions
   // messages without reshuffling. Each `tool_result` becomes a standalone
   // `role: tool` message; intermediate text/image blocks accumulate into a
@@ -170,13 +182,15 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
   // the end of the turn. Preserves the relative order of tool_result blocks
   // vs. surrounding text in mixed-content user turns.
   if (typeof content === 'string') {
-    return content ? [{ role: 'user', content }] : [];
+    const messages: OpenAIMessage[] = [];
+    flushToolImages(messages, pendingToolImages);
+    if (content) messages.push({ role: 'user', content });
+    return messages;
   }
   if (!Array.isArray(content)) return [];
 
   const messages: OpenAIMessage[] = [];
   let pendingParts: JsonRecord[] = [];
-  let pendingToolImages: JsonRecord[] = [];
 
   const flushPendingUser = () => {
     if (pendingParts.length === 0) return;
@@ -188,22 +202,6 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
       if (text) messages.push({ role: 'user', content: text });
     }
     pendingParts = [];
-  };
-
-  // Images extracted from tool_results are emitted as ONE user message after
-  // the contiguous tool-message group: every role:tool message must directly
-  // follow the assistant tool_calls turn or a sibling tool message, so a user
-  // message may never be interleaved between parallel tool results.
-  const flushToolImages = () => {
-    if (pendingToolImages.length === 0) return;
-    messages.push({
-      role: 'user',
-      content: [
-        { type: 'text', text: 'Images from the preceding tool result:' },
-        ...pendingToolImages,
-      ],
-    });
-    pendingToolImages = [];
   };
 
   for (const block of content) {
@@ -218,15 +216,14 @@ function buildUserMessages(content: unknown): OpenAIMessage[] {
       });
       pendingToolImages.push(...imageParts);
     } else if (block.type === 'text' && typeof block.text === 'string') {
-      flushToolImages();
+      flushToolImages(messages, pendingToolImages);
       pendingParts.push({ type: 'text', text: block.text });
     } else if (block.type === 'image') {
-      flushToolImages();
+      flushToolImages(messages, pendingToolImages);
       const part = imageBlockToImagePart(block);
       if (part) pendingParts.push(part);
     }
   }
-  flushToolImages();
   flushPendingUser();
   return messages;
 }
@@ -267,6 +264,7 @@ function toChatToolChoice(choice: unknown): unknown {
 /** Anthropic Messages request → chat_completions request (used for routing/forwarding). */
 export function messagesToChatCompletionsRequest(body: JsonRecord): JsonRecord {
   const messages: OpenAIMessage[] = [];
+  const pendingToolImages: JsonRecord[] = [];
 
   const systemText = systemToString(body.system);
   if (systemText) messages.push({ role: 'system', content: systemText });
@@ -275,12 +273,17 @@ export function messagesToChatCompletionsRequest(body: JsonRecord): JsonRecord {
   for (const item of inputMessages) {
     if (!isRecord(item)) continue;
     const role = item.role === 'assistant' ? 'assistant' : 'user';
-    messages.push(
-      ...(role === 'assistant'
-        ? buildAssistantMessage(item.content)
-        : buildUserMessages(item.content)),
-    );
+    if (role === 'assistant') {
+      flushToolImages(messages, pendingToolImages);
+      messages.push(...buildAssistantMessage(item.content));
+    } else {
+      messages.push(...buildUserMessages(item.content, pendingToolImages));
+    }
   }
+  // Anthropic combines consecutive user messages into one logical turn.
+  // Keep extracted images buffered across those message boundaries so all
+  // sibling tool results stay contiguous in the OpenAI-compatible request.
+  flushToolImages(messages, pendingToolImages);
 
   const chatBody: JsonRecord = { messages };
 

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -600,6 +600,75 @@ describe('chatgpt-adapter', () => {
   });
 
   describe('collectChatGptSseResponse', () => {
+    it('maps a context error event to HTTP 400 without losing provider details', () => {
+      const sse =
+        'event: error\ndata: {"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model."}';
+
+      try {
+        collectChatGptSseResponse(sse, 'gpt-5.6-sol');
+        fail('Expected ResponsesSseError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ResponsesSseError);
+        expect((err as ResponsesSseError).status).toBe(400);
+        expect(JSON.parse((err as ResponsesSseError).body)).toEqual({
+          error: {
+            message: 'Your input exceeds the context window of this model.',
+            code: 'context_length_exceeded',
+            type: 'invalid_request_error',
+          },
+        });
+      }
+    });
+
+    it('maps a nested response.failed context error to HTTP 400', () => {
+      const sse =
+        'event: response.failed\ndata: {"response":{"error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Prompt is too large"}}}';
+
+      try {
+        collectChatGptSseResponse(sse, 'gpt-5.6-terra');
+        fail('Expected ResponsesSseError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ResponsesSseError);
+        expect((err as ResponsesSseError).status).toBe(400);
+      }
+    });
+
+    it('uses a useful error type when an unfamiliar code is present', () => {
+      const sse =
+        'event: error\ndata: {"type":"invalid_request_error","code":"request_rejected","message":"Invalid request"}';
+
+      try {
+        collectChatGptSseResponse(sse, 'gpt-5.6-sol');
+        fail('Expected ResponsesSseError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ResponsesSseError);
+        expect((err as ResponsesSseError).status).toBe(400);
+      }
+    });
+
+    it.each([
+      [{ code: 'resource_not_found' }, 404],
+      [{ code: 'unauthorized' }, 401],
+      [{ code: 'opaque', type: 'authentication_error' }, 401],
+      [{ code: 'forbidden' }, 403],
+      [{ code: 'opaque', type: 'permission_denied' }, 403],
+      [{ code: 'server_error' }, 500],
+      [{ code: 'rate_limit_exceeded' }, 429],
+      [{ code: 'bad_request' }, 400],
+      [{ type: 'invalid_request_error' }, 400],
+      [{}, 502],
+    ])('preserves Responses error status precedence for %j', (details, expectedStatus) => {
+      const sse = `event: error\ndata: ${JSON.stringify({ ...details, message: 'failed' })}`;
+
+      try {
+        collectChatGptSseResponse(sse, 'gpt-5.6-sol');
+        fail('Expected ResponsesSseError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ResponsesSseError);
+        expect((err as ResponsesSseError).status).toBe(expectedStatus);
+      }
+    });
+
     it('collects text deltas and completed usage into a non-streaming envelope', () => {
       const sse = [
         'event: response.output_text.delta\ndata: {"delta":"Hello "}',

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -615,12 +615,13 @@ export function buildResponsesSseError(data: Record<string, unknown>): Responses
 }
 
 function statusFromResponsesError(code: string | undefined, type: string | undefined): number {
-  const value = (code ?? type ?? '').toLowerCase();
+  const value = `${code ?? ''} ${type ?? ''}`.toLowerCase();
   if (value.includes('model_not_found') || value.includes('not_found')) return 404;
   if (value.includes('rate_limit')) return 429;
-  if (value.includes('invalid') || value.includes('bad_request')) return 400;
   if (value.includes('unauthorized') || value.includes('authentication')) return 401;
   if (value.includes('forbidden') || value.includes('permission')) return 403;
   if (value.includes('server')) return 500;
+  if (value.includes('context_length_exceeded')) return 400;
+  if (value.includes('invalid') || value.includes('bad_request')) return 400;
   return 502;
 }


### PR DESCRIPTION
### ✨ What changed
- Extract tool-result images before OpenAI-compatible forwarding.
- Buffer image parts across consecutive Anthropic user messages.
- Map deterministic ChatGPT context-limit errors to HTTP 400.

### 💭 Why
Base64 images inside tool outputs were tokenized as text. Per Anthropic's message semantics, consecutive user messages form one turn, so tool responses split across them must remain contiguous.

### 👤 For users
Image-bearing tool results keep vision context without inflating prompts or causing avoidable retries.

### 📝 Notes
Supersedes #2793 and preserves @daragao3's original commits.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves vision context for tool-result images on OpenAI-compatible routes. Tool outputs containing base64 images were previously tokenized as text, so a single screenshot could inflate input tokens past 100K and risk overflowing the provider context window.

- Extracts `tool_result` images into a follow-up user message as `image_url` parts, replacing them in the tool output with a short text placeholder.
- Buffers extracted images across consecutive user messages, since Anthropic treats those as one logical turn, so parallel tool results stay contiguous.
- Maps ChatGPT Codex `context_length_exceeded` errors to HTTP 400 instead of 502 with provider error details preserved.

<sup>Written for commit 312d4dc3708398f9a39ef29731b33e0a0f98c136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

