### PR TITLE
fix: scrub provider secrets from upstream error logs

### DIFF
--- a/.changeset/scrub-logged-provider-errors.md
+++ b/.changeset/scrub-logged-provider-errors.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Scrub provider credentials from upstream error bodies before they are written to logs.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -3500,9 +3500,11 @@ describe('proxy-response-handler', () => {
       const { res } = mockResponse();
       const recorder = mockRecorder();
       const meta = makeMeta({ provider: 'anthropic', model: 'claude-sonnet-4' });
-      // The 200-char slice falls inside the key: scrubbing after slicing would
-      // leave its leading half in the log.
-      const straddling = `${'A'.repeat(169)} x-api-key: ${ANTHROPIC_KEY} trailing`;
+      // A 300-char key pushes the sentinel past the 200-char slice. Only
+      // scrub-then-slice collapses the key first and keeps the sentinel in the
+      // log; slice-then-scrub cuts inside the key and drops the sentinel.
+      const longKey = `sk-ant-api03-${'A'.repeat(300)}`;
+      const straddling = `${'x'.repeat(100)} ${longKey} TAIL_SENTINEL`;
       const failedFallbacks: FailedFallback[] = [
         {
           model: 'claude-3-haiku',
@@ -3527,6 +3529,7 @@ describe('proxy-response-handler', () => {
 
       const logged = loggedLines();
       expect(logged).toContain('[REDACTED]');
+      expect(logged).toContain('TAIL_SENTINEL');
       expect(logged).not.toContain('sk-ant-api03-AAAA');
     });
   });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -10,6 +10,7 @@ import { RoutingMeta } from '../proxy.service';
 import { FailedFallback } from '../proxy-fallback.service';
 import { IngestionContext } from '../../../otlp/interfaces/ingestion-context.interface';
 import { StreamUsage } from '../stream-writer';
+import { Logger } from '@nestjs/common';
 import type { AutofixRecord } from '../../autofix/autofix.types';
 
 const testCtx: IngestionContext = {
@@ -3403,6 +3404,130 @@ describe('proxy-response-handler', () => {
         'Internal Server Error',
         expect.objectContaining({ specificityCategory: 'coding' }),
       );
+    });
+  });
+  /* ── Credential scrubbing in log output ── */
+
+  describe('secret scrubbing of logged upstream error bodies', () => {
+    // Anthropic 401s echo the caller's own auth header back inside the error
+    // body. Everything we log has to go through scrubSecrets first.
+    const ANTHROPIC_KEY = 'sk-ant-api03-AAAABBBBCCCCDDDDEEEEFFFF';
+    const BEARER_TOKEN = 'sk-proj-1111222233334444555566667777';
+    const LEAKY_401_BODY = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'authentication_error',
+        message: `invalid x-api-key: ${ANTHROPIC_KEY}`,
+      },
+      request_headers: {
+        'x-api-key': ANTHROPIC_KEY,
+        authorization: `Bearer ${BEARER_TOKEN}`,
+      },
+    });
+
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    function loggedLines(): string {
+      return warnSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    }
+
+    it('scrubs credentials from the "Upstream error" log line', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta({ provider: 'anthropic', model: 'claude-sonnet-4' });
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        401,
+        LEAKY_401_BODY,
+        undefined,
+        recorder as any,
+        'trace-secret-1',
+      );
+
+      const logged = loggedLines();
+      expect(logged).toContain('Upstream error 401');
+      expect(logged).toContain('[REDACTED]');
+      expect(logged).not.toContain(ANTHROPIC_KEY);
+      expect(logged).not.toContain(BEARER_TOKEN);
+    });
+
+    it('scrubs credentials from the "Fallback chain exhausted" log line', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta({ provider: 'anthropic', model: 'claude-sonnet-4' });
+      const failedFallbacks: FailedFallback[] = [
+        {
+          model: 'claude-3-haiku',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          status: 401,
+          errorBody: LEAKY_401_BODY,
+        },
+      ];
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        401,
+        LEAKY_401_BODY,
+        failedFallbacks,
+        recorder as any,
+        'trace-secret-2',
+      );
+
+      const logged = loggedLines();
+      expect(logged).toContain('Fallback chain exhausted');
+      expect(logged).toContain('[REDACTED]');
+      expect(logged).not.toContain(ANTHROPIC_KEY);
+      expect(logged).not.toContain(BEARER_TOKEN);
+    });
+
+    it('masks a key that straddles the truncation boundary', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta({ provider: 'anthropic', model: 'claude-sonnet-4' });
+      // The 200-char slice falls inside the key: scrubbing after slicing would
+      // leave its leading half in the log.
+      const straddling = `${'A'.repeat(169)} x-api-key: ${ANTHROPIC_KEY} trailing`;
+      const failedFallbacks: FailedFallback[] = [
+        {
+          model: 'claude-3-haiku',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          status: 401,
+          errorBody: straddling,
+        },
+      ];
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        401,
+        straddling,
+        failedFallbacks,
+        recorder as any,
+        'trace-secret-3',
+      );
+
+      const logged = loggedLines();
+      expect(logged).toContain('[REDACTED]');
+      expect(logged).not.toContain('sk-ant-api03-AAAA');
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -1,4 +1,4 @@
-import { HttpException } from '@nestjs/common';
+import { HttpException, Logger } from '@nestjs/common';
 import { FREE_PLAN_REQUESTS_PER_MONTH } from 'manifest-shared';
 import { ManifestError } from '../../../common/errors/manifest-error';
 import { ProxyController } from '../proxy.controller';
