### PR TITLE
feat: encrypt request recordings at rest

### DIFF
--- a/.changeset/encrypt-recordings-at-rest.md
+++ b/.changeset/encrypt-recordings-at-rest.md
@@ -1,0 +1,4 @@
+---
+"manifest": minor
+---
+Encrypt stored request recordings with the at-rest encryption key. Existing gzip-only recordings remain readable.

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -269,10 +269,11 @@ jobs:
 
           docker run --rm --user 65532:65532 \
             -e RECORDING_KEY="$storage_key" \
+            -e RECORDING_PROMPT="$prompt" \
             -v manifest_request_recordings:/recordings:ro \
             --entrypoint /nodejs/bin/node \
             manifestdotbuild/manifest:latest \
-            -e "const fs=require('fs');const b=fs.readFileSync('/recordings/'+process.env.RECORDING_KEY);if(b[0]!==0x1f||b[1]!==0x8b)process.exit(1)"
+            -e "const fs=require('fs');const b=fs.readFileSync('/recordings/'+process.env.RECORDING_KEY);if(b.subarray(0,4).toString('ascii')!=='MRE1')process.exit(1);if(b.includes(process.env.RECORDING_PROMPT))process.exit(2)"
 
           docker compose up -d --force-recreate --no-deps manifest
           for i in $(seq 1 60); do

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -129,7 +129,7 @@ cp .env.example .env
 openssl rand -hex 32
 ```
 
-`MANIFEST_ENCRYPTION_KEY` encrypts the provider API keys and OAuth tokens
+`MANIFEST_ENCRYPTION_KEY` encrypts the provider API keys, OAuth tokens and stored request recordings
 Manifest stores. Left unset it falls back to `BETTER_AUTH_SECRET`, which means
 one leaked session-signing secret also decrypts every stored credential. Set it
 before first boot — adding it later means re-encrypting what is already stored.

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -129,10 +129,13 @@ cp .env.example .env
 openssl rand -hex 32
 ```
 
