### PR TITLE
feat: add claude-fable-5-1 to the Anthropic subscription model catalog

### DIFF
--- a/.changeset/fluffy-fable-subscription.md
+++ b/.changeset/fluffy-fable-subscription.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add claude-fable-5-1 to the Anthropic subscription model catalog so Claude Max / Pro connections can serve it instead of silently falling through to an API key

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1862,6 +1862,7 @@ describe('ModelDiscoveryService', () => {
       // environments (pricing-cache state moves ids around).
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
+        'claude-fable-5-1',
         'claude-haiku-4',
         'claude-opus-4',
         'claude-opus-5',
@@ -2228,9 +2229,10 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Subscription membership comes only from the curated knownModels list.
-      expect(result).toHaveLength(6);
+      expect(result).toHaveLength(7);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
+        'claude-fable-5-1',
         'claude-haiku-4',
         'claude-opus-4',
         'claude-opus-5',
@@ -2429,9 +2431,10 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Even without pricingSync, knownModels are returned directly
-      expect(result).toHaveLength(6);
+      expect(result).toHaveLength(7);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
+        'claude-fable-5-1',
         'claude-haiku-4',
         'claude-opus-4',
         'claude-opus-5',

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -304,6 +304,7 @@ describe('buildSubscriptionFallbackModels', () => {
 
     expect(result.map((model) => model.id)).toEqual([
       'claude-fable-5',
+      'claude-fable-5-1',
       'claude-opus-4',
       'claude-sonnet-4',
       'claude-haiku-4',

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -12,6 +12,10 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionTokenPrefix: 'sk-ant-oat',
     knownModels: Object.freeze([
       'claude-fable-5',
+      // Anthropic subscription membership comes exclusively from this curated
+      // list (no live discovery), so point releases callers address directly
+      // need their own entry — the claude-fable-5 prefix alone never emits it.
+      'claude-fable-5-1',
       'claude-opus-4',
       'claude-sonnet-4',
       'claude-haiku-4',


### PR DESCRIPTION
## Problem

The Anthropic subscription (Claude Max / Pro) model catalog is built exclusively from the curated `knownModels` list in `packages/shared/src/subscription/configs.ts` — there is no live discovery for this connection type. That list stops at `claude-fable-5`, so `claude-fable-5-1` never appears in a subscription connection's catalog.

Consequence in production: a tenant with both a subscription and an API key connected who explicitly requests `claude-fable-5-1` can only match the api_key catalog, so the request silently bills the API key (observed: ~$1.15 across 4 requests on one tenant) while `claude-fable-5` traffic rides the flat-fee subscription at $0.

## Fix

Add `claude-fable-5-1` as its own `knownModels` entry. The `claude-fable-5` prefix only matters for the supplement path (when live discovery returns dated variants); the fallback list emits literal ids only, so point releases callers address directly need explicit entries.

## Tests

- `packages/shared`: 423 passed, configs.ts at 100%
- `packages/backend` (`model-fallback`, `model-discovery.service`): 241 passed — curated-list assertions updated to include the new id (length 6 → 7)

## Notes

A follow-up PR will make explicit-model resolution prefer the subscription connection when both auth routes can serve the same model, so the catalog gap class can't silently bill a key again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `claude-fable-5-1` to the Anthropic subscription model catalog so subscription connections can serve it instead of silently falling through to an API key and billing usage. Subscription catalogs are built from a curated list with no live discovery, so point releases callers address directly need explicit entries.

<sup>Written for commit cf429b8a42144cf30e26f8704836d77008123387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

