### PR TITLE
fix: reject unsupported Anthropic tools

### DIFF
--- a/.changeset/quiet-cats-drop-tools.md
+++ b/.changeset/quiet-cats-drop-tools.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Reject unsupported Anthropic tools before forwarding to another provider protocol.

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -77,6 +77,11 @@ export const MANIFEST_ERRORS = {
     template:
       'Built-in local providers are only available in self-hosted Manifest. On Manifest Cloud, expose the runtime through a public URL or tunnel and connect it as a custom provider.',
   },
+  M304: {
+    title: 'Anthropic tools not available for selected provider',
+    template:
+      'Provider "{provider}" cannot execute these Anthropic tools: {tools}. Use an Anthropic model or remove these tools.',
+  },
   M500: {
     title: 'Internal server error',
     template: 'Something broke on our end. Try again in a moment.',

--- a/packages/backend/src/common/errors/manifest-error.ts
+++ b/packages/backend/src/common/errors/manifest-error.ts
@@ -58,6 +58,7 @@ export const MANIFEST_CODE_TO_REASON: Record<RecordableManifestCode, ManifestBlo
     M300: 'manifest_invalid_request',
     M302: 'model_not_available',
     M303: 'local_provider_unavailable',
+    M304: 'manifest_invalid_request',
     M500: 'manifest_internal_error',
   };
 

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -2,6 +2,7 @@ import {
   chatCompletionsResponseToMessages,
   createMessagesStreamTransformer,
   messagesToChatCompletionsRequest,
+  unsupportedAnthropicToolNames,
 } from '../anthropic-messages-adapter';
 
 describe('Anthropic Messages adapter', () => {
@@ -464,9 +465,12 @@ describe('Anthropic Messages adapter', () => {
         'my_custom',
         'explicit_custom',
       ]);
+      expect(tools[0].function).not.toHaveProperty('parameters');
+      expect(tools[1].function).not.toHaveProperty('parameters');
+      expect(tools[2].function).not.toHaveProperty('parameters');
     });
 
