### PR TITLE
Turn Harnesses into a nav link with a grid or table workspace

### DIFF
--- a/design-system/registry/components.json
+++ b/design-system/registry/components.json
@@ -3566,23 +3566,16 @@
       "classes": [
         "sidebar",
         "sidebar--mobile-open",
-        "sidebar__agent-icon",
-        "sidebar__agent-item",
-        "sidebar__agent-item--active",
-        "sidebar__agent-item-name",
-        "sidebar__agents-empty",
-        "sidebar__agents-list",
         "sidebar__feedback",
         "sidebar__feedback-hint",
         "sidebar__feedback-title",
         "sidebar__footer",
         "sidebar__link",
         "sidebar__link--disabled",
+        "sidebar__link-row",
         "sidebar__logo",
         "sidebar__logo-dot",
         "sidebar__section-add",
-        "sidebar__section-caret",
-        "sidebar__section-header",
         "sidebar__section-label",
         "sidebar__spacer"
       ],
@@ -4308,6 +4301,15 @@
       "files": [
         "controls.css"
       ]
+    },
+    "workspace-table": {
+      "classes": [
+        "workspace-table__actions",
+        "workspace-table__name"
+      ],
+      "files": [
+        "agents.css"
+      ]
     }
   },
   "primitives": [],
@@ -4503,74 +4505,67 @@
       "line": 784
     },
     {
-      "selector": ".sidebar__agent-item",
-      "prop": "gap",
-      "value": "8px",
-      "file": "theme.css",
-      "line": 922
-    },
-    {
       "selector": ".theme-toggle",
       "prop": "padding",
       "value": "6px 12px",
       "file": "theme.css",
-      "line": 1000
+      "line": 927
     },
     {
       "selector": ".theme-toggle",
       "prop": "width",
       "value": "100%",
       "file": "theme.css",
-      "line": 1009
+      "line": 936
     },
     {
       "selector": ".chart-tooltip",
       "prop": "font-size",
       "value": "var(--font-size-xs)",
       "file": "theme.css",
-      "line": 1086
+      "line": 1013
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "height",
       "value": "64px",
       "file": "theme.css",
-      "line": 1117
+      "line": 1044
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "background",
       "value": "linear-gradient(transparent, hsl(var(--card)) 70%)",
       "file": "theme.css",
-      "line": 1118
+      "line": 1045
     },
     {
       "selector": ".expandable-card__fade",
       "prop": "padding-bottom",
       "value": "12px",
       "file": "theme.css",
-      "line": 1123
+      "line": 1050
     },
     {
       "selector": ".modal",
       "prop": "box-shadow",
       "value": "rgba(0, 0, 0, 0.08) 0px 0px 0px 1px,\n    0 25px 50px -12px rgb(0 0 0 / 0.25)",
       "file": "theme.css",
-      "line": 1174
+      "line": 1101
     },
     {
       "selector": ".modal__close",
       "prop": "width",
       "value": "2rem",
       "file": "theme.css",
-      "line": 1199
+      "line": 1126
     },
     {
       "selector": ".modal__close",
       "prop": "height",
       "value": "2rem",
       "file": "theme.css",
-      "line": 1200
+      "line": 1127
     },
     {
       "selector": ".toast",
@@ -4730,7 +4725,7 @@
       "value": "var(--tooltip-font-size)",
       "file": "charts.css",
       "line": 78,
-      "losesTo": "theme.css:1086"
+      "losesTo": "theme.css:1013"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4738,7 +4733,7 @@
       "value": "80px",
       "file": "charts.css",
       "line": 110,
-      "losesTo": "theme.css:1117"
+      "losesTo": "theme.css:1044"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4746,7 +4741,7 @@
       "value": "linear-gradient(transparent, hsl(var(--card)) 60%)",
       "file": "charts.css",
       "line": 111,
-      "losesTo": "theme.css:1118"
+      "losesTo": "theme.css:1045"
     },
     {
       "selector": ".expandable-card__fade",
@@ -4754,7 +4749,7 @@
       "value": "16px",
       "file": "charts.css",
       "line": 116,
-      "losesTo": "theme.css:1123"
+      "losesTo": "theme.css:1050"
     },
     {
       "selector": ".toast",
@@ -4866,7 +4861,7 @@
       "value": "2rem",
       "file": "layout.css",
       "line": 141,
-      "losesTo": "theme.css:1009"
+      "losesTo": "theme.css:936"
     },
     {
       "selector": ".theme-toggle",
@@ -4874,7 +4869,7 @@
       "value": "0",
       "file": "layout.css",
       "line": 149,
-      "losesTo": "theme.css:1000"
+      "losesTo": "theme.css:927"
     },
     {
       "selector": ".modal",
@@ -4882,7 +4877,7 @@
       "value": "var(--card-shadow),\n    0 25px 50px -12px rgb(0 0 0 / 0.25)",
       "file": "modals.css",
       "line": 22,
-      "losesTo": "theme.css:1174"
+      "losesTo": "theme.css:1101"
     },
     {
       "selector": ".modal__close",
@@ -4890,7 +4885,7 @@
       "value": "32px",
       "file": "modals.css",
       "line": 47,
-      "losesTo": "theme.css:1199"
+      "losesTo": "theme.css:1126"
     },
     {
       "selector": ".modal__close",
@@ -4898,7 +4893,7 @@
       "value": "32px",
       "file": "modals.css",
       "line": 48,
-      "losesTo": "theme.css:1200"
+      "losesTo": "theme.css:1127"
     },
     {
       "selector": ".setup-modal__header",
@@ -4971,14 +4966,6 @@
       "file": "request-drawer.css",
       "line": 1054,
       "losesTo": "syntax-highlight.css:41"
-    },
-    {
-      "selector": ".sidebar__agent-item",
-      "prop": "gap",
-      "value": "var(--gap-xs)",
-      "file": "theme.css",
-      "line": 824,
-      "losesTo": "theme.css:922"
     },
     {
       "selector": ".welcome__progress-header span",
@@ -5099,9 +5086,9 @@
   "stats": {
     "tokens": 79,
     "darkOverrides": 38,
-    "blocks": 314,
-    "classes": 1701,
-    "canonicalRules": 47,
-    "ghostRules": 47
+    "blocks": 315,
+    "classes": 1696,
+    "canonicalRules": 46,
+    "ghostRules": 46
   }
 }