@@ -1917,6 +1917,28 @@ describe('ProxyController', () => {
         source: 'provider',
       }),
     });
+  });
+
+  it('scrubs provider credentials out of the logged Responses SSE failure', async () => {
+    // A ChatGPT-family SSE failure carries the raw upstream body, which on a
+    // 401 can contain the caller's own key.
+    const key = 'sk-ant-api03-AAAABBBBCCCCDDDDEEEEFFFF';
+    const leaky = JSON.stringify({
+      error: { message: `invalid x-api-key: ${key}`, type: 'authentication_error' },
+    });
+    proxyService.proxyRequest.mockRejectedValue(new ResponsesSseError(leaky, 401, leaky));
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+
+    const logged = errorSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    errorSpy.mockRestore();
+    expect(logged).toContain('Proxy error:');
+    expect(logged).toContain('[REDACTED]');
+    expect(logged).not.toContain(key);
   });
 
   it('should forward HttpException as friendly chat message', async () => {

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -22,6 +22,7 @@ import {
   parseStructuredProviderError,
   sanitizeProviderError,
 } from './proxy-error-sanitizer';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
 import {
   collectResponsesSseResponse,
   createResponsesStreamTransformer,
@@ -302,8 +303,11 @@ export async function handleProviderError(
     'provider error',
   );
 
+  // Scrub BEFORE slicing: a credential straddling the 500-char cut would
+  // otherwise survive in fragments. Some providers (Anthropic 401s) echo the
+  // caller's Authorization / x-api-key header back inside the error body.
   logger.warn(
-    `Upstream error ${errorStatus}: provider=${meta.provider} model=${meta.model} tier=${meta.tier} body=${errorBody.slice(0, 500)}`,
+    `Upstream error ${errorStatus}: provider=${meta.provider} model=${meta.model} tier=${meta.tier} body=${scrubSecrets(errorBody).slice(0, 500)}`,
   );
   res.status(errorStatus);
   setHeaders(res, metaHeaders);
@@ -396,7 +400,7 @@ function handleFallbackExhausted(
     'primary failure',
   );
 
-  logger.warn(`Fallback chain exhausted: ${errorBody.slice(0, 200)}`);
+  logger.warn(`Fallback chain exhausted: ${scrubSecrets(errorBody).slice(0, 200)}`);
   const classified = classifyProviderError(errorStatus, errorBody);
   const structured = parseStructuredProviderError(errorStatus, errorBody);
   const providerCode = classified?.code ?? structured?.code;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -61,6 +61,7 @@ import type {
 } from './proxy-types';
 import { ResponsesSseError } from './chatgpt-adapter';
 import { redactInlineImageDataUrls } from './inline-image-redaction';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
 import { openAiModelId, subscriptionOpenAiModelId } from './openai-model-id';
 import { openAiModelCapabilities, type OpenAiModelCapabilities } from './openai-model-capabilities';
 import { PlanService } from '../../billing/plan.service';
@@ -684,7 +685,9 @@ export class ProxyController {
             ? err.getStatus()
             : 500;
     const providerErrorBody = err instanceof ResponsesSseError ? err.body : message;
-    this.logger.error(`Proxy error: ${message}`);
+    // `message` is the raw upstream body for a ResponsesSseError, so scrub it
+    // before it reaches stdout (the recorded/returned copies already are).
+    this.logger.error(`Proxy error: ${scrubSecrets(message)}`);
 
     // Who failed? A ManifestError says so explicitly. Pre-response dead sockets
     // and timeouts become synthetic 503/504 responses in proxy-transport. A


### PR DESCRIPTION
### ✨ What changed
- Pass upstream error bodies through `scrubSecrets` before the two `logger.warn` lines in `proxy-response-handler.ts`, scrubbing before the slice so a key straddling the cut is still masked.
- Scrub the `Proxy error:` line in `proxy.controller.ts`, where the message is the raw upstream body for a `ResponsesSseError`.
- Tests assert a 401 body carrying `x-api-key` and `Authorization: Bearer` values reaches the logger masked.

### 💭 Why
Some providers (Anthropic 401s) echo the caller's credential back inside the error body. The database and client paths already scrub it, but these log lines printed it raw, so one bad upstream call wrote a tenant's provider key to stdout and any log aggregator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops upstream error bodies from leaking provider credentials into logs. Some providers, notably Anthropic 401s, echo the caller's `x-api-key` or `Authorization: Bearer` value back inside the error body, and the `Upstream error`, `Fallback chain exhausted`, and `Proxy error:` log lines printed that body raw. All three lines now pass the body through `scrubSecrets` before writing, and scrubbing happens before the truncation slice so a key straddling the cut is still masked. Client- and database-facing paths already scrubbed these bodies; only log output changes.

<sup>Written for commit d177c2fff00af8e38be7074a934547e9d1d60703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

