### PR TITLE
Record the real origin of waiting-list claims

### DIFF
--- a/.changeset/waitlist-claim-source.md
+++ b/.changeset/waitlist-claim-source.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Waiting-list claims now record where they were made (cloud or self-hosted) instead of a generic label, and a repeat claim updates the attribution to the latest origin.

--- a/packages/backend/src/waitlist/dto/pivot-claim.dto.spec.ts
+++ b/packages/backend/src/waitlist/dto/pivot-claim.dto.spec.ts
@@ -28,4 +28,11 @@ describe('PivotClaimDto', () => {
     const { errors } = validate({ email: 'jane@example.com', newsletter: true });
     expect(errors.map((error) => error.property)).toContain('newsletter');
   });
+
+  it('accepts the two claim sources and rejects anything else', () => {
+    expect(validate({ email: 'a@b.co', source: 'cloud' }).errors).toHaveLength(0);
+    expect(validate({ email: 'a@b.co', source: 'self-hosted' }).errors).toHaveLength(0);
+    const { errors } = validate({ email: 'a@b.co', source: 'website' });
+    expect(errors.map((error) => error.property)).toContain('source');
+  });
 });

--- a/packages/backend/src/waitlist/dto/pivot-claim.dto.spec.ts
+++ b/packages/backend/src/waitlist/dto/pivot-claim.dto.spec.ts
@@ -29,6 +29,11 @@ describe('PivotClaimDto', () => {
     expect(errors.map((error) => error.property)).toContain('newsletter');
   });
 
