### PR TITLE
fix: redact inline images in recordings and observations

### DIFF
--- a/.changeset/redact-images-in-recordings.md
+++ b/.changeset/redact-images-in-recordings.md
@@ -1,0 +1,4 @@
+---
+"manifest": patch
+---
+Strip inline base64 images from stored request recordings and Phoenix observations.

--- a/packages/backend/src/routing/autofix/observation-payload.spec.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.spec.ts
@@ -98,6 +98,40 @@ describe('scrubBody', () => {
     const huge = { messages: [{ role: 'user', content: 'x'.repeat(MAX_BODY_BYTES) }] };
     expect(scrubBody(huge)).toBeNull();
   });
+
+  it('replaces an inline base64 image with a marker', () => {
+    const base64 = 'A'.repeat(2048);
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'image_url', image_url: { url: `data:image/png;base64,${base64}` } }],
+        },
+      ],
+    };
+    const scrubbed = JSON.stringify(scrubBody(body));
+
+    expect(scrubbed).not.toContain(base64);
+    expect(scrubbed).toContain('[inline image: image/png,');
+    expect(JSON.stringify(body)).toContain(base64);
+  });
+
+  it('ships a body that only exceeded the cap because of its images', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: { url: `data:image/jpeg;base64,${'B'.repeat(MAX_BODY_BYTES)}` },
+            },
+          ],
+        },
+      ],
+    };
+    expect(JSON.stringify(scrubBody(body))).toContain('[inline image: image/jpeg,');
+  });
 });
 
 describe('scrubProviderUrl', () => {
@@ -244,5 +278,22 @@ describe('toObservation', () => {
   it('returns null when the body is too large to ship', () => {
     const requestBody = { messages: [{ content: 'x'.repeat(MAX_BODY_BYTES) }] };
     expect(toObservation({ ...baseInput, requestBody })).toBeNull();
+  });
+
+  it('sends no inline image bytes to Phoenix', () => {
+    const base64 = 'A'.repeat(4096);
+    const requestBody = {
+      model: 'gpt-5.1',
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'image_url', image_url: { url: `data:image/webp;base64,${base64}` } }],
+        },
+      ],
+    };
+    const observation = toObservation({ ...baseInput, requestBody });
+
+    expect(JSON.stringify(observation)).not.toContain(base64);
+    expect(JSON.stringify(observation?.request)).toContain('[inline image: image/webp,');
   });
 });

--- a/packages/backend/src/routing/autofix/observation-payload.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.ts
@@ -1,5 +1,6 @@
 import { isAnthropicExtraUsageError } from 'manifest-shared';
 import { scrubSecrets } from '../../common/utils/secret-scrub';
+import { redactInlineImageDataUrls } from '../proxy/inline-image-redaction';
 import type { ProviderWireFormat, ProxyApiMode } from '../proxy/proxy-types';
 import type { AuthType } from 'manifest-shared';
 import { normalizeProviderError } from './provider-error-normalizer';
@@ -100,13 +101,19 @@ function scrubValue(value: unknown): unknown {
 }
 
 /**
- * Strip credentials from a request body before it leaves this process, or return
- * null when the body is too large to ship. The body is the caller's, not ours,
- * and it can carry a key a user pasted into a prompt or a tool definition.
+ * Strip credentials and inline base64 images from a request body before it
+ * leaves this process, or return null when the body is too large to ship. The
+ * body is the caller's, not ours, and it can carry a key a user pasted into a
+ * prompt or a tool definition.
  */
 export function scrubBody(body: Record<string, unknown>): Record<string, unknown> | null {
-  if (Buffer.byteLength(JSON.stringify(body), 'utf8') > MAX_BODY_BYTES) return null;
-  return scrubValue(body) as Record<string, unknown>;
+  // Inline base64 images go first: an observation is evidence about the shape of
+  // a request, and no Phoenix operation reads image bytes. Dropping them before
+  // the size check also keeps a request that only failed the cap because of a
+  // screenshot reportable.
+  const withoutImages = redactInlineImageDataUrls(body);
+  if (Buffer.byteLength(JSON.stringify(withoutImages), 'utf8') > MAX_BODY_BYTES) return null;
+  return scrubValue(withoutImages) as Record<string, unknown>;
 }
 
 export interface ObservationInput {

--- a/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
@@ -169,4 +169,23 @@ describe('redactInlineImageDataUrls', () => {
     expect(redactInlineImageDataUrls(body)).toBe(body);
   });
 
+  it('still walks the sibling fields of a native image block', () => {
+    const body = {
+      source: {
+        media_type: 'image/png',
+        data: 'AAAA',
+        thumbnail: { inline_data: { mime_type: 'image/png', data: 'BBBB' } },
+        preview: 'data:image/png;base64,CCCC',
+      },
+    };
+    expect(redactInlineImageDataUrls(body)).toEqual({
+      source: {
+        media_type: 'image/png',
+        data: '[inline image: image/png, 3 bytes, 4 base64 chars]',
+        thumbnail: { inline_data: { mime_type: 'image/png', data: '[inline image: image/png, 3 bytes, 4 base64 chars]' } },
+        preview: '[inline image: image/png, 3 bytes, 4 base64 chars]',
+      },
+    });
+  });
+
 });

