### PR TITLE
Keep the sidebar bottom stack visible with many harnesses

### DIFF
--- a/design-system/registry/components.json
+++ b/design-system/registry/components.json
@@ -4503,81 +4503,74 @@
       "line": 784
     },
     {
-      "selector": ".sidebar",
-      "prop": "overflow-y",
-      "value": "auto",
-      "file": "theme.css",
-      "line": 788
-    },
-    {
       "selector": ".sidebar__agent-item",
       "prop": "gap",
       "value": "8px",
       "file": "theme.css",
-      "line": 958
+      "line": 944
     },
     {
       "selector": ".theme-toggle",
       "prop": "padding",
       "value": "6px 12px",
       "file": "theme.css",
-      "line": 1036
+      "line": 1022
     },
     {
       "selector": ".theme-toggle",
       "prop": "width",
       "value": "100%",
       "file": "theme.css",
-      "line": 1045
+      "line": 1031
     },
     {
       "selector": ".chart-tooltip",
       "prop": "font-size",
       "value": "var(--font-size-xs)",
       "file": "theme.css",
-      "line": 1122
+      "line": 1108
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "height",
       "value": "64px",
       "file": "theme.css",
-      "line": 1153
+      "line": 1139
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "background",
       "value": "linear-gradient(transparent, hsl(var(--card)) 70%)",
       "file": "theme.css",
-      "line": 1154
+      "line": 1140
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "padding-bottom",
       "value": "12px",
       "file": "theme.css",
-      "line": 1159
+      "line": 1145
     },
     {
       "selector": ".modal",
       "prop": "box-shadow",
       "value": "rgba(0, 0, 0, 0.08) 0px 0px 0px 1px,\n    0 25px 50px -12px rgb(0 0 0 / 0.25)",
       "file": "theme.css",
-      "line": 1210
+      "line": 1196
     },
     {
       "selector": ".modal__close",
       "prop": "width",
       "value": "2rem",
       "file": "theme.css",
-      "line": 1235
+      "line": 1221
     },
     {
       "selector": ".modal__close",
       "prop": "height",
       "value": "2rem",
       "file": "theme.css",
-      "line": 1236
+      "line": 1222
     },
     {
       "selector": ".toast",
@@ -4737,7 +4730,7 @@
       "value": "var(--tooltip-font-size)",
       "file": "charts.css",
       "line": 78,
-      "losesTo": "theme.css:1122"
+      "losesTo": "theme.css:1108"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4745,7 +4738,7 @@
       "value": "80px",
       "file": "charts.css",
       "line": 110,
-      "losesTo": "theme.css:1153"
+      "losesTo": "theme.css:1139"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4753,7 +4746,7 @@
       "value": "linear-gradient(transparent, hsl(var(--card)) 60%)",
       "file": "charts.css",
       "line": 111,
-      "losesTo": "theme.css:1154"
+      "losesTo": "theme.css:1140"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4761,7 +4754,7 @@
       "value": "16px",
       "file": "charts.css",
       "line": 116,
-      "losesTo": "theme.css:1159"
+      "losesTo": "theme.css:1145"
     },
     {
       "selector": ".toast",
@@ -4810,14 +4803,6 @@
       "file": "controls.css",
       "line": 261,
       "losesTo": "theme.css:784"
-    },
-    {
-      "selector": ".sidebar",
-      "prop": "overflow-y",
-      "value": "hidden",
-      "file": "controls.css",
-      "line": 269,
-      "losesTo": "theme.css:788"
     },
     {
       "selector": ".custom-select__option--top > svg",
@@ -4881,7 +4866,7 @@
       "value": "2rem",
       "file": "layout.css",
       "line": 141,
-      "losesTo": "theme.css:1045"
+      "losesTo": "theme.css:1031"
     },
     {
       "selector": ".theme-toggle",
@@ -4889,7 +4874,7 @@
       "value": "0",
       "file": "layout.css",
       "line": 149,
-      "losesTo": "theme.css:1036"
+      "losesTo": "theme.css:1022"
     },
     {
       "selector": ".modal",
@@ -4897,7 +4882,7 @@
       "value": "var(--card-shadow),\n    0 25px 50px -12px rgb(0 0 0 / 0.25)",
       "file": "modals.css",
       "line": 22,
-      "losesTo": "theme.css:1210"
+      "losesTo": "theme.css:1196"
     },
     {
       "selector": ".modal__close",
@@ -4905,7 +4890,7 @@
       "value": "32px",
       "file": "modals.css",
       "line": 47,
-      "losesTo": "theme.css:1235"
+      "losesTo": "theme.css:1221"
     },
     {
       "selector": ".modal__close",
@@ -4913,7 +4898,7 @@
       "value": "32px",
       "file": "modals.css",
       "line": 48,
-      "losesTo": "theme.css:1236"
+      "losesTo": "theme.css:1222"
     },
     {
       "selector": ".setup-modal__header",
@@ -4993,7 +4978,7 @@
       "value": "var(--gap-xs)",
       "file": "theme.css",
       "line": 824,
-      "losesTo": "theme.css:958"
+      "losesTo": "theme.css:944"
     },
     {
       "selector": ".welcome__progress-header span",
@@ -5116,7 +5101,7 @@
     "darkOverrides": 38,
     "blocks": 314,
     "classes": 1701,
-    "canonicalRules": 48,
-    "ghostRules": 48
+    "canonicalRules": 47,
+    "ghostRules": 47
   }
 }

