### PR TITLE
fix: keep routing model picker fast with large catalogs

### DIFF
--- a/.changeset/routing-picker-perf.md
+++ b/.changeset/routing-picker-perf.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+The routing model picker now window-renders long catalogs so scrolling stays in place instead of lagging or jumping back to the top.

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -2,6 +2,7 @@ import {
   createMemo,
   createSignal,
   For,
+  onCleanup,
   onMount,
   Show,
   startTransition,
@@ -30,13 +31,16 @@ import ModelCapabilityBadges, {
 } from './ModelCapabilityBadges.js';
 import VirtualList from './VirtualList.js';
 
+const PICKER_NARROW_QUERY = '(max-width: 640px)';
 const PICKER_GROUP_HEADER_HEIGHT = 32;
 const PICKER_MODEL_ROW_HEIGHT = 40;
+/** Stacked label + four cells + gaps + padding in the ≤640px layout. */
+const PICKER_MODEL_ROW_HEIGHT_NARROW = 160;
 
 type ModalModel = { value: string; label: string; pricing: AvailableModel };
 type PickerItem =
-  | { kind: 'header'; key: string; provId: string; name: string }
-  | { kind: 'model'; key: string; provId: string; name: string; model: ModalModel };
+  | { kind: 'header'; provId: string; name: string }
+  | { kind: 'model'; provId: string; name: string; model: ModalModel };
 
 interface Props {
   tierId: string;
@@ -136,11 +140,20 @@ const ModelPickerModal: Component<Props> = (props) => {
     props.requiredCapability ? new Set([props.requiredCapability]) : new Set(),
   );
   const [refreshingProvId, setRefreshingProvId] = createSignal<string | null>(null);
+  const [isNarrow, setIsNarrow] = createSignal(false);
   // Parent callbacks refetch resources read inside this modal's Suspense
   // boundary. Keep the current picker visible until those resources settle.
   const notifyProviderRefreshed = () => startTransition(() => props.onProviderRefreshed?.());
 
   onMount(() => {
+    if (typeof window.matchMedia === 'function') {
+      const media = window.matchMedia(PICKER_NARROW_QUERY);
+      const sync = () => setIsNarrow(media.matches);
+      sync();
+      media.addEventListener('change', sync);
+      onCleanup(() => media.removeEventListener('change', sync));
+    }
+
     const agentName = props.agentName;
     if (!agentName) return;
     const now = new Date();
@@ -328,14 +341,12 @@ const ModelPickerModal: Component<Props> = (props) => {
     for (const group of groupedModels()) {
       items.push({
         kind: 'header',
-        key: `h:${group.provId}`,
         provId: group.provId,
         name: group.name,
       });
       for (const model of group.models) {
         items.push({
           kind: 'model',
-          key: `m:${group.provId}:${model.value}`,
           provId: group.provId,
           name: group.name,
           model,
@@ -346,7 +357,14 @@ const ModelPickerModal: Component<Props> = (props) => {
   });
 
   const pickerItemHeight = (item: PickerItem) =>
-    item.kind === 'header' ? PICKER_GROUP_HEADER_HEIGHT : PICKER_MODEL_ROW_HEIGHT;
+    item.kind === 'header'
+      ? PICKER_GROUP_HEADER_HEIGHT
+      : isNarrow()
+        ? PICKER_MODEL_ROW_HEIGHT_NARROW
+        : PICKER_MODEL_ROW_HEIGHT;
+
+  const pickerResetKey = () =>
+    `${activeTab()}\0${search()}\0${showFreeOnly()}\0${[...requiredCapabilities()].sort().join(',')}`;
 
   /** Returns the role of a model in the current tier: "Primary", "Fallback 1", etc. or null */
   const modelRole = (
@@ -655,6 +673,7 @@ const ModelPickerModal: Component<Props> = (props) => {
             class="routing-modal__list"
             items={pickerItems()}
             itemHeight={pickerItemHeight}
+            resetKey={pickerResetKey()}
           >
             {(item) =>
               item.kind === 'header' ? (

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -1,4 +1,12 @@
-import { createSignal, For, onMount, Show, startTransition, type Component } from 'solid-js';
+import {
+  createMemo,
+  createSignal,
+  For,
+  onMount,
+  Show,
+  startTransition,
+  type Component,
+} from 'solid-js';
 import {
   refreshModels,
   refreshProviderModels,
@@ -20,6 +28,15 @@ import ModelCapabilityBadges, {
   CAPABILITY_LABELS,
   ModelModalityBadges,
 } from './ModelCapabilityBadges.js';
+import VirtualList from './VirtualList.js';
+
+const PICKER_GROUP_HEADER_HEIGHT = 32;
+const PICKER_MODEL_ROW_HEIGHT = 40;
+
+type ModalModel = { value: string; label: string; pricing: AvailableModel };
+type PickerItem =
+  | { kind: 'header'; key: string; provId: string; name: string }
+  | { kind: 'model'; key: string; provId: string; name: string; model: ModalModel };
 
 interface Props {
   tierId: string;
@@ -215,7 +232,7 @@ const ModelPickerModal: Component<Props> = (props) => {
     return ids;
   };
 
-  const groupedModels = () => {
+  const groupedModels = createMemo(() => {
     const q = search().toLowerCase().trim();
     const labels = providerLabelMap();
     const providerIds = providerIdSet();
@@ -223,7 +240,6 @@ const ModelPickerModal: Component<Props> = (props) => {
     const tab = activeTab();
     const hasConnectedProviders = (props.connectedProviders ?? []).length > 0;
 
-    type ModalModel = { value: string; label: string; pricing: AvailableModel };
     const groupMap = new Map<string, { provId: string; name: string; models: ModalModel[] }>();
 
     const freeOnly = tab === 'api_key' && showFreeOnly();
@@ -305,7 +321,32 @@ const ModelPickerModal: Component<Props> = (props) => {
     }
     groups.sort((a, b) => a.name.localeCompare(b.name));
     return groups;
-  };
+  });
+
+  const pickerItems = createMemo((): PickerItem[] => {
+    const items: PickerItem[] = [];
+    for (const group of groupedModels()) {
+      items.push({
+        kind: 'header',
+        key: `h:${group.provId}`,
+        provId: group.provId,
+        name: group.name,
+      });
+      for (const model of group.models) {
+        items.push({
+          kind: 'model',
+          key: `m:${group.provId}:${model.value}`,
+          provId: group.provId,
+          name: group.name,
+          model,
+        });
+      }
+    }
+    return items;
+  });
+
+  const pickerItemHeight = (item: PickerItem) =>
+    item.kind === 'header' ? PICKER_GROUP_HEADER_HEIGHT : PICKER_MODEL_ROW_HEIGHT;
 
   /** Returns the role of a model in the current tier: "Primary", "Fallback 1", etc. or null */
   const modelRole = (
@@ -575,56 +616,85 @@ const ModelPickerModal: Component<Props> = (props) => {
           </div>
         </div>
 
-        <div class="routing-modal__list">
-          <Show when={groupedModels().length > 0}>
-            <div class="routing-modal__table-head" aria-hidden="true">
-              <span>Model</span>
-              <span>Capabilities</span>
-              <span>Input</span>
-              <span>Output</span>
-              <span>Price</span>
+        <Show when={groupedModels().length > 0}>
+          <div class="routing-modal__table-head" aria-hidden="true">
+            <span>Model</span>
+            <span>Capabilities</span>
+            <span>Input</span>
+            <span>Output</span>
+            <span>Price</span>
+          </div>
+        </Show>
+        <Show
+          when={pickerItems().length > 0}
+          fallback={
+            <div class="routing-modal__list">
+              <div class="routing-modal__empty">
+                {search().trim()
+                  ? 'No models match your search.'
+                  : showFreeOnly()
+                    ? 'No free models available from your connected providers.'
+                    : isSub()
+                      ? 'No subscription providers connected. Connect a provider to see models.'
+                      : isLocal()
+                        ? 'No local providers connected. Connect a local provider to see models.'
+                        : 'No API key providers connected. Connect a provider to see models.'}
+                <Show when={!search().trim() && !showFreeOnly() && props.onConnectProviders}>
+                  <button
+                    class="btn btn--primary btn--sm"
+                    onClick={() => props.onConnectProviders?.()}
+                  >
+                    Connect provider
+                  </button>
+                </Show>
+              </div>
             </div>
-          </Show>
-          <For each={groupedModels()}>
-            {(group) => (
-              <div class="routing-modal__group">
+          }
+        >
+          <VirtualList
+            class="routing-modal__list"
+            items={pickerItems()}
+            itemHeight={pickerItemHeight}
+          >
+            {(item) =>
+              item.kind === 'header' ? (
                 <div class="routing-modal__group-header">
                   <span class="routing-modal__group-icon">
-                    {group.provId.startsWith('custom:')
+                    {item.provId.startsWith('custom:')
                       ? (() => {
                           const cp = (props.customProviders ?? []).find(
-                            (c) => `custom:${c.id}` === group.provId,
+                            (c) => `custom:${c.id}` === item.provId,
                           );
                           return (
-                            customProviderLogo(group.name, 16, cp?.base_url) ?? (
+                            customProviderLogo(item.name, 16, cp?.base_url) ?? (
                               <span
                                 class="provider-card__logo-letter"
                                 style={{
-                                  background: customProviderColor(group.name),
+                                  background: customProviderColor(item.name),
                                   width: '16px',
                                   height: '16px',
                                   'font-size': '9px',
                                   'border-radius': '50%',
                                 }}
                               >
-                                {group.name.charAt(0).toUpperCase()}
+                                {item.name.charAt(0).toUpperCase()}
                               </span>
                             )
                           );
                         })()
-                      : providerIcon(group.provId, 16)}
+                      : providerIcon(item.provId, 16)}
                   </span>
-                  <span class="routing-modal__group-name">{group.name}</span>
-                  <Show when={props.agentName && !group.provId.startsWith('custom:')}>
+                  <span class="routing-modal__group-name">{item.name}</span>
+                  <Show when={props.agentName && !item.provId.startsWith('custom:')}>
                     <button
                       class="routing-modal__group-refresh"
                       disabled={refreshingProvId() !== null}
                       onClick={(e) => {
                         e.stopPropagation();
-                        void handleRefreshGroup(group.provId, group.name);
+                        void handleRefreshGroup(item.provId, item.name);
                       }}
-                      aria-label={`Refresh ${group.name} models`}
-                      title={`Refresh ${group.name} models`}
+                      aria-label={`Refresh ${item.name} models`}
+                      title={`Refresh ${item.name} models`}
                     >
                       <svg
                         width="12"
@@ -638,7 +708,7 @@ const ModelPickerModal: Component<Props> = (props) => {
                         aria-hidden="true"
                         classList={{
                           'routing-modal__group-refresh-icon--spinning':
-                            refreshingProvId() === group.provId,
+                            refreshingProvId() === item.provId,
                         }}
                       >
                         <path d="M21 12a9 9 0 1 1-3-6.7L21 8" />
@@ -647,116 +717,95 @@ const ModelPickerModal: Component<Props> = (props) => {
                     </button>
                   </Show>
                 </div>
-                <For each={group.models}>
-                  {(model) => {
-                    const disabledReason = () => missingRequiredCapability(model.pricing);
-                    const disabled = () => disabledReason() !== null;
-                    return (
-                      <button
-                        class="routing-modal__model"
-                        classList={{ 'routing-modal__model--disabled': disabled() }}
-                        disabled={disabled()}
-                        title={disabledReason() ?? undefined}
-                        onClick={() =>
-                          props.onSelect(props.tierId, model.value, group.provId, activeTab())
-                        }
-                      >
-                        <span class="routing-modal__model-left">
-                          <span class="routing-modal__model-label">
-                            {model.label}
-                            <Show when={modelRole(model.value, group.provId, activeTab())}>
-                              {(role) => <span class="routing-modal__role-tag">{role()}</span>}
-                            </Show>
-                          </span>
+              ) : (
+                (() => {
+                  const model = item.model;
+                  const disabledReason = () => missingRequiredCapability(model.pricing);
+                  const disabled = () => disabledReason() !== null;
+                  return (
+                    <button
+                      class="routing-modal__model"
+                      classList={{ 'routing-modal__model--disabled': disabled() }}
+                      disabled={disabled()}
+                      title={disabledReason() ?? undefined}
+                      onClick={() =>
+                        props.onSelect(props.tierId, model.value, item.provId, activeTab())
+                      }
+                    >
+                      <span class="routing-modal__model-left">
+                        <span class="routing-modal__model-label">
+                          {model.label}
+                          <Show when={modelRole(model.value, item.provId, activeTab())}>
+                            {(role) => <span class="routing-modal__role-tag">{role()}</span>}
+                          </Show>
                         </span>
-                        <span class="routing-modal__model-cell">
-                          <span class="routing-modal__model-cell-label">Capabilities</span>
-                          <Show
-                            when={actionCapabilitiesFor(model.pricing).length > 0}
-                            fallback={
-                              <span
-                                class="model-capability-badges model-capability-badges--compact"
-                                aria-label="No stream or tools"
-                              />
-                            }
-                          >
-                            <ModelCapabilityBadges
-                              capabilities={actionCapabilitiesFor(model.pricing)}
-                              compact
-                              iconOnly
+                      </span>
+                      <span class="routing-modal__model-cell">
+                        <span class="routing-modal__model-cell-label">Capabilities</span>
+                        <Show
+                          when={actionCapabilitiesFor(model.pricing).length > 0}
+                          fallback={
+                            <span
+                              class="model-capability-badges model-capability-badges--compact"
+                              aria-label="No stream or tools"
                             />
-                          </Show>
-                        </span>
-                        <span class="routing-modal__model-cell">
-                          <span class="routing-modal__model-cell-label">Input</span>
-                          <ModelModalityBadges
-                            modalities={inputModalitiesFor(model.pricing)}
-                            direction="input"
+                          }
+                        >
+                          <ModelCapabilityBadges
+                            capabilities={actionCapabilitiesFor(model.pricing)}
                             compact
                             iconOnly
                           />
-                        </span>
-                        <span class="routing-modal__model-cell">
-                          <span class="routing-modal__model-cell-label">Output</span>
-                          <ModelModalityBadges
-                            modalities={outputModalitiesFor(model.pricing)}
-                            direction="output"
-                            compact
-                            iconOnly
-                          />
-                        </span>
-                        <span class="routing-modal__model-cell routing-modal__model-cell--price">
-                          <span class="routing-modal__model-cell-label">Price</span>
-                          <Show
-                            when={isPaid()}
-                            fallback={
+                        </Show>
+                      </span>
+                      <span class="routing-modal__model-cell">
+                        <span class="routing-modal__model-cell-label">Input</span>
+                        <ModelModalityBadges
+                          modalities={inputModalitiesFor(model.pricing)}
+                          direction="input"
+                          compact
+                          iconOnly
+                        />
+                      </span>
+                      <span class="routing-modal__model-cell">
+                        <span class="routing-modal__model-cell-label">Output</span>
+                        <ModelModalityBadges
+                          modalities={outputModalitiesFor(model.pricing)}
+                          direction="output"
+                          compact
+                          iconOnly
+                        />
+                      </span>
+                      <span class="routing-modal__model-cell routing-modal__model-cell--price">
+                        <span class="routing-modal__model-cell-label">Price</span>
+                        <Show
+                          when={isPaid()}
+                          fallback={
+                            <span class="routing-modal__model-price">
+                              {isLocal()
+                                ? 'Runs on your machine'
+                                : (formatPerRequestCost(model.pricing.cost_per_request) ??
+                                  'Included in subscription')}
+                            </span>
+                          }
+                        >
+                          <Show when={model.pricing}>
+                            {(p) => (
                               <span class="routing-modal__model-price">
-                                {isLocal()
-                                  ? 'Runs on your machine'
-                                  : (formatPerRequestCost(model.pricing.cost_per_request) ??
-                                    'Included in subscription')}
+                                {pricePerM(p().input_price_per_token)} in ·{' '}
+                                {pricePerM(p().output_price_per_token)} out
                               </span>
-                            }
-                          >
-                            <Show when={model.pricing}>
-                              {(p) => (
-                                <span class="routing-modal__model-price">
-                                  {pricePerM(p().input_price_per_token)} in ·{' '}
-                                  {pricePerM(p().output_price_per_token)} out
-                                </span>
-                              )}
-                            </Show>
+                            )}
                           </Show>
-                        </span>
-                      </button>
-                    );
-                  }}
-                </For>
-              </div>
-            )}
-          </For>
-          <Show when={groupedModels().length === 0}>
-            <div class="routing-modal__empty">
-              {search().trim()
-                ? 'No models match your search.'
-                : showFreeOnly()
-                  ? 'No free models available from your connected providers.'
-                  : isSub()
-                    ? 'No subscription providers connected. Connect a provider to see models.'
-                    : isLocal()
-                      ? 'No local providers connected. Connect a local provider to see models.'
-                      : 'No API key providers connected. Connect a provider to see models.'}
-              <Show when={!search().trim() && !showFreeOnly() && props.onConnectProviders}>
-                <button
-                  class="btn btn--primary btn--sm"
-                  onClick={() => props.onConnectProviders?.()}
-                >
-                  Connect provider
-                </button>
-              </Show>
-            </div>
-          </Show>
-        </div>
+                        </Show>
+                      </span>
+                    </button>
+                  );
+                })()
+              )
+            }
+          </VirtualList>
+        </Show>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/VirtualList.tsx
+++ b/packages/frontend/src/components/VirtualList.tsx
@@ -12,6 +12,7 @@ import {
 /** Used until the scroller has a real layout height, so the first paint is windowed. */
 export const VIRTUAL_LIST_DEFAULT_VIEWPORT = 480;
 const DEFAULT_OVERSCAN = 8;
+const RESET_UNSET = Symbol('virtual-list-reset-unset');
 
 export interface VirtualListProps<T> {
   items: readonly T[];
@@ -48,9 +49,9 @@ const VirtualList = <T,>(props: VirtualListProps<T>): JSX.Element => {
 
   createEffect((previous: unknown) => {
     const key = props.resetKey;
-    if (previous !== undefined && key !== previous) applyScrollTop(0);
+    if (previous !== RESET_UNSET && key !== previous) applyScrollTop(0);
     return key;
-  });
+  }, RESET_UNSET);
 
   const layout = createMemo(() => {
     const items = props.items;

--- a/packages/frontend/src/components/VirtualList.tsx
+++ b/packages/frontend/src/components/VirtualList.tsx
@@ -1,4 +1,13 @@
-import { createMemo, createSignal, For, onCleanup, onMount, type JSX } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  untrack,
+  type JSX,
+} from 'solid-js';
 
 /** Used until the scroller has a real layout height, so the first paint is windowed. */
 export const VIRTUAL_LIST_DEFAULT_VIEWPORT = 480;
@@ -9,6 +18,8 @@ export interface VirtualListProps<T> {
   itemHeight: (item: T, index: number) => number;
   overscan?: number;
   class?: string;
+  /** When this value changes, the scroller returns to the top. */
+  resetKey?: unknown;
   children: (item: T, index: number) => JSX.Element;
 }
 
@@ -16,6 +27,11 @@ const VirtualList = <T,>(props: VirtualListProps<T>): JSX.Element => {
   const [scrollTop, setScrollTop] = createSignal(0);
   const [viewport, setViewport] = createSignal(VIRTUAL_LIST_DEFAULT_VIEWPORT);
   let scroller: HTMLDivElement | undefined;
+
+  const applyScrollTop = (next: number) => {
+    setScrollTop(next);
+    if (scroller) scroller.scrollTop = next;
+  };
 
   const measure = () => {
     const height = scroller?.clientHeight ?? 0;
@@ -30,6 +46,12 @@ const VirtualList = <T,>(props: VirtualListProps<T>): JSX.Element => {
     onCleanup(() => observer.disconnect());
   });
 
+  createEffect((previous: unknown) => {
+    const key = props.resetKey;
+    if (previous !== undefined && key !== previous) applyScrollTop(0);
+    return key;
+  });
+
   const layout = createMemo(() => {
     const items = props.items;
     const heights = items.map((item, index) => props.itemHeight(item, index));
@@ -40,6 +62,11 @@ const VirtualList = <T,>(props: VirtualListProps<T>): JSX.Element => {
       acc += heights[i]!;
     }
     return { heights, offsets, total: acc };
+  });
+
+  createEffect(() => {
+    const max = Math.max(0, layout().total - viewport());
+    if (untrack(scrollTop) > max) applyScrollTop(max);
   });
 
   const visible = createMemo(() => {

--- a/packages/frontend/src/components/VirtualList.tsx
+++ b/packages/frontend/src/components/VirtualList.tsx
@@ -1,0 +1,102 @@
+import { createMemo, createSignal, For, onCleanup, onMount, type JSX } from 'solid-js';
+
+/** Used until the scroller has a real layout height, so the first paint is windowed. */
+export const VIRTUAL_LIST_DEFAULT_VIEWPORT = 480;
+const DEFAULT_OVERSCAN = 8;
+
+export interface VirtualListProps<T> {
+  items: readonly T[];
+  itemHeight: (item: T, index: number) => number;
+  overscan?: number;
+  class?: string;
+  children: (item: T, index: number) => JSX.Element;
+}
+
+const VirtualList = <T,>(props: VirtualListProps<T>): JSX.Element => {
+  const [scrollTop, setScrollTop] = createSignal(0);
+  const [viewport, setViewport] = createSignal(VIRTUAL_LIST_DEFAULT_VIEWPORT);
+  let scroller: HTMLDivElement | undefined;
+
+  const measure = () => {
+    const height = scroller?.clientHeight ?? 0;
+    if (height > 0) setViewport(height);
+  };
+
+  onMount(() => {
+    measure();
+    if (!scroller || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(scroller);
+    onCleanup(() => observer.disconnect());
+  });
+
+  const layout = createMemo(() => {
+    const items = props.items;
+    const heights = items.map((item, index) => props.itemHeight(item, index));
+    const offsets = new Array<number>(items.length);
+    let acc = 0;
+    for (let i = 0; i < items.length; i++) {
+      offsets[i] = acc;
+      acc += heights[i]!;
+    }
+    return { heights, offsets, total: acc };
+  });
+
+  const visible = createMemo(() => {
+    const items = props.items;
+    const { heights, offsets, total } = layout();
+    const overscan = props.overscan ?? DEFAULT_OVERSCAN;
+    const top = scrollTop();
+    const bottom = top + viewport();
+
+    let lo = 0;
+    let hi = items.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (offsets[mid]! + heights[mid]! <= top) lo = mid + 1;
+      else hi = mid - 1;
+    }
+    const start = Math.max(0, lo - overscan);
+
+    lo = start;
+    hi = items.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (offsets[mid]! < bottom) lo = mid + 1;
+      else hi = mid - 1;
+    }
+    const end = Math.min(items.length, lo + overscan);
+    const slice: T[] = [];
+    for (let i = start; i < end; i++) slice.push(items[i]!);
+    const last = end - 1;
+    return {
+      start,
+      slice,
+      padTop: offsets[start] ?? 0,
+      padBottom: total - (last < 0 ? 0 : (offsets[last] ?? 0) + (heights[last] ?? 0)),
+    };
+  });
+
+  return (
+    <div
+      class={props.class}
+      ref={(el) => {
+        scroller = el;
+      }}
+      onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+    >
+      <div
+        style={{
+          'padding-top': `${visible().padTop}px`,
+          'padding-bottom': `${visible().padBottom}px`,
+        }}
+      >
+        <For each={visible().slice}>
+          {(item, index) => props.children(item, visible().start + index())}
+        </For>
+      </div>
+    </div>
+  );
+};
+
+export default VirtualList;

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -167,6 +167,12 @@
   padding: 0;
   margin-top: 12px;
   border-top: 1px solid hsl(var(--border));
+  overscroll-behavior: contain;
+}
+
+.routing-modal__table-head + .routing-modal__list {
+  margin-top: 0;
+  border-top: none;
 }
 
 .routing-modal__table-head {
@@ -174,7 +180,10 @@
   grid-template-columns: var(--routing-modal-model-grid);
   align-items: center;
   gap: 12px;
+  flex-shrink: 0;
+  margin-top: 12px;
   padding: 8px 24px 8px 48px;
+  border-top: 1px solid hsl(var(--border));
   border-bottom: 1px solid hsl(var(--border));
   color: hsl(var(--muted-foreground));
   font-size: var(--font-size-xs);
@@ -206,11 +215,10 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 24px 6px;
-  position: sticky;
-  top: 0;
+  box-sizing: border-box;
+  height: 32px;
+  padding: 0 24px;
   background: hsl(var(--card));
-  z-index: 1;
 }
 
 .routing-modal__group-icon {
@@ -273,8 +281,10 @@
   grid-template-columns: var(--routing-modal-model-grid);
   align-items: center;
   gap: 12px;
+  box-sizing: border-box;
   width: 100%;
-  padding: 9px 24px 9px 48px;
+  height: 40px;
+  padding: 0 24px 0 48px;
   background: none;
   border: none;
   border-top: 1px solid hsl(var(--border) / 0.5);

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -501,6 +501,7 @@
     grid-template-columns: minmax(0, 1fr);
     align-items: start;
     gap: 8px;
+    height: 160px;
     padding: 10px 16px 10px 48px;
   }
 

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -185,12 +185,15 @@
   padding: 8px 24px 8px 48px;
   border-top: 1px solid hsl(var(--border));
   border-bottom: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
   color: hsl(var(--muted-foreground));
   font-size: var(--font-size-xs);
   font-weight: 600;
   line-height: 1;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  position: relative;
+  z-index: 2;
 }
 
 .routing-modal__table-head > span:not(:first-child) {

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -501,8 +501,11 @@
     grid-template-columns: minmax(0, 1fr);
     align-items: start;
     gap: 8px;
-    height: 160px;
     padding: 10px 16px 10px 48px;
+  }
+
+  .routing-modal__card .routing-modal__model {
+    height: 160px;
   }
 
   .routing-modal__model-cell {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -1511,5 +1511,27 @@ describe('ModelPickerModal', () => {
       expect(container.textContent).toContain('GPT-4o 199');
       expect(container.querySelectorAll('.routing-modal__model').length).toBe(1);
     });
+
+    it('resets to the top of the filtered list after the user had scrolled', () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="simple"
+          models={manyModels}
+          tiers={tiers}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      const list = container.querySelector('.routing-modal__list') as HTMLElement;
+      Object.defineProperty(list, 'scrollTop', { configurable: true, writable: true, value: 7800 });
+      fireEvent.scroll(list);
+
+      const search = container.querySelector('.routing-modal__search') as HTMLInputElement;
+      fireEvent.input(search, { target: { value: 'GPT-4o 000' } });
+
+      expect(container.textContent).toContain('GPT-4o 000');
+      expect(container.querySelectorAll('.routing-modal__model').length).toBe(1);
+    });
   });
 });

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -1449,4 +1449,67 @@ describe('ModelPickerModal', () => {
     fireEvent.click(localTab);
     expect(localTab.getAttribute('aria-selected')).toBe('true');
   });
+
+  describe('large catalogs', () => {
+    const manyModels: AvailableModel[] = Array.from({ length: 200 }, (_, i) => ({
+      ...baseModels[0]!,
+      model_name: `gpt-4o-${i}`,
+      display_name: `GPT-4o ${String(i).padStart(3, '0')}`,
+    }));
+
+    it('does not mount every model row when the catalog is large', () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="simple"
+          models={manyModels}
+          tiers={tiers}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+
+      const rows = container.querySelectorAll('.routing-modal__model');
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.length).toBeLessThan(80);
+      expect(container.textContent).not.toContain('GPT-4o 199');
+    });
+
+    it('reveals a late model after the list is scrolled', () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="simple"
+          models={manyModels}
+          tiers={tiers}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      const list = container.querySelector('.routing-modal__list') as HTMLElement;
+      Object.defineProperty(list, 'scrollTop', { configurable: true, writable: true, value: 7800 });
+      fireEvent.scroll(list);
+
+      expect(container.textContent).toContain('GPT-4o 199');
+      expect(container.textContent).not.toContain('GPT-4o 000');
+    });
+
+    it('search still brings a late model into the window', () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="simple"
+          models={manyModels}
+          tiers={tiers}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      const search = container.querySelector('.routing-modal__search') as HTMLInputElement;
+      fireEvent.input(search, { target: { value: 'GPT-4o 199' } });
+
+      expect(container.textContent).toContain('GPT-4o 199');
+      expect(container.querySelectorAll('.routing-modal__model').length).toBe(1);
+    });
+  });
 });

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -1527,11 +1527,14 @@ describe('ModelPickerModal', () => {
       Object.defineProperty(list, 'scrollTop', { configurable: true, writable: true, value: 7800 });
       fireEvent.scroll(list);
 
+      expect(container.textContent).not.toContain('GPT-4o 000');
+
       const search = container.querySelector('.routing-modal__search') as HTMLInputElement;
-      fireEvent.input(search, { target: { value: 'GPT-4o 000' } });
+      // Matches every row, so shrink-clamp cannot explain a jump back to the top.
+      fireEvent.input(search, { target: { value: 'GPT-4o' } });
 
       expect(container.textContent).toContain('GPT-4o 000');
-      expect(container.querySelectorAll('.routing-modal__model').length).toBe(1);
+      expect(container.textContent).not.toContain('GPT-4o 199');
     });
   });
 });

--- a/packages/frontend/tests/components/VirtualList.test.tsx
+++ b/packages/frontend/tests/components/VirtualList.test.tsx
@@ -98,6 +98,7 @@ describe('VirtualList', () => {
     fireEvent.scroll(scroller);
     setItems(rows(5));
 
+    expect(scroller.scrollTop).toBe(0);
     expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="row-80"]')).toBeNull();
   });
@@ -116,6 +117,25 @@ describe('VirtualList', () => {
 
     setResetKey('filtered');
 
+    expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="row-80"]')).toBeNull();
+  });
+
+  it('resets when resetKey goes from unset to a value', () => {
+    const [resetKey, setResetKey] = createSignal<string | undefined>(undefined);
+    const { container } = render(() => (
+      <VirtualList items={rows(100)} itemHeight={() => 20} class="vl" resetKey={resetKey()}>
+        {(item) => <div data-testid={item.id}>{item.id}</div>}
+      </VirtualList>
+    ));
+    const scroller = container.querySelector('.vl') as HTMLElement;
+    Object.defineProperty(scroller, 'scrollTop', { configurable: true, writable: true, value: 1600 });
+    fireEvent.scroll(scroller);
+    expect(container.querySelector('[data-testid="row-0"]')).toBeNull();
+
+    setResetKey('now');
+
+    expect(scroller.scrollTop).toBe(0);
     expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="row-80"]')).toBeNull();
   });

--- a/packages/frontend/tests/components/VirtualList.test.tsx
+++ b/packages/frontend/tests/components/VirtualList.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import VirtualList from '../../src/components/VirtualList';
+
+const rows = (count: number) => Array.from({ length: count }, (_, i) => ({ id: `row-${i}` }));
+
+describe('VirtualList', () => {
+  it('does not mount items that sit far below the default viewport', () => {
+    const { container } = render(() => (
+      <VirtualList items={rows(100)} itemHeight={() => 20} class="vl">
+        {(item) => <div data-testid={item.id}>{item.id}</div>}
+      </VirtualList>
+    ));
+
+    expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="row-99"]')).toBeNull();
+    expect(container.querySelectorAll('[data-testid^="row-"]').length).toBeLessThan(50);
+  });
+
+  it('mounts later items after the scroller moves down', () => {
+    const { container } = render(() => (
+      <VirtualList items={rows(100)} itemHeight={() => 20} class="vl">
+        {(item) => <div data-testid={item.id}>{item.id}</div>}
+      </VirtualList>
+    ));
+    const scroller = container.querySelector('.vl') as HTMLElement;
+    Object.defineProperty(scroller, 'scrollTop', { configurable: true, value: 1600 });
+    fireEvent.scroll(scroller);
+
+    expect(container.querySelector('[data-testid="row-80"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="row-0"]')).toBeNull();
+  });
+
+  it('renders every item when the catalog fits in the viewport', () => {
+    const { container } = render(() => (
+      <VirtualList items={rows(3)} itemHeight={() => 20} class="vl">
+        {(item) => <div data-testid={item.id}>{item.id}</div>}
+      </VirtualList>
+    ));
+
+    expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="row-1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="row-2"]')).not.toBeNull();
+  });
+
+  it('renders an empty spacer when there are no items', () => {
+    const { container } = render(() => (
+      <VirtualList items={[]} itemHeight={() => 20} class="vl">
+        {(item) => <div data-testid={item.id}>{item.id}</div>}
+      </VirtualList>
+    ));
+
+    expect(container.querySelector('.vl')).not.toBeNull();
+    expect(container.querySelectorAll('[data-testid^="row-"]').length).toBe(0);
+  });
+
+  it('narrows the window after ResizeObserver reports a real scroller height', () => {
+    const callbacks: ResizeObserverCallback[] = [];
+    class FakeObserver implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback);
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    const original = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = FakeObserver as unknown as typeof ResizeObserver;
+
+    const { container, unmount } = render(() => (
+      <VirtualList items={rows(100)} itemHeight={() => 20} class="vl">
+        {(item) => <div data-testid={item.id}>{item.id}</div>}
+      </VirtualList>
+    ));
+    const scroller = container.querySelector('.vl') as HTMLElement;
+    Object.defineProperty(scroller, 'clientHeight', { configurable: true, value: 80 });
+    callbacks[0]?.([], {} as ResizeObserver);
+
+    expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="row-20"]')).toBeNull();
+    unmount();
+    globalThis.ResizeObserver = original;
+  });
+});

--- a/packages/frontend/tests/components/VirtualList.test.tsx
+++ b/packages/frontend/tests/components/VirtualList.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, fireEvent } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
 import VirtualList from '../../src/components/VirtualList';
 
 const rows = (count: number) => Array.from({ length: count }, (_, i) => ({ id: `row-${i}` }));
@@ -67,18 +68,55 @@ describe('VirtualList', () => {
     const original = globalThis.ResizeObserver;
     globalThis.ResizeObserver = FakeObserver as unknown as typeof ResizeObserver;
 
-    const { container, unmount } = render(() => (
-      <VirtualList items={rows(100)} itemHeight={() => 20} class="vl">
+    try {
+      const { container, unmount } = render(() => (
+        <VirtualList items={rows(100)} itemHeight={() => 20} class="vl">
+          {(item) => <div data-testid={item.id}>{item.id}</div>}
+        </VirtualList>
+      ));
+      const scroller = container.querySelector('.vl') as HTMLElement;
+      Object.defineProperty(scroller, 'clientHeight', { configurable: true, value: 80 });
+      callbacks[0]?.([], {} as ResizeObserver);
+
+      expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="row-20"]')).toBeNull();
+      unmount();
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
+  });
+
+  it('clamps the window when the list shrinks under the current scroll offset', () => {
+    const [items, setItems] = createSignal(rows(100));
+    const { container } = render(() => (
+      <VirtualList items={items()} itemHeight={() => 20} class="vl">
         {(item) => <div data-testid={item.id}>{item.id}</div>}
       </VirtualList>
     ));
     const scroller = container.querySelector('.vl') as HTMLElement;
-    Object.defineProperty(scroller, 'clientHeight', { configurable: true, value: 80 });
-    callbacks[0]?.([], {} as ResizeObserver);
+    Object.defineProperty(scroller, 'scrollTop', { configurable: true, writable: true, value: 1600 });
+    fireEvent.scroll(scroller);
+    setItems(rows(5));
 
     expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="row-20"]')).toBeNull();
-    unmount();
-    globalThis.ResizeObserver = original;
+    expect(container.querySelector('[data-testid="row-80"]')).toBeNull();
+  });
+
+  it('returns to the top when resetKey changes', () => {
+    const [resetKey, setResetKey] = createSignal('all');
+    const { container } = render(() => (
+      <VirtualList items={rows(100)} itemHeight={() => 20} class="vl" resetKey={resetKey()}>
+        {(item) => <div data-testid={item.id}>{item.id}</div>}
+      </VirtualList>
+    ));
+    const scroller = container.querySelector('.vl') as HTMLElement;
+    Object.defineProperty(scroller, 'scrollTop', { configurable: true, writable: true, value: 1600 });
+    fireEvent.scroll(scroller);
+    expect(container.querySelector('[data-testid="row-0"]')).toBeNull();
+
+    setResetKey('filtered');
+
+    expect(container.querySelector('[data-testid="row-0"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="row-80"]')).toBeNull();
   });
 });


### PR DESCRIPTION
### ✨ What changed
- Window the routing model picker so only visible rows mount
- Memoize grouped catalog rows so refresh does not rebuild the list
- Keep column headers outside the scroller

### 💭 Why
With a large connected catalog the picker mounted every model at once. Scrolling lagged, and a parent refresh remounted the list so the scroll position jumped back to the top.

### 👤 For users
Opening a route's model picker with hundreds of models stays responsive. Scrolling down no longer snaps back to the top.

### 📝 Notes
- Frontend tests: 4263 passed, including new VirtualList and large-catalog picker cases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The routing model picker now window-renders visible rows from large catalogs instead of mounting every model, keeping opening and scrolling responsive. It preserves scroll position across parent refreshes, resets to the top when search or filters change, keeps headers above scrolled rows, and uses stacked rows on screens ≤640px.

- Memoizes grouped items, recalculates the viewport on resize, and clamps scroll when results shrink.
- Adds coverage for virtualization, filtering, responsive sizing, list changes, and header layout.

<sup>Written for commit 54b2d35c1d3e82589f60b0a9b8c2d994a518ba10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

