### PR TITLE
fix: remove self-hosted loopback auto-login

### DIFF
--- a/.changeset/remove-loopback-synthetic-user.md
+++ b/.changeset/remove-loopback-synthetic-user.md
@@ -1,0 +1,4 @@
+---
+"manifest": patch
+---
+Remove the self-hosted loopback auto-login. Requests from 127.0.0.1 without a session are no longer treated as a signed-in local user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,7 +419,7 @@ See `packages/backend/.env.example` for all variables. Key ones:
 - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` — GitHub OAuth (optional)
 - `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` — Discord OAuth (optional)
 - `SEED_DATA` — Set `true` to seed demo data on startup. Dev/test only — ignored when `NODE_ENV=production` (use the first-run setup wizard instead).
-- `MANIFEST_MODE` — `selfhosted` or `cloud` (default: `cloud`; auto-detected as `selfhosted` inside Docker via `/.dockerenv` or Podman via `/run/.containerenv`). Self-hosted mode enables loopback auth shortcuts and allows custom-provider URLs with `http://` / private IPs. `local` is accepted as a legacy alias for `selfhosted`.
+- `MANIFEST_MODE` — `selfhosted` or `cloud` (default: `cloud`; auto-detected as `selfhosted` inside Docker via `/.dockerenv` or Podman via `/run/.containerenv`). Self-hosted mode allows custom-provider URLs with `http://` / private IPs. `local` is accepted as a legacy alias for `selfhosted`.
 - `MANIFEST_TELEMETRY_DISABLED` — Set `1` to opt out of anonymous telemetry (self-hosted only).
 - `MANIFEST_PUBLIC_STATS` — Set `true` to expose `/api/v1/public/*` aggregate stats without auth (cloud-only marketing use).
 - `TELEMETRY_ENDPOINT` — Where self-hosted installs POST the anonymous usage report. Default: `https://telemetry.manifest.build/v1/report`. See [Telemetry](#anonymous-usage-telemetry-self-hosted).

--- a/packages/backend/src/auth/session.guard.spec.ts
+++ b/packages/backend/src/auth/session.guard.spec.ts
@@ -21,9 +21,8 @@ function createMockContext(overrides: { ip?: string; headers?: Record<string, st
   context: ExecutionContext;
   request: Record<string, unknown>;
 } {
-  // The guard reads request.socket.remoteAddress (the actual TCP peer) for
-  // its loopback decision. Mirror the test's `ip` field onto the socket so
-  // existing assertions still describe the scenario they intend to.
+  // The guard no longer looks at the peer address at all. `ip` is kept so the
+  // tests can still describe whether a request came from loopback or not.
   const peerIp = overrides.ip ?? '127.0.0.1';
   const request: Record<string, unknown> = {
     ip: peerIp,
@@ -232,7 +231,7 @@ describe('SessionGuard', () => {
     });
   });
 
-  describe('self-hosted loopback fallback', () => {
+  describe('self-hosted mode — no loopback auto-login', () => {
     const originalEnv = process.env['MANIFEST_MODE'];
 
     beforeEach(() => {
@@ -259,39 +258,35 @@ describe('SessionGuard', () => {
       expect(request['authMethod']).toBe('session');
     });
 
-    it('falls back to synthetic user when no session on loopback', async () => {
+    it('leaves a loopback request without a session unauthenticated', async () => {
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
       (auth.api.getSession as jest.Mock).mockResolvedValue(null);
       const { context, request } = createMockContext({ ip: '127.0.0.1' });
 
-      await guard.canActivate(context);
+      // Still returns true so ApiKeyGuard gets to reject the request.
+      const result = await guard.canActivate(context);
 
-      expect(request['user']).toEqual({
-        id: 'local',
-        name: 'Local User',
-        email: 'local@localhost',
-      });
-      expect(request['authMethod']).toBe('session');
-      expect(tenantCache.resolve).toHaveBeenCalledWith('local');
-      expect(request['tenantContext']).toEqual({ tenantId: 'tenant-1', userId: 'local' });
+      expect(result).toBe(true);
+      expect(request['user']).toBeUndefined();
+      expect(request['authMethod']).toBeUndefined();
+      expect(request['tenantContext']).toBeUndefined();
+      expect(tenantCache.resolve).not.toHaveBeenCalled();
     });
 
-    it('falls back to synthetic user when getSession throws on loopback', async () => {
+    it('leaves a loopback request unauthenticated when getSession throws', async () => {
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
       (auth.api.getSession as jest.Mock).mockRejectedValue(new Error('DB error'));
       const { context, request } = createMockContext({ ip: '127.0.0.1' });
 
-      await guard.canActivate(context);
+      const result = await guard.canActivate(context);
 
-      expect(request['user']).toEqual({
-        id: 'local',
-        name: 'Local User',
-        email: 'local@localhost',
-      });
-      expect(request['authMethod']).toBe('session');
+      expect(result).toBe(true);
+      expect(request['user']).toBeUndefined();
+      expect(request['authMethod']).toBeUndefined();
+      expect(tenantCache.resolve).not.toHaveBeenCalled();
     });
 
-    it('does not apply loopback fallback for non-loopback IPs', async () => {
+    it('leaves a non-loopback request unauthenticated', async () => {
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
       (auth.api.getSession as jest.Mock).mockResolvedValue(null);
       const { context, request } = createMockContext({ ip: '203.0.113.1' });

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -5,8 +5,6 @@ import { fromNodeHeaders } from 'better-auth/node';
 import { createHash } from 'crypto';
 import { auth } from './auth.instance';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
-import { isLoopbackPeer } from '../common/utils/local-ip';
-import { isSelfHosted } from '../common/utils/detect-self-hosted';
 import { TenantCacheService } from '../common/services/tenant-cache.service';
 import { RequestWithTenantContext } from '../common/decorators/tenant-context.decorator';
 
@@ -88,24 +86,6 @@ export class SessionGuard implements CanActivate, OnModuleDestroy {
       }
     } catch (err) {
       this.logger.warn(`Session lookup failed: ${(err as Error).message}`);
-    }
-
-    // In the self-hosted version, fall back to a synthetic user for loopback
-    // requests without a session (e.g. curl, programmatic access).
-    //
-    // Use the TCP peer address (request.socket.remoteAddress) — request.ip
-    // honors `trust proxy` and X-Forwarded-For, which a remote attacker can
-    // forge when the backend is reachable directly or sits behind a proxy
-    // that fails to strip XFF. The socket address cannot be spoofed.
-    if (isSelfHosted() && isLoopbackPeer(request)) {
-      (request as Request & { user: unknown }).user = {
-        id: 'local',
-        name: 'Local User',
-        email: 'local@localhost',
-      };
-      (request as Request & { authMethod: string }).authMethod = 'session';
-      await this.attachTenantContext(request, { id: 'local' });
-      return true;
     }
 
     // Always pass — let ApiKeyGuard handle unauthenticated requests


### PR DESCRIPTION
### ✨ What changed
- `SessionGuard` no longer grants a synthetic `Local User` to sessionless requests whose TCP peer is 127.0.0.1 in self-hosted mode.
- Spec rewritten to assert that such requests carry no user and fall through to `ApiKeyGuard`.
- CLAUDE.md `MANIFEST_MODE` entry no longer mentions loopback auth.

### 💭 Why
Self-hosted mode is auto-enabled by `KUBERNETES_SERVICE_HOST` and container markers. With a service-mesh sidecar (Istio, Envoy, Linkerd) or a reverse proxy on the same host, every internet request reaches the backend from 127.0.0.1, so every visitor became the trusted local user with full dashboard access. The dashboard itself always requires a Better Auth session, and Docker installs never see loopback peers, so the path only served curl on a laptop.

### 👤 For users
Self-hosted operators calling the API from the same machine now need a session cookie or an API key, like every other caller.

### 📝 Notes
- The `NODE_ENV=development` loopback bypass in `AgentKeyAuthGuard` is unchanged and tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the self-hosted loopback auto-login in `SessionGuard` so sessionless requests from 127.0.0.1 are no longer treated as a signed-in local user. In self-hosted deployments behind a service mesh or same-host reverse proxy, every visitor appeared to come from loopback and was granted full dashboard access; now those requests fall through to `ApiKeyGuard`, and self-hosted operators calling the API from the same machine need a session cookie or API key.

- Session lookup errors on loopback no longer fall back to the synthetic user either.
- Updates the guard spec and `CLAUDE.md`, and adds a patch changeset for `manifest`.
- The `NODE_ENV=development` loopback bypass in `AgentKeyAuthGuard` is unchanged.

<sup>Written for commit 6380e68156f3fd04f0e302cc683d599b4bf45f28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