--- a/design-system/registry/components.json
+++ b/design-system/registry/components.json
@@ -4503,74 +4503,81 @@
       "line": 784
     },
     {
+      "selector": ".sidebar",
+      "prop": "overflow-y",
+      "value": "auto",
+      "file": "theme.css",
+      "line": 788
+    },
+    {
       "selector": ".sidebar__agent-item",
       "prop": "gap",
       "value": "8px",
       "file": "theme.css",
-      "line": 922
+      "line": 958
     },
     {
       "selector": ".theme-toggle",
       "prop": "padding",
       "value": "6px 12px",
       "file": "theme.css",
-      "line": 1000
+      "line": 1036
     },
     {
       "selector": ".theme-toggle",
       "prop": "width",
       "value": "100%",
       "file": "theme.css",
-      "line": 1009
+      "line": 1045
     },
     {
       "selector": ".chart-tooltip",
       "prop": "font-size",
       "value": "var(--font-size-xs)",
       "file": "theme.css",
-      "line": 1086
+      "line": 1122
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "height",
       "value": "64px",
       "file": "theme.css",
-      "line": 1117
+      "line": 1153
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "background",
       "value": "linear-gradient(transparent, hsl(var(--card)) 70%)",
       "file": "theme.css",
-      "line": 1118
+      "line": 1154
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "padding-bottom",
       "value": "12px",
       "file": "theme.css",
-      "line": 1123
+      "line": 1159
     },
     {
       "selector": ".modal",
       "prop": "box-shadow",
       "value": "rgba(0, 0, 0, 0.08) 0px 0px 0px 1px,\n    0 25px 50px -12px rgb(0 0 0 / 0.25)",
       "file": "theme.css",
-      "line": 1174
+      "line": 1210
     },
     {
       "selector": ".modal__close",
       "prop": "width",
       "value": "2rem",
       "file": "theme.css",
-      "line": 1199
+      "line": 1235
     },
     {
       "selector": ".modal__close",
       "prop": "height",
       "value": "2rem",
       "file": "theme.css",
-      "line": 1200
+      "line": 1236
     },
     {
       "selector": ".toast",
@@ -4730,7 +4737,7 @@
       "value": "var(--tooltip-font-size)",
       "file": "charts.css",
       "line": 78,
-      "losesTo": "theme.css:1086"
+      "losesTo": "theme.css:1122"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4738,7 +4745,7 @@
       "value": "80px",
       "file": "charts.css",
       "line": 110,
-      "losesTo": "theme.css:1117"
+      "losesTo": "theme.css:1153"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4746,7 +4753,7 @@
       "value": "linear-gradient(transparent, hsl(var(--card)) 60%)",
       "file": "charts.css",
       "line": 111,
-      "losesTo": "theme.css:1118"
+      "losesTo": "theme.css:1154"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4754,7 +4761,7 @@
       "value": "16px",
       "file": "charts.css",
       "line": 116,
-      "losesTo": "theme.css:1123"
+      "losesTo": "theme.css:1159"
     },
     {
       "selector": ".toast",
@@ -4803,6 +4810,14 @@
       "file": "controls.css",
       "line": 261,
       "losesTo": "theme.css:784"
+    },
+    {
+      "selector": ".sidebar",
+      "prop": "overflow-y",
+      "value": "hidden",
+      "file": "controls.css",
+      "line": 269,
+      "losesTo": "theme.css:788"
     },
     {
       "selector": ".custom-select__option--top > svg",
@@ -4866,7 +4881,7 @@
       "value": "2rem",
       "file": "layout.css",
       "line": 141,
-      "losesTo": "theme.css:1009"
+      "losesTo": "theme.css:1045"
     },
     {
       "selector": ".theme-toggle",
@@ -4874,7 +4889,7 @@
       "value": "0",
       "file": "layout.css",
       "line": 149,
-      "losesTo": "theme.css:1000"
+      "losesTo": "theme.css:1036"
     },
     {
       "selector": ".modal",
@@ -4882,7 +4897,7 @@
       "value": "var(--card-shadow),\n    0 25px 50px -12px rgb(0 0 0 / 0.25)",
       "file": "modals.css",
       "line": 22,
-      "losesTo": "theme.css:1174"
+      "losesTo": "theme.css:1210"
     },
     {
       "selector": ".modal__close",
@@ -4890,7 +4905,7 @@
       "value": "32px",
       "file": "modals.css",
       "line": 47,
-      "losesTo": "theme.css:1199"
+      "losesTo": "theme.css:1235"
     },
     {
       "selector": ".modal__close",
@@ -4898,7 +4913,7 @@
       "value": "32px",
       "file": "modals.css",
       "line": 48,
-      "losesTo": "theme.css:1200"
+      "losesTo": "theme.css:1236"
     },
     {
       "selector": ".setup-modal__header",
@@ -4978,7 +4993,7 @@
       "value": "var(--gap-xs)",
       "file": "theme.css",
       "line": 824,
-      "losesTo": "theme.css:922"
+      "losesTo": "theme.css:958"
     },
     {
       "selector": ".welcome__progress-header span",
@@ -5101,7 +5116,7 @@
     "darkOverrides": 38,
     "blocks": 314,
     "classes": 1701,
-    "canonicalRules": 47,
-    "ghostRules": 47
+    "canonicalRules": 48,
+    "ghostRules": 48
   }
 }

