### PR TITLE
Announce the new direction in the Docker Hub README

### DIFF
--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -15,6 +15,24 @@
   <a href="https://discord.gg/FepAked3W7"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
+<blockquote>
+  <h3>🚀 Manifest is becoming the self-healing layer for APIs</h3>
+
+  <p>
+    We're building a new product that fixes failed API requests on the fly, independently of the gateway.
+  </p>
+
+  <p>
+    <strong>This open-source gateway stays available and maintained.</strong>
+  </p>
+
+  <p>
+    <a href="https://manifest.build/blog/manifest-is-taking-a-new-direction/" target="_blank" rel="noopener noreferrer">
+      <strong>Read about the new direction →</strong>
+    </a>
+  </p>
+</blockquote>
+
 ## What is Manifest?
 
 Manifest is a smart model router for **AI agents** like OpenClaw, Hermes, or anything speaking the OpenAI-compatible HTTP API. It sits between your agents and your providers (API keys, subscriptions, or local models) and sends each request to the right one. Simple questions go to fast, cheap models. Hard problems go to the powerful ones. One endpoint for every provider, and a smaller bill as a bonus.

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -27,7 +27,7 @@
   </p>
 
   <p>
-    <a href="https://manifest.build/blog/manifest-is-taking-a-new-direction/" target="_blank" rel="noopener noreferrer">
+    <a href="https://manifest.build/blog/introducing-paid-plans/" target="_blank" rel="noopener noreferrer">
       <strong>Read about the new direction →</strong>
     </a>
   </p>


### PR DESCRIPTION
✨ What changed
- A blockquote at the top of the Docker Hub description announces that Manifest is becoming the self-healing layer for APIs
- It links to the blog post, and uses text only because Docker Hub strips images from descriptions

💭 Why
The Docker Hub page said nothing about the new product direction.

👤 For users
Docker Hub visitors see the announcement above the What is Manifest section.

🔧 For operators
After merge, copy the updated file contents onto hub.docker.com by hand: the description sync is still manual.

🧪 How to test
1. Open docker/DOCKER_README.md on the branch: the blockquote sits above the What is Manifest section
2. Click the link: the blog post opens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an announcement blockquote to the Docker Hub README so visitors see Manifest's new direction as the self-healing layer for APIs. The README previously had no mention of the new direction.

The announcement is text-only because Docker Hub strips images from descriptions. After merging, copy the README contents to hub.docker.com manually; the sync is still manual.

<sup>Written for commit b7acbe72dd213499d8d61f25c775b75a76478615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

