### PR TITLE
fix: pin Better Auth to 1.6.25

### DIFF
--- a/.changeset/quiet-auth-rollback.md
+++ b/.changeset/quiet-auth-rollback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Pin Better Auth to 1.6.25 to restore upgrades from populated 1.6 databases.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,12 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+      # Better Auth minor releases can require database migrations. Keep the
+      # package family together and out of broad dependency bundles.
+      better-auth:
+        patterns:
+          - "better-auth"
+          - "@better-auth/*"
       patch-and-minor:
         applies-to: version-updates
         update-types:
@@ -41,6 +47,8 @@ updates:
         exclude-patterns:
           - "vitest"
           - "@vitest/*"
+          - "better-auth"
+          - "@better-auth/*"
       security:
         applies-to: security-updates
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,12 @@ updates:
       # Better Auth minor releases can require database migrations. Keep the
       # package family together and out of broad dependency bundles.
       better-auth:
+        applies-to: version-updates
+        patterns:
+          - "better-auth"
+          - "@better-auth/*"
+      better-auth-security:
+        applies-to: security-updates
         patterns:
           - "better-auth"
           - "@better-auth/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,12 +1193,12 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.25.tgz",
+      "integrity": "sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.41.1",
+        "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
       },
@@ -1207,7 +1207,7 @@
         "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.4.0",
+        "better-call": "1.3.7",
         "jose": "^6.1.0",
         "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
@@ -1222,14 +1222,14 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.7.1.tgz",
-      "integrity": "sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.25.tgz",
+      "integrity": "sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
-        "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0"
+        "drizzle-orm": "^0.45.2"
       },
       "peerDependenciesMeta": {
         "drizzle-orm": {
@@ -1238,12 +1238,12 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.7.1.tgz",
-      "integrity": "sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.25.tgz",
+      "integrity": "sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
@@ -1254,22 +1254,22 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.7.1.tgz",
-      "integrity": "sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.25.tgz",
+      "integrity": "sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.7.1.tgz",
-      "integrity": "sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.25.tgz",
+      "integrity": "sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
@@ -1280,12 +1280,12 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.7.1.tgz",
-      "integrity": "sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.25.tgz",
+      "integrity": "sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -1299,13 +1299,29 @@
         }
       }
     },
+    "node_modules/@better-auth/stripe": {
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/stripe/-/stripe-1.6.25.tgz",
+      "integrity": "sha512-Upo4byI29iXivg3lkcdqK4buYG32NMdR45+mT1qb4+uceKZIn7wZCqKsYesv8HZ7Ee81WfBOI0kGNVn4Z/G8bA==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.5",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.25",
+        "better-auth": "^1.6.25",
+        "better-call": "1.3.7",
+        "stripe": "^18 || ^19 || ^20 || ^21 || ^22"
+      }
+    },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.7.1.tgz",
-      "integrity": "sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.25.tgz",
+      "integrity": "sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1"
       }
@@ -6966,27 +6982,27 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-auth": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.7.1.tgz",
-      "integrity": "sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.25.tgz",
+      "integrity": "sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.7.1",
-        "@better-auth/drizzle-adapter": "1.7.1",
-        "@better-auth/kysely-adapter": "1.7.1",
-        "@better-auth/memory-adapter": "1.7.1",
-        "@better-auth/mongo-adapter": "1.7.1",
-        "@better-auth/prisma-adapter": "1.7.1",
-        "@better-auth/telemetry": "1.7.1",
+        "@better-auth/core": "1.6.25",
+        "@better-auth/drizzle-adapter": "1.6.25",
+        "@better-auth/kysely-adapter": "1.6.25",
+        "@better-auth/memory-adapter": "1.6.25",
+        "@better-auth/mongo-adapter": "1.6.25",
+        "@better-auth/prisma-adapter": "1.6.25",
+        "@better-auth/telemetry": "1.6.25",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
-        "@noble/ciphers": "^2.2.0",
-        "@noble/hashes": "^2.2.0",
-        "better-call": "1.4.0",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
-        "jose": "^6.2.3",
+        "jose": "^6.1.3",
         "kysely": "^0.28.17 || ^0.29.0",
-        "nanostores": "^1.3.0",
+        "nanostores": "^1.1.1",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -6996,8 +7012,8 @@
         "@tanstack/react-start": "^1.0.0",
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1",
-        "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -7071,15 +7087,15 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.4.0.tgz",
-      "integrity": "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.5.0",
-        "@better-fetch/fetch": "^1.3.1",
-        "rou3": "^0.9.1",
-        "set-cookie-parser": "^3.1.2"
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -7088,15 +7104,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/better-call/node_modules/@better-auth/utils": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.5.0.tgz",
-      "integrity": "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^2.0.1"
       }
     },
     "node_modules/better-path-resolve": {
@@ -13800,9 +13807,9 @@
       }
     },
     "node_modules/rou3": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.2.tgz",