--- a/design-system/registry/llms.txt
+++ b/design-system/registry/llms.txt
@@ -418,7 +418,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 ## Migration map — legacy component → primitive to use instead (0)
 (empty until primitives exist)
 
-## Canonical rules — same selector+property declared twice with different values; the winner renders (47)
+## Canonical rules — same selector+property declared twice with different values; the winner renders (48)
 .view-more-link { color: hsl(var(--foreground)) }  ← analytics-overview.css:170
 .custom-select__option--top > svg { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
@@ -446,17 +446,18 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .feed-item { gap: var(--gap-md) }  ← theme.css:587
 .feed-item { padding: 10px 0 }  ← theme.css:588
 .sidebar { padding: var(--gap-lg) 0 0 0 }  ← theme.css:784
-.sidebar__agent-item { gap: 8px }  ← theme.css:922
-.theme-toggle { padding: 6px 12px }  ← theme.css:1000
-.theme-toggle { width: 100% }  ← theme.css:1009
-.chart-tooltip { font-size: var(--font-size-xs) }  ← theme.css:1086
-.expandable-card__fade { height: 64px }  ← theme.css:1117
-.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 70%) }  ← theme.css:1118
-.expandable-card__fade { padding-bottom: 12px }  ← theme.css:1123
+.sidebar { overflow-y: auto }  ← theme.css:788
+.sidebar__agent-item { gap: 8px }  ← theme.css:958
+.theme-toggle { padding: 6px 12px }  ← theme.css:1036
+.theme-toggle { width: 100% }  ← theme.css:1045
+.chart-tooltip { font-size: var(--font-size-xs) }  ← theme.css:1122
+.expandable-card__fade { height: 64px }  ← theme.css:1153
+.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 70%) }  ← theme.css:1154
+.expandable-card__fade { padding-bottom: 12px }  ← theme.css:1159
 .modal { box-shadow: rgba(0, 0, 0, 0.08) 0px 0px 0px 1px,
-    0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1174
-.modal__close { width: 2rem }  ← theme.css:1199
-.modal__close { height: 2rem }  ← theme.css:1200
+    0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1210
+.modal__close { width: 2rem }  ← theme.css:1235
+.modal__close { height: 2rem }  ← theme.css:1236
 .toast { align-items: flex-start }  ← toast.css:16
 .toast { gap: var(--gap-sm) }  ← toast.css:17
 .toast { padding: 12px var(--gap-md) }  ← toast.css:18
@@ -469,7 +470,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .welcome__route-test-heading { align-items: center }  ← welcome.css:903
 .welcome__route-test-heading { gap: 10px }  ← welcome.css:904
 
-## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (47)
+## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (48)
 .summary-card { box-shadow: var(--card-shadow) }  at cards.css:7 loses to theme.css:196
 .trend--up { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:237
 .trend--down { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:242
@@ -480,16 +481,17 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .chart-card { box-shadow: var(--card-shadow) }  at cards.css:86 loses to theme.css:284
 .chart-card__header { align-items: stretch }  at cards.css:92 loses to theme.css:290
 .chart-card__value-row { align-items: center }  at cards.css:160 loses to theme.css:322
-.chart-tooltip { font-size: var(--tooltip-font-size) }  at charts.css:78 loses to theme.css:1086
-.expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1117
-.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1118
-.expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1123
+.chart-tooltip { font-size: var(--tooltip-font-size) }  at charts.css:78 loses to theme.css:1122
+.expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1153
+.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1154
+.expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1159
 .toast { align-items: center }  at controls.css:172 loses to toast.css:16
 .toast { gap: 10px }  at controls.css:173 loses to toast.css:17
 .toast { padding: 12px 16px }  at controls.css:174 loses to toast.css:18
 .toast { box-shadow: 0 4px 16px rgb(0 0 0 / 0.15) }  at controls.css:177 loses to toast.css:22
 .toast { animation: toast-in 200ms ease-out }  at controls.css:180 loses to toast.css:26
 .sidebar { padding: var(--gap-md) 0 }  at controls.css:261 loses to theme.css:784
+.sidebar { overflow-y: hidden }  at controls.css:269 loses to theme.css:788
 .custom-select__option--top > svg { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
 .tier-badge--fallback { background: hsl(var(--muted-foreground) / 0.1) }  at data.css:299 loses to overview.css:194
@@ -497,12 +499,12 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .feed-item { align-items: flex-start }  at data.css:507 loses to theme.css:586
 .feed-item { gap: 12px }  at data.css:508 loses to theme.css:587
 .feed-item { padding: 12px 0 }  at data.css:509 loses to theme.css:588
-.theme-toggle { width: 2rem }  at layout.css:141 loses to theme.css:1009
-.theme-toggle { padding: 0 }  at layout.css:149 loses to theme.css:1000
+.theme-toggle { width: 2rem }  at layout.css:141 loses to theme.css:1045
+.theme-toggle { padding: 0 }  at layout.css:149 loses to theme.css:1036
 .modal { box-shadow: var(--card-shadow),
-    0 25px 50px -12px rgb(0 0 0 / 0.25) }  at modals.css:22 loses to theme.css:1174
-.modal__close { width: 32px }  at modals.css:47 loses to theme.css:1199
-.modal__close { height: 32px }  at modals.css:48 loses to theme.css:1200
+    0 25px 50px -12px rgb(0 0 0 / 0.25) }  at modals.css:22 loses to theme.css:1210
+.modal__close { width: 32px }  at modals.css:47 loses to theme.css:1235
+.modal__close { height: 32px }  at modals.css:48 loses to theme.css:1236
 .setup-modal__header { align-items: flex-start }  at modals.css:64 loses to overview.css:15
 .setup-modal__next { padding: 8px 20px }  at modals.css:105 loses to overview.css:42
 .setup-modal__next { color: hsl(var(--primary-foreground)) }  at modals.css:109 loses to overview.css:46
@@ -512,7 +514,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .request-tool { border-radius: var(--radius) }  at request-drawer.css:647 loses to request-drawer.css:875
 .request-tool { background: hsl(var(--card)) }  at request-drawer.css:648 loses to request-drawer.css:876
 .hljs-attr { color: hsl(187 60% 38%) }  at request-drawer.css:1054 loses to syntax-highlight.css:41
-.sidebar__agent-item { gap: var(--gap-xs) }  at theme.css:824 loses to theme.css:922
+.sidebar__agent-item { gap: var(--gap-xs) }  at theme.css:824 loses to theme.css:958
 .welcome__progress-header span { letter-spacing: 0.09em }  at welcome.css:548 loses to welcome.css:554
 .welcome__text-link:focus-visible { outline: 3px solid hsl(var(--ring)) }  at welcome.css:726 loses to welcome.css:865
 .welcome__text-link:focus-visible { outline-offset: 2px }  at welcome.css:727 loses to welcome.css:866

--- a/design-system/registry/llms.txt
+++ b/design-system/registry/llms.txt
@@ -418,7 +418,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 ## Migration map — legacy component → primitive to use instead (0)
 (empty until primitives exist)
 
-## Canonical rules — same selector+property declared twice with different values; the winner renders (48)
+## Canonical rules — same selector+property declared twice with different values; the winner renders (47)
 .view-more-link { color: hsl(var(--foreground)) }  ← analytics-overview.css:170
 .custom-select__option--top > svg { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
@@ -446,18 +446,17 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .feed-item { gap: var(--gap-md) }  ← theme.css:587
 .feed-item { padding: 10px 0 }  ← theme.css:588
 .sidebar { padding: var(--gap-lg) 0 0 0 }  ← theme.css:784
-.sidebar { overflow-y: auto }  ← theme.css:788
-.sidebar__agent-item { gap: 8px }  ← theme.css:958
-.theme-toggle { padding: 6px 12px }  ← theme.css:1036
-.theme-toggle { width: 100% }  ← theme.css:1045
-.chart-tooltip { font-size: var(--font-size-xs) }  ← theme.css:1122
-.expandable-card__fade { height: 64px }  ← theme.css:1153
-.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 70%) }  ← theme.css:1154
-.expandable-card__fade { padding-bottom: 12px }  ← theme.css:1159
+.sidebar__agent-item { gap: 8px }  ← theme.css:944
+.theme-toggle { padding: 6px 12px }  ← theme.css:1022
+.theme-toggle { width: 100% }  ← theme.css:1031
+.chart-tooltip { font-size: var(--font-size-xs) }  ← theme.css:1108
+.expandable-card__fade { height: 64px }  ← theme.css:1139
+.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 70%) }  ← theme.css:1140
+.expandable-card__fade { padding-bottom: 12px }  ← theme.css:1145
 .modal { box-shadow: rgba(0, 0, 0, 0.08) 0px 0px 0px 1px,
-    0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1210
-.modal__close { width: 2rem }  ← theme.css:1235
-.modal__close { height: 2rem }  ← theme.css:1236
+    0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1196
+.modal__close { width: 2rem }  ← theme.css:1221
+.modal__close { height: 2rem }  ← theme.css:1222
 .toast { align-items: flex-start }  ← toast.css:16
 .toast { gap: var(--gap-sm) }  ← toast.css:17
 .toast { padding: 12px var(--gap-md) }  ← toast.css:18
@@ -470,7 +469,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .welcome__route-test-heading { align-items: center }  ← welcome.css:903
 .welcome__route-test-heading { gap: 10px }  ← welcome.css:904
 
-## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (48)
+## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (47)
 .summary-card { box-shadow: var(--card-shadow) }  at cards.css:7 loses to theme.css:196
 .trend--up { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:237
 .trend--down { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:242
@@ -481,17 +480,16 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .chart-card { box-shadow: var(--card-shadow) }  at cards.css:86 loses to theme.css:284
 .chart-card__header { align-items: stretch }  at cards.css:92 loses to theme.css:290
 .chart-card__value-row { align-items: center }  at cards.css:160 loses to theme.css:322
-.chart-tooltip { font-size: var(--tooltip-font-size) }  at charts.css:78 loses to theme.css:1122
-.expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1153
-.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1154
-.expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1159
+.chart-tooltip { font-size: var(--tooltip-font-size) }  at charts.css:78 loses to theme.css:1108
+.expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1139
+.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1140
+.expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1145
 .toast { align-items: center }  at controls.css:172 loses to toast.css:16
 .toast { gap: 10px }  at controls.css:173 loses to toast.css:17
 .toast { padding: 12px 16px }  at controls.css:174 loses to toast.css:18
 .toast { box-shadow: 0 4px 16px rgb(0 0 0 / 0.15) }  at controls.css:177 loses to toast.css:22
 .toast { animation: toast-in 200ms ease-out }  at controls.css:180 loses to toast.css:26
 .sidebar { padding: var(--gap-md) 0 }  at controls.css:261 loses to theme.css:784
-.sidebar { overflow-y: hidden }  at controls.css:269 loses to theme.css:788
 .custom-select__option--top > svg { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
 .tier-badge--fallback { background: hsl(var(--muted-foreground) / 0.1) }  at data.css:299 loses to overview.css:194
@@ -499,12 +497,12 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .feed-item { align-items: flex-start }  at data.css:507 loses to theme.css:586
 .feed-item { gap: 12px }  at data.css:508 loses to theme.css:587
 .feed-item { padding: 12px 0 }  at data.css:509 loses to theme.css:588
-.theme-toggle { width: 2rem }  at layout.css:141 loses to theme.css:1045
-.theme-toggle { padding: 0 }  at layout.css:149 loses to theme.css:1036
+.theme-toggle { width: 2rem }  at layout.css:141 loses to theme.css:1031
+.theme-toggle { padding: 0 }  at layout.css:149 loses to theme.css:1022
 .modal { box-shadow: var(--card-shadow),
-    0 25px 50px -12px rgb(0 0 0 / 0.25) }  at modals.css:22 loses to theme.css:1210
-.modal__close { width: 32px }  at modals.css:47 loses to theme.css:1235
-.modal__close { height: 32px }  at modals.css:48 loses to theme.css:1236
+    0 25px 50px -12px rgb(0 0 0 / 0.25) }  at modals.css:22 loses to theme.css:1196
+.modal__close { width: 32px }  at modals.css:47 loses to theme.css:1221
+.modal__close { height: 32px }  at modals.css:48 loses to theme.css:1222
 .setup-modal__header { align-items: flex-start }  at modals.css:64 loses to overview.css:15
 .setup-modal__next { padding: 8px 20px }  at modals.css:105 loses to overview.css:42
 .setup-modal__next { color: hsl(var(--primary-foreground)) }  at modals.css:109 loses to overview.css:46
@@ -514,7 +512,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .request-tool { border-radius: var(--radius) }  at request-drawer.css:647 loses to request-drawer.css:875
 .request-tool { background: hsl(var(--card)) }  at request-drawer.css:648 loses to request-drawer.css:876
 .hljs-attr { color: hsl(187 60% 38%) }  at request-drawer.css:1054 loses to syntax-highlight.css:41
-.sidebar__agent-item { gap: var(--gap-xs) }  at theme.css:824 loses to theme.css:958
+.sidebar__agent-item { gap: var(--gap-xs) }  at theme.css:824 loses to theme.css:944
 .welcome__progress-header span { letter-spacing: 0.09em }  at welcome.css:548 loses to welcome.css:554
 .welcome__text-link:focus-visible { outline: 3px solid hsl(var(--ring)) }  at welcome.css:726 loses to welcome.css:865
 .welcome__text-link:focus-visible { outline-offset: 2px }  at welcome.css:727 loses to welcome.css:866

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -262,11 +262,11 @@
   display: flex;
   flex-direction: column;
   z-index: 10;
-  /* The column itself never scrolls: the harness list is the one scrollable
-     region, so the nav and the pinned bottom stack (pivot card, usage,
-     upgrade) stay visible whatever the list length. Short viewports fall
-     back to whole-column scrolling (media query beside the list rules). */
-  overflow-y: hidden;
+  /* The harness list carries its own cap and scroll (see theme.css), so on
+     any reasonable height the bottom stack (pivot card, usage, upgrade)
+     stays in view without this column ever scrolling; on very short
+     viewports the column overflows and scrolls as it always did. */
+  overflow-y: auto;
 }
 
 .sidebar__section-label {

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -262,7 +262,11 @@
   display: flex;
   flex-direction: column;
   z-index: 10;
-  overflow-y: auto;
+  /* The column itself never scrolls: the harness list is the one scrollable
+     region, so the nav and the pinned bottom stack (pivot card, usage,
+     upgrade) stay visible whatever the list length. Short viewports fall
+     back to whole-column scrolling (media query beside the list rules). */
+  overflow-y: hidden;
 }
 
 .sidebar__section-label {

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -264,8 +264,12 @@
   z-index: 10;
   /* The harness list carries its own cap and scroll (see theme.css), so on
      any reasonable height the bottom stack (pivot card, usage, upgrade)
-     stays in view without this column ever scrolling; on very short
-     viewports the column overflows and scrolls as it always did. */
+     stays in view without this column ever scrolling. On very short
+     viewports the column overflows and scrolls around the still-capped
+     list — deliberately: keeping the list compact brings the bottom stack
+     back with the least column scrolling, and a viewport threshold that
+     lifts the cap proved worse (it silently restored the push-down bug on
+     any window with devtools open). */
   overflow-y: auto;
 }
 

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -912,10 +912,46 @@ h6 {
   background: hsl(var(--border));
 }
 
-/* Harness list items reuse the shared link base (above); these are the only
-   harness-specific overrides — a wider icon gap and a bolder label. */
+/* Harness list items reuse the shared link base (above). The list is the
+   sidebar's only scrollable region: it shrinks before anything else, capped
+   at ~5.5 rows so the half row already hints at more, and the flex column
+   sizes it to whatever space the nav and the pinned bottom stack leave. */
 .sidebar__agents-list {
   padding: 0;
+  flex: 0 1 auto;
+  min-height: 74px; /* two ~36px rows — the list never collapses entirely */
+  max-height: 198px; /* 5.5 rows of ~36px (6px padding + 22px line + 2px margin) */
+  overflow-y: auto;
+  /* Pure-CSS scroll shadows: the sidebar-background covers travel with the
+     content (attachment: local) and unmask the pinned gradients only on the
+     side where more content remains. */
+  background:
+    linear-gradient(hsl(var(--sidebar-background)) 30%, transparent),
+    linear-gradient(transparent, hsl(var(--sidebar-background)) 70%) 0 100%,
+    radial-gradient(farthest-side at 50% 0, hsl(var(--sidebar-foreground) / 0.18), transparent),
+    radial-gradient(farthest-side at 50% 100%, hsl(var(--sidebar-foreground) / 0.18), transparent) 0
+      100%;
+  background-repeat: no-repeat;
+  background-size:
+    100% 32px,
+    100% 32px,
+    100% 12px,
+    100% 12px;
+  background-attachment: local, local, scroll, scroll;
+}
+
+/* Short viewports cannot fit the pinned bottom stack above the fold: fall
+   back to the historic whole-column scroll so nothing becomes unreachable. */
+@media (max-height: 720px) {
+  .sidebar {
+    overflow-y: auto;
+  }
+  .sidebar__agents-list {
+    max-height: none;
+    min-height: 0;
+    overflow-y: visible;
+    background: none;
+  }
 }
 
 .sidebar__agent-item {
@@ -1423,6 +1459,14 @@ h6 {
   .sidebar__spacer,
   .sidebar__feedback {
     display: block;
+  }
+  /* The mobile drawer scrolls as one column; the desktop list cap and its
+     scroll shadows would only nest a second scrollbar here. */
+  .sidebar__agents-list {
+    max-height: none;
+    min-height: 0;
+    overflow-y: visible;
+    background: none;
   }
   .sidebar__link {
     flex: 0 0 auto;

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -940,20 +940,6 @@ h6 {
   background-attachment: local, local, scroll, scroll;
 }
 
-/* Short viewports cannot fit the pinned bottom stack above the fold: fall
-   back to the historic whole-column scroll so nothing becomes unreachable. */
-@media (max-height: 720px) {
-  .sidebar {
-    overflow-y: auto;
-  }
-  .sidebar__agents-list {
-    max-height: none;
-    min-height: 0;
-    overflow-y: visible;
-    background: none;
-  }
-}
-
 .sidebar__agent-item {
   gap: 8px;
   font-weight: 500;


### PR DESCRIPTION
✨ What changed
- The harness list is now capped at five and a half rows and scrolls in place
- Scroll shadows appear only on the side where more harnesses remain
- The announcement card and the usage block stay visible on any reasonable window height
- On very short viewports the column scrolls around the still-capped list, so the bottom stack is never far; the mobile drawer keeps its single-column scroll

💭 Why
With many harnesses the list pushed the announcement card below the fold, making its button unreachable without scrolling the whole column.

👤 For users
The bottom of the sidebar stays visible; long harness lists scroll in place with a visual hint.

🔧 For operators
No operator impact.

🧪 How to test
1. Create a dozen harnesses: the list caps at about five and a half rows and scrolls in place
2. The announcement card and usage block stay visible at the bottom
3. On a very short window the column scrolls too, with the list still compact
4. On mobile width, the drawer scrolls as one column as before