-    it('treats unknown non-custom tool types as custom tools with a safe empty schema (issue #1897)', () => {
+    it('does not invent an empty schema for unknown typed tools', () => {
       const result = messagesToChatCompletionsRequest({
         messages: [{ role: 'user', content: 'x' }],
         tools: [{ type: 'advisor_20260301', name: 'advisor', description: 'Plan the task' }],
@@ -478,7 +482,6 @@ describe('Anthropic Messages adapter', () => {
           function: {
             name: 'advisor',
             description: 'Plan the task',
-            parameters: { type: 'object', properties: {}, additionalProperties: false },
           },
         },
       ]);
@@ -623,6 +626,35 @@ describe('Anthropic Messages adapter', () => {
         messages: ['nope', null, { role: 'user', content: 'ok' }],
       } as Record<string, unknown>);
       expect(result.messages).toEqual([{ role: 'user', content: 'ok' }]);
+    });
+  });
+
+  describe('unsupportedAnthropicToolNames', () => {
+    it('finds server, client, and future implicit tools without matching custom tools', () => {
+      expect(
+        unsupportedAnthropicToolNames({
+          tools: [
+            { type: 'web_search_20260318', name: 'search' },
+            { name: 'search', input_schema: { type: 'object' } },
+            { type: 'bash_20250124', name: 'bash' },
+            { type: 'future_tool_20270101', name: 'future_tool' },
+            { type: 'web_search_20260318', name: 'search' },
+            { type: 'mcp_toolset' },
+          ],
+        }),
+      ).toEqual(['search', 'bash', 'future_tool', 'mcp_toolset']);
+    });
+
+    it('ignores absent tools and custom tools', () => {
+      expect(unsupportedAnthropicToolNames({})).toEqual([]);
+      expect(
+        unsupportedAnthropicToolNames({
+          tools: [
+            { name: 'lookup', input_schema: { type: 'object' } },
+            { type: 'custom', name: 'explicit_custom' },
+          ],
+        }),
+      ).toEqual([]);
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -76,6 +76,37 @@ describe('ProviderClient', () => {
       expect(result.isAnthropic).toBe(false);
     });
 
+    it('allocates a provider attempt only when transport is ready to start', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const startRecording = jest.fn();
+      const attempt = {
+        id: 'attempt-lazy',
+        attemptNumber: 1,
+        startedAtMs: 0,
+        startedAt: new Date(0).toISOString(),
+        pendingWrite: Promise.resolve(true),
+        startRecording,
+      };
+      const startAttempt = jest.fn(() => attempt);
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        apiMode: 'chat_completions',
+        startAttempt,
+      });
+
+      expect(startAttempt).toHaveBeenCalledTimes(1);
+      expect(startRecording).toHaveBeenCalledWith({
+        requestBody: expect.objectContaining({ model: 'gpt-4o' }),
+        wireFormat: 'openai_chat_completions',
+      });
+      expect(result.attempt).toBe(attempt);
+    });
+
     it('turns an empty non-streaming Chat Completions response into a provider failure', async () => {
       const upstreamBody = {
         id: 'chatcmpl-empty',
@@ -1163,6 +1194,49 @@ describe('ProviderClient', () => {
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.metadata).toBeUndefined();
       expect(sentBody.safety_identifier).toBeUndefined();
+    });
+
+    it('rejects implicit Anthropic tools before forwarding to MiniMax chat completions', async () => {
+      const resolveChatBody = jest.fn().mockResolvedValue({
+        messages: [{ role: 'user', content: 'find cats' }],
+        tools: [
+          { type: 'function', function: { name: 'web_search' } },
+          { type: 'function', function: { name: 'bash' } },
+          {
+            type: 'function',
+            function: { name: 'lookup', parameters: { type: 'object' } },
+          },
+        ],
+        tool_choice: 'auto',
+      });
+      const startAttempt = jest.fn();
+      const request = client.forward({
+        provider: 'minimax',
+        apiKey: 'sk-test',
+        model: 'MiniMax-M2.5',
+        body: {
+          model: 'MiniMax-M2.5',
+          messages: [{ role: 'user', content: 'find cats' }],
+          tools: [
+            { type: 'web_search_20250305', name: 'web_search' },
+            { type: 'bash_20250124', name: 'bash' },
+            { name: 'lookup', input_schema: { type: 'object' } },
+          ],
+          tool_choice: { type: 'auto' },
+        },
+        resolveChatBody,
+        startAttempt,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      await expect(request).rejects.toMatchObject({ code: 'M304', status: 400 });
+      await expect(request).rejects.toThrow(
+        'Provider "minimax" cannot execute these Anthropic tools: web_search, bash',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(resolveChatBody).not.toHaveBeenCalled();
+      expect(startAttempt).not.toHaveBeenCalled();
     });
 
     it('forwards Anthropic-Messages inbound to an Anthropic upstream without OpenAI translation (issue #1886)', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -15,6 +15,7 @@ import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+import { ManifestError } from '../../../common/errors/manifest-error';
 import { getProviderParamSpecs, type ProviderParamSpecCatalog } from 'manifest-shared';
 
 const specCatalog: ProviderParamSpecCatalog = [
@@ -473,6 +474,26 @@ describe('ProxyFallbackService', () => {
       expect(result.response.status).toBe(503);
       expect(result.attempt).toBe(attempt);
       expect(attempt).toEqual(expect.objectContaining({ completedAtMs: expect.any(Number) }));
+    });
+
+    it('does not allocate a provider attempt for a local Manifest rejection', async () => {
+      providerClient.forward.mockRejectedValue(
+        new ManifestError('M304', 400, { provider: 'minimax', tools: 'web_search' }),
+      );
+      const startProviderAttempt = jest.fn();
+
+      const request = service.tryForwardToProvider({
+        provider: 'minimax',
+        apiKey: 'sk-test',
+        model: 'MiniMax-M2.5',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        startProviderAttempt,
+      });
+
+      await expect(request).rejects.toMatchObject({ code: 'M304', status: 400 });
+      expect(startProviderAttempt).not.toHaveBeenCalled();
     });
 
     it('returns a tagged transport failure when an OAuth retry cannot connect', async () => {

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -15,34 +15,12 @@ const sanitizeToolUseId = (id: string): string => id.replace(/[^a-zA-Z0-9_-]/g, 
 
 type JsonRecord = Record<string, unknown>;
 
-const DEFAULT_CUSTOM_TOOL_INPUT_SCHEMA = {
-  type: 'object',
-  properties: {},
-  additionalProperties: false,
-} as const;
-
-const ANTHROPIC_SERVER_TOOL_PREFIXES = [
-  'bash_',
-  'code_execution_',
-  'computer_',
-  'memory_',
-  'text_editor_',
-  'tool_search_tool_',
-  'web_fetch_',
-  'web_search_',
-] as const;
-
-const ANTHROPIC_SERVER_TOOL_TYPES = ['mcp_toolset'] as const;
-
 function isRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-function isAnthropicServerToolType(type: string): boolean {
-  return (
-    ANTHROPIC_SERVER_TOOL_TYPES.includes(type as (typeof ANTHROPIC_SERVER_TOOL_TYPES)[number]) ||
-    ANTHROPIC_SERVER_TOOL_PREFIXES.some((prefix) => type.startsWith(prefix))
-  );
+function isImplicitAnthropicTool(tool: JsonRecord): tool is JsonRecord & { type: string } {
+  return tool.input_schema === undefined && typeof tool.type === 'string' && tool.type !== 'custom';
 }
 
 function normalizeOpenAiFunctionSchema(schema: unknown): unknown {
@@ -232,8 +210,10 @@ function buildUserMessages(content: unknown, pendingToolImages: JsonRecord[]): O
 // Messages — `toolCount` and the specificity detector read `function.name`
 // and array length, nothing else. The Anthropic wire body is emitted by
 // `applyAnthropicMessagesMutations` directly from the inbound body, so this
-// translation can lose Anthropic-only tool fields (e.g. server-tool `type`
-// tags, omitted input_schema) without affecting upstream behavior.
+// translation can lose Anthropic-only tool fields (e.g. provider-defined
+// `type` tags and implicit schemas) without affecting native upstream behavior.
+// Cross-protocol forwarding rejects those untranslatable tools only after the
+// provider is selected; the scorer must continue to see their names and count.
 function toChatTools(tools: unknown[]): JsonRecord[] {
   return tools.filter(isRecord).map((tool) => ({
     type: 'function',
@@ -242,11 +222,7 @@ function toChatTools(tools: unknown[]): JsonRecord[] {
       ...(typeof tool.description === 'string' && { description: tool.description }),
       ...(tool.input_schema !== undefined
         ? { parameters: normalizeOpenAiFunctionSchema(tool.input_schema) }
-        : typeof tool.type === 'string' &&
-            tool.type !== 'custom' &&
-            !isAnthropicServerToolType(tool.type)
-          ? { parameters: DEFAULT_CUSTOM_TOOL_INPUT_SCHEMA }
-          : {}),
+        : {}),
     },
   }));
 }
@@ -259,6 +235,25 @@ function toChatToolChoice(choice: unknown): unknown {
     return { type: 'function', function: { name: choice.name } };
   }
   return undefined;
+}
+
+/**
+ * Find Anthropic-provided tools that another provider protocol cannot execute.
+ *
+ * Server tools need an executor and Anthropic-schema client tools need their
+ * provider-defined schemas. A cross-protocol target has neither. Reject these
+ * tools after routing instead of silently changing the request contract.
+ */
+export function unsupportedAnthropicToolNames(body: JsonRecord): string[] {
+  if (!Array.isArray(body.tools)) return [];
+  return [
+    ...new Set(
+      body.tools
+        .filter(isRecord)
+        .filter(isImplicitAnthropicTool)
+        .map((tool) => (typeof tool.name === 'string' ? tool.name : tool.type)),
+    ),
+  ];
 }
 
 /** Anthropic Messages request → chat_completions request (used for routing/forwarding). */

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -46,6 +46,7 @@ import { qualifyChatGptResponse } from './chatgpt-response-qualifier';
 import { isProviderAvailableForDeployment } from '../../common/utils/provider-availability';
 import { ManifestError } from '../../common/errors/manifest-error';
 import { MANAGED_FREE_PROVIDER_BY_ID } from '../../common/constants/managed-free-providers';
+import { unsupportedAnthropicToolNames } from './anthropic-messages-adapter';
 
 export interface ForwardResult {
   response: Response;
@@ -342,12 +343,23 @@ export class ProviderClient {
       opts.apiMode !== undefined &&
       opts.apiMode !== 'chat_completions' &&
       INPUT_WIRE_FORMATS[opts.apiMode] !== resolvedWireFormat;
+    if (opts.apiMode === 'messages' && needsChatBody) {
+      const unsupportedTools = unsupportedAnthropicToolNames(body);
+      if (unsupportedTools.length > 0) {
+        throw new ManifestError('M304', HttpStatus.BAD_REQUEST, {
+          tools: unsupportedTools.join(', '),
+          provider,
+        });
+      }
+    }
     const chatBody = needsChatBody ? await opts.resolveChatBody?.() : undefined;
+    let attempt = opts.attempt;
 
     const bareModel = stripModelPrefix(model, endpointKey);
     if (endpoint.format === 'kiro') {
       const requestSource = chatBody ?? body;
-      opts.attempt?.startRecording?.({
+      attempt ??= opts.startAttempt?.();
+      attempt?.startRecording?.({
         requestBody: requestSource,
         wireFormat: 'kiro_chat',
       });
@@ -369,6 +381,7 @@ export class ProviderClient {
         wireFormat: 'kiro_chat',
         wireApiMode: opts.apiMode,
         responsesTextFormat: textFormat,
+        attempt,
       };
     }
     const { url, headers, requestBody, structuredOutputToolName } = this.buildRequest({
@@ -404,14 +417,8 @@ export class ProviderClient {
 
     const retryWireBody = async (
       wireRequestBody: Record<string, unknown>,
-      attempt: ProviderAttemptRef | undefined = opts.attempt,
+      retryAttempt: ProviderAttemptRef | undefined = attempt,
     ): Promise<ForwardResult> => {
-      if (resolvedWireFormat) {
-        attempt?.startRecording?.({
-          requestBody: wireRequestBody,
-          wireFormat: resolvedWireFormat,
-        });
-      }
       this.logger.debug(`Forwarding to ${endpointKey}: ${url.replace(/key=[^&]+/, 'key=***')}`);
 
       // SSRF defense in depth for user-supplied endpoint URLs (custom providers,
@@ -424,6 +431,15 @@ export class ProviderClient {
           const message = err instanceof Error ? err.message : String(err);
           throw new Error(`Refusing to forward to disallowed URL: ${message}`);
         }
+      }
+
+      retryAttempt ??= opts.startAttempt?.();
+      attempt ??= retryAttempt;
+      if (resolvedWireFormat) {
+        retryAttempt?.startRecording?.({
+          requestBody: wireRequestBody,
+          wireFormat: resolvedWireFormat,
+        });
       }
 
       const result = await this.executeFetch(url, finalHeaders, wireRequestBody, signal, stream, {
@@ -439,7 +455,7 @@ export class ProviderClient {
         !stream &&
         endpoint.format === 'openai' &&
         (opts.apiMode === undefined || opts.apiMode === 'chat_completions')
-          ? await qualifyEmptyChatCompletion(result.response, attempt)
+          ? await qualifyEmptyChatCompletion(result.response, retryAttempt)
           : result.response;
       const qualifiedResult =
         endpointKey === 'openai-subscription'
@@ -458,6 +474,7 @@ export class ProviderClient {
         wireFormat: resolvedWireFormat,
         wireApiMode: resolvedWireApiMode,
         retryWireBody,
+        attempt: retryAttempt,
       };
     };
 

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -86,6 +86,7 @@ import {
   type RouteCredentialDeps,
 } from './route-credentials';
 import { recordingResponseFromText } from './attempt-recording-capture';
+import { ManifestError } from '../../common/errors/manifest-error';
 
 // Fallback cooldown applied when an upstream 429 carries no usable Retry-After.
 // Kept short (15s) on purpose: many providers rate-limit on brief RPM/burst
@@ -738,13 +739,19 @@ export class ProxyFallbackService {
     const providerResource =
       authType === 'subscription' && provider.toLowerCase() === 'gemini' ? resourceUrl : undefined;
 
-    const attempt = opts.startProviderAttempt?.({
-      provider,
-      model: opts.model,
-      authType,
-      tenantProviderId: opts.tenantProviderId,
-      keyLabel: opts.providerKeyLabel,
-    });
+    let attempt: ProviderAttemptRef | undefined;
+    const startAttempt = opts.startProviderAttempt
+      ? () => {
+          attempt ??= opts.startProviderAttempt?.({
+            provider,
+            model: opts.model,
+            authType,
+            tenantProviderId: opts.tenantProviderId,
+            keyLabel: opts.providerKeyLabel,
+          });
+          return attempt;
+        }
+      : undefined;
     try {
       const forward = await this.providerClient.forward({
         provider,
@@ -772,11 +779,13 @@ export class ProxyFallbackService {
             }
           : {}),
         providerResource,
-        attempt,
+        startAttempt,
       });
+      attempt = forward.attempt ?? attempt ?? startAttempt?.();
       if (attempt) attempt.completedAtMs = Date.now();
       return { ...forward, attempt, providerCallStarted: true };
     } catch (error) {
+      if (!attempt && !(error instanceof ManifestError)) attempt = startAttempt?.();
       if (attempt) attempt.completedAtMs = Date.now();
       if (attempt && error instanceof Error) {
         (error as AttemptTaggedError)[PROVIDER_ATTEMPT_REF] = attempt;

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -120,6 +120,8 @@ export interface ForwardOptions {
   providerResource?: string;
   /** Persisted identity of this exact upstream call. */
   attempt?: ProviderAttemptRef;
+  /** Allocate the attempt only after local validation and request construction succeed. */
+  startAttempt?: () => ProviderAttemptRef | undefined;
 }
 
 /** Options for ProxyService.proxyRequest. */


### PR DESCRIPTION
### ✨ What changed

- Reject implicit Anthropic tools after provider selection.
- Keep native Anthropic forwarding and custom tool schemas unchanged.
- Return a documented M304 error naming incompatible tools.

### 💭 Why

Cross-protocol providers cannot execute Anthropic server tools or infer client-tool schemas. Empty schemas and silent removal both change the request contract.

### 👤 For users

MiniMax requests now fail early with an actionable compatibility error instead of a missing-parameters error or an ungrounded response.

### 📝 Notes

Closes #2754. Supersedes #2772.