+  it('rejects an explicit null source; only omission earns the default', () => {
+    const { errors } = validate({ email: 'a@b.co', source: null });
+    expect(errors.map((error) => error.property)).toContain('source');
+  });
+
   it('accepts the two claim sources and rejects anything else', () => {
     expect(validate({ email: 'a@b.co', source: 'cloud' }).errors).toHaveLength(0);
     expect(validate({ email: 'a@b.co', source: 'self-hosted' }).errors).toHaveLength(0);

--- a/packages/backend/src/waitlist/dto/pivot-claim.dto.ts
+++ b/packages/backend/src/waitlist/dto/pivot-claim.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsEmail, IsIn, IsOptional, MaxLength } from 'class-validator';
+import { IsEmail, IsIn, MaxLength, ValidateIf } from 'class-validator';
 
 /** Claim origins this route may record; `website` belongs to Peacock's own form. */
 export const PIVOT_CLAIM_SOURCES = ['cloud', 'self-hosted'] as const;
@@ -12,8 +12,9 @@ export class PivotClaimDto {
   @MaxLength(254)
   email!: string;
 
-  /** Where the claim was made; absent defaults to self-hosted. */
-  @IsOptional()
+  /** Where the claim was made; absent defaults to self-hosted. Explicit
+   * null is rejected: only omission earns the default. */
+  @ValidateIf((claim) => claim.source !== undefined)
   @IsIn([...PIVOT_CLAIM_SOURCES])
   source?: PivotClaimSource;
 }

--- a/packages/backend/src/waitlist/dto/pivot-claim.dto.ts
+++ b/packages/backend/src/waitlist/dto/pivot-claim.dto.ts
@@ -1,5 +1,9 @@
 import { Transform } from 'class-transformer';
-import { IsEmail, MaxLength } from 'class-validator';
+import { IsEmail, IsIn, IsOptional, MaxLength } from 'class-validator';
+
+/** Claim origins this route may record; `website` belongs to Peacock's own form. */
+export const PIVOT_CLAIM_SOURCES = ['cloud', 'self-hosted'] as const;
+export type PivotClaimSource = (typeof PIVOT_CLAIM_SOURCES)[number];
 
 /** Body of the public pivot waiting-list claim. */
 export class PivotClaimDto {
@@ -7,4 +11,9 @@ export class PivotClaimDto {
   @IsEmail()
   @MaxLength(254)
   email!: string;
+
+  /** Where the claim was made; absent defaults to self-hosted. */
+  @IsOptional()
+  @IsIn([...PIVOT_CLAIM_SOURCES])
+  source?: PivotClaimSource;
 }

--- a/packages/backend/src/waitlist/dto/pivot-claim.dto.ts
+++ b/packages/backend/src/waitlist/dto/pivot-claim.dto.ts
@@ -5,6 +5,9 @@ import { IsEmail, IsIn, MaxLength, ValidateIf } from 'class-validator';
 export const PIVOT_CLAIM_SOURCES = ['cloud', 'self-hosted'] as const;
 export type PivotClaimSource = (typeof PIVOT_CLAIM_SOURCES)[number];
 
+/** Fallback when a claim carries no source and no same-origin signal. */
+export const DEFAULT_PIVOT_CLAIM_SOURCE: PivotClaimSource = 'self-hosted';
+
 /** Body of the public pivot waiting-list claim. */
 export class PivotClaimDto {
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))

--- a/packages/backend/src/waitlist/waitlist.controller.spec.ts
+++ b/packages/backend/src/waitlist/waitlist.controller.spec.ts
@@ -1,6 +1,34 @@
+import { Request } from 'express';
 import { Repository } from 'typeorm';
 import { WaitlistClaim } from '../entities/waitlist-claim.entity';
-import { WaitlistController } from './waitlist.controller';
+import { WaitlistController, claimRequestIsSameOrigin } from './waitlist.controller';
+
+function reqWith(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+describe('claimRequestIsSameOrigin', () => {
+  it('matches when the Origin host equals the Host header', () => {
+    expect(
+      claimRequestIsSameOrigin({
+        origin: 'https://app.manifest.build',
+        host: 'app.manifest.build',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a foreign origin', () => {
+    expect(
+      claimRequestIsSameOrigin({ origin: 'https://someone.example', host: 'app.manifest.build' }),
+    ).toBe(false);
+  });
+
+  it('rejects missing, array, or malformed headers', () => {
+    expect(claimRequestIsSameOrigin({})).toBe(false);
+    expect(claimRequestIsSameOrigin({ origin: ['a', 'b'], host: 'x' })).toBe(false);
+    expect(claimRequestIsSameOrigin({ origin: 'not a url', host: 'x' })).toBe(false);
+  });
+});
 
 describe('WaitlistController', () => {
   let chain: {
@@ -36,7 +64,7 @@ describe('WaitlistController', () => {
 
   it('stores a claim with a normalized email and the declared source', async () => {
     await expect(
-      controller.receivePivotClaim({ email: '  Jane@Example.COM ', source: 'cloud' }),
+      controller.receivePivotClaim({ email: '  Jane@Example.COM ', source: 'cloud' }, reqWith()),
     ).resolves.toEqual({ ok: true });
 
     expect(chain.values).toHaveBeenCalledWith(
@@ -46,13 +74,37 @@ describe('WaitlistController', () => {
     expect(Number.isNaN(Date.parse(row.claimed_at))).toBe(false);
   });
 
-  it('defaults a missing source to self-hosted', async () => {
-    await controller.receivePivotClaim({ email: 'jane@example.com' });
+  it('infers cloud for a sourceless same-origin claim (stale cloud bundle)', async () => {
+    await controller.receivePivotClaim(
+      { email: 'jane@example.com' },
+      reqWith({ origin: 'https://app.manifest.build', host: 'app.manifest.build' }),
+    );
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ source: 'cloud' }));
+  });
+
+  it('defaults a sourceless cross-origin or headerless claim to self-hosted', async () => {
+    await controller.receivePivotClaim({ email: 'jane@example.com' }, reqWith());
     expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ source: 'self-hosted' }));
   });
 
-  it('lets the latest claim win on an email conflict, source included', async () => {
-    await controller.receivePivotClaim({ email: 'jane@example.com', source: 'self-hosted' });
-    expect(chain.orUpdate).toHaveBeenCalledWith(['source', 'claimed_at'], ['email']);
+  it('lets an explicit source win over the origin inference', async () => {
+    await controller.receivePivotClaim(
+      { email: 'jane@example.com', source: 'self-hosted' },
+      reqWith({ origin: 'https://app.manifest.build', host: 'app.manifest.build' }),
+    );
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ source: 'self-hosted' }));
+  });
+
+  it('lets the latest claim win on conflict, but never over a website row', async () => {
+    await controller.receivePivotClaim(
+      { email: 'jane@example.com', source: 'self-hosted' },
+      reqWith(),
+    );
+    expect(chain.orUpdate).toHaveBeenCalledWith(['source', 'claimed_at'], ['email'], {
+      overwriteCondition: {
+        where: '"waitlist_claims"."source" != :websiteSource',
+        parameters: { websiteSource: 'website' },
+      },
+    });
   });
 });

--- a/packages/backend/src/waitlist/waitlist.controller.spec.ts
+++ b/packages/backend/src/waitlist/waitlist.controller.spec.ts
@@ -34,20 +34,25 @@ describe('WaitlistController', () => {
     expect(chain.execute).not.toHaveBeenCalled();
   });
 
-  it('stores a pivot claim with a normalized email', async () => {
-    await expect(controller.receivePivotClaim({ email: '  Jane@Example.COM ' })).resolves.toEqual({
-      ok: true,
-    });
+  it('stores a claim with a normalized email and the declared source', async () => {
+    await expect(
+      controller.receivePivotClaim({ email: '  Jane@Example.COM ', source: 'cloud' }),
+    ).resolves.toEqual({ ok: true });
 
     expect(chain.values).toHaveBeenCalledWith(
-      expect.objectContaining({ email: 'jane@example.com', source: 'pivot' }),
+      expect.objectContaining({ email: 'jane@example.com', source: 'cloud' }),
     );
     const row = chain.values.mock.calls[0][0] as { claimed_at: string };
     expect(Number.isNaN(Date.parse(row.claimed_at))).toBe(false);
   });
 
-  it('only refreshes claimed_at on an email conflict, preserving the original source', async () => {
+  it('defaults a missing source to self-hosted', async () => {
     await controller.receivePivotClaim({ email: 'jane@example.com' });
-    expect(chain.orUpdate).toHaveBeenCalledWith(['claimed_at'], ['email']);
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ source: 'self-hosted' }));
+  });
+
+  it('lets the latest claim win on an email conflict, source included', async () => {
+    await controller.receivePivotClaim({ email: 'jane@example.com', source: 'self-hosted' });
+    expect(chain.orUpdate).toHaveBeenCalledWith(['source', 'claimed_at'], ['email']);
   });
 });

--- a/packages/backend/src/waitlist/waitlist.controller.ts
+++ b/packages/backend/src/waitlist/waitlist.controller.ts
@@ -1,9 +1,29 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, Req } from '@nestjs/common';
+import { Request } from 'express';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Public } from '../common/decorators/public.decorator';
 import { WaitlistClaim } from '../entities/waitlist-claim.entity';
-import { PivotClaimDto } from './dto/pivot-claim.dto';
+import { DEFAULT_PIVOT_CLAIM_SOURCE, PivotClaimDto } from './dto/pivot-claim.dto';
+
+/**
+ * Same-origin check for the sourceless fallback: a stale cloud bundle from
+ * before the source field posts same-origin to its own backend, while
+ * self-hosted dashboards post cross-origin. Explicit sources bypass this.
+ */
+export function claimRequestIsSameOrigin(headers: {
+  origin?: string | string[];
+  host?: string | string[];
+}): boolean {
+  const origin = headers.origin;
+  const host = headers.host;
+  if (typeof origin !== 'string' || typeof host !== 'string') return false;
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
 
 @Controller('api/v1/waitlist')
 export class WaitlistController {
@@ -35,17 +55,32 @@ export class WaitlistController {
   @Public()
   @Post('pivot/claim')
   @HttpCode(HttpStatus.OK)
-  async receivePivotClaim(@Body() dto: PivotClaimDto): Promise<{ ok: boolean }> {
+  async receivePivotClaim(
+    @Body() dto: PivotClaimDto,
+    @Req() req: Request,
+  ): Promise<{ ok: boolean }> {
+    // An explicit source always wins; a sourceless same-origin post is the
+    // cloud dashboard (a cached pre-source bundle) talking to its own
+    // backend, anything else defaults to self-hosted.
+    const source =
+      dto.source ?? (claimRequestIsSameOrigin(req.headers) ? 'cloud' : DEFAULT_PIVOT_CLAIM_SOURCE);
     await this.claimRepo
       .createQueryBuilder()
       .insert()
       .into(WaitlistClaim)
       .values({
         email: dto.email.trim().toLowerCase(),
-        source: dto.source ?? 'self-hosted',
+        source,
         claimed_at: new Date().toISOString(),
       })
-      .orUpdate(['source', 'claimed_at'], ['email'])
+      // Latest claim wins among the sources this route owns; a website row
+      // (Peacock's own form) is never overwritten by this public endpoint.
+      .orUpdate(['source', 'claimed_at'], ['email'], {
+        overwriteCondition: {
+          where: '"waitlist_claims"."source" != :websiteSource',
+          parameters: { websiteSource: 'website' },
+        },
+      })
       .execute();
     return { ok: true };
   }

--- a/packages/backend/src/waitlist/waitlist.controller.ts
+++ b/packages/backend/src/waitlist/waitlist.controller.ts
@@ -28,25 +28,24 @@ export class WaitlistController {
    * Pivot waiting-list claim. Public and CORS-open on purpose: cloud posts
    * same-origin and self-hosted dashboards post here straight from the
    * browser, so any locally-registered user can join with a corrected email.
-   * The upsert dedupes by email; the global throttler still applies.
+   * The upsert dedupes by email and the latest claim wins, source included:
+   * attribution reflects where the person last joined from, matching the
+   * historical phone-home behavior. The global throttler still applies.
    */
   @Public()
   @Post('pivot/claim')
   @HttpCode(HttpStatus.OK)
   async receivePivotClaim(@Body() dto: PivotClaimDto): Promise<{ ok: boolean }> {
-    // On an email conflict only claimed_at is refreshed: a row registered
-    // under another source keeps its original attribution, so the pivot
-    // route never rewrites history it does not own.
     await this.claimRepo
       .createQueryBuilder()
       .insert()
       .into(WaitlistClaim)
       .values({
         email: dto.email.trim().toLowerCase(),
-        source: 'pivot',
+        source: dto.source ?? 'self-hosted',
         claimed_at: new Date().toISOString(),
       })
-      .orUpdate(['claimed_at'], ['email'])
+      .orUpdate(['source', 'claimed_at'], ['email'])
       .execute();
     return { ok: true };
   }

--- a/packages/backend/test/waitlist.e2e-spec.ts
+++ b/packages/backend/test/waitlist.e2e-spec.ts
@@ -42,6 +42,38 @@ describe('POST /api/v1/waitlist/pivot/claim', () => {
     expect(rows).toEqual([{ source: 'self-hosted' }]);
   });
 
+  it('infers cloud for a sourceless same-origin claim', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/waitlist/pivot/claim')
+      .set('Host', 'claims.test')
+      .set('Origin', 'http://claims.test')
+      .send({ email: 'stale@b.co' })
+      .expect(200);
+
+    const ds = app.get(DataSource);
+    const rows = await ds.query(`SELECT source FROM waitlist_claims`);
+    expect(rows).toEqual([{ source: 'cloud' }]);
+  });
+
+  it('never overwrites a website row, while still answering ok', async () => {
+    const ds = app.get(DataSource);
+    await ds.query(
+      `INSERT INTO waitlist_claims (email, source, claimed_at) VALUES ($1, $2, now() - interval '1 day')`,
+      ['site@b.co', 'website'],
+    );
+
+    await request(app.getHttpServer())
+      .post('/api/v1/waitlist/pivot/claim')
+      .send({ email: 'site@b.co', source: 'cloud' })
+      .expect(200)
+      .expect({ ok: true });
+
+    const rows = await ds.query(
+      `SELECT source, claimed_at < now() - interval '1 hour' AS untouched FROM waitlist_claims`,
+    );
+    expect(rows).toEqual([{ source: 'website', untouched: true }]);
+  });
+
   it('rejects a source outside cloud/self-hosted', async () => {
     await request(app.getHttpServer())
       .post('/api/v1/waitlist/pivot/claim')

--- a/packages/backend/test/waitlist.e2e-spec.ts
+++ b/packages/backend/test/waitlist.e2e-spec.ts
@@ -19,16 +19,34 @@ beforeEach(async () => {
 });
 
 describe('POST /api/v1/waitlist/pivot/claim', () => {
-  it('stores a claim with a normalized email and pivot source', async () => {
+  it('stores a claim with a normalized email and the declared cloud source', async () => {
     await request(app.getHttpServer())
       .post('/api/v1/waitlist/pivot/claim')
-      .send({ email: '  Jane@Example.COM ' })
+      .send({ email: '  Jane@Example.COM ', source: 'cloud' })
       .expect(200)
       .expect({ ok: true });
 
     const ds = app.get(DataSource);
     const rows = await ds.query(`SELECT email, source FROM waitlist_claims`);
-    expect(rows).toEqual([{ email: 'jane@example.com', source: 'pivot' }]);
+    expect(rows).toEqual([{ email: 'jane@example.com', source: 'cloud' }]);
+  });
+
+  it('defaults a sourceless claim to self-hosted', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/waitlist/pivot/claim')
+      .send({ email: 'a@b.co' })
+      .expect(200);
+
+    const ds = app.get(DataSource);
+    const rows = await ds.query(`SELECT source FROM waitlist_claims`);
+    expect(rows).toEqual([{ source: 'self-hosted' }]);
+  });
+
+  it('rejects a source outside cloud/self-hosted', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/waitlist/pivot/claim')
+      .send({ email: 'a@b.co', source: 'website' })
+      .expect(400);
   });
 
   it('dedupes by email on a second claim', async () => {
@@ -41,7 +59,7 @@ describe('POST /api/v1/waitlist/pivot/claim', () => {
     expect(rows).toHaveLength(1);
   });
 
-  it('preserves the original source of an already-registered email', async () => {
+  it('lets the latest claim overwrite the source of an already-registered email', async () => {
     const ds = app.get(DataSource);
     await ds.query(
       `INSERT INTO waitlist_claims (email, source, claimed_at) VALUES ($1, $2, now() - interval '1 day')`,
@@ -50,13 +68,13 @@ describe('POST /api/v1/waitlist/pivot/claim', () => {
 
     await request(app.getHttpServer())
       .post('/api/v1/waitlist/pivot/claim')
-      .send({ email: 'old@b.co' })
+      .send({ email: 'old@b.co', source: 'cloud' })
       .expect(200);
 
     const rows = await ds.query(
       `SELECT email, source, claimed_at > now() - interval '1 hour' AS refreshed FROM waitlist_claims`,
     );
-    expect(rows).toEqual([{ email: 'old@b.co', source: 'self-hosted', refreshed: true }]);
+    expect(rows).toEqual([{ email: 'old@b.co', source: 'cloud', refreshed: true }]);
   });
 
   it('rejects an invalid email with 400 and stores nothing', async () => {

--- a/packages/frontend/src/services/waitlist.ts
+++ b/packages/frontend/src/services/waitlist.ts
@@ -40,13 +40,24 @@ export function hasPivotJoined(userId: string): boolean {
  * of a fake success.
  */
 export async function submitPivotClaim(email: string, selfHosted: boolean): Promise<boolean> {
-  try {
-    const res = await fetch(getPivotClaimUrl(selfHosted), {
+  const url = getPivotClaimUrl(selfHosted);
+  const post = (body: Record<string, string>) =>
+    fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, source: selfHosted ? 'self-hosted' : 'cloud' }),
+      body: JSON.stringify(body),
     });
-    return res.ok;
+  try {
+    const res = await post({ email, source: selfHosted ? 'self-hosted' : 'cloud' });
+    if (res.ok) return true;
+    // A pre-source cloud backend (rollback) rejects the unknown field with a
+    // 400; one retry without it keeps the claim working, with attribution
+    // falling back to the server default. A truly invalid email 400s again.
+    if (res.status === 400) {
+      const retry = await post({ email });
+      return retry.ok;
+    }
+    return false;
   } catch {
     return false;
   }

--- a/packages/frontend/src/services/waitlist.ts
+++ b/packages/frontend/src/services/waitlist.ts
@@ -34,15 +34,17 @@ export function hasPivotJoined(userId: string): boolean {
 }
 
 /**
- * Submit the claim. Returns false on any failure so the modal can show a
- * real error instead of a fake success.
+ * Submit the claim. The deployment mode rides along as the claim source so
+ * attribution in waitlist_claims reflects where the person joined from.
+ * Returns false on any failure so the modal can show a real error instead
+ * of a fake success.
  */
 export async function submitPivotClaim(email: string, selfHosted: boolean): Promise<boolean> {
   try {
     const res = await fetch(getPivotClaimUrl(selfHosted), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email }),
+      body: JSON.stringify({ email, source: selfHosted ? 'self-hosted' : 'cloud' }),
     });
     return res.ok;
   } catch {

--- a/packages/frontend/tests/services/waitlist.test.ts
+++ b/packages/frontend/tests/services/waitlist.test.ts
@@ -79,9 +79,26 @@ describe('waitlist service', () => {
       expect(body.source).toBe('self-hosted');
     });
 
-    it('reports failure on a non-2xx response', async () => {
+    it('retries once without the source field when a pre-source backend answers 400', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 400 })
+        .mockResolvedValueOnce({ ok: true });
+      await expect(submitPivotClaim('jane@example.com', true)).resolves.toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const retryBody = JSON.parse((mockFetch.mock.calls[1][1] as RequestInit).body as string);
+      expect(retryBody).toEqual({ email: 'jane@example.com' });
+    });
+
+    it('reports failure when the retry also fails (truly invalid email)', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 400 });
       await expect(submitPivotClaim('bad', false)).resolves.toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry on non-400 failures', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+      await expect(submitPivotClaim('jane@example.com', false)).resolves.toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('reports failure when the request throws', async () => {

--- a/packages/frontend/tests/services/waitlist.test.ts
+++ b/packages/frontend/tests/services/waitlist.test.ts
@@ -62,14 +62,21 @@ describe('waitlist service', () => {
   });
 
   describe('submitPivotClaim', () => {
-    it('posts the email as JSON and reports success', async () => {
+    it('posts the email with the cloud source from cloud deployments', async () => {
       mockFetch.mockResolvedValue({ ok: true });
       await expect(submitPivotClaim('jane@example.com', false)).resolves.toBe(true);
       expect(mockFetch).toHaveBeenCalledWith('/api/v1/waitlist/pivot/claim', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: 'jane@example.com' }),
+        body: JSON.stringify({ email: 'jane@example.com', source: 'cloud' }),
       });
+    });
+
+    it('posts the self-hosted source from self-hosted deployments', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      await submitPivotClaim('jane@example.com', true);
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.source).toBe('self-hosted');
     });
 
     it('reports failure on a non-2xx response', async () => {


### PR DESCRIPTION
✨ What changed
- Waiting-list claims now carry their real origin: cloud or self-hosted, depending on the dashboard that posted them
- A repeat claim with the same email updates the attribution to the latest origin, matching the historical phone-home behavior
- Any other source value is rejected; the website source stays exclusive to the site form

💭 Why
Every claim landed with a generic or stale label, so people joining from the cloud showed up as self-hosted users: wrong data for outreach segmentation.

👤 For users
No visible change; joining the waiting list works exactly as before.

🔧 For operators
Existing mislabeled rows self-correct the next time the person joins again from the right place.

🧪 How to test
1. Join from a cloud dashboard: the claim row reads source cloud
2. Join from a self-hosted dashboard: the row reads self-hosted
3. Join again from the other side: the same row flips to the latest origin

Stacked on #2809; it retargets to main once that one merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the real origin of waiting-list claims so cloud joins no longer show up as self-hosted users.

- Claims carry `cloud` or `self-hosted` matching the dashboard that posted them; a sourceless claim is labeled `cloud` when same-origin, otherwise it defaults to `self-hosted`, and an explicit `null` is rejected.
- A repeat claim with the same email overwrites the previous source, except `website` rows from the site form, which stay untouched.
- The backend rejects any other source value.
- The frontend retries once without the source field if an older backend returns 400, keeping claims working through rollbacks.
- No visible change for users joining the waiting list.

<sup>Written for commit 98900d21bea8511e9ff62c9b4c185d3bd519963e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

