### PR TITLE
fix: allow custom provider streaming

### DIFF
--- a/.changeset/bright-custom-streams.md
+++ b/.changeset/bright-custom-streams.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Allow custom provider models to use streaming response mode.

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -93,6 +93,16 @@ describe('resolveModelCapabilityMetadata', () => {
     });
   });
 
+  it('marks custom provider models as stream-capable', async () => {
+    const resolved = await resolveModelCapabilityMetadata(
+      makeModel({ id: 'custom:cp-1/local-model', provider: 'custom:cp-1' }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(resolved.capabilities).toEqual(['stream']);
+  });
+
   it('keeps discovery-time modalities when models.dev has no entry', async () => {
     const resolved = await resolveModelCapabilityMetadata(
       makeModel({

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -158,6 +158,7 @@ export async function resolveModelCapabilityMetadata(
 
 export function modelSupportsStreaming(providerId: string, modelId: string): boolean {
   const provider = resolveProviderId(providerId);
+  if (provider.startsWith('custom:')) return true;
   if (!STREAMING_ENDPOINT_PROVIDERS.has(provider)) return false;
   if (provider === 'openai' && isOpenAiNonStreamingModel(modelId)) return false;
   return true;

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -637,7 +637,7 @@ describe('HeaderTierService', () => {
         id: 'h1',
         name: 'Premium',
         agent_id: 'agent-1',
-        override_route: route('unsupported', 'api_key', 'local-model'),
+        override_route: route('openai', 'api_key', 'gpt-image-1'),
         fallback_routes: [route('openai', 'api_key', 'gpt-4o')],
         response_mode: 'stream',
       } as HeaderTier);
@@ -676,7 +676,7 @@ describe('HeaderTierService', () => {
         name: 'Premium',
         agent_id: 'agent-1',
         override_route: route('openai', 'api_key', 'gpt-4o'),
-        fallback_routes: [route('unsupported', 'api_key', 'local-model')],
+        fallback_routes: [route('openai', 'api_key', 'gpt-image-1')],
       } as HeaderTier;
       repo.findOne.mockResolvedValue(existing);
 
@@ -697,7 +697,7 @@ describe('HeaderTierService', () => {
       } as HeaderTier);
 
       await expect(
-        svc.setOverride('agent-1', 'tenant-1', 'h1', 'local-model', 'unsupported', 'api_key'),
+        svc.setOverride('agent-1', 'tenant-1', 'h1', 'gpt-image-1', 'openai', 'api_key'),
       ).rejects.toThrow(/add at least one stream-capable model/);
       expect(repo.save).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -637,7 +637,7 @@ describe('HeaderTierService', () => {
         id: 'h1',
         name: 'Premium',
         agent_id: 'agent-1',
-        override_route: route('custom:local', 'api_key', 'local-model'),
+        override_route: route('unsupported', 'api_key', 'local-model'),
         fallback_routes: [route('openai', 'api_key', 'gpt-4o')],
         response_mode: 'stream',
       } as HeaderTier);
@@ -676,7 +676,7 @@ describe('HeaderTierService', () => {
         name: 'Premium',
         agent_id: 'agent-1',
         override_route: route('openai', 'api_key', 'gpt-4o'),
-        fallback_routes: [route('custom:local', 'api_key', 'local-model')],
+        fallback_routes: [route('unsupported', 'api_key', 'local-model')],
       } as HeaderTier;
       repo.findOne.mockResolvedValue(existing);
 
@@ -697,7 +697,7 @@ describe('HeaderTierService', () => {
       } as HeaderTier);
 
       await expect(
-        svc.setOverride('agent-1', 'tenant-1', 'h1', 'local-model', 'custom:local', 'api_key'),
+        svc.setOverride('agent-1', 'tenant-1', 'h1', 'local-model', 'unsupported', 'api_key'),
       ).rejects.toThrow(/add at least one stream-capable model/);
       expect(repo.save).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -2608,7 +2608,7 @@ describe('ProxyService — orchestration', () => {
         tier: 'standard',
         route: route('openai', 'api_key', 'gpt-4o'),
         fallback_routes: [
-          route('custom:local', 'api_key', 'local-model'),
+          route('unsupported', 'api_key', 'local-model'),
           route('anthropic', 'api_key', 'claude'),
         ],
         response_mode: 'stream',

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -2608,7 +2608,7 @@ describe('ProxyService — orchestration', () => {
         tier: 'standard',
         route: route('openai', 'api_key', 'gpt-4o'),
         fallback_routes: [
-          route('unsupported', 'api_key', 'local-model'),
+          route('openai', 'api_key', 'gpt-image-1'),
           route('anthropic', 'api_key', 'claude'),
         ],
         response_mode: 'stream',

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -1028,7 +1028,7 @@ describe('ResolveService', () => {
       tierService.getTiers.mockResolvedValue([
         {
           tier: 'simple',
-          override_route: route('unsupported', 'api_key', 'local-model'),
+          override_route: route('openai', 'api_key', 'gpt-image-1'),
           auto_assigned_route: null,
           fallback_routes: [
             route('openai', 'api_key', 'gpt-4o'),
@@ -1050,7 +1050,7 @@ describe('ResolveService', () => {
           tier: 'simple',
           override_route: route('openai', 'api_key', 'gpt-4o'),
           auto_assigned_route: null,
-          fallback_routes: [route('unsupported', 'api_key', 'local-model')],
+          fallback_routes: [route('openai', 'api_key', 'gpt-image-1')],
           response_mode: 'stream',
         } as TierAssignment,
       ]);

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -1028,7 +1028,7 @@ describe('ResolveService', () => {
       tierService.getTiers.mockResolvedValue([
         {
           tier: 'simple',
-          override_route: route('custom:local', 'api_key', 'local-model'),
+          override_route: route('unsupported', 'api_key', 'local-model'),
           auto_assigned_route: null,
           fallback_routes: [
             route('openai', 'api_key', 'gpt-4o'),
@@ -1050,7 +1050,7 @@ describe('ResolveService', () => {
           tier: 'simple',
           override_route: route('openai', 'api_key', 'gpt-4o'),
           auto_assigned_route: null,
-          fallback_routes: [route('custom:local', 'api_key', 'local-model')],
+          fallback_routes: [route('unsupported', 'api_key', 'local-model')],
           response_mode: 'stream',
         } as TierAssignment,
       ]);

--- a/packages/backend/src/routing/routing-core/__tests__/response-mode-guard.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/response-mode-guard.spec.ts
@@ -13,13 +13,13 @@ const route = (provider: string, model: string): ModelRoute => ({
 
 describe('assertStreamableResponseMode', () => {
   it('rejects stream mode when no saved route supports streaming', () => {
-    const unsupported = route('unsupported', 'local-model');
+    const nonStreaming = route('openai', 'gpt-image-1');
 
     expect(() =>
-      assertStreamableResponseMode('stream', 'tier "default"', unsupported, null),
+      assertStreamableResponseMode('stream', 'tier "default"', nonStreaming, null),
     ).toThrow(BadRequestException);
     expect(() =>
-      assertStreamableResponseMode('stream', 'tier "default"', unsupported, null),
+      assertStreamableResponseMode('stream', 'tier "default"', nonStreaming, null),
     ).toThrow(/add at least one stream-capable model/);
   });
 
@@ -32,20 +32,20 @@ describe('assertStreamableResponseMode', () => {
   });
 
   it('allows a non-stream primary when a stream-capable fallback exists', () => {
-    const unsupported = route('unsupported', 'local-model');
+    const nonStreaming = route('openai', 'gpt-image-1');
     const openai = route('openai', 'gpt-4o');
 
     expect(() =>
-      assertStreamableResponseMode('stream', 'tier "default"', unsupported, [openai]),
+      assertStreamableResponseMode('stream', 'tier "default"', nonStreaming, [openai]),
     ).not.toThrow();
   });
 
   it('allows a non-stream fallback when the primary supports streaming', () => {
     const openai = route('openai', 'gpt-4o');
-    const unsupported = route('unsupported', 'local-model');
+    const nonStreaming = route('openai', 'gpt-image-1');
 
     expect(() =>
-      assertStreamableResponseMode('stream', 'tier "default"', openai, [unsupported]),
+      assertStreamableResponseMode('stream', 'tier "default"', openai, [nonStreaming]),
     ).not.toThrow();
   });
 
@@ -70,11 +70,11 @@ describe('effectiveRoutesForResponseMode', () => {
   });
 
   it('lifts the first stream-capable fallback when streaming skips the primary', () => {
-    const unsupported = route('unsupported', 'local-model');
+    const nonStreaming = route('openai', 'gpt-image-1');
     const openai = route('openai', 'gpt-4o');
     const anthropic = route('anthropic', 'claude-3-5-sonnet');
 
-    expect(effectiveRoutesForResponseMode('stream', unsupported, [openai, anthropic])).toEqual({
+    expect(effectiveRoutesForResponseMode('stream', nonStreaming, [openai, anthropic])).toEqual({
       primaryRoute: openai,
       fallbackRoutes: [anthropic],
     });
@@ -82,9 +82,9 @@ describe('effectiveRoutesForResponseMode', () => {
 
   it('filters non-stream fallbacks while keeping a stream-capable primary', () => {
     const openai = route('openai', 'gpt-4o');
-    const unsupported = route('unsupported', 'local-model');
+    const nonStreaming = route('openai', 'gpt-image-1');
 
-    expect(effectiveRoutesForResponseMode('stream', openai, [unsupported])).toEqual({
+    expect(effectiveRoutesForResponseMode('stream', openai, [nonStreaming])).toEqual({
       primaryRoute: openai,
       fallbackRoutes: null,
     });

--- a/packages/backend/src/routing/routing-core/__tests__/response-mode-guard.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/response-mode-guard.spec.ts
@@ -13,31 +13,39 @@ const route = (provider: string, model: string): ModelRoute => ({
 
 describe('assertStreamableResponseMode', () => {
   it('rejects stream mode when no saved route supports streaming', () => {
+    const unsupported = route('unsupported', 'local-model');
+
+    expect(() =>
+      assertStreamableResponseMode('stream', 'tier "default"', unsupported, null),
+    ).toThrow(BadRequestException);
+    expect(() =>
+      assertStreamableResponseMode('stream', 'tier "default"', unsupported, null),
+    ).toThrow(/add at least one stream-capable model/);
+  });
+
+  it('allows custom provider routes in stream mode', () => {
     const custom = route('custom:abc', 'custom:abc/local-model');
 
-    expect(() => assertStreamableResponseMode('stream', 'tier "default"', custom, null)).toThrow(
-      BadRequestException,
-    );
-    expect(() => assertStreamableResponseMode('stream', 'tier "default"', custom, null)).toThrow(
-      /add at least one stream-capable model/,
-    );
+    expect(() =>
+      assertStreamableResponseMode('stream', 'custom tier "local"', custom, null),
+    ).not.toThrow();
   });
 
   it('allows a non-stream primary when a stream-capable fallback exists', () => {
-    const custom = route('custom:abc', 'custom:abc/local-model');
+    const unsupported = route('unsupported', 'local-model');
     const openai = route('openai', 'gpt-4o');
 
     expect(() =>
-      assertStreamableResponseMode('stream', 'tier "default"', custom, [openai]),
+      assertStreamableResponseMode('stream', 'tier "default"', unsupported, [openai]),
     ).not.toThrow();
   });
 
   it('allows a non-stream fallback when the primary supports streaming', () => {
     const openai = route('openai', 'gpt-4o');
-    const custom = route('custom:abc', 'custom:abc/local-model');
+    const unsupported = route('unsupported', 'local-model');
 
     expect(() =>
-      assertStreamableResponseMode('stream', 'tier "default"', openai, [custom]),
+      assertStreamableResponseMode('stream', 'tier "default"', openai, [unsupported]),
     ).not.toThrow();
   });
 
@@ -62,11 +70,11 @@ describe('effectiveRoutesForResponseMode', () => {
   });
 
   it('lifts the first stream-capable fallback when streaming skips the primary', () => {
-    const custom = route('custom:abc', 'custom:abc/local-model');
+    const unsupported = route('unsupported', 'local-model');
     const openai = route('openai', 'gpt-4o');
     const anthropic = route('anthropic', 'claude-3-5-sonnet');
 
-    expect(effectiveRoutesForResponseMode('stream', custom, [openai, anthropic])).toEqual({
+    expect(effectiveRoutesForResponseMode('stream', unsupported, [openai, anthropic])).toEqual({
       primaryRoute: openai,
       fallbackRoutes: [anthropic],
     });
@@ -74,9 +82,9 @@ describe('effectiveRoutesForResponseMode', () => {
 
   it('filters non-stream fallbacks while keeping a stream-capable primary', () => {
     const openai = route('openai', 'gpt-4o');
-    const custom = route('custom:abc', 'custom:abc/local-model');
+    const unsupported = route('unsupported', 'local-model');
 
-    expect(effectiveRoutesForResponseMode('stream', openai, [custom])).toEqual({
+    expect(effectiveRoutesForResponseMode('stream', openai, [unsupported])).toEqual({
       primaryRoute: openai,
       fallbackRoutes: null,
     });

--- a/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
@@ -428,7 +428,7 @@ describe('SpecificityService', () => {
     it('rejects clearing the only stream-capable route while stream mode is active', async () => {
       repo.findOne.mockResolvedValue({
         category: 'coding',
-        override_route: route('custom:local', 'api_key', 'local-model'),
+        override_route: route('unsupported', 'api_key', 'local-model'),
         auto_assigned_route: null,
         fallback_routes: [route('openai', 'api_key', 'gpt-4o')],
         response_mode: 'stream',
@@ -476,7 +476,7 @@ describe('SpecificityService', () => {
         category: 'coding',
         override_route: route('openai', 'api_key', 'gpt-4o'),
         auto_assigned_route: null,
-        fallback_routes: [route('custom:local', 'api_key', 'local-model')],
+        fallback_routes: [route('unsupported', 'api_key', 'local-model')],
       } as SpecificityAssignment;
       repo.findOne.mockResolvedValue(existing);
 
@@ -495,7 +495,7 @@ describe('SpecificityService', () => {
       } as SpecificityAssignment);
 
       await expect(
-        svc.setOverride('agent-1', 'tenant-1', 'coding', 'local-model', 'custom:local', 'api_key'),
+        svc.setOverride('agent-1', 'tenant-1', 'coding', 'local-model', 'unsupported', 'api_key'),
       ).rejects.toThrow(/add at least one stream-capable model/);
       expect(repo.save).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
@@ -428,7 +428,7 @@ describe('SpecificityService', () => {
     it('rejects clearing the only stream-capable route while stream mode is active', async () => {
       repo.findOne.mockResolvedValue({
         category: 'coding',
-        override_route: route('unsupported', 'api_key', 'local-model'),
+        override_route: route('openai', 'api_key', 'gpt-image-1'),
         auto_assigned_route: null,
         fallback_routes: [route('openai', 'api_key', 'gpt-4o')],
         response_mode: 'stream',
@@ -476,7 +476,7 @@ describe('SpecificityService', () => {
         category: 'coding',
         override_route: route('openai', 'api_key', 'gpt-4o'),
         auto_assigned_route: null,
-        fallback_routes: [route('unsupported', 'api_key', 'local-model')],
+        fallback_routes: [route('openai', 'api_key', 'gpt-image-1')],
       } as SpecificityAssignment;
       repo.findOne.mockResolvedValue(existing);
 
@@ -495,7 +495,7 @@ describe('SpecificityService', () => {
       } as SpecificityAssignment);
 
       await expect(
-        svc.setOverride('agent-1', 'tenant-1', 'coding', 'local-model', 'unsupported', 'api_key'),
+        svc.setOverride('agent-1', 'tenant-1', 'coding', 'gpt-image-1', 'openai', 'api_key'),
       ).rejects.toThrow(/add at least one stream-capable model/);
       expect(repo.save).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -666,7 +666,7 @@ describe('TierService', () => {
     it('rejects clearing the only stream-capable route while stream mode is active', async () => {
       tierRepo.findOne.mockResolvedValue({
         tier: 'standard',
-        override_route: route('custom:local', 'api_key', 'local-model'),
+        override_route: route('unsupported', 'api_key', 'local-model'),
         auto_assigned_route: null,
         fallback_routes: [route('openai', 'api_key', 'gpt-4o')],
         response_mode: 'stream',
@@ -683,7 +683,7 @@ describe('TierService', () => {
     it('rejects stream mode when the route chain has no stream-capable model', async () => {
       tierRepo.findOne.mockResolvedValue({
         tier: 'standard',
-        override_route: route('custom:local', 'api_key', 'local-model'),
+        override_route: route('unsupported', 'api_key', 'local-model'),
         auto_assigned_route: null,
         fallback_routes: null,
       } as TierAssignment);
@@ -699,7 +699,7 @@ describe('TierService', () => {
         tier: 'standard',
         override_route: route('openai', 'api_key', 'gpt-4o'),
         auto_assigned_route: null,
-        fallback_routes: [route('custom:local', 'api_key', 'local-model')],
+        fallback_routes: [route('unsupported', 'api_key', 'local-model')],
       } as TierAssignment;
       tierRepo.findOne.mockResolvedValue(existing);
 
@@ -734,7 +734,7 @@ describe('TierService', () => {
       } as TierAssignment;
       tierRepo.findOne.mockResolvedValue(existing);
       discoveryService.getModelsForAgent.mockResolvedValue([
-        discovered('local-model', 'custom:local', 'api_key'),
+        discovered('local-model', 'unsupported', 'api_key'),
       ]);
 
       const result = await svc.setFallbacks(
@@ -742,10 +742,10 @@ describe('TierService', () => {
         'tenant-1',
         'standard',
         ['local-model'],
-        [route('custom:local', 'api_key', 'local-model')],
+        [route('unsupported', 'api_key', 'local-model')],
       );
 
-      expect(result).toEqual([route('custom:local', 'api_key', 'local-model')]);
+      expect(result).toEqual([route('unsupported', 'api_key', 'local-model')]);
       expect(tierRepo.save).toHaveBeenCalledWith(existing);
     });
   });

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -666,7 +666,7 @@ describe('TierService', () => {
     it('rejects clearing the only stream-capable route while stream mode is active', async () => {
       tierRepo.findOne.mockResolvedValue({
         tier: 'standard',
-        override_route: route('unsupported', 'api_key', 'local-model'),
+        override_route: route('openai', 'api_key', 'gpt-image-1'),
         auto_assigned_route: null,
         fallback_routes: [route('openai', 'api_key', 'gpt-4o')],
         response_mode: 'stream',
@@ -683,7 +683,7 @@ describe('TierService', () => {
     it('rejects stream mode when the route chain has no stream-capable model', async () => {
       tierRepo.findOne.mockResolvedValue({
         tier: 'standard',
-        override_route: route('unsupported', 'api_key', 'local-model'),
+        override_route: route('openai', 'api_key', 'gpt-image-1'),
         auto_assigned_route: null,
         fallback_routes: null,
       } as TierAssignment);
@@ -699,7 +699,7 @@ describe('TierService', () => {
         tier: 'standard',
         override_route: route('openai', 'api_key', 'gpt-4o'),
         auto_assigned_route: null,
-        fallback_routes: [route('unsupported', 'api_key', 'local-model')],
+        fallback_routes: [route('openai', 'api_key', 'gpt-image-1')],
       } as TierAssignment;
       tierRepo.findOne.mockResolvedValue(existing);
 
@@ -734,18 +734,18 @@ describe('TierService', () => {
       } as TierAssignment;
       tierRepo.findOne.mockResolvedValue(existing);
       discoveryService.getModelsForAgent.mockResolvedValue([
-        discovered('local-model', 'unsupported', 'api_key'),
+        discovered('gpt-image-1', 'openai', 'api_key'),
       ]);
 
       const result = await svc.setFallbacks(
         'agent-1',
         'tenant-1',
         'standard',
-        ['local-model'],
-        [route('unsupported', 'api_key', 'local-model')],
+        ['gpt-image-1'],
+        [route('openai', 'api_key', 'gpt-image-1')],
       );
 
-      expect(result).toEqual([route('unsupported', 'api_key', 'local-model')]);
+      expect(result).toEqual([route('openai', 'api_key', 'gpt-image-1')]);
       expect(tierRepo.save).toHaveBeenCalledWith(existing);
     });
   });


### PR DESCRIPTION
### ✨ What changed

- Enable Stream mode for custom provider routes.

### 💭 Why

Custom providers already forward streaming requests to compatible endpoints.

### 👤 For users

Custom providers can now use Stream mode.