-`MANIFEST_ENCRYPTION_KEY` encrypts the provider API keys, OAuth tokens and stored request recordings
-Manifest stores. Left unset it falls back to `BETTER_AUTH_SECRET`, which means
-one leaked session-signing secret also decrypts every stored credential. Set it
-before first boot — adding it later means re-encrypting what is already stored.
+`MANIFEST_ENCRYPTION_KEY` encrypts everything Manifest stores at rest: provider
+API keys, OAuth tokens and request recordings. Left unset it falls back to
+`BETTER_AUTH_SECRET`, which means one leaked session-signing secret also
+decrypts every stored credential and recording. Set it before first boot.
+Recordings written under a previous secret are not migrated: after the secret
+changes they can no longer be decrypted and the dashboard shows them as
+unavailable, while retention removes them on schedule.
 
 (Optional: to use a stronger database password, set BOTH `POSTGRES_PASSWORD` and `DATABASE_URL` in `.env`, they must agree, and any special characters in the password need to be percent-encoded in the URL.)
 

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -129,10 +129,11 @@ cp .env.example .env
 openssl rand -hex 32
 ```
 
-`MANIFEST_ENCRYPTION_KEY` encrypts everything Manifest stores at rest: provider
-API keys, OAuth tokens and request recordings. Left unset it falls back to
-`BETTER_AUTH_SECRET`, which means one leaked session-signing secret also
-decrypts every stored credential and recording. Set it before first boot.
+`MANIFEST_ENCRYPTION_KEY` encrypts the provider API keys, OAuth tokens and
+request recordings Manifest stores; the rest of the database is not encrypted
+by it. Left unset it falls back to `BETTER_AUTH_SECRET`, which means one leaked
+session-signing secret also decrypts every stored credential and recording.
+Set it before first boot.
 Recordings written under a previous secret are not migrated: after the secret
 changes they can no longer be decrypted and the dashboard shows them as
 unavailable, while retention removes them on schedule.

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -3,6 +3,7 @@ BETTER_AUTH_SECRET=          # Min 32 chars. Generate with: openssl rand -hex 32
 DATABASE_URL=                # PostgreSQL connection string: postgresql://user:password@host:port/database
 
 # ── At-rest encryption (recommended) ─────────────────
+# Also encrypts stored request recordings; changing the secret makes older recordings unreadable.
 # Encrypts stored LLM provider API keys / OAuth tokens (the AES-256-GCM key
 # is derived from this secret via scrypt). If unset, MANIFEST falls back to
 # BETTER_AUTH_SECRET — convenient, but a session-cookie leak then also

--- a/packages/backend/src/analytics/services/message-details.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-details.service.spec.ts
@@ -1,4 +1,9 @@
+const ORIGINAL_ENCRYPTION_KEY = process.env['MANIFEST_ENCRYPTION_KEY'];
 process.env['MANIFEST_ENCRYPTION_KEY'] ??= 'test-recording-secret-at-least-32-characters';
+afterAll(() => {
+  if (ORIGINAL_ENCRYPTION_KEY === undefined) delete process.env['MANIFEST_ENCRYPTION_KEY'];
+  else process.env['MANIFEST_ENCRYPTION_KEY'] = ORIGINAL_ENCRYPTION_KEY;
+});
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';

--- a/packages/backend/src/analytics/services/message-details.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-details.service.spec.ts
@@ -1,7 +1,9 @@
+process.env['MANIFEST_ENCRYPTION_KEY'] ??= 'test-recording-secret-at-least-32-characters';
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException } from '@nestjs/common';
-import { gzipSync } from 'node:zlib';
+import { encodeRequestRecording } from '../../common/utils/request-recording-codec';
 import { MessageDetailsService } from './message-details.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
 
@@ -360,7 +362,7 @@ describe('MessageDetailsService', () => {
       response_body: { type: 'json', body: { choices: [] } },
     };
     const recordingStorage = {
-      get: jest.fn().mockResolvedValue(gzipSync(JSON.stringify(storedPayload))),
+      get: jest.fn().mockResolvedValue(await encodeRequestRecording(storedPayload as never)),
     };
     const requestAware = new MessageDetailsService(
       { find: jest.fn().mockResolvedValue(attempts) } as never,

--- a/packages/backend/src/common/services/request-recording-storage.service.spec.ts
+++ b/packages/backend/src/common/services/request-recording-storage.service.spec.ts
@@ -150,7 +150,7 @@ describe('S3RecordingStorage', () => {
 
   beforeEach(() => jest.clearAllMocks());
 
-  it('writes gzip JSON objects to the configured private bucket', async () => {
+  it('writes opaque encrypted objects to the configured private bucket', async () => {
     send.mockResolvedValue({});
 
     await storage.put('request-recordings/v1/request-1.json.gz', Buffer.from('body'));
@@ -160,10 +160,12 @@ describe('S3RecordingStorage', () => {
       expect.objectContaining({
         Bucket: 'recordings',
         Key: 'request-recordings/v1/request-1.json.gz',
-        ContentType: 'application/json',
-        ContentEncoding: 'gzip',
+        ContentType: 'application/octet-stream',
       }),
     );
+    // The body is ciphertext, so declaring gzip would make S3-compatible stores
+    // and CDNs try to decompress it on GET.
+    expect(send.mock.calls[0][0].input.ContentEncoding).toBeUndefined();
   });
 
   it('reads object bytes through the S3 streaming body helper', async () => {

--- a/packages/backend/src/common/services/request-recording-storage.service.ts
+++ b/packages/backend/src/common/services/request-recording-storage.service.ts
@@ -175,8 +175,10 @@ export class S3RecordingStorage implements RecordingStorage {
         Bucket: this.config.bucket,
         Key: key,
         Body: body,
-        ContentType: 'application/json',
-        ContentEncoding: 'gzip',
+        // The body is client-side ciphertext (see request-recording-codec), not
+        // readable JSON, and declaring ContentEncoding: gzip made some
+        // S3-compatible stores and CDNs try to gunzip it transparently on GET.
+        ContentType: 'application/octet-stream',
       }),
     );
   }

--- a/packages/backend/src/common/utils/crypto.util.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.spec.ts
@@ -195,7 +195,7 @@ describe('encryptBuffer / decryptBuffer', () => {
   it('uses a distinct IV for every encryption of the same input', () => {
     const first = encryptBuffer(plain, secret);
     const second = encryptBuffer(plain, secret);
-    expect(first.subarray(20, 32).equals(second.subarray(20, 32))).toBe(false);
+    expect(first.subarray(4, 16).equals(second.subarray(4, 16))).toBe(false);
     expect(first.equals(second)).toBe(false);
   });
 

--- a/packages/backend/src/common/utils/crypto.util.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.spec.ts
@@ -1,4 +1,12 @@
-import { getEncryptionSecret, encrypt, decrypt, isEncrypted } from './crypto.util';
+import {
+  getEncryptionSecret,
+  encrypt,
+  decrypt,
+  decryptBuffer,
+  encryptBuffer,
+  hasBinaryEnvelope,
+  isEncrypted,
+} from './crypto.util';
 
 describe('getEncryptionSecret', () => {
   const originalEnv = process.env;
@@ -165,5 +173,49 @@ describe('isEncrypted', () => {
     // must be rejected as not-encrypted. This guards the
     // `buf.toString('base64') !== part` branch inside isEncrypted.
     expect(isEncrypted('AB:AB:AB:AB')).toBe(false);
+  });
+});
+
+describe('encryptBuffer / decryptBuffer', () => {
+  const secret = 'buffer-secret-that-is-at-least-32-characters';
+  const plain = Buffer.from('binary payload with a known marker', 'utf8');
+
+  it('round-trips arbitrary bytes', () => {
+    expect(decryptBuffer(encryptBuffer(plain, secret), secret)).toEqual(plain);
+  });
+
+  it('stamps the self-identifying magic prefix', () => {
+    const blob = encryptBuffer(plain, secret);
+    expect(blob.subarray(0, 4).toString('ascii')).toBe('MRE1');
+    expect(hasBinaryEnvelope(blob)).toBe(true);
+    expect(hasBinaryEnvelope(Buffer.from([0x1f, 0x8b, 0x08]))).toBe(false);
+    expect(hasBinaryEnvelope(Buffer.from('MR', 'ascii'))).toBe(false);
+  });
+
+  it('uses a distinct IV for every encryption of the same input', () => {
+    const first = encryptBuffer(plain, secret);
+    const second = encryptBuffer(plain, secret);
+    expect(first.subarray(20, 32).equals(second.subarray(20, 32))).toBe(false);
+    expect(first.equals(second)).toBe(false);
+  });
+
+  it('rejects a tampered ciphertext', () => {
+    const blob = encryptBuffer(plain, secret);
+    blob[blob.length - 1] = blob[blob.length - 1] ^ 0xff;
+    expect(() => decryptBuffer(blob, secret)).toThrow();
+  });
+
+  it('rejects the wrong secret', () => {
+    const blob = encryptBuffer(plain, secret);
+    expect(() => decryptBuffer(blob, 'another-secret-that-is-at-least-32-chars')).toThrow();
+  });
+
+  it('rejects blobs without the magic prefix or with a truncated header', () => {
+    expect(() => decryptBuffer(Buffer.from([0x1f, 0x8b, 0x08, 0x00]), secret)).toThrow(
+      'Invalid encrypted blob format',
+    );
+    expect(() => decryptBuffer(Buffer.from('MRE1short', 'ascii'), secret)).toThrow(
+      'Invalid encrypted blob format',
+    );
   });
 });

--- a/packages/backend/src/common/utils/crypto.util.ts
+++ b/packages/backend/src/common/utils/crypto.util.ts
@@ -117,3 +117,41 @@ export function isEncrypted(value: string): boolean {
     return false;
   }
 }
+
+// Binary envelope for blobs that are not text (compressed request recordings).
+// Layout: magic(4) | salt(16) | iv(12) | tag(16) | ciphertext. The magic prefix
+// makes a stored blob self-identifying, so a reader can tell an encrypted
+// recording from a legacy gzip-only one without extra bookkeeping.
+export const BINARY_ENVELOPE_MAGIC = Buffer.from('MRE1', 'ascii');
+const TAG_LENGTH = 16;
+const BINARY_HEADER_LENGTH = BINARY_ENVELOPE_MAGIC.length + SALT_LENGTH + IV_LENGTH + TAG_LENGTH;
+
+export function hasBinaryEnvelope(blob: Buffer): boolean {
+  return (
+    blob.length >= BINARY_ENVELOPE_MAGIC.length &&
+    blob.subarray(0, BINARY_ENVELOPE_MAGIC.length).equals(BINARY_ENVELOPE_MAGIC)
+  );
+}
+
+export function encryptBuffer(plain: Buffer, secret: string): Buffer {
+  const salt = randomBytes(SALT_LENGTH);
+  const key = deriveKey(secret, salt);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plain), cipher.final()]);
+  return Buffer.concat([BINARY_ENVELOPE_MAGIC, salt, iv, cipher.getAuthTag(), encrypted]);
+}
+
+export function decryptBuffer(blob: Buffer, secret: string): Buffer {
+  if (!hasBinaryEnvelope(blob) || blob.length < BINARY_HEADER_LENGTH) {
+    throw new Error('Invalid encrypted blob format');
+  }
+  let offset = BINARY_ENVELOPE_MAGIC.length;
+  const salt = blob.subarray(offset, (offset += SALT_LENGTH));
+  const iv = blob.subarray(offset, (offset += IV_LENGTH));
+  const tag = blob.subarray(offset, (offset += TAG_LENGTH));
+  const encrypted = blob.subarray(offset);
+  const decipher = createDecipheriv(ALGORITHM, deriveKey(secret, salt), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]);
+}

--- a/packages/backend/src/common/utils/crypto.util.ts
+++ b/packages/backend/src/common/utils/crypto.util.ts
@@ -119,12 +119,19 @@ export function isEncrypted(value: string): boolean {
 }
 
 // Binary envelope for blobs that are not text (compressed request recordings).
-// Layout: magic(4) | salt(16) | iv(12) | tag(16) | ciphertext. The magic prefix
-// makes a stored blob self-identifying, so a reader can tell an encrypted
-// recording from a legacy gzip-only one without extra bookkeeping.
+// Layout: magic(4) | iv(12) | tag(16) | ciphertext. The magic prefix makes a
+// stored blob self-identifying, so a reader can tell an encrypted recording
+// from a legacy gzip-only one without extra bookkeeping.
+//
+// Unlike the string envelope there is no per-blob salt: the key is derived
+// once per secret with a fixed, versioned salt and served from the deriveKey
+// cache, so a recording write or read costs one AES pass instead of a full
+// scrypt run on the request path. GCM's guarantee rests on the random 96-bit
+// IV per blob, not on the salt. Bump the salt string to rotate the derivation.
 export const BINARY_ENVELOPE_MAGIC = Buffer.from('MRE1', 'ascii');
+const BINARY_KDF_SALT = Buffer.from('manifest-recording-envelope-v1', 'utf8');
 const TAG_LENGTH = 16;
-const BINARY_HEADER_LENGTH = BINARY_ENVELOPE_MAGIC.length + SALT_LENGTH + IV_LENGTH + TAG_LENGTH;
+const BINARY_HEADER_LENGTH = BINARY_ENVELOPE_MAGIC.length + IV_LENGTH + TAG_LENGTH;
 
 export function hasBinaryEnvelope(blob: Buffer): boolean {
   return (
@@ -134,12 +141,11 @@ export function hasBinaryEnvelope(blob: Buffer): boolean {
 }
 
 export function encryptBuffer(plain: Buffer, secret: string): Buffer {
-  const salt = randomBytes(SALT_LENGTH);
-  const key = deriveKey(secret, salt);
+  const key = deriveKey(secret, BINARY_KDF_SALT);
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
   const encrypted = Buffer.concat([cipher.update(plain), cipher.final()]);
-  return Buffer.concat([BINARY_ENVELOPE_MAGIC, salt, iv, cipher.getAuthTag(), encrypted]);
+  return Buffer.concat([BINARY_ENVELOPE_MAGIC, iv, cipher.getAuthTag(), encrypted]);
 }
 
 export function decryptBuffer(blob: Buffer, secret: string): Buffer {
@@ -147,11 +153,10 @@ export function decryptBuffer(blob: Buffer, secret: string): Buffer {
     throw new Error('Invalid encrypted blob format');
   }
   let offset = BINARY_ENVELOPE_MAGIC.length;
-  const salt = blob.subarray(offset, (offset += SALT_LENGTH));
   const iv = blob.subarray(offset, (offset += IV_LENGTH));
   const tag = blob.subarray(offset, (offset += TAG_LENGTH));
   const encrypted = blob.subarray(offset);
-  const decipher = createDecipheriv(ALGORITHM, deriveKey(secret, salt), iv);
+  const decipher = createDecipheriv(ALGORITHM, deriveKey(secret, BINARY_KDF_SALT), iv);
   decipher.setAuthTag(tag);
   return Buffer.concat([decipher.update(encrypted), decipher.final()]);
 }

--- a/packages/backend/src/common/utils/request-recording-codec.spec.ts
+++ b/packages/backend/src/common/utils/request-recording-codec.spec.ts
@@ -1,6 +1,20 @@
+import { gzipSync } from 'node:zlib';
 import { decodeRequestRecording, encodeRequestRecording } from './request-recording-codec';
 
+const TEST_SECRET = 'recording-codec-secret-at-least-32-characters';
+
 describe('request recording codec', () => {
+  const originalKey = process.env['MANIFEST_ENCRYPTION_KEY'];
+
+  beforeEach(() => {
+    process.env['MANIFEST_ENCRYPTION_KEY'] = TEST_SECRET;
+  });
+
+  afterAll(() => {
+    if (originalKey === undefined) delete process.env['MANIFEST_ENCRYPTION_KEY'];
+    else process.env['MANIFEST_ENCRYPTION_KEY'] = originalKey;
+  });
+
   it('round-trips versioned request and response payloads through gzip', async () => {
     const payload = {
       version: 1 as const,
@@ -68,5 +82,53 @@ describe('request recording codec', () => {
     await expect(decodeRequestRecording(await encodeRequestRecording(payload))).resolves.toEqual(
       payload,
     );
+  });
+
+  it('encrypts the stored blob so the plaintext JSON is not recoverable from the bytes', async () => {
+    const payload = {
+      version: 1 as const,
+      wire_format: 'openai_chat_completions',
+      request_body: { model: 'test-model', messages: [{ role: 'user', content: 'top-secret-42' }] },
+      response_body: { type: 'json' as const, body: { choices: [] } },
+    };
+
+    const encoded = await encodeRequestRecording(payload);
+
+    expect(encoded.subarray(0, 4).toString('ascii')).toBe('MRE1');
+    expect(encoded.includes('top-secret-42')).toBe(false);
+    expect(encoded.includes('openai_chat_completions')).toBe(false);
+  });
+
+  it('still decodes legacy gzip-only recordings written before encryption', async () => {
+    const payload = {
+      version: 1 as const,
+      wire_format: 'anthropic_messages',
+      request_body: { model: 'legacy-model' },
+      response_body: null,
+    };
+
+    const legacy = gzipSync(Buffer.from(JSON.stringify(payload), 'utf8'));
+
+    expect(legacy.subarray(0, 2)).toEqual(Buffer.from([0x1f, 0x8b]));
+    await expect(decodeRequestRecording(legacy)).resolves.toEqual(payload);
+  });
+
+  it('rejects a blob that is neither encrypted nor gzip', async () => {
+    await expect(decodeRequestRecording(Buffer.from('not a recording', 'utf8'))).rejects.toThrow(
+      'Unrecognized request recording blob: not encrypted and not gzip',
+    );
+  });
+
+  it('rejects an encrypted blob written under a different secret', async () => {
+    const encoded = await encodeRequestRecording({
+      version: 1 as const,
+      wire_format: 'openai_chat_completions',
+      request_body: {},
+      response_body: null,
+    });
+
+    process.env['MANIFEST_ENCRYPTION_KEY'] = 'a-totally-different-secret-32-chars-long';
+
+    await expect(decodeRequestRecording(encoded)).rejects.toThrow();
   });
 });

--- a/packages/backend/src/common/utils/request-recording-codec.ts
+++ b/packages/backend/src/common/utils/request-recording-codec.ts
@@ -1,16 +1,43 @@
 import { promisify } from 'node:util';
 import { gunzip, gzip } from 'node:zlib';
 import type { StoredAttemptRecording } from '../../routing/proxy/attempt-recording.types';
+import {
+  decryptBuffer,
+  encryptBuffer,
+  getEncryptionSecret,
+  hasBinaryEnvelope,
+} from './crypto.util';
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
 
+// Recordings hold the exact provider-bound request body and the full response,
+// so they are encrypted with the same at-rest secret as provider credentials.
+// Blobs written before that change are gzip-only; they still start with the
+// gzip magic and keep decoding through the legacy path below.
+const GZIP_MAGIC = Buffer.from([0x1f, 0x8b]);
+
+function isGzip(body: Buffer): boolean {
+  return body.length >= GZIP_MAGIC.length && body.subarray(0, GZIP_MAGIC.length).equals(GZIP_MAGIC);
+}
+
 export async function encodeRequestRecording(payload: StoredAttemptRecording): Promise<Buffer> {
-  return gzipAsync(Buffer.from(JSON.stringify(payload), 'utf8'));
+  const compressed = await gzipAsync(Buffer.from(JSON.stringify(payload), 'utf8'));
+  return encryptBuffer(compressed, getEncryptionSecret());
 }
 
 export async function decodeRequestRecording(body: Buffer): Promise<StoredAttemptRecording> {
-  const payload = JSON.parse((await gunzipAsync(body)).toString('utf8')) as StoredAttemptRecording;
+  let compressed: Buffer;
+  if (hasBinaryEnvelope(body)) {
+    compressed = decryptBuffer(body, getEncryptionSecret());
+  } else if (isGzip(body)) {
+    compressed = body;
+  } else {
+    throw new Error('Unrecognized request recording blob: not encrypted and not gzip');
+  }
+  const payload = JSON.parse(
+    (await gunzipAsync(compressed)).toString('utf8'),
+  ) as StoredAttemptRecording;
   if (
     payload.version !== 1 ||
     typeof payload.wire_format !== 'string' ||

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -1,4 +1,9 @@
+const ORIGINAL_ENCRYPTION_KEY = process.env['MANIFEST_ENCRYPTION_KEY'];
 process.env['MANIFEST_ENCRYPTION_KEY'] ??= 'test-recording-secret-at-least-32-characters';
+afterAll(() => {
+  if (ORIGINAL_ENCRYPTION_KEY === undefined) delete process.env['MANIFEST_ENCRYPTION_KEY'];
+  else process.env['MANIFEST_ENCRYPTION_KEY'] = ORIGINAL_ENCRYPTION_KEY;
+});
 
 import { keyPrefix, verifyKey } from '../common/utils/hash.util';
 import { decodeRequestRecording } from '../common/utils/request-recording-codec';

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -1,3 +1,5 @@
+process.env['MANIFEST_ENCRYPTION_KEY'] ??= 'test-recording-secret-at-least-32-characters';
+
 import { keyPrefix, verifyKey } from '../common/utils/hash.util';
 import { decodeRequestRecording } from '../common/utils/request-recording-codec';
 import { DatabaseSeederService } from './database-seeder.service';

--- a/packages/backend/src/routing/proxy/attempt-recording.service.spec.ts
+++ b/packages/backend/src/routing/proxy/attempt-recording.service.spec.ts
@@ -1,4 +1,9 @@
+const ORIGINAL_ENCRYPTION_KEY = process.env['MANIFEST_ENCRYPTION_KEY'];
 process.env['MANIFEST_ENCRYPTION_KEY'] ??= 'test-recording-secret-at-least-32-characters';
+afterAll(() => {
+  if (ORIGINAL_ENCRYPTION_KEY === undefined) delete process.env['MANIFEST_ENCRYPTION_KEY'];
+  else process.env['MANIFEST_ENCRYPTION_KEY'] = ORIGINAL_ENCRYPTION_KEY;
+});
 
 import { decodeRequestRecording } from '../../common/utils/request-recording-codec';
 import type { StoredAttemptRecording } from './attempt-recording.types';

--- a/packages/backend/src/routing/proxy/attempt-recording.service.spec.ts
+++ b/packages/backend/src/routing/proxy/attempt-recording.service.spec.ts
@@ -1,3 +1,5 @@
+process.env['MANIFEST_ENCRYPTION_KEY'] ??= 'test-recording-secret-at-least-32-characters';
+
 import { decodeRequestRecording } from '../../common/utils/request-recording-codec';
 import type { StoredAttemptRecording } from './attempt-recording.types';
 import { AttemptRecordingService } from './attempt-recording.service';

--- a/packages/backend/test/request-recordings.e2e-spec.ts
+++ b/packages/backend/test/request-recordings.e2e-spec.ts
@@ -119,7 +119,9 @@ describe(`Provider Attempt recording E2E (${expectedBackend})`, () => {
     expect(metadataTables).toHaveLength(0);
 
     const objectBytes = await storage.get(jsonRecording.recording_key);
-    expect([...objectBytes.subarray(0, 2)]).toEqual([0x1f, 0x8b]);
+    // Encrypted envelope, not gzip: the on-disk object must not expose the exchange.
+    expect(objectBytes.subarray(0, 4).toString('ascii')).toBe('MRE1');
+    expect(objectBytes.includes(Buffer.from(largeTail, 'utf8'))).toBe(false);
     await expect(decodeRequestRecording(objectBytes)).resolves.toEqual({
       version: 1,
       wire_format: 'openai_chat_completions',


### PR DESCRIPTION
### ✨ What changed
- `encodeRequestRecording` now gzips and then encrypts with AES-256-GCM under the at-rest secret (`MANIFEST_ENCRYPTION_KEY`, falling back to `BETTER_AUTH_SECRET`). Blobs carry a 4-byte `MRE1` prefix so they are self-identifying.
- `decodeRequestRecording` decrypts `MRE1` blobs and still decodes legacy gzip-only blobs, so existing recordings stay readable.
- New `encryptBuffer` / `decryptBuffer` in `crypto.util.ts` reuse the existing key derivation.
- S3 puts send `application/octet-stream` and no longer declare `ContentEncoding: gzip`, which made some S3-compatible stores gunzip ciphertext on GET.

### 💭 Why
Recordings hold the exact provider-bound prompt and the full response for up to a year. They were stored as plain gzip on S3 or on disk, so a bucket credential or a disk image exposed every conversation.

### 🔧 For operators
- No new variables. Rotating `MANIFEST_ENCRYPTION_KEY` (or `BETTER_AUTH_SECRET` when it is the fallback) makes recordings written under the old secret unreadable; provider keys have a rotation path in #2817, recordings do not yet.
- No S3 header changes needed; server-side encryption is not requested, client-side encryption covers at-rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts request recordings at rest with AES-256-GCM under the existing at-rest key, so stored prompts and responses are no longer plaintext gzip on S3 or disk. Legacy gzip-only recordings still decode.

**Changes**
- S3 puts now use `application/octet-stream` and drop `ContentEncoding: gzip`, so compatible stores no longer gunzip ciphertext on GET.
- The recording envelope derives its key once per secret with a fixed, versioned salt, so each read or write costs one AES pass instead of a full scrypt run.
- Docker smoke test and e2e test now assert the stored blob starts with `MRE1` and does not contain the plaintext prompt.

**Migration**
- No new environment variables; `MANIFEST_ENCRYPTION_KEY` (or the `BETTER_AUTH_SECRET` fallback) now also protects recordings, but not the rest of the database.
- Rotating the at-rest secret makes recordings written under the old secret unreadable; they show as unavailable in the dashboard until retention removes them.

<sup>Written for commit b6601b41780551e7056d75b06737f20b8e26010e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

