### PR TITLE
fix: keep subscription context windows current

### DIFF
--- a/.changeset/calm-context-cache.md
+++ b/.changeset/calm-context-cache.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep configured subscription context windows current without replacing provider values.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -187,6 +187,30 @@ describe('ModelDiscoveryService', () => {
       expect(providerRepo.save).toHaveBeenCalledWith(provider);
     });
 
+    it('caches the current configured window after capability enrichment', async () => {
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'gpt-5.6-sol',
+          contextWindow: 272000,
+          contextWindowSource: 'subscription_config',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+        }),
+      ]);
+      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({ toolCall: true });
+      const provider = makeProvider({ auth_type: 'subscription' });
+
+      const result = await service.discoverModels(provider);
+      const sol = result.find((model) => model.id === 'gpt-5.6-sol');
+
+      expect(sol).toMatchObject({
+        contextWindow: 1050000,
+        contextWindowSource: 'subscription_config',
+        capabilityCode: true,
+      });
+      expect(provider.cached_models).toEqual(result);
+    });
+
     it('should return [] when decrypt fails', async () => {
       mockDecrypt.mockImplementation(() => {
         throw new Error('bad key');
@@ -814,6 +838,37 @@ describe('ModelDiscoveryService', () => {
       const result = await service.getModelsForAgent('agent-1');
 
       expect(result.map((m) => m.id)).toEqual(['gpt-5.5', 'gpt-5.3-codex-spark']);
+    });
+
+    it('updates only explicitly configured subscription context windows', async () => {
+      providerRepo.find.mockResolvedValue([
+        makeProvider({
+          provider: 'openai',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({
+              id: 'gpt-5.6-sol',
+              contextWindow: 272000,
+              contextWindowSource: 'subscription_config',
+            }),
+            makeModel({
+              id: 'gpt-5.6-terra',
+              contextWindow: 272000,
+              contextWindowSource: 'provider',
+            }),
+            makeModel({ id: 'gpt-5.6-luna', contextWindow: 272000 }),
+          ],
+        }),
+      ]);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('tenant-1');
+
+      expect(result.map((model) => [model.id, model.contextWindow])).toEqual([
+        ['gpt-5.6-sol', 1050000],
+        ['gpt-5.6-terra', 272000],
+        ['gpt-5.6-luna', 272000],
+      ]);
     });
 
     it('should keep Mistral Vibe subscription cached models that API-key Mistral hides', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -187,17 +187,22 @@ describe('ModelDiscoveryService', () => {
       expect(providerRepo.save).toHaveBeenCalledWith(provider);
     });
 
-    it('caches the current configured window after capability enrichment', async () => {
+    it('caches the current configured window after models.dev enrichment', async () => {
       fetcher.fetch.mockResolvedValue([
         makeModel({
           id: 'gpt-5.6-sol',
           contextWindow: 272000,
           contextWindowSource: 'subscription_config',
-          inputPricePerToken: 0,
-          outputPricePerToken: 0,
         }),
       ]);
-      mockModelsDevSync.lookupModelCapabilities.mockReturnValue({ toolCall: true });
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        name: 'GPT-5.6 Sol',
+        contextWindow: 400000,
+        inputPricePerToken: 0.000001,
+        outputPricePerToken: 0.000002,
+        reasoning: true,
+        toolCall: true,
+      });
       const provider = makeProvider({ auth_type: 'subscription' });
 
       const result = await service.discoverModels(provider);
@@ -206,6 +211,7 @@ describe('ModelDiscoveryService', () => {
       expect(sol).toMatchObject({
         contextWindow: 1050000,
         contextWindowSource: 'subscription_config',
+        inputPricePerToken: 0.000001,
         capabilityCode: true,
       });
       expect(provider.cached_models).toEqual(result);

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -203,6 +203,9 @@ describe('ModelDiscoveryService', () => {
         reasoning: true,
         toolCall: true,
       });
+      mockComputeScore.mockImplementation(({ context_window }) =>
+        context_window >= 1000000 ? 5 : 4,
+      );
       const provider = makeProvider({ auth_type: 'subscription' });
 
       const result = await service.discoverModels(provider);
@@ -213,7 +216,14 @@ describe('ModelDiscoveryService', () => {
         contextWindowSource: 'subscription_config',
         inputPricePerToken: 0.000001,
         capabilityCode: true,
+        qualityScore: 5,
       });
+      expect(mockComputeScore).toHaveBeenCalledWith(
+        expect.objectContaining({ context_window: 400000 }),
+      );
+      expect(mockComputeScore).toHaveBeenCalledWith(
+        expect.objectContaining({ context_window: 1050000 }),
+      );
       expect(provider.cached_models).toEqual(result);
     });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -308,7 +308,6 @@ export class ModelDiscoveryService {
     // curated list so users can always select known supported models.
     if (provider.auth_type === 'subscription') {
       raw = supplementWithKnownModels(raw, provider.provider);
-      raw = raw.map((model) => reconcileCachedSubscriptionContextWindow(model, provider.provider));
     }
 
     // Preserve the full AuthType union (api_key / subscription / local) —
@@ -319,13 +318,19 @@ export class ModelDiscoveryService {
       ...this.enrichModel(model, provider.provider),
       authType,
     }));
+    const reconciled =
+      provider.auth_type === 'subscription'
+        ? enriched.map((model) =>
+            reconcileCachedSubscriptionContextWindow(model, provider.provider),
+          )
+        : enriched;
 
     // Filter out models confirmed to lack tool support (models.dev toolCall === false).
     // AI agents (OpenClaw, Hermes, SDK-based agents) almost always
     // include tools in every request, so models without tool calling are
     // unusable. Only filter when models.dev has data — if no entry exists we
     // keep the model (we don't know its capabilities).
-    const filtered = enriched.filter((model) => {
+    const filtered = reconciled.filter((model) => {
       const metadata = resolveProviderMetadataIdentity(provider.provider, model.id);
       const metadataProvider = metadata.provider ?? provider.provider;
       const mdEntry = this.modelsDevSync?.lookupModelCapabilities(metadataProvider, metadata.model);

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -38,6 +38,7 @@ import {
   buildFallbackModels,
   buildModelsDevFallback,
   buildSubscriptionFallbackModels,
+  reconcileCachedSubscriptionContextWindow,
   supplementWithKnownModels,
 } from './model-fallback';
 import { lookupKnownPrice } from './known-model-prices';
@@ -307,6 +308,7 @@ export class ModelDiscoveryService {
     // curated list so users can always select known supported models.
     if (provider.auth_type === 'subscription') {
       raw = supplementWithKnownModels(raw, provider.provider);
+      raw = raw.map((model) => reconcileCachedSubscriptionContextWindow(model, provider.provider));
     }
 
     // Preserve the full AuthType union (api_key / subscription / local) —
@@ -551,7 +553,11 @@ export class ModelDiscoveryService {
       const providerId = p.provider.toLowerCase();
       const filterKey = nonChatFilterKey(providerId, providerAuthType);
       const cached = filterNonChatModels(rawCached, filterKey);
-      for (const m of cached) {
+      for (const cachedModel of cached) {
+        const m =
+          providerAuthType === 'subscription'
+            ? reconcileCachedSubscriptionContextWindow(cachedModel, p.provider)
+            : cachedModel;
         const effectiveAuthType = m.authType ?? providerAuthType;
         // Deduplicate by the routable tuple, not just model ID. Multiple
         // providers can expose the same native model name, and the picker must

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -320,9 +320,10 @@ export class ModelDiscoveryService {
     }));
     const reconciled =
       provider.auth_type === 'subscription'
-        ? enriched.map((model) =>
-            reconcileCachedSubscriptionContextWindow(model, provider.provider),
-          )
+        ? enriched.map((model) => {
+            const current = reconcileCachedSubscriptionContextWindow(model, provider.provider);
+            return current === model ? model : this.computeScore(current);
+          })
         : enriched;
 
     // Filter out models confirmed to lack tool support (models.dev toolCall === false).

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -2,6 +2,7 @@ import {
   buildFallbackModels,
   buildModelsDevFallback,
   buildSubscriptionFallbackModels,
+  reconcileCachedSubscriptionContextWindow,
   supplementWithKnownModels,
   findOpenRouterPrefix,
   lookupWithVariants,
@@ -321,6 +322,7 @@ describe('buildSubscriptionFallbackModels', () => {
     expect(result.find((model) => model.id === 'claude-opus-4')?.contextWindow).toBe(200000);
     expect(result.find((model) => model.id === 'claude-opus-5')?.contextWindow).toBe(1000000);
     expect(result.find((model) => model.id === 'claude-sonnet-5')?.contextWindow).toBe(1000000);
+    expect(result.every((model) => model.contextWindowSource === 'subscription_config')).toBe(true);
   });
 
   it('applies moonshot per-model context windows without prefix bleed', () => {
@@ -377,6 +379,12 @@ describe('supplementWithKnownModels', () => {
     expect(result).toHaveLength(1);
   });
 
+  it('marks supplemented context windows as subscription configuration', () => {
+    const result = supplementWithKnownModels([], 'openai');
+
+    expect(result.every((model) => model.contextWindowSource === 'subscription_config')).toBe(true);
+  });
+
   it('should not add known models that are already covered', () => {
     const raw = [
       {
@@ -420,6 +428,60 @@ describe('supplementWithKnownModels', () => {
     expect(ids).toContain('gemini-3.1-flash-lite-preview');
     expect(ids).not.toContain('gemini-3.1-pro-preview');
     expect(ids).not.toContain('gemini-3-flash-preview');
+  });
+});
+
+describe('reconcileCachedSubscriptionContextWindow', () => {
+  const model = {
+    id: 'gpt-5.6-sol',
+    displayName: 'GPT-5.6 Sol',
+    provider: 'openai',
+    contextWindow: 272000,
+    inputPricePerToken: 0,
+    outputPricePerToken: 0,
+    capabilityReasoning: true,
+    capabilityCode: true,
+    qualityScore: 5,
+  };
+
+  it('updates a context window that came from subscription configuration', () => {
+    expect(
+      reconcileCachedSubscriptionContextWindow(
+        { ...model, contextWindowSource: 'subscription_config' },
+        'openai',
+      ),
+    ).toMatchObject({ contextWindow: 1050000, contextWindowSource: 'subscription_config' });
+  });
+
+  it('preserves a context window reported by the provider', () => {
+    const cached = { ...model, contextWindowSource: 'provider' as const };
+
+    expect(reconcileCachedSubscriptionContextWindow(cached, 'openai')).toBe(cached);
+  });
+
+  it('preserves an untagged legacy context window', () => {
+    expect(reconcileCachedSubscriptionContextWindow(model, 'openai')).toBe(model);
+  });
+
+  it('preserves tagged rows outside the current subscription catalog', () => {
+    const cached = {
+      ...model,
+      id: 'unknown-model',
+      contextWindowSource: 'subscription_config' as const,
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(cached, 'openai')).toBe(cached);
+    expect(reconcileCachedSubscriptionContextWindow(cached, 'unknown-provider')).toBe(cached);
+  });
+
+  it('returns an already-current row unchanged', () => {
+    const cached = {
+      ...model,
+      contextWindow: 1050000,
+      contextWindowSource: 'subscription_config' as const,
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(cached, 'openai')).toBe(cached);
   });
 });
 

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -463,6 +463,20 @@ describe('reconcileCachedSubscriptionContextWindow', () => {
     expect(reconcileCachedSubscriptionContextWindow(model, 'openai')).toBe(model);
   });
 
+  it('matches subscription catalogs and context overrides by prefix', () => {
+    const cached = {
+      ...model,
+      id: 'claude-opus-4-8-20260801',
+      provider: 'anthropic',
+      contextWindow: 200000,
+      contextWindowSource: 'subscription_config' as const,
+    };
+
+    expect(reconcileCachedSubscriptionContextWindow(cached, 'anthropic')).toMatchObject({
+      contextWindow: 1000000,
+    });
+  });
+
   it('preserves tagged rows outside the current subscription catalog', () => {
     const cached = {
       ...model,

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -296,12 +296,45 @@ export function buildSubscriptionFallbackModels(providerId: string): DiscoveredM
     displayName: modelId,
     provider: providerId,
     contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
+    contextWindowSource: 'subscription_config',
     inputPricePerToken: 0,
     outputPricePerToken: 0,
     capabilityReasoning: false,
     capabilityCode: false,
     qualityScore: 3,
   }));
+}
+
+/**
+ * Recalculate context windows that were copied from subscription configuration.
+ * Provider values and legacy rows without provenance remain unchanged.
+ */
+export function reconcileCachedSubscriptionContextWindow(
+  model: DiscoveredModel,
+  providerId: string,
+): DiscoveredModel {
+  if (model.contextWindowSource !== 'subscription_config') return model;
+
+  const knownModels = getSubscriptionKnownModels(providerId);
+  if (!knownModels) return model;
+  const matchMode = getSubscriptionKnownModelsMatch(providerId);
+  const normalizedModelId = model.id.toLowerCase();
+  const isKnownModel = knownModels.some((knownModel) => {
+    const normalizedKnownModel = knownModel.toLowerCase();
+    if (normalizedKnownModel === normalizedModelId) return true;
+    return matchMode !== 'exact' && normalizedModelId.startsWith(`${normalizedKnownModel}-`);
+  });
+  if (!isKnownModel) return model;
+
+  const capabilities = getSubscriptionCapabilities(providerId);
+  const contextWindow = resolveSubscriptionContextWindow(
+    model.id,
+    capabilities?.maxContextWindow ?? 200000,
+    capabilities,
+  );
+  if (contextWindow === model.contextWindow) return model;
+
+  return { ...model, contextWindow };
 }
 
 /**
@@ -335,6 +368,7 @@ export function supplementWithKnownModels(
       displayName: modelId,
       provider: providerId,
       contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
+      contextWindowSource: 'subscription_config',
       inputPricePerToken: 0,
       outputPricePerToken: 0,
       capabilityReasoning: false,

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -28,6 +28,8 @@ export interface DiscoveredModel {
   displayName: string;
   provider: string;
   contextWindow: number;
+  /** Identifies context windows that can be recalculated without replacing provider metadata. */
+  contextWindowSource?: 'provider' | 'subscription_config';
   inputPricePerToken: number | null;
   outputPricePerToken: number | null;
   cacheReadPricePerToken?: number;

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2464,6 +2464,7 @@ describe('ProviderModelFetcherService', () => {
           displayName: 'GPT-5.5',
           provider: 'openai',
           contextWindow: 192000,
+          contextWindowSource: 'provider',
           inputPricePerToken: 0,
           outputPricePerToken: 0,
           capabilityCode: true,
@@ -2533,6 +2534,7 @@ describe('ProviderModelFetcherService', () => {
 
       const result = await service.fetch('openai', 'token', 'subscription');
       expect(result[0].contextWindow).toBe(200000);
+      expect(result[0].contextWindowSource).toBe('subscription_config');
     });
 
     it('should return [] when models is not an array', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -70,6 +70,7 @@ interface ModelParserConfig<T> {
   getId: (entry: T) => string;
   getDisplayName: (entry: T, id: string) => string;
   contextWindow?: number | ((entry: T) => number);
+  contextWindowSource?: (entry: T) => DiscoveredModel['contextWindowSource'];
   inputPricePerToken?: number | null;
   outputPricePerToken?: number | null;
   capabilityReasoning?: boolean;
@@ -92,12 +93,14 @@ function createModelParser<T>(
         const entry = m as T;
         const id = config.getId(entry);
         const ctxVal = config.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+        const contextWindowSource = config.contextWindowSource?.(entry);
         const supportedEndpoints = config.supportedEndpoints?.(entry);
         return {
           id,
           displayName: config.getDisplayName(entry, id),
           provider,
           contextWindow: typeof ctxVal === 'function' ? ctxVal(entry) : ctxVal,
+          ...(contextWindowSource ? { contextWindowSource } : {}),
           inputPricePerToken: config.inputPricePerToken ?? null,
           outputPricePerToken: config.outputPricePerToken ?? null,
           capabilityReasoning: config.capabilityReasoning ?? false,
@@ -736,6 +739,8 @@ const parseOpenaiSubscription = createModelParser<OpenAISubscriptionModelEntry>(
   getId: (entry) => entry.slug,
   getDisplayName: (entry, id) => entry.display_name || id,
   contextWindow: (entry) => entry.context_window ?? 200000,
+  contextWindowSource: (entry) =>
+    typeof entry.context_window === 'number' ? 'provider' : 'subscription_config',
   inputPricePerToken: 0,
   outputPricePerToken: 0,
   capabilityCode: true,


### PR DESCRIPTION
### ✨ What changed
- Record whether a subscription context window comes from the provider or configuration.
- Recalculate configuration values during discovery and cached reads.
- Keep provider values and untagged legacy rows unchanged.

### 💭 Why
Subscription configuration can change after model data is cached. Source tags allow safe updates without guessing about provider metadata.

### 👤 For users
New and refreshed subscription caches use current configured context windows.

### 📝 Notes
Legacy rows remain unchanged until the normal model refresh runs.
This is a safer alternative to #2795. Original investigation by @daragao3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps subscription context windows current when subscription configuration changes after model data is cached.

- Tags each context window as coming from the provider or from subscription configuration.
- Recalculates configuration-sourced context windows after models.dev enrichment (rescoring when changed) and during cached reads.
- Leaves provider-sourced and untagged legacy rows unchanged until the normal model refresh.

<sup>Written for commit e69ef159d348eafeb19eeedc3652c39ca4071f67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

