### PR TITLE
Use a Markdown blockquote for the Docker Hub announcement

### DIFF
--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -15,23 +15,13 @@
   <a href="https://discord.gg/FepAked3W7"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
-<blockquote>
-  <h3>🚀 Manifest is becoming the self-healing layer for APIs</h3>
-
-  <p>
-    We're building a new product that fixes failed API requests on the fly, independently of the gateway.
-  </p>
-
-  <p>
-    <strong>This open-source gateway stays available and maintained.</strong>
-  </p>
-
-  <p>
-    <a href="https://manifest.build/blog/introducing-paid-plans/" target="_blank" rel="noopener noreferrer">
-      <strong>Read about the new direction →</strong>
-    </a>
-  </p>
-</blockquote>
+> ### 🚀 Manifest is becoming the self-healing layer for APIs
+>
+> We're building a new product that fixes failed API requests on the fly, independently of the gateway.
+>
+> **This open-source gateway stays available and maintained.**
+>
+> **[Read about the new direction →](https://manifest.build/blog/introducing-paid-plans/)**
 
 ## What is Manifest?
 


### PR DESCRIPTION
✨ What changed
- The new-direction announcement in the Docker Hub description now uses a Markdown blockquote instead of raw HTML

💭 Why
Docker Hub renders raw HTML inconsistently and can drop it entirely, so the announcement could have appeared as unstyled text. The Markdown form matches the rest of the file.

👤 For users
The announcement renders reliably on Docker Hub. Same content, same link.

🔧 For operators
After merge, copy the updated file contents onto hub.docker.com by hand as usual.

🧪 How to test
1. Open docker/DOCKER_README.md on the branch: the announcement is a '>' blockquote above the What is Manifest section
2. Click the link: the blog post opens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the raw HTML blockquote in the Docker Hub announcement with Markdown so it renders reliably instead of being dropped or shown unstyled.

- The announcement text and link are unchanged.
- After merging, copy the updated `docker/DOCKER_README.md` contents onto hub.docker.com manually.

<sup>Written for commit 4deadd14ad24def89bbbca2efaadd12e519098b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