--- a/design-system/registry/components.json
+++ b/design-system/registry/components.json
@@ -4305,6 +4305,7 @@
     "workspace-table": {
       "classes": [
         "workspace-table__actions",
+        "workspace-table__icon",
         "workspace-table__name"
       ],
       "files": [
@@ -5087,7 +5088,7 @@
     "tokens": 79,
     "darkOverrides": 38,
     "blocks": 315,
-    "classes": 1696,
+    "classes": 1697,
     "canonicalRules": 46,
     "ghostRules": 46
   }

--- a/design-system/registry/llms.txt
+++ b/design-system/registry/llms.txt
@@ -96,7 +96,7 @@
 --z-toast: 8000
 --z-tooltip: 9999
 
-## Blocks (315 BEM blocks, 1696 classes)
+## Blocks (315 BEM blocks, 1697 classes)
 account-back-btn (agents.css): account-back-btn
 account-email-footer (agents.css): account-email-footer
 account-email-toggle (agents.css): account-email-toggle--disabled
@@ -411,7 +411,7 @@ waiting-banner (overview.css): waiting-banner waiting-banner--success
 welcome (welcome.css): welcome welcome__actions welcome__actions--split welcome__actions--sticky welcome__actions-note welcome__agent-wait welcome__agent-wait--success welcome__agent-wait-heading welcome__autofix-details welcome__autofix-examples welcome__autofix-heading welcome__autofix-how welcome__autofix-section welcome__availability-note welcome__error welcome__eyebrow welcome__first-request welcome__form-panel welcome__harness-summary welcome__harness-summary-icon welcome__harness-summary-name welcome__harness-summary-type welcome__inline-code welcome__input-hint welcome__launch-orbit welcome__launch-rocket welcome__launch-rocket--complete welcome__launch-stack welcome__launch-stack--complete welcome__launch-stack-header welcome__launch-track welcome__legal welcome__liftoff welcome__liftoff-action welcome__liftoff-beacon welcome__liftoff-copy welcome__liftoff-description welcome__liftoff-earth welcome__liftoff-exit welcome__liftoff-flash welcome__liftoff-kicker welcome__liftoff-orbit welcome__liftoff-plume welcome__liftoff-plume-inner welcome__liftoff-rocket welcome__liftoff-smoke welcome__liftoff-stars welcome__liftoff-stars--far welcome__liftoff-stars--near welcome__liftoff-status welcome__liftoff-title welcome__liftoff-title--launch welcome__liftoff-title--orbit welcome__liftoff-titles welcome__logo-dark welcome__logo-light welcome__logo-mark welcome__main welcome__model-badge welcome__nav welcome__nav-btn welcome__nav-check welcome__nav-dot welcome__nav-hint welcome__nav-item welcome__nav-item--active welcome__nav-item--done welcome__nav-label welcome__nav-mobile-rocket welcome__nav-mobile-rocket--complete welcome__output welcome__panel welcome__panel--playground welcome__panel--setup welcome__panel-desc welcome__panel-header welcome__panel-title welcome__pending welcome__plan-heading welcome__plan-section welcome__playground welcome__playground-actions welcome__playground-link welcome__progress welcome__progress-header welcome__prompt-label welcome__provider-connected welcome__provider-list welcome__request-failure welcome__response welcome__rocket-flame welcome__route-test-heading welcome__route-test-section welcome__route-test-title welcome__section-desc welcome__section-heading welcome__setup-snippets welcome__sidebar welcome__sidebar-footer welcome__sidebar-top welcome__skip-row welcome__spinner welcome__stats welcome__success-icon welcome__text-link welcome__textarea
 wingman-drawer (controls.css): wingman-drawer wingman-drawer--resizing wingman-drawer__actions wingman-drawer__frame wingman-drawer__head wingman-drawer__icon-btn wingman-drawer__resizer wingman-drawer__sub wingman-drawer__title
 wingman-fab (controls.css): wingman-fab wingman-fab__label
-workspace-table (agents.css): workspace-table__actions workspace-table__name
+workspace-table (agents.css): workspace-table__actions workspace-table__icon workspace-table__name
 
 ## Primitives (0)
 (none yet — phase 2 builds them in src/components/ui/)

--- a/design-system/registry/llms.txt
+++ b/design-system/registry/llms.txt
@@ -96,7 +96,7 @@
 --z-toast: 8000
 --z-tooltip: 9999
 
-## Blocks (314 BEM blocks, 1701 classes)
+## Blocks (315 BEM blocks, 1696 classes)
 account-back-btn (agents.css): account-back-btn
 account-email-footer (agents.css): account-email-footer
 account-email-toggle (agents.css): account-email-toggle--disabled
@@ -355,7 +355,7 @@ setup-segment (wizard.css): setup-segment setup-segment--full setup-segment__btn
 setup-step (wizard.css): setup-step__desc setup-step__heading
 setup-step-providers (overview.css): setup-step-providers
 setup-steps (controls.css): setup-steps setup-steps__content setup-steps__divider setup-steps__number setup-steps__step
-sidebar (controls.css, theme.css): sidebar sidebar--mobile-open sidebar__agent-icon sidebar__agent-item sidebar__agent-item--active sidebar__agent-item-name sidebar__agents-empty sidebar__agents-list sidebar__feedback sidebar__feedback-hint sidebar__feedback-title sidebar__footer sidebar__link sidebar__link--disabled sidebar__logo sidebar__logo-dot sidebar__section-add sidebar__section-caret sidebar__section-header sidebar__section-label sidebar__spacer
+sidebar (controls.css, theme.css): sidebar sidebar--mobile-open sidebar__feedback sidebar__feedback-hint sidebar__feedback-title sidebar__footer sidebar__link sidebar__link--disabled sidebar__link-row sidebar__logo sidebar__logo-dot sidebar__section-add sidebar__section-label sidebar__spacer
 sidebar-pivot (pivot.css): sidebar-pivot sidebar-pivot__bottom sidebar-pivot__btn sidebar-pivot__canvas sidebar-pivot__desc sidebar-pivot__dismiss sidebar-pivot__header sidebar-pivot__joined sidebar-pivot__title sidebar-pivot__top
 sidebar-pivot-modal (pivot.css): sidebar-pivot-modal sidebar-pivot-modal__logo
 sidebar-upgrade (modals.css): sidebar-upgrade
@@ -411,6 +411,7 @@ waiting-banner (overview.css): waiting-banner waiting-banner--success
 welcome (welcome.css): welcome welcome__actions welcome__actions--split welcome__actions--sticky welcome__actions-note welcome__agent-wait welcome__agent-wait--success welcome__agent-wait-heading welcome__autofix-details welcome__autofix-examples welcome__autofix-heading welcome__autofix-how welcome__autofix-section welcome__availability-note welcome__error welcome__eyebrow welcome__first-request welcome__form-panel welcome__harness-summary welcome__harness-summary-icon welcome__harness-summary-name welcome__harness-summary-type welcome__inline-code welcome__input-hint welcome__launch-orbit welcome__launch-rocket welcome__launch-rocket--complete welcome__launch-stack welcome__launch-stack--complete welcome__launch-stack-header welcome__launch-track welcome__legal welcome__liftoff welcome__liftoff-action welcome__liftoff-beacon welcome__liftoff-copy welcome__liftoff-description welcome__liftoff-earth welcome__liftoff-exit welcome__liftoff-flash welcome__liftoff-kicker welcome__liftoff-orbit welcome__liftoff-plume welcome__liftoff-plume-inner welcome__liftoff-rocket welcome__liftoff-smoke welcome__liftoff-stars welcome__liftoff-stars--far welcome__liftoff-stars--near welcome__liftoff-status welcome__liftoff-title welcome__liftoff-title--launch welcome__liftoff-title--orbit welcome__liftoff-titles welcome__logo-dark welcome__logo-light welcome__logo-mark welcome__main welcome__model-badge welcome__nav welcome__nav-btn welcome__nav-check welcome__nav-dot welcome__nav-hint welcome__nav-item welcome__nav-item--active welcome__nav-item--done welcome__nav-label welcome__nav-mobile-rocket welcome__nav-mobile-rocket--complete welcome__output welcome__panel welcome__panel--playground welcome__panel--setup welcome__panel-desc welcome__panel-header welcome__panel-title welcome__pending welcome__plan-heading welcome__plan-section welcome__playground welcome__playground-actions welcome__playground-link welcome__progress welcome__progress-header welcome__prompt-label welcome__provider-connected welcome__provider-list welcome__request-failure welcome__response welcome__rocket-flame welcome__route-test-heading welcome__route-test-section welcome__route-test-title welcome__section-desc welcome__section-heading welcome__setup-snippets welcome__sidebar welcome__sidebar-footer welcome__sidebar-top welcome__skip-row welcome__spinner welcome__stats welcome__success-icon welcome__text-link welcome__textarea
 wingman-drawer (controls.css): wingman-drawer wingman-drawer--resizing wingman-drawer__actions wingman-drawer__frame wingman-drawer__head wingman-drawer__icon-btn wingman-drawer__resizer wingman-drawer__sub wingman-drawer__title
 wingman-fab (controls.css): wingman-fab wingman-fab__label
+workspace-table (agents.css): workspace-table__actions workspace-table__name
 
 ## Primitives (0)
 (none yet — phase 2 builds them in src/components/ui/)
@@ -418,7 +419,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 ## Migration map — legacy component → primitive to use instead (0)
 (empty until primitives exist)
 
-## Canonical rules — same selector+property declared twice with different values; the winner renders (47)
+## Canonical rules — same selector+property declared twice with different values; the winner renders (46)
 .view-more-link { color: hsl(var(--foreground)) }  ← analytics-overview.css:170
 .custom-select__option--top > svg { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
@@ -446,17 +447,16 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .feed-item { gap: var(--gap-md) }  ← theme.css:587
 .feed-item { padding: 10px 0 }  ← theme.css:588
 .sidebar { padding: var(--gap-lg) 0 0 0 }  ← theme.css:784
-.sidebar__agent-item { gap: 8px }  ← theme.css:922
-.theme-toggle { padding: 6px 12px }  ← theme.css:1000
-.theme-toggle { width: 100% }  ← theme.css:1009
-.chart-tooltip { font-size: var(--font-size-xs) }  ← theme.css:1086
-.expandable-card__fade { height: 64px }  ← theme.css:1117
-.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 70%) }  ← theme.css:1118
-.expandable-card__fade { padding-bottom: 12px }  ← theme.css:1123
+.theme-toggle { padding: 6px 12px }  ← theme.css:927
+.theme-toggle { width: 100% }  ← theme.css:936
+.chart-tooltip { font-size: var(--font-size-xs) }  ← theme.css:1013
+.expandable-card__fade { height: 64px }  ← theme.css:1044
+.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 70%) }  ← theme.css:1045
+.expandable-card__fade { padding-bottom: 12px }  ← theme.css:1050
 .modal { box-shadow: rgba(0, 0, 0, 0.08) 0px 0px 0px 1px,
-    0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1174
-.modal__close { width: 2rem }  ← theme.css:1199
-.modal__close { height: 2rem }  ← theme.css:1200
+    0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1101
+.modal__close { width: 2rem }  ← theme.css:1126
+.modal__close { height: 2rem }  ← theme.css:1127
 .toast { align-items: flex-start }  ← toast.css:16
 .toast { gap: var(--gap-sm) }  ← toast.css:17
 .toast { padding: 12px var(--gap-md) }  ← toast.css:18
@@ -469,7 +469,7 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .welcome__route-test-heading { align-items: center }  ← welcome.css:903
 .welcome__route-test-heading { gap: 10px }  ← welcome.css:904
 
-## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (47)
+## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (46)
 .summary-card { box-shadow: var(--card-shadow) }  at cards.css:7 loses to theme.css:196
 .trend--up { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:237
 .trend--down { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:242
@@ -480,10 +480,10 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .chart-card { box-shadow: var(--card-shadow) }  at cards.css:86 loses to theme.css:284
 .chart-card__header { align-items: stretch }  at cards.css:92 loses to theme.css:290
 .chart-card__value-row { align-items: center }  at cards.css:160 loses to theme.css:322
-.chart-tooltip { font-size: var(--tooltip-font-size) }  at charts.css:78 loses to theme.css:1086
-.expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1117
-.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1118
-.expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1123
+.chart-tooltip { font-size: var(--tooltip-font-size) }  at charts.css:78 loses to theme.css:1013
+.expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1044
+.expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1045
+.expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1050
 .toast { align-items: center }  at controls.css:172 loses to toast.css:16
 .toast { gap: 10px }  at controls.css:173 loses to toast.css:17
 .toast { padding: 12px 16px }  at controls.css:174 loses to toast.css:18
@@ -497,12 +497,12 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .feed-item { align-items: flex-start }  at data.css:507 loses to theme.css:586
 .feed-item { gap: 12px }  at data.css:508 loses to theme.css:587
 .feed-item { padding: 12px 0 }  at data.css:509 loses to theme.css:588
-.theme-toggle { width: 2rem }  at layout.css:141 loses to theme.css:1009
-.theme-toggle { padding: 0 }  at layout.css:149 loses to theme.css:1000
+.theme-toggle { width: 2rem }  at layout.css:141 loses to theme.css:936
+.theme-toggle { padding: 0 }  at layout.css:149 loses to theme.css:927
 .modal { box-shadow: var(--card-shadow),
-    0 25px 50px -12px rgb(0 0 0 / 0.25) }  at modals.css:22 loses to theme.css:1174
-.modal__close { width: 32px }  at modals.css:47 loses to theme.css:1199
-.modal__close { height: 32px }  at modals.css:48 loses to theme.css:1200
+    0 25px 50px -12px rgb(0 0 0 / 0.25) }  at modals.css:22 loses to theme.css:1101
+.modal__close { width: 32px }  at modals.css:47 loses to theme.css:1126
+.modal__close { height: 32px }  at modals.css:48 loses to theme.css:1127
 .setup-modal__header { align-items: flex-start }  at modals.css:64 loses to overview.css:15
 .setup-modal__next { padding: 8px 20px }  at modals.css:105 loses to overview.css:42
 .setup-modal__next { color: hsl(var(--primary-foreground)) }  at modals.css:109 loses to overview.css:46
@@ -512,7 +512,6 @@ wingman-fab (controls.css): wingman-fab wingman-fab__label
 .request-tool { border-radius: var(--radius) }  at request-drawer.css:647 loses to request-drawer.css:875
 .request-tool { background: hsl(var(--card)) }  at request-drawer.css:648 loses to request-drawer.css:876
 .hljs-attr { color: hsl(187 60% 38%) }  at request-drawer.css:1054 loses to syntax-highlight.css:41
-.sidebar__agent-item { gap: var(--gap-xs) }  at theme.css:824 loses to theme.css:922
 .welcome__progress-header span { letter-spacing: 0.09em }  at welcome.css:548 loses to welcome.css:554
 .welcome__text-link:focus-visible { outline: 3px solid hsl(var(--ring)) }  at welcome.css:726 loses to welcome.css:865
 .welcome__text-link:focus-visible { outline-offset: 2px }  at welcome.css:727 loses to welcome.css:866

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -1,25 +1,14 @@
 import { A, useLocation } from '@solidjs/router';
-import { Show, For, createSignal, createResource, type Component } from 'solid-js';
-import { useAgentName } from '../services/routing.js';
-import { getAgents } from '../services/api.js';
+import { Show, createSignal, createResource, type Component } from 'solid-js';
 import { getBillingStatus } from '../services/api/billing.js';
 import { FREE_REQUEST_LIMIT_LABEL } from '../services/billing-display.js';
 import { checkIsSelfHosted } from '../services/setup-status.js';
-import { agentPing } from '../services/sse.js';
-import { platformIcon } from 'manifest-shared';
 import AddAgentModal from './AddAgentModal.jsx';
 import PivotAnnouncement from './PivotAnnouncement.jsx';
 
 interface SidebarProps {
   mobileOpen?: boolean;
   onNavigate?: () => void;
-}
-
-interface HarnessItem {
-  agent_name: string;
-  display_name?: string;
-  agent_platform?: string | null;
-  agent_category?: string | null;
 }
 
 /**
@@ -36,8 +25,6 @@ function makeIsGlobalActive(pathname: () => string) {
 const Sidebar: Component<SidebarProps> = (props) => {
   const location = useLocation();
   const isGlobalActive = makeIsGlobalActive(() => location.pathname);
-  const getAgentName = useAgentName();
-  const [agentsCollapsed, setAgentsCollapsed] = createSignal(false);
   const [addModalOpen, setAddModalOpen] = createSignal(false);
   // Local providers only exist on self-hosted installs — a cloud backend
   // can't reach the user's localhost, so the Local entry is hidden there.
@@ -52,24 +39,6 @@ const Sidebar: Component<SidebarProps> = (props) => {
   const showUpgrade = () => billing()?.enabled && billing()?.plan === 'free';
   const requestLimitLabel = () =>
     billing()?.requests.limit?.toLocaleString('en-US') ?? FREE_REQUEST_LIMIT_LABEL;
-
-  // Harness list for the in-nav switcher. Refetches whenever the agent SSE ping
-  // fires (create/delete/rename). Uses the DEFAULT getAgents() — playground agents
-  // (the reserved Playground) are excluded so they never leak into the switcher.
-  const [agents] = createResource(
-    () => agentPing(),
-    async (): Promise<HarnessItem[]> => {
-      try {
-        const data = (await getAgents()) as { agents?: HarnessItem[] } | HarnessItem[] | null;
-        if (Array.isArray(data)) return data;
-        return data?.agents ?? [];
-      } catch {
-        return [];
-      }
-    },
-  );
-
-  const currentAgent = () => getAgentName();
 
   const handleNav = () => {
     props.onNavigate?.();
@@ -104,6 +73,36 @@ const Sidebar: Component<SidebarProps> = (props) => {
       >
         Requests
       </A>
+      {/* Harnesses is a plain nav entry to the /harnesses page; the + keeps
+          the one-click create from the nav. */}
+      <div class="sidebar__link-row">
+        <A
+          href="/harnesses"
+          class="sidebar__link"
+          classList={{ active: isGlobalActive('/harnesses') }}
+          aria-current={isGlobalActive('/harnesses') ? 'page' : undefined}
+        >
+          Harnesses
+        </A>
+        <button
+          type="button"
+          class="sidebar__section-add"
+          title="Create new harness"
+          aria-label="Create new harness"
+          onClick={() => setAddModalOpen(true)}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6z" />
+          </svg>
+        </button>
+      </div>
       <div class="sidebar__section-label">PROVIDERS</div>
       <Show when={selfHosted()}>
         <A
@@ -131,86 +130,6 @@ const Sidebar: Component<SidebarProps> = (props) => {
       >
         Subscriptions
       </A>
-
-      {/* Harnesses — collapsible section with a + create button.
-          The collapse toggle and the create button are sibling buttons (never
-          nested) so both are independently keyboard-operable. */}
-      <div class="sidebar__section-header">
-        <button
-          type="button"
-          class="sidebar__section-caret"
-          onClick={() => setAgentsCollapsed(!agentsCollapsed())}
-          aria-expanded={!agentsCollapsed()}
-        >
-          <span>HARNESSES</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="12"
-            height="12"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-            style={{
-              transition: 'transform 150ms',
-              transform: agentsCollapsed() ? 'rotate(-90deg)' : 'rotate(0deg)',
-            }}
-          >
-            <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
-          </svg>
-        </button>
-        <button
-          type="button"
-          class="sidebar__section-add"
-          title="Create new harness"
-          aria-label="Create new harness"
-          onClick={() => setAddModalOpen(true)}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="14"
-            height="14"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6z" />
-          </svg>
-        </button>
-      </div>
-
-      <Show when={!agentsCollapsed()}>
-        <div class="sidebar__agents-list">
-          <For
-            each={agents() ?? []}
-            fallback={
-              <Show when={!agents.loading}>
-                <div class="sidebar__agents-empty">No harnesses yet</div>
-              </Show>
-            }
-          >
-            {(agent) => {
-              const name = () => agent.agent_name;
-              const display = () => agent.display_name || agent.agent_name;
-              const icon = () => platformIcon(agent.agent_platform, agent.agent_category);
-              const isSelected = () => currentAgent() === name();
-              return (
-                <A
-                  href={`/harnesses/${encodeURIComponent(name())}`}
-                  class="sidebar__agent-item"
-                  classList={{ 'sidebar__agent-item--active': isSelected() }}
-                  aria-current={isSelected() ? 'page' : undefined}
-                  onClick={handleNav}
-                >
-                  <Show when={icon()}>
-                    <img src={icon()} alt="" class="sidebar__agent-icon" />
-                  </Show>
-                  <span class="sidebar__agent-item-name">{display()}</span>
-                </A>
-              );
-            }}
-          </For>
-        </div>
-      </Show>
 
       <div class="sidebar__section-label">TOOLS</div>
       <A

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -208,7 +208,7 @@ const Sidebar: Component<SidebarProps> = (props) => {
         </A>
       </Show>
 
-      {/* Create-harness modal, opened by the HARNESSES section + button */}
+      {/* Create-harness modal, opened by the + button next to the Harnesses nav link */}
       <AddAgentModal open={addModalOpen()} onClose={() => setAddModalOpen(false)} />
     </nav>
   );

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -141,13 +141,12 @@ const Workspace: Component = () => {
           <span class="breadcrumb">View and manage all your connected harnesses</span>
         </div>
         <div class="header-controls">
-          <div class="panel__tabs" role="tablist" aria-label="Harness list layout">
+          <div class="panel__tabs" role="group" aria-label="Harness list layout">
             <button
               type="button"
-              role="tab"
               class="panel__tab"
               classList={{ 'panel__tab--active': view() === 'grid' }}
-              aria-selected={view() === 'grid'}
+              aria-pressed={view() === 'grid'}
               aria-label="Grid view"
               title="Grid view"
               onClick={() => switchView('grid')}
@@ -164,10 +163,9 @@ const Workspace: Component = () => {
             </button>
             <button
               type="button"
-              role="tab"
               class="panel__tab"
               classList={{ 'panel__tab--active': view() === 'table' }}
-              aria-selected={view() === 'table'}
+              aria-pressed={view() === 'table'}
               aria-label="Table view"
               title="Table view"
               onClick={() => switchView('table')}
@@ -206,23 +204,56 @@ const Workspace: Component = () => {
       <Show
         when={!data.loading}
         fallback={
-          <div class="agents-grid">
-            <For each={[1, 2, 3, 4, 5, 6]}>
-              {() => (
-                <div class="agent-card agent-card--skeleton">
-                  <div class="skeleton skeleton--text" style="width: 60%; height: 20px;" />
-                  <div style="display: flex; gap: 16px; margin-top: 12px;">
-                    <div class="skeleton skeleton--text" style="width: 30%; height: 14px;" />
-                    <div class="skeleton skeleton--text" style="width: 30%; height: 14px;" />
+          <Show
+            when={view() === 'grid'}
+            fallback={
+              <div class="panel" style="padding: 0;">
+                <table class="data-table" style="width: 100%;">
+                  <tbody>
+                    <For each={[1, 2, 3, 4, 5]}>
+                      {() => (
+                        <tr>
+                          <td>
+                            <div class="skeleton skeleton--text" style="width: 40%;" />
+                          </td>
+                          <td>
+                            <div class="skeleton skeleton--text" style="width: 60%;" />
+                          </td>
+                          <td>
+                            <div class="skeleton skeleton--text" style="width: 60%;" />
+                          </td>
+                          <td>
+                            <div class="skeleton skeleton--text" style="width: 50%;" />
+                          </td>
+                          <td>
+                            <div class="skeleton skeleton--text" style="width: 70%;" />
+                          </td>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+            }
+          >
+            <div class="agents-grid">
+              <For each={[1, 2, 3, 4, 5, 6]}>
+                {() => (
+                  <div class="agent-card agent-card--skeleton">
+                    <div class="skeleton skeleton--text" style="width: 60%; height: 20px;" />
+                    <div style="display: flex; gap: 16px; margin-top: 12px;">
+                      <div class="skeleton skeleton--text" style="width: 30%; height: 14px;" />
+                      <div class="skeleton skeleton--text" style="width: 30%; height: 14px;" />
+                    </div>
+                    <div
+                      class="skeleton skeleton--rect"
+                      style="width: 100%; height: 50px; margin-top: 12px;"
+                    />
                   </div>
-                  <div
-                    class="skeleton skeleton--rect"
-                    style="width: 100%; height: 50px; margin-top: 12px;"
-                  />
-                </div>
-              )}
-            </For>
-          </div>
+                )}
+              </For>
+            </div>
+          </Show>
         }
       >
         <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -103,6 +103,23 @@ const Workspace: Component = () => {
     }
   });
   const [duplicateSource, setDuplicateSource] = createSignal<string | null>(null);
+  // Shared by the grid card menu and the table row menu so both views stay in sync.
+  const harnessActionItems = (agentName: string) => [
+    {
+      label: 'Duplicate',
+      icon: <DuplicateIcon />,
+      onClick: () => setDuplicateSource(agentName),
+    },
+    {
+      label: 'Delete',
+      danger: true,
+      icon: <DeleteIcon />,
+      onClick: () => {
+        setDeleteTarget(agentName);
+        setDeleteConfirmName('');
+      },
+    },
+  ];
   const [deleteTarget, setDeleteTarget] = createSignal<string | null>(null);
   const [deleteConfirmName, setDeleteConfirmName] = createSignal('');
   const [deleting, setDeleting] = createSignal(false);
@@ -209,6 +226,16 @@ const Workspace: Component = () => {
             fallback={
               <div class="panel" style="padding: 0;">
                 <table class="data-table" style="width: 100%;">
+                  <thead>
+                    <tr>
+                      <th>Harness</th>
+                      <th>Requests</th>
+                      <th>Tokens</th>
+                      <th>Cost</th>
+                      <th>Last active</th>
+                      <th aria-label="Actions" />
+                    </tr>
+                  </thead>
                   <tbody>
                     <For each={[1, 2, 3, 4, 5]}>
                       {() => (
@@ -227,6 +254,12 @@ const Workspace: Component = () => {
                           </td>
                           <td>
                             <div class="skeleton skeleton--text" style="width: 70%;" />
+                          </td>
+                          <td class="workspace-table__actions">
+                            <div
+                              class="skeleton"
+                              style="width: 20px; height: 20px; margin-left: auto;"
+                            />
                           </td>
                         </tr>
                       )}
@@ -307,34 +340,20 @@ const Workspace: Component = () => {
                                     alt=""
                                     width="16"
                                     height="16"
+                                    class="workspace-table__icon"
                                   />
                                 </Show>
                                 {agent.display_name ?? agent.agent_name}
                               </A>
                             </td>
-                            <td>{agent.message_count}</td>
+                            <td>{formatNumber(agent.message_count)}</td>
                             <td>{formatNumber(agent.total_tokens)}</td>
                             <td>{formatCost(agent.total_cost) ?? '—'}</td>
                             <td>{agent.last_active ? formatTime(agent.last_active) : '—'}</td>
                             <td class="workspace-table__actions">
                               <ActionMenu
                                 ariaLabel={`Actions for ${agent.agent_name}`}
-                                items={[
-                                  {
-                                    label: 'Duplicate',
-                                    icon: <DuplicateIcon />,
-                                    onClick: () => setDuplicateSource(agent.agent_name),
-                                  },
-                                  {
-                                    label: 'Delete',
-                                    danger: true,
-                                    icon: <DeleteIcon />,
-                                    onClick: () => {
-                                      setDeleteTarget(agent.agent_name);
-                                      setDeleteConfirmName('');
-                                    },
-                                  },
-                                ]}
+                                items={harnessActionItems(agent.agent_name)}
                               />
                             </td>
                           </tr>
@@ -376,7 +395,9 @@ const Workspace: Component = () => {
                           </div>
                           <div class="agent-card__stat">
                             <span class="agent-card__stat-label">Requests</span>
-                            <span class="agent-card__stat-value">{agent.message_count}</span>
+                            <span class="agent-card__stat-value">
+                              {formatNumber(agent.message_count)}
+                            </span>
                           </div>
                         </div>
                         <div class="agent-card__chart">
@@ -386,22 +407,7 @@ const Workspace: Component = () => {
                       <ActionMenu
                         class="agent-card__menu"
                         ariaLabel={`Actions for ${agent.agent_name}`}
-                        items={[
-                          {
-                            label: 'Duplicate',
-                            icon: <DuplicateIcon />,
-                            onClick: () => setDuplicateSource(agent.agent_name),
-                          },
-                          {
-                            label: 'Delete',
-                            danger: true,
-                            icon: <DeleteIcon />,
-                            onClick: () => {
-                              setDeleteTarget(agent.agent_name);
-                              setDeleteConfirmName('');
-                            },
-                          },
-                        ]}
+                        items={harnessActionItems(agent.agent_name)}
                       />
                     </div>
                   )}

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -7,7 +7,7 @@ import AddAgentModal from '../components/AddAgentModal.jsx';
 import DuplicateAgentModal from '../components/DuplicateAgentModal.jsx';
 import { getAgents, deleteAgent } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
-import { formatNumber } from '../services/formatters.js';
+import { formatCost, formatNumber, formatTime } from '../services/formatters.js';
 import Sparkline from '../components/Sparkline.jsx';
 import { agentPing, analyticsPing } from '../services/sse.js';
 import { platformIcon } from 'manifest-shared';
@@ -63,12 +63,32 @@ const DeleteIcon: Component = () => (
   </svg>
 );
 
+type HarnessView = 'grid' | 'table';
+const VIEW_STORAGE_KEY = 'manifest_harness_view';
+
+function readStoredView(): HarnessView {
+  try {
+    return localStorage.getItem(VIEW_STORAGE_KEY) === 'table' ? 'table' : 'grid';
+  } catch {
+    return 'grid';
+  }
+}
+
 const Workspace: Component = () => {
   const [data, { refetch }] = createResource(
     () => ({ _agentPing: agentPing(), _analyticsPing: analyticsPing() }),
     () => getAgents() as Promise<AgentsData>,
   );
   const [modalOpen, setModalOpen] = createSignal(false);
+  const [view, setView] = createSignal<HarnessView>(readStoredView());
+  const switchView = (next: HarnessView) => {
+    setView(next);
+    try {
+      localStorage.setItem(VIEW_STORAGE_KEY, next);
+    } catch {
+      /* storage unavailable */
+    }
+  };
   // Deep-link support: visiting /harnesses?add=true auto-opens the connect modal so
   // onboarding surfaces can route a user straight into creating an agent. We
   // clear the param so a refresh or back-navigation doesn't re-trigger it.
@@ -120,23 +140,67 @@ const Workspace: Component = () => {
           <h1>My Harnesses</h1>
           <span class="breadcrumb">View and manage all your connected harnesses</span>
         </div>
-        <button class="btn btn--primary btn--sm" onClick={() => setModalOpen(true)}>
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-          Connect Harness
-        </button>
+        <div class="header-controls">
+          <div class="panel__tabs" role="tablist" aria-label="Harness list layout">
+            <button
+              type="button"
+              role="tab"
+              class="panel__tab"
+              classList={{ 'panel__tab--active': view() === 'grid' }}
+              aria-selected={view() === 'grid'}
+              aria-label="Grid view"
+              title="Grid view"
+              onClick={() => switchView('grid')}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M4 4h7v7H4zm9 0h7v7h-7zM4 13h7v7H4zm9 0h7v7h-7z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              class="panel__tab"
+              classList={{ 'panel__tab--active': view() === 'table' }}
+              aria-selected={view() === 'table'}
+              aria-label="Table view"
+              title="Table view"
+              onClick={() => switchView('table')}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M4 5h16v3H4zm0 5.5h16v3H4zM4 16h16v3H4z" />
+              </svg>
+            </button>
+          </div>
+          <button class="btn btn--primary btn--sm" onClick={() => setModalOpen(true)}>
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            Connect Harness
+          </button>
+        </div>
       </div>
 
       <Show
@@ -180,68 +244,139 @@ const Workspace: Component = () => {
               </div>
             }
           >
-            <div class="agents-grid">
-              <For each={data()!.agents}>
-                {(agent) => (
-                  <div class="agent-card-wrap">
-                    <A
-                      href={`/harnesses/${encodeURIComponent(agent.agent_name)}`}
-                      class="agent-card"
-                    >
-                      <div class="agent-card__top">
-                        <Show when={platformIcon(agent.agent_platform, agent.agent_category)}>
-                          <img
-                            src={platformIcon(agent.agent_platform, agent.agent_category)}
-                            alt=""
-                            width="18"
-                            height="18"
-                            class="agent-card__platform-icon"
-                          />
-                        </Show>
-                        <span class="agent-card__name">
-                          {agent.display_name ?? agent.agent_name}
-                        </span>
-                      </div>
-                      <div class="agent-card__stats">
-                        <div class="agent-card__stat">
-                          <span class="agent-card__stat-label">Tokens</span>
-                          <span class="agent-card__stat-value">
-                            {formatNumber(agent.total_tokens)}
+            <Show
+              when={view() === 'grid'}
+              fallback={
+                <div class="panel" style="padding: 0; overflow-x: auto;">
+                  <table class="data-table" style="width: 100%;">
+                    <thead>
+                      <tr>
+                        <th>Harness</th>
+                        <th>Requests</th>
+                        <th>Tokens</th>
+                        <th>Cost</th>
+                        <th>Last active</th>
+                        <th aria-label="Actions" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={data()!.agents}>
+                        {(agent) => (
+                          <tr>
+                            <td>
+                              <A
+                                href={`/harnesses/${encodeURIComponent(agent.agent_name)}`}
+                                class="workspace-table__name"
+                              >
+                                <Show
+                                  when={platformIcon(agent.agent_platform, agent.agent_category)}
+                                >
+                                  <img
+                                    src={platformIcon(agent.agent_platform, agent.agent_category)}
+                                    alt=""
+                                    width="16"
+                                    height="16"
+                                  />
+                                </Show>
+                                {agent.display_name ?? agent.agent_name}
+                              </A>
+                            </td>
+                            <td>{agent.message_count}</td>
+                            <td>{formatNumber(agent.total_tokens)}</td>
+                            <td>{formatCost(agent.total_cost) ?? '—'}</td>
+                            <td>{agent.last_active ? formatTime(agent.last_active) : '—'}</td>
+                            <td class="workspace-table__actions">
+                              <ActionMenu
+                                ariaLabel={`Actions for ${agent.agent_name}`}
+                                items={[
+                                  {
+                                    label: 'Duplicate',
+                                    icon: <DuplicateIcon />,
+                                    onClick: () => setDuplicateSource(agent.agent_name),
+                                  },
+                                  {
+                                    label: 'Delete',
+                                    danger: true,
+                                    icon: <DeleteIcon />,
+                                    onClick: () => {
+                                      setDeleteTarget(agent.agent_name);
+                                      setDeleteConfirmName('');
+                                    },
+                                  },
+                                ]}
+                              />
+                            </td>
+                          </tr>
+                        )}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+              }
+            >
+              <div class="agents-grid">
+                <For each={data()!.agents}>
+                  {(agent) => (
+                    <div class="agent-card-wrap">
+                      <A
+                        href={`/harnesses/${encodeURIComponent(agent.agent_name)}`}
+                        class="agent-card"
+                      >
+                        <div class="agent-card__top">
+                          <Show when={platformIcon(agent.agent_platform, agent.agent_category)}>
+                            <img
+                              src={platformIcon(agent.agent_platform, agent.agent_category)}
+                              alt=""
+                              width="18"
+                              height="18"
+                              class="agent-card__platform-icon"
+                            />
+                          </Show>
+                          <span class="agent-card__name">
+                            {agent.display_name ?? agent.agent_name}
                           </span>
                         </div>
-                        <div class="agent-card__stat">
-                          <span class="agent-card__stat-label">Requests</span>
-                          <span class="agent-card__stat-value">{agent.message_count}</span>
+                        <div class="agent-card__stats">
+                          <div class="agent-card__stat">
+                            <span class="agent-card__stat-label">Tokens</span>
+                            <span class="agent-card__stat-value">
+                              {formatNumber(agent.total_tokens)}
+                            </span>
+                          </div>
+                          <div class="agent-card__stat">
+                            <span class="agent-card__stat-label">Requests</span>
+                            <span class="agent-card__stat-value">{agent.message_count}</span>
+                          </div>
                         </div>
-                      </div>
-                      <div class="agent-card__chart">
-                        <Sparkline data={agent.sparkline} width={280} height={50} />
-                      </div>
-                    </A>
-                    <ActionMenu
-                      class="agent-card__menu"
-                      ariaLabel={`Actions for ${agent.agent_name}`}
-                      items={[
-                        {
-                          label: 'Duplicate',
-                          icon: <DuplicateIcon />,
-                          onClick: () => setDuplicateSource(agent.agent_name),
-                        },
-                        {
-                          label: 'Delete',
-                          danger: true,
-                          icon: <DeleteIcon />,
-                          onClick: () => {
-                            setDeleteTarget(agent.agent_name);
-                            setDeleteConfirmName('');
+                        <div class="agent-card__chart">
+                          <Sparkline data={agent.sparkline} width={280} height={50} />
+                        </div>
+                      </A>
+                      <ActionMenu
+                        class="agent-card__menu"
+                        ariaLabel={`Actions for ${agent.agent_name}`}
+                        items={[
+                          {
+                            label: 'Duplicate',
+                            icon: <DuplicateIcon />,
+                            onClick: () => setDuplicateSource(agent.agent_name),
                           },
-                        },
-                      ]}
-                    />
-                  </div>
-                )}
-              </For>
-            </div>
+                          {
+                            label: 'Delete',
+                            danger: true,
+                            icon: <DeleteIcon />,
+                            onClick: () => {
+                              setDeleteTarget(agent.agent_name);
+                              setDeleteConfirmName('');
+                            },
+                          },
+                        ]}
+                      />
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
           </Show>
         </Show>
       </Show>

--- a/packages/frontend/src/services/formatters.ts
+++ b/packages/frontend/src/services/formatters.ts
@@ -21,7 +21,7 @@ export function formatNumber(n: number): string {
  */
 export function formatCost(n: number): string | null {
   n = Number(n);
-  if (n < 0) return null;
+  if (!Number.isFinite(n) || n < 0) return null;
   if (n > 0 && n < 0.01) return '< $0.01';
   return `$${n.toFixed(2)}`;
 }
@@ -53,6 +53,7 @@ export function formatTrend(pct: number): string {
 export function formatTime(ts: string): string {
   const normalized = ts.replace(' ', 'T');
   const d = new Date(normalized.endsWith('Z') ? normalized : normalized + 'Z');
+  if (Number.isNaN(d.getTime())) return '—';
   const date = d.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -855,3 +855,21 @@
 .dark .overview__platform-icon[src*='other'] {
   filter: invert(1);
 }
+
+/* ── Harness table view (Workspace) ─────────────────── */
+.workspace-table__name {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  color: hsl(var(--foreground));
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.workspace-table__name:hover {
+  text-decoration: underline;
+}
+
+.workspace-table__actions {
+  text-align: right;
+}

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -873,3 +873,15 @@
 .workspace-table__actions {
   text-align: right;
 }
+
+.workspace-table__icon {
+  flex-shrink: 0;
+}
+
+.dark .workspace-table__icon[src*='openai'],
+.dark .workspace-table__icon[src*='anthropic'],
+.dark .workspace-table__icon[src*='vercel'],
+.dark .workspace-table__icon[src*='opencode'],
+.dark .workspace-table__icon[src*='other'] {
+  filter: invert(1);
+}

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -816,9 +816,7 @@ h6 {
   letter-spacing: 0.05em;
 }
 
-/* Base styling shared by global nav links and harness switcher items. */
-.sidebar__link,
-.sidebar__agent-item {
+.sidebar__link {
   display: flex;
   align-items: center;
   gap: var(--gap-xs);
@@ -831,8 +829,7 @@ h6 {
   transition: all var(--transition-fast);
 }
 
-.sidebar__link:hover,
-.sidebar__agent-item:hover {
+.sidebar__link:hover {
   background: hsl(var(--sidebar-accent));
   color: hsl(var(--sidebar-accent-foreground));
 }
@@ -843,49 +840,15 @@ h6 {
   font-weight: 500;
 }
 
-/* HARNESSES section header — a row holding the collapse toggle and + button. */
-.sidebar__section-header {
+/* Nav row pairing a link with the create button (Harnesses). */
+.sidebar__link-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin: var(--gap-md) 0.5rem 1px;
-  border-radius: var(--radius);
-  transition: background var(--transition-fast);
 }
 
-.sidebar__section-header:hover {
-  background: hsl(var(--sidebar-accent));
-}
-
-/* Collapse toggle: carries the uppercased section label styling so it reads as
-   a section heading, with the caret icon trailing the text. */
-.sidebar__section-caret {
-  display: flex;
-  align-items: center;
-  gap: 4px;
+.sidebar__link-row .sidebar__link {
   flex: 1;
   min-width: 0;
-  padding: 6px var(--gap-md);
-  background: none;
-  border: none;
-  border-radius: var(--radius);
-  font-size: var(--font-size-xs);
-  font-weight: 500;
-  color: hsl(var(--muted-foreground));
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  text-align: left;
-  cursor: pointer;
-  transition: background var(--transition-fast);
-}
-
-.sidebar__section-caret:focus-visible {
-  background: hsl(var(--sidebar-accent));
-  color: hsl(var(--sidebar-foreground));
-}
-
-.sidebar__section-header:hover .sidebar__section-caret {
-  color: hsl(var(--sidebar-foreground));
 }
 
 .sidebar__section-add {
@@ -898,7 +861,7 @@ h6 {
   border: none;
   border-radius: var(--radius-sm);
   padding: 0;
-  margin-right: 2px;
+  margin-right: var(--gap-md);
   color: hsl(var(--muted-foreground));
   cursor: pointer;
   transition:
@@ -910,42 +873,6 @@ h6 {
 .sidebar__section-add:focus-visible {
   color: hsl(var(--sidebar-foreground));
   background: hsl(var(--border));
-}
-
-/* Harness list items reuse the shared link base (above); these are the only
-   harness-specific overrides — a wider icon gap and a bolder label. */
-.sidebar__agents-list {
-  padding: 0;
-}
-
-.sidebar__agent-item {
-  gap: 8px;
-  font-weight: 500;
-}
-
-.sidebar__agent-item--active {
-  background: hsl(var(--sidebar-accent));
-  color: hsl(var(--sidebar-primary));
-  font-weight: 600;
-}
-
-.sidebar__agent-icon {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-
-.sidebar__agent-item-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.sidebar__agents-empty {
-  padding: 6px var(--gap-lg);
-  margin: 1px 0.5rem;
-  font-size: var(--font-size-sm);
-  color: hsl(var(--muted-foreground));
 }
 
 .sidebar__spacer {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -296,11 +296,12 @@ describe("Sidebar — create-harness modal", () => {
     expect(mockAddModal).toHaveBeenCalledWith(true);
   });
 
-  it("clicking + does not navigate away from the current page", async () => {
-    const { container } = render(() => <Sidebar />);
+  it("clicking + opens the modal without triggering navigation", async () => {
+    const onNavigate = vi.fn();
+    const { container } = render(() => <Sidebar onNavigate={onNavigate} />);
     const addBtn = container.querySelector(".sidebar__section-add") as HTMLButtonElement;
     await fireEvent.click(addBtn);
-    expect(container.querySelector('a.sidebar__link[href="/harnesses"]')).not.toBeNull();
+    expect(onNavigate).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -27,13 +27,6 @@ vi.mock("@solidjs/router", () => ({
   useLocation: () => ({ get pathname() { return mockPathname; } }),
 }));
 
-// getAgents returns the harness list rendered in the in-nav switcher. Each test
-// can override the resolved value via mockGetAgents.
-const mockGetAgents = vi.fn();
-vi.mock("../../src/services/api.js", () => ({
-  getAgents: (...args: unknown[]) => mockGetAgents(...args),
-}));
-
 const mockGetBillingStatus = vi.fn();
 vi.mock("../../src/services/api/billing.js", () => ({
   getBillingStatus: (...args: unknown[]) => mockGetBillingStatus(...args),
@@ -79,29 +72,12 @@ vi.mock("../../src/components/AddAgentModal.jsx", async () => {
 });
 
 import Sidebar from "../../src/components/Sidebar";
-import { refreshAgents } from "../../src/services/sse";
-
-const SAMPLE_AGENTS = [
-  {
-    agent_name: "alpha",
-    display_name: "Alpha Harness",
-    agent_platform: "openclaw",
-    agent_category: "personal",
-  },
-  {
-    // No display_name → falls back to agent_name. No platform → no icon.
-    agent_name: "beta",
-    agent_platform: null,
-    agent_category: null,
-  },
-];
 
 beforeEach(() => {
   sessionStorage.clear();
   vi.clearAllMocks();
   mockPathname = "/overview";
   mockIsSelfHosted = true;
-  mockGetAgents.mockResolvedValue({ agents: SAMPLE_AGENTS });
   mockGetBillingStatus.mockResolvedValue({
     enabled: false,
     plan: "free",

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -138,9 +138,12 @@ describe("Sidebar — global nav links", () => {
     expect(container.textContent).not.toContain("Local");
   });
 
-  it("renders the HARNESSES section label", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("HARNESSES")).toBeDefined();
+  it("renders the Harnesses nav link under Requests", () => {
+    const { container } = render(() => <Sidebar />);
+    const links = Array.from(container.querySelectorAll("a.sidebar__link")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(links.indexOf("/harnesses")).toBe(links.indexOf("/messages") + 1);
   });
 
   it("renders the TOOLS section with Playground link", () => {
@@ -168,7 +171,7 @@ describe("Sidebar — global nav links", () => {
     expect(container.querySelector('a[href="/playground"]')).not.toBeNull();
   });
 
-  it("keeps exactly the expected sidebar__link set (no static Harnesses link)", async () => {
+  it("keeps exactly the expected sidebar__link set", async () => {
     const { container } = render(() => <Sidebar />);
     await waitFor(() =>
       expect(container.querySelector('a[href="/providers/local"]')).not.toBeNull(),
@@ -179,14 +182,12 @@ describe("Sidebar — global nav links", () => {
     expect(links).toEqual([
       "/overview",
       "/messages",
+      "/harnesses",
       "/providers/local",
       "/providers/usage-based",
       "/providers/subscriptions",
       "/playground",
     ]);
-    // The collapsible section replaces the old static link — there is no
-    // sidebar__link pointing at /harnesses anymore.
-    expect(container.querySelector('a.sidebar__link[href="/harnesses"]')).toBeNull();
   });
 });
 
@@ -242,187 +243,28 @@ describe("Sidebar — global nav active state", () => {
   });
 });
 
-describe("Sidebar — harness switcher list", () => {
-  it("renders one harness item per agent", async () => {
+describe("Sidebar — harnesses nav link", () => {
+  it("renders Harnesses as a nav link to /harnesses with the create button beside it", () => {
     const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(2);
-    });
-    expect(mockGetAgents).toHaveBeenCalledWith();
+    const row = container.querySelector(".sidebar__link-row");
+    expect(row).not.toBeNull();
+    const link = row!.querySelector('a.sidebar__link[href="/harnesses"]');
+    expect(link?.textContent).toBe("Harnesses");
+    expect(row!.querySelector("button.sidebar__section-add")).not.toBeNull();
   });
 
-  it("links each item to /harnesses/:name and shows the display name", async () => {
+  it("marks the link active on /harnesses and its subpages", () => {
+    mockPathname = "/harnesses/alpha/routing";
     const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector('a[href="/harnesses/alpha"]')).not.toBeNull();
-    });
-    const alpha = container.querySelector('a[href="/harnesses/alpha"]');
-    expect(alpha?.textContent).toContain("Alpha Harness");
+    const link = container.querySelector('a.sidebar__link[href="/harnesses"]');
+    expect(link?.classList.contains("active")).toBe(true);
+    expect(link?.getAttribute("aria-current")).toBe("page");
   });
 
-  it("URL-encodes harness names with special characters in the item href", async () => {
-    mockGetAgents.mockResolvedValueOnce({ agents: [{ agent_name: "a/b c", display_name: "A B" }] });
+  it("does not render the old per-agent switcher", () => {
     const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector("a.sidebar__agent-item")).not.toBeNull();
-    });
-    const item = container.querySelector("a.sidebar__agent-item");
-    expect(item?.getAttribute("href")).toBe("/harnesses/a%2Fb%20c");
-  });
-
-  it("falls back to agent_name when display_name is missing", async () => {
-    const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector('a[href="/harnesses/beta"]')).not.toBeNull();
-    });
-    const beta = container.querySelector('a[href="/harnesses/beta"]');
-    expect(beta?.textContent).toContain("beta");
-  });
-
-  it("renders a platform icon for agents that have one and omits it otherwise", async () => {
-    const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(2);
-    });
-    const alpha = container.querySelector('a[href="/harnesses/alpha"]');
-    const beta = container.querySelector('a[href="/harnesses/beta"]');
-    // alpha has a known platform → icon present; beta has no platform → no icon.
-    expect(alpha?.querySelector("img.sidebar__agent-icon")).not.toBeNull();
-    expect(beta?.querySelector("img.sidebar__agent-icon")).toBeNull();
-  });
-
-  it("marks the current /harnesses/:name route active", async () => {
-    mockPathname = "/harnesses/alpha";
-    const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector('a[href="/harnesses/alpha"]')).not.toBeNull();
-    });
-    const alpha = container.querySelector('a[href="/harnesses/alpha"]');
-    const beta = container.querySelector('a[href="/harnesses/beta"]');
-    expect(alpha?.getAttribute("aria-current")).toBe("page");
-    expect(alpha?.classList.contains("sidebar__agent-item--active")).toBe(true);
-    expect(beta?.getAttribute("aria-current")).not.toBe("page");
-  });
-
-  it("excludes Playground agents by calling getAgents() with the default (no includePlayground)", async () => {
-    render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(mockGetAgents).toHaveBeenCalled();
-    });
-    // Default invocation = playground agents excluded (getAgents(false)).
-    expect(mockGetAgents).toHaveBeenCalledWith();
-  });
-
-  it("resolves a bare array response (no { agents } wrapper)", async () => {
-    mockGetAgents.mockResolvedValue(SAMPLE_AGENTS);
-    const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(2);
-    });
-  });
-
-  it("refetches when a harness is created locally", async () => {
-    mockGetAgents.mockResolvedValueOnce({ agents: [] }).mockResolvedValueOnce({
-      agents: [{ agent_name: "new-harness", display_name: "New Harness" }],
-    });
-    const { container } = render(() => <Sidebar />);
-
-    await waitFor(() => {
-      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
-    });
-
-    refreshAgents();
-
-    await waitFor(() => {
-      expect(container.querySelector('a[href="/harnesses/new-harness"]')).not.toBeNull();
-    });
-    expect(mockGetAgents).toHaveBeenCalledTimes(2);
-  });
-
-  it("renders the empty state only once the resource resolves empty (not while loading)", async () => {
-    // Hold the resource in its loading state with a promise we resolve manually.
-    let resolveAgents!: (v: unknown) => void;
-    mockGetAgents.mockReturnValue(
-      new Promise((res) => {
-        resolveAgents = res;
-      }),
-    );
-    const { container } = render(() => <Sidebar />);
-    // The section is expanded, but while loading the empty state must NOT flash.
-    expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
-    expect(container.querySelector(".sidebar__agents-empty")).toBeNull();
-
-    // Resolve to an empty list → empty state appears now that loading is done.
-    resolveAgents({ agents: [] });
-    await waitFor(() => {
-      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
-    });
-    expect(container.querySelector(".sidebar__agents-empty")?.textContent).toContain(
-      "No harnesses yet",
-    );
-    expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(0);
-  });
-
-  it("falls back to an empty list (and empty state) when getAgents rejects", async () => {
-    mockGetAgents.mockRejectedValue(new Error("boom"));
-    const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
-    });
-  });
-
-  it("falls back to an empty list when getAgents resolves to null", async () => {
-    mockGetAgents.mockResolvedValue(null);
-    const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
-    });
-    expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(0);
-  });
-});
-
-describe("Sidebar — collapse toggle", () => {
-  it("the collapse toggle is a real button labelled HARNESSES with aria-expanded", async () => {
-    const { container } = render(() => <Sidebar />);
-    const caret = container.querySelector(".sidebar__section-caret");
-    // Keyboard-operable: it is a <button> (native keyboard semantics), not a div.
-    expect(caret?.tagName).toBe("BUTTON");
-    expect((caret as HTMLButtonElement).type).toBe("button");
-    expect(caret?.textContent).toContain("HARNESSES");
-    expect(caret?.getAttribute("aria-expanded")).toBe("true");
-  });
-
-  it("hides the harness list when the toggle is clicked, and re-shows on toggle back", async () => {
-    const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
-    });
-
-    const caret = container.querySelector(".sidebar__section-caret") as HTMLButtonElement;
-    expect(caret.getAttribute("aria-expanded")).toBe("true");
-
-    await fireEvent.click(caret);
     expect(container.querySelector(".sidebar__agents-list")).toBeNull();
-    expect(caret.getAttribute("aria-expanded")).toBe("false");
-
-    await fireEvent.click(caret);
-    expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
-    expect(caret.getAttribute("aria-expanded")).toBe("true");
-  });
-
-  it("the section toggle and the + create button are sibling buttons (not nested)", () => {
-    const { container } = render(() => <Sidebar />);
-    const caret = container.querySelector(".sidebar__section-caret");
-    const add = container.querySelector(".sidebar__section-add");
-    expect(caret?.tagName).toBe("BUTTON");
-    expect(add?.tagName).toBe("BUTTON");
-    // A button must never contain another button.
-    expect(caret?.querySelector("button")).toBeNull();
-    expect(add?.querySelector("button")).toBeNull();
-    // They share the same parent — true siblings.
-    expect(add?.parentElement).toBe(caret?.parentElement);
-    // No interactive <div> remains for the section header.
-    expect(container.querySelector("div.sidebar__section-label--interactive")).toBeNull();
+    expect(container.querySelector(".sidebar__section-caret")).toBeNull();
   });
 });
 
@@ -454,15 +296,11 @@ describe("Sidebar — create-harness modal", () => {
     expect(mockAddModal).toHaveBeenCalledWith(true);
   });
 
-  it("clicking + does not also toggle the section collapse", async () => {
+  it("clicking + does not navigate away from the current page", async () => {
     const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
-    });
     const addBtn = container.querySelector(".sidebar__section-add") as HTMLButtonElement;
     await fireEvent.click(addBtn);
-    // List stays visible — the + click stopped propagation to the label toggle.
-    expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
+    expect(container.querySelector('a.sidebar__link[href="/harnesses"]')).not.toBeNull();
   });
 });
 
@@ -493,13 +331,10 @@ describe("Sidebar — structure and interaction", () => {
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onNavigate when a harness item is clicked", async () => {
+  it("calls onNavigate when the Harnesses link is clicked", async () => {
     const onNavigate = vi.fn();
     const { container } = render(() => <Sidebar onNavigate={onNavigate} />);
-    await waitFor(() => {
-      expect(container.querySelector('a[href="/harnesses/alpha"]')).not.toBeNull();
-    });
-    const item = container.querySelector('a[href="/harnesses/alpha"]') as HTMLAnchorElement;
+    const item = container.querySelector('a.sidebar__link[href="/harnesses"]') as HTMLAnchorElement;
     item.addEventListener("click", (event) => event.preventDefault(), { once: true });
     await fireEvent.click(item);
     expect(onNavigate).toHaveBeenCalled();
@@ -558,7 +393,8 @@ describe("Sidebar — usage card", () => {
   it("hides the usage card when the billing fetch fails (fail-soft fallback)", async () => {
     mockGetBillingStatus.mockRejectedValue(new Error("boom"));
     const { container } = render(() => <Sidebar />);
-    await waitFor(() => expect(container.querySelector(".sidebar__agents-list")).not.toBeNull());
+    await waitFor(() => expect(mockGetBillingStatus).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(container.querySelector(".sidebar-usage")).toBeNull();
   });
 

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -75,7 +75,12 @@ vi.mock('../../src/services/toast-store.js', () => ({
 
 vi.mock('../../src/services/formatters.js', () => ({
   formatNumber: (v: number) => String(v),
-  formatCost: (v: number) => (Number.isFinite(v) ? `$${v.toFixed(2)}` : null),
+  // Mirrors the real formatCost contract: Number() coercion, null for
+  // negative or non-finite input (so null coerces to 0 and renders $0.00).
+  formatCost: (v: number) => {
+    const n = Number(v);
+    return Number.isFinite(n) && n >= 0 ? `$${n.toFixed(2)}` : null;
+  },
   formatTime: (ts: string) => ts,
 }));
 
@@ -862,12 +867,13 @@ describe('Workspace — view toggle', () => {
 
   it('renders em dashes for missing cost and last_active in the table view', async () => {
     localStorage.setItem('manifest_harness_view', 'table');
+    // total_cost omitted: Number(undefined) is NaN, which the real formatCost
+    // maps to null, firing the em-dash fallback (null would render $0.00).
     mockGetAgents.mockResolvedValue({
       agents: [
         {
           agent_name: 'idle-agent',
           message_count: 0,
-          total_cost: null,
           total_tokens: 0,
           last_active: null,
           sparkline: [],

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@solidjs/testing-library';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
 
 const mockNavigate = vi.fn();
 let mockSearchParams: Record<string, string | undefined> = {};
@@ -76,6 +76,7 @@ vi.mock('../../src/services/toast-store.js', () => ({
 vi.mock('../../src/services/formatters.js', () => ({
   formatNumber: (v: number) => String(v),
   formatCost: (v: number) => `$${v.toFixed(2)}`,
+  formatTime: (ts: string) => ts,
 }));
 
 vi.mock('../../src/components/Sparkline.jsx', () => ({
@@ -160,6 +161,7 @@ import Workspace from '../../src/pages/Workspace';
 describe('Workspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockSearchParams = {};
     mockGetAgents.mockResolvedValue({
       agents: [
@@ -734,5 +736,42 @@ describe('Workspace', () => {
       fireEvent.keyDown(overlay, { key: 'Escape' });
       expect(container.textContent).not.toContain('Delete demo-agent');
     });
+  });
+});
+
+describe('Workspace — view toggle', () => {
+  it('defaults to the grid view with the toggle visible', async () => {
+    const { container } = render(() => <Workspace />);
+    await waitFor(() => expect(container.querySelector('.agents-grid')).not.toBeNull());
+    const tabs = container.querySelectorAll('.panel__tabs .panel__tab');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0].classList.contains('panel__tab--active')).toBe(true);
+    expect(container.querySelector('table.data-table')).toBeNull();
+  });
+
+  it('switches to the table view with one row per harness and persists the choice', async () => {
+    const { container } = render(() => <Workspace />);
+    await waitFor(() => expect(container.querySelector('.agents-grid')).not.toBeNull());
+    fireEvent.click(screen.getByLabelText('Table view'));
+
+    const table = container.querySelector('table.data-table');
+    expect(table).not.toBeNull();
+    const row = table!.querySelector('tbody tr')!;
+    expect(row.textContent).toContain('Demo Agent');
+    expect(row.textContent).toContain('42');
+    expect(row.textContent).toContain('15000');
+    expect(row.textContent).toContain('$5.50');
+    expect(row.querySelector('a[href="/harnesses/demo-agent"]')).not.toBeNull();
+    expect(container.querySelector('.agents-grid')).toBeNull();
+    expect(localStorage.getItem('manifest_harness_view')).toBe('table');
+  });
+
+  it('restores the persisted table view on mount and can switch back', async () => {
+    localStorage.setItem('manifest_harness_view', 'table');
+    const { container } = render(() => <Workspace />);
+    await waitFor(() => expect(container.querySelector('table.data-table')).not.toBeNull());
+    fireEvent.click(screen.getByLabelText('Grid view'));
+    expect(container.querySelector('.agents-grid')).not.toBeNull();
+    expect(localStorage.getItem('manifest_harness_view')).toBe('grid');
   });
 });

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -75,7 +75,7 @@ vi.mock('../../src/services/toast-store.js', () => ({
 
 vi.mock('../../src/services/formatters.js', () => ({
   formatNumber: (v: number) => String(v),
-  formatCost: (v: number) => `$${v.toFixed(2)}`,
+  formatCost: (v: number) => (Number.isFinite(v) ? `$${v.toFixed(2)}` : null),
   formatTime: (ts: string) => ts,
 }));
 
@@ -749,6 +749,8 @@ describe('Workspace — view toggle', () => {
         {
           agent_name: 'demo-agent',
           display_name: 'Demo Agent',
+          agent_platform: 'openclaw',
+          agent_category: 'personal',
           message_count: 42,
           last_active: '2024-01-01',
           total_cost: 5.5,
@@ -781,6 +783,8 @@ describe('Workspace — view toggle', () => {
     expect(row.textContent).toContain('15000');
     expect(row.textContent).toContain('$5.50');
     expect(row.querySelector('a[href="/harnesses/demo-agent"]')).not.toBeNull();
+    // The platform icon carries the class the dark-mode invert rules target.
+    expect(row.querySelector('img.workspace-table__icon')).not.toBeNull();
     expect(container.querySelector('.agents-grid')).toBeNull();
     expect(localStorage.getItem('manifest_harness_view')).toBe('table');
   });
@@ -792,5 +796,119 @@ describe('Workspace — view toggle', () => {
     fireEvent.click(screen.getByLabelText('Grid view'));
     expect(container.querySelector('.agents-grid')).not.toBeNull();
     expect(localStorage.getItem('manifest_harness_view')).toBe('grid');
+  });
+
+  it('falls back to grid view when localStorage.getItem throws', async () => {
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => {
+          throw new Error('blocked');
+        },
+        setItem: () => {},
+      },
+      configurable: true,
+    });
+    try {
+      const { container } = render(() => <Workspace />);
+      await waitFor(() => expect(container.textContent).toContain('Demo Agent'));
+      expect(container.querySelector('.agents-grid')).not.toBeNull();
+    } finally {
+      if (original) Object.defineProperty(window, 'localStorage', original);
+    }
+  });
+
+  it('still switches to table view when localStorage.setItem throws', async () => {
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('quota');
+        },
+      },
+      configurable: true,
+    });
+    try {
+      const { container } = render(() => <Workspace />);
+      await waitFor(() => expect(container.textContent).toContain('Demo Agent'));
+      fireEvent.click(screen.getByLabelText('Table view'));
+      expect(container.querySelector('table.data-table')).not.toBeNull();
+    } finally {
+      if (original) Object.defineProperty(window, 'localStorage', original);
+    }
+  });
+
+  it('shows the table skeleton with the real header while loading in table view', async () => {
+    localStorage.setItem('manifest_harness_view', 'table');
+    let resolveAgents!: (v: unknown) => void;
+    mockGetAgents.mockReturnValue(
+      new Promise((res) => {
+        resolveAgents = res;
+      }),
+    );
+    const { container } = render(() => <Workspace />);
+    const table = container.querySelector('table.data-table');
+    expect(table).not.toBeNull();
+    expect(table!.querySelector('thead')?.textContent).toContain('Harness');
+    // Skeleton rows mirror the loaded table: 6 cells including the actions column.
+    const firstRow = table!.querySelector('tbody tr')!;
+    expect(firstRow.querySelectorAll('td')).toHaveLength(6);
+    expect(firstRow.querySelector('.skeleton')).not.toBeNull();
+    expect(container.querySelector('.agents-grid')).toBeNull();
+    resolveAgents({ agents: [] });
+    await waitFor(() => expect(container.textContent).toContain('No harnesses yet'));
+  });
+
+  it('renders em dashes for missing cost and last_active in the table view', async () => {
+    localStorage.setItem('manifest_harness_view', 'table');
+    mockGetAgents.mockResolvedValue({
+      agents: [
+        {
+          agent_name: 'idle-agent',
+          message_count: 0,
+          total_cost: null,
+          total_tokens: 0,
+          last_active: null,
+          sparkline: [],
+        },
+      ],
+    });
+    const { container } = render(() => <Workspace />);
+    await waitFor(() =>
+      expect(container.querySelector('table.data-table tbody tr')).not.toBeNull(),
+    );
+    const cells = Array.from(
+      container.querySelectorAll('table.data-table tbody tr td'),
+      (td) => td.textContent,
+    );
+    // Cost and Last active both fall back to an em dash.
+    expect(cells[3]).toBe('—');
+    expect(cells[4]).toBe('—');
+  });
+
+  it('drives Duplicate and Delete from the table row action menu', async () => {
+    localStorage.setItem('manifest_harness_view', 'table');
+    const { container } = render(() => <Workspace />);
+    await waitFor(() =>
+      expect(
+        container.querySelector('.workspace-table__actions .action-menu__trigger'),
+      ).not.toBeNull(),
+    );
+    const trigger = container.querySelector(
+      '.workspace-table__actions .action-menu__trigger',
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-label')).toBe('Actions for demo-agent');
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByText('Duplicate'));
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="duplicate-modal"]')).not.toBeNull(),
+    );
+    fireEvent.click(screen.getByTestId('duplicate-modal-close'));
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByText('Delete'));
+    await waitFor(() => expect(container.textContent).toContain('Delete demo-agent'));
   });
 });

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -76,10 +76,13 @@ vi.mock('../../src/services/toast-store.js', () => ({
 vi.mock('../../src/services/formatters.js', () => ({
   formatNumber: (v: number) => String(v),
   // Mirrors the real formatCost contract: Number() coercion, null for
-  // negative or non-finite input (so null coerces to 0 and renders $0.00).
+  // negative or non-finite input (so null coerces to 0 and renders $0.00),
+  // and the sub-cent floor for costs between 0 and $0.01.
   formatCost: (v: number) => {
     const n = Number(v);
-    return Number.isFinite(n) && n >= 0 ? `$${n.toFixed(2)}` : null;
+    if (!Number.isFinite(n) || n < 0) return null;
+    if (n > 0 && n < 0.01) return '< $0.01';
+    return `$${n.toFixed(2)}`;
   },
   formatTime: (ts: string) => ts,
 }));

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -740,9 +740,28 @@ describe('Workspace', () => {
 });
 
 describe('Workspace — view toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockSearchParams = {};
+    mockGetAgents.mockResolvedValue({
+      agents: [
+        {
+          agent_name: 'demo-agent',
+          display_name: 'Demo Agent',
+          message_count: 42,
+          last_active: '2024-01-01',
+          total_cost: 5.5,
+          total_tokens: 15000,
+          sparkline: [1, 2, 3],
+        },
+      ],
+    });
+  });
+
   it('defaults to the grid view with the toggle visible', async () => {
     const { container } = render(() => <Workspace />);
-    await waitFor(() => expect(container.querySelector('.agents-grid')).not.toBeNull());
+    await waitFor(() => expect(container.textContent).toContain('Demo Agent'));
     const tabs = container.querySelectorAll('.panel__tabs .panel__tab');
     expect(tabs).toHaveLength(2);
     expect(tabs[0].classList.contains('panel__tab--active')).toBe(true);
@@ -751,7 +770,7 @@ describe('Workspace — view toggle', () => {
 
   it('switches to the table view with one row per harness and persists the choice', async () => {
     const { container } = render(() => <Workspace />);
-    await waitFor(() => expect(container.querySelector('.agents-grid')).not.toBeNull());
+    await waitFor(() => expect(container.textContent).toContain('Demo Agent'));
     fireEvent.click(screen.getByLabelText('Table view'));
 
     const table = container.querySelector('table.data-table');

--- a/packages/frontend/tests/services/formatters.test.ts
+++ b/packages/frontend/tests/services/formatters.test.ts
@@ -42,6 +42,12 @@ describe('formatCost', () => {
     expect(formatCost(-0.01)).toBeNull();
     expect(formatCost(-9909)).toBeNull();
   });
+  it('returns null for non-finite input instead of "$NaN"', () => {
+    expect(formatCost(NaN)).toBeNull();
+    expect(formatCost(undefined as unknown as number)).toBeNull();
+    expect(formatCost(null as unknown as number)).toBe('$0.00');
+    expect(formatCost(Infinity)).toBeNull();
+  });
   it("returns '< $0.01' for sub-cent positive costs", () => {
     expect(formatCost(0.002836)).toBe('< $0.01');
     expect(formatCost(0.009)).toBe('< $0.01');
@@ -183,6 +189,15 @@ describe('formatTime', () => {
   it('handles space-separated timestamp', () => {
     const result = formatTime('2024-01-15 09:22:41');
     expect(result).toMatch(/\w+ \d+, \d{2}:\d{2}:\d{2}/);
+  });
+  it('renders an em dash for an unparseable timestamp', () => {
+    // The agents endpoint can fall back to Date.toString() output for
+    // never-active harnesses; formatTime must not render "Invalid Date".
+    expect(formatTime('Mon Sep 01 2026 14:03:12 GMT+0200 (Central European Summer Time)')).toBe(
+      '—',
+    );
+    expect(formatTime('')).toBe('—');
+    expect(formatTime('not-a-date')).toBe('—');
   });
 });
 


### PR DESCRIPTION
✨ What changed
- The sidebar no longer lists every harness: Harnesses is a plain nav entry under Requests, with the + kept for one-click create
- The workspace page gains a grid or table view toggle, remembered per browser
- The table shows requests, tokens, cost, last activity, and the usual row actions

💭 Why
A long harness list crowded the sidebar and pushed the bottom cards out of view; the workspace page is the right home for browsing harnesses.

👤 For users
The sidebar stays short whatever the fleet size, and the harness list can be browsed as cards or as a table.

🔧 For operators
No operator impact.

🧪 How to test
1. The sidebar shows Overview, Requests, Harnesses; the + opens the create modal
2. Harnesses opens the workspace page; the two buttons top right switch between cards and table
3. Reload: the chosen view sticks

Stacked on #2810; it retargets once the chain merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the sidebar's per-harness list with a single Harnesses nav entry, so the sidebar stays short regardless of fleet size. Harness browsing moves to the workspace page, which now offers a grid or table view that's remembered per browser.

- The sidebar shows Harnesses under Requests; the + button still opens the create modal.
- The table view shows requests, tokens, cost, last activity, and row actions; the grid view is unchanged.
- Missing cost and last activity fall back to em dashes instead of Invalid Date or $NaN.
- View preference persists per browser via `localStorage`.
- Loading skeletons match the selected view, so table mode never flashes card placeholders.

<sup>Written for commit fd512a064b9c8933d140a871c60201722f0db0f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