--- a/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
@@ -117,4 +117,56 @@ describe('redactInlineImageDataUrls', () => {
 
     expect(redactInlineImageDataUrls(body)).toBe(body);
   });
+  it('redacts Anthropic base64 image sources and keeps sibling fields', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'what is this?' },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+            { type: 'document', source: { type: 'base64', media_type: 'application/pdf', data: 'BBBB' } },
+          ],
+        },
+      ],
+    };
+    const result = redactInlineImageDataUrls(body);
+    const [text, image, doc] = result.messages[0]!.content as Array<Record<string, unknown>>;
+    expect(text).toEqual({ type: 'text', text: 'what is this?' });
+    expect(image.source).toEqual({
+      type: 'base64',
+      media_type: 'image/png',
+      data: '[inline image: image/png, 3 bytes, 4 base64 chars]',
+    });
+    expect(doc.source).toEqual({ type: 'base64', media_type: 'application/pdf', data: 'BBBB' });
+    expect((body.messages[0]!.content[1] as { source: { data: string } }).source.data).toBe('AAAA');
+  });
+
+  it('redacts Google inline_data and inlineData parts', () => {
+    const body = {
+      contents: [
+        {
+          parts: [
+            { inline_data: { mime_type: 'image/jpeg', data: 'Q0ND' } },
+            { inlineData: { mimeType: 'image/webp', data: 'RERE' } },
+            { text: 'caption' },
+          ],
+        },
+      ],
+    };
+    const result = redactInlineImageDataUrls(body);
+    expect(result.contents[0]!.parts[0]).toEqual({
+      inline_data: { mime_type: 'image/jpeg', data: '[inline image: image/jpeg, 3 bytes, 4 base64 chars]' },
+    });
+    expect(result.contents[0]!.parts[1]).toEqual({
+      inlineData: { mimeType: 'image/webp', data: '[inline image: image/webp, 3 bytes, 4 base64 chars]' },
+    });
+    expect(result.contents[0]!.parts[2]).toEqual({ text: 'caption' });
+  });
+
+  it('leaves records with an empty or non-string data field alone', () => {
+    const body = { source: { media_type: 'image/png', data: '' }, other: { mime_type: 'image/png', data: 5 } };
+    expect(redactInlineImageDataUrls(body)).toBe(body);
+  });
+
 });

--- a/packages/backend/src/routing/proxy/attempt-recording-capture.spec.ts
+++ b/packages/backend/src/routing/proxy/attempt-recording-capture.spec.ts
@@ -46,6 +46,33 @@ describe('Provider Attempt recording capture', () => {
     });
   });
 