-      "integrity": "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==",
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
       "license": "MIT"
     },
     "node_modules/router": {
@@ -16481,7 +16488,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1116.0",
-        "@better-auth/stripe": "1.7.1",
+        "@better-auth/stripe": "1.6.25",
         "@nestjs/cache-manager": "^3.1.3",
         "@nestjs/common": "^11.2.1",
         "@nestjs/config": "^4.0.4",
@@ -16494,7 +16501,7 @@
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.4",
         "@sentry/nestjs": "^10.70.0",
-        "better-auth": "1.7.1",
+        "better-auth": "1.6.25",
         "cache-manager": "^7.2.9",
         "cacheable": "^2.5.0",
         "class-transformer": "^0.5.1",
@@ -16538,22 +16545,6 @@
         "typescript": "^5.7.0"
       }
     },
-    "packages/backend/node_modules/@better-auth/stripe": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/stripe/-/stripe-1.7.1.tgz",
-      "integrity": "sha512-BMntdoP6q6cWZuMBaWAPmvqc3TQXbXSNoGuNJMNxABvnYkTm/8gl6QzlwoBq5zTAkz0rmW4TiCY5xVTU6Fak/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "defu": "^6.1.5",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
-        "better-auth": "^1.7.1",
-        "better-call": "1.4.0",
-        "stripe": "^18 || ^19 || ^20 || ^21 || ^22"
-      }
-    },
     "packages/backend/node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -16572,10 +16563,10 @@
       "name": "manifest-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@better-auth/stripe": "1.7.1",
+        "@better-auth/stripe": "1.6.25",
         "@solidjs/meta": "^0.29.4",
         "@solidjs/router": "^0.16.2",
-        "better-auth": "1.7.1",
+        "better-auth": "1.6.25",
         "dompurify": "^3.4.14",
         "highlight.js": "^11.12.0",
         "manifest-shared": "*",
@@ -16595,22 +16586,6 @@
         "vite": "^6.1.0",
         "vite-plugin-solid": "^2.11.14",
         "vitest": "^4.1.10"
-      }
-    },
-    "packages/frontend/node_modules/@better-auth/stripe": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/stripe/-/stripe-1.7.1.tgz",
-      "integrity": "sha512-BMntdoP6q6cWZuMBaWAPmvqc3TQXbXSNoGuNJMNxABvnYkTm/8gl6QzlwoBq5zTAkz0rmW4TiCY5xVTU6Fak/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "defu": "^6.1.5",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@better-auth/core": "^1.7.1",
-        "better-auth": "^1.7.1",
-        "better-call": "1.4.0",
-        "stripe": "^18 || ^19 || ^20 || ^21 || ^22"
       }
     },
     "packages/frontend/node_modules/typescript": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1116.0",
-    "@better-auth/stripe": "1.7.1",
+    "@better-auth/stripe": "1.6.25",
     "@nestjs/cache-manager": "^3.1.3",
     "@nestjs/common": "^11.2.1",
     "@nestjs/config": "^4.0.4",
@@ -38,7 +38,7 @@
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.4",
     "@sentry/nestjs": "^10.70.0",
-    "better-auth": "1.7.1",
+    "better-auth": "1.6.25",
     "cache-manager": "^7.2.9",
     "cacheable": "^2.5.0",
     "class-transformer": "^0.5.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,10 +12,10 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@better-auth/stripe": "1.7.1",
+    "@better-auth/stripe": "1.6.25",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.16.2",
-    "better-auth": "1.7.1",
+    "better-auth": "1.6.25",
     "dompurify": "^3.4.14",
     "highlight.js": "^11.12.0",
     "manifest-shared": "*",


### PR DESCRIPTION
### ✨ What changed
- Pin Better Auth and its Stripe integration to 1.6.25.
- Isolate future Better Auth updates in Dependabot.
- Add a patch changeset.

### 💭 Why
Better Auth 1.7 requires a separate migration for populated databases. The grouped dependency update in #2757 caused every production deployment after August 27 to fail during auth startup.

### 👤 For users
Existing installations can upgrade without the Better Auth startup failure.

### 🔧 For operators
No database migration is required for this rollback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls back Better Auth from 1.7.1 to 1.6.25 to fix startup failures on populated databases. Better Auth 1.7 requires a database migration that isn't applied in existing installations, so deployments after the previous update failed during auth startup.

**Dependencies**
- Pins `better-auth` and `@better-auth/stripe` to 1.6.25 in backend and frontend.
- Adds Dependabot groups so Better Auth version and security updates stay isolated from broad dependency bundles.
- Adds a patch changeset for the rollback.

<sup>Written for commit 60a03cfb1db5d5227f1a99a658294dede6e75abe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