+  it('stores an inline image as a marker instead of its base64 bytes', () => {
+    const base64 = 'A'.repeat(2048);
+    const requestBody = {
+      model: 'gpt-5.1',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'what is in this screenshot?' },
+            { type: 'image_url', image_url: { url: `data:image/png;base64,${base64}` } },
+          ],
+        },
+      ],
+    };
+    const snapshot = JSON.stringify(requestBody);
+
+    const capture = createAttemptRecordingCapture(requestBody, 'openai_chat_completions');
+    capture.setJson({ ok: true });
+    const stored = JSON.stringify(capture.buildRecording().request_body);
+
+    expect(stored).not.toContain(base64);
+    expect(stored).toContain('[inline image: image/png,');
+    expect(stored).toContain('what is in this screenshot?');
+    // The provider still gets the image: only the stored copy is redacted.
+    expect(JSON.stringify(requestBody)).toBe(snapshot);
+  });
+
   it('keeps the attempt request when no response was captured', () => {
     const capture = createAttemptRecordingCapture({ messages: [] }, 'openai_chat_completions');
     expect(capture.buildResponseBody()).toBeNull();

--- a/packages/backend/src/routing/proxy/attempt-recording-capture.ts
+++ b/packages/backend/src/routing/proxy/attempt-recording-capture.ts
@@ -1,3 +1,4 @@
+import { redactInlineImageDataUrls } from './inline-image-redaction';
 import type { RecordingResponseBody, StoredAttemptRecording } from './attempt-recording.types';
 
 export interface AttemptRecordingCapture {
@@ -16,6 +17,15 @@ export function recordingResponseFromText(raw: string): RecordingResponseBody {
   }
 }
 
+/**
+ * Build one Provider Attempt recording. The stored request body is the
+ * provider-facing body with inline base64 images replaced by a short marker:
+ * the recording is a debugging artifact, and a single screenshot pasted by an
+ * agent would otherwise be persisted in full for every attempt. The body sent
+ * to the provider is untouched — only this stored copy is redacted, and
+ * {@link redactInlineImageDataUrls} returns a copy so the caller's object is
+ * never mutated.
+ */
 export function createAttemptRecordingCapture(
   requestBody: Record<string, unknown>,
   wireFormat: string,
@@ -46,7 +56,7 @@ export function createAttemptRecordingCapture(
       return {
         version: 1,
         wire_format: wireFormat,
-        request_body: requestBody,
+        request_body: redactInlineImageDataUrls(requestBody),
         response_body: buildResponseBody(),
       };
     },

--- a/packages/backend/src/routing/proxy/inline-image-redaction.ts
+++ b/packages/backend/src/routing/proxy/inline-image-redaction.ts
@@ -14,12 +14,17 @@ function redactValue(value: unknown): RedactResult {
   if (Array.isArray(value)) return redactArray(value);
   if (!isPlainRecord(value)) return { value, changed: false };
 
-  const inline = redactInlineBase64Record(value);
-  if (inline) return inline;
-
+  const inlineData = inlineImageDataMarker(value);
   const out: Record<string, unknown> = {};
   let changed = false;
   for (const [key, nested] of Object.entries(value)) {
+    // Provider-native image blocks keep the bytes in `data`; the sibling
+    // fields are still walked so nothing nested beside them survives.
+    if (inlineData !== null && key === 'data') {
+      out[key] = inlineData;
+      changed = true;
+      continue;
+    }
     const result = redactValue(nested);
     out[key] = result.value;
     changed ||= result.changed;
@@ -50,14 +55,14 @@ function redactString(value: string): RedactResult {
 // key, so both wire formats and their casing variants are covered.
 const INLINE_MIME_KEYS = ['media_type', 'mime_type', 'mimeType'] as const;
 
-function redactInlineBase64Record(value: Record<string, unknown>): RedactResult | null {
+function inlineImageDataMarker(value: Record<string, unknown>): string | null {
   const data = value['data'];
   if (typeof data !== 'string' || data.length === 0) return null;
   const mimeKey = INLINE_MIME_KEYS.find((key) => typeof value[key] === 'string');
   if (!mimeKey) return null;
   const mimeType = value[mimeKey] as string;
   if (!/^image\//i.test(mimeType)) return null;
-  return { value: { ...value, data: describeInlineImage(mimeType, data) }, changed: true };
+  return describeInlineImage(mimeType, data);
 }
 
 function describeInlineImage(mimeType: string, base64: string): string {

--- a/packages/backend/src/routing/proxy/inline-image-redaction.ts
+++ b/packages/backend/src/routing/proxy/inline-image-redaction.ts
@@ -14,6 +14,9 @@ function redactValue(value: unknown): RedactResult {
   if (Array.isArray(value)) return redactArray(value);
   if (!isPlainRecord(value)) return { value, changed: false };
 
+  const inline = redactInlineBase64Record(value);
+  if (inline) return inline;
+
   const out: Record<string, unknown> = {};
   let changed = false;
   for (const [key, nested] of Object.entries(value)) {
@@ -37,14 +40,29 @@ function redactArray(values: unknown[]): RedactResult {
 function redactString(value: string): RedactResult {
   const match = INLINE_IMAGE_DATA_URL_RE.exec(value);
   if (!match) return { value, changed: false };
+  return { value: describeInlineImage(match[1], value.slice(match[0].length)), changed: true };
+}
 
-  const mimeType = match[1].toLowerCase();
-  const base64Chars = value.length - match[0].length;
-  const decodedBytes = estimateDecodedBase64Bytes(value.slice(match[0].length));
-  return {
-    value: `[inline image: ${mimeType}, ${decodedBytes} bytes, ${base64Chars} base64 chars]`,
-    changed: true,
-  };
+// Provider-native image blocks carry the bytes in a `data` field next to the
+// mime type instead of inside a data URL: Anthropic `source: { type: 'base64',
+// media_type, data }` and Google `inline_data: { mime_type, data }` (also
+// camel-cased as `inlineData` / `mimeType`). Match on the shape, not the parent
+// key, so both wire formats and their casing variants are covered.
+const INLINE_MIME_KEYS = ['media_type', 'mime_type', 'mimeType'] as const;
+
+function redactInlineBase64Record(value: Record<string, unknown>): RedactResult | null {
+  const data = value['data'];
+  if (typeof data !== 'string' || data.length === 0) return null;
+  const mimeKey = INLINE_MIME_KEYS.find((key) => typeof value[key] === 'string');
+  if (!mimeKey) return null;
+  const mimeType = value[mimeKey] as string;
+  if (!/^image\//i.test(mimeType)) return null;
+  return { value: { ...value, data: describeInlineImage(mimeType, data) }, changed: true };
+}
+
+function describeInlineImage(mimeType: string, base64: string): string {
+  const decodedBytes = estimateDecodedBase64Bytes(base64);
+  return `[inline image: ${mimeType.toLowerCase()}, ${decodedBytes} bytes, ${base64.length} base64 chars]`;
 }
 
 function estimateDecodedBase64Bytes(data: string): number {

--- a/packages/backend/test/request-recordings.e2e-spec.ts
+++ b/packages/backend/test/request-recordings.e2e-spec.ts
@@ -171,6 +171,36 @@ describe(`Provider Attempt recording E2E (${expectedBackend})`, () => {
     expect(attempt.recording.response_body.raw_sse).toBe(response.text);
   }, 15_000);
 
+  it('stores no inline image bytes while still forwarding them to the provider', async () => {
+    const base64 = 'A'.repeat(4096);
+    const known = new Set([jsonRecording.recording_key, streamRecording.recording_key]);
+
+    await agentAuth(api().post('/v1/chat/completions'))
+      .send({
+        model: modelKey(),
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'describe this screenshot' },
+              { type: 'image_url', image_url: { url: `data:image/png;base64,${base64}` } },
+            ],
+          },
+        ],
+        stream: false,
+      })
+      .expect(200);
+
+    const imageRecording = await waitForRecordingOutside(known);
+    const stored = JSON.stringify(
+      await decodeRequestRecording(await storage.get(imageRecording.recording_key)),
+    );
+    expect(stored).not.toContain(base64);
+    expect(stored).toContain('[inline image: image/png,');
+    expect(stored).toContain('describe this screenshot');
+    expect(JSON.stringify(providerRequestBodies.at(-1))).toContain(base64);
+  });
+
   it('does not expose a recording across tenant boundaries', async () => {
     const timestamp = new Date().toISOString();
     await dataSource.query(
@@ -368,6 +398,26 @@ async function waitForLatestRecording(
   throw new Error(
     `Timed out waiting for a Provider Attempt recording: ${JSON.stringify(attempts)}`,
   );
+}
+
+async function waitForRecordingOutside(
+  knownKeys: Set<string>,
+  timeoutMs = 5_000,
+): Promise<AttemptRecordingPointer> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = (await dataSource.query(
+      `SELECT id AS attempt_id, request_id, recording_key
+       FROM agent_messages
+       WHERE recording_key IS NOT NULL
+       ORDER BY timestamp DESC, id DESC
+       LIMIT 5`,
+    )) as AttemptRecordingPointer[];
+    const fresh = rows.find((row) => !knownKeys.has(row.recording_key));
+    if (fresh) return fresh;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('Timed out waiting for the inline-image Provider Attempt recording');
 }
 
 async function waitForStorageObject(recording: AttemptRecordingPointer): Promise<void> {


### PR DESCRIPTION
### ✨ What changed
- Stored Provider Attempt recordings now hold the request body with inline base64 images replaced by a marker (`attempt-recording-capture.ts`). The body sent to the provider is untouched.
- Phoenix observation payloads strip inline images before the size check and the credential scrub (`observation-payload.ts`), which makes the existing comment there true.
- Unit specs for both sinks, and the recordings e2e asserts the stored blob no longer contains the base64 string.

### 💭 Why
`redactInlineImageDataUrls` was only applied to the copy used for tier scoring. The persisted recording and the observation shipped to Phoenix carried every screenshot in full, for every attempt, for up to a year.

### 📝 Notes
- Non-goal: the `/api/heal` request body still carries images, because Phoenix returns a `healedBody` that is resent to the provider.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stored Provider Attempt recordings and Phoenix observations now replace inline base64 images with a short marker instead of persisting full screenshots. This covers OpenAI-style data URLs plus Anthropic `source` and Google `inline_data`/`inlineData` image blocks.

- The body sent to the provider is untouched; only the stored or shipped copy is redacted.
- Redaction happens before the observation size check, so a request that only exceeded the cap because of images is still reportable.
- Images nested beside native image blocks (for example, thumbnails or previews) are redacted too.
- The `/api/heal` request body still carries images, because Phoenix returns a healed body that is resent to the provider.

<sup>Written for commit 38301069302ea77bb2ac627ea4a6b05d25437b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

