### PR TITLE
fix: route explicit bare model to its subscription connection

### DIFF
--- a/.changeset/explicit-subscription-preference.md
+++ b/.changeset/explicit-subscription-preference.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route an explicit bare model id to the subscription connection when both a subscription and an api_key connection of the same provider serve it, instead of silently metering the key.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1414,10 +1414,54 @@ describe('ProxyService — orchestration', () => {
       expect(autofixService.maybeHeal).not.toHaveBeenCalled();
     });
 
-    it('returns model-not-available when two connections carry the same bare name', async () => {
+    it('prefers the subscription when one provider carries a bare name on both auths', async () => {
       modelDiscovery.getModelsForAgent.mockResolvedValue([
         discoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'api_key' }),
         discoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'subscription' }),
+      ]);
+
+      const result = await svc.proxyRequest(
+        baseOpts({ body: { model: 'gpt-4o', messages: [{ role: 'user', content: 'hi' }] } }),
+      );
+
+      expect(resolveService.resolve).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openai', authType: 'subscription', model: 'gpt-4o' }),
+      );
+      expect(result.meta.manifest_error_code).toBeUndefined();
+    });
+
+    it('surfaces a subscription failure to the caller without falling back to the api_key', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'api_key' }),
+        discoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'subscription' }),
+      ]);
+      // Break the subscription credentials: the caller pinned the model, so
+      // the error is theirs to see — Manifest must not meter the key instead.
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: JSON.stringify({ t: 'access', r: 'refresh', e: 0 }),
+        id: 'up-oai',
+        region: null,
+        label: 'Default',
+        priority: 0,
+      });
+      openaiOauth.unwrapToken.mockResolvedValue(null);
+
+      const result = await svc.proxyRequest(
+        baseOpts({ body: { model: 'gpt-4o', messages: [{ role: 'user', content: 'hi' }] } }),
+      );
+      const body = await result.forward.response.text();
+
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(fallbackService.tryFallbacks).not.toHaveBeenCalled();
+      expect(body).toContain('M102');
+      expect(body).toContain('subscription credentials could not be refreshed');
+    });
+
+    it('returns model-not-available when two providers carry the same bare name', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'subscription' }),
+        discoveredModel({ id: 'gpt-4o', provider: 'azure', authType: 'api_key' }),
       ]);
 
       const result = await svc.proxyRequest(

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -62,6 +62,7 @@ import { peekStream, STREAM_WARMUP_MS } from './stream-warmup';
 import { toChatCompletionsRequest } from './responses-adapter';
 import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
 import { effectiveRoutesForResponseMode } from '../routing-core/response-mode-guard';
+import { subscriptionPreferredRoute } from '../routing-core/route-helpers';
 import {
   explicitModelRouteCandidate,
   OPENAI_MODEL_ID_AUTO,
@@ -998,6 +999,14 @@ export class ProxyService {
     const models = await this.modelDiscovery.getModelsForAgent(tenantId, agentId);
     const catalogRoute = routeForOpenAiModelId(requestedModel, models);
     if (catalogRoute) return this.explicitRouting(agentId, tenantId, catalogRoute);
+
+    // A bare ID served by both the subscription and api_key connections of
+    // one provider is not ambiguous: the flat-fee subscription already covers
+    // the request, so route it there instead of silently metering the key.
+    if (!requestedModel.includes('/')) {
+      const preferred = subscriptionPreferredRoute(requestedModel, models);
+      if (preferred) return this.explicitRouting(agentId, tenantId, preferred);
+    }
 
     // A bare ID already present under multiple connections is ambiguous, not
     // undiscovered. Preserve M302 instead of silently picking an auth type.

--- a/packages/backend/src/routing/routing-core/__tests__/route-helpers.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/route-helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   readFallbackRoutes,
   readOverrideRoute,
   routeMatches,
+  subscriptionPreferredRoute,
   unambiguousRoute,
 } from '../route-helpers';
 import type { ModelRoute } from 'manifest-shared';
@@ -123,6 +124,68 @@ describe('route-helpers', () => {
     it('returns null when matched model has no authType', () => {
       const list = [discovered('gpt-4o', 'openai', undefined as never)];
       expect(unambiguousRoute('gpt-4o', list)).toBeNull();
+    });
+  });
+
+  describe('subscriptionPreferredRoute', () => {
+    it('resolves a same-provider subscription + api_key pair to the subscription', () => {
+      const list = [
+        discovered('gpt-4o', 'openai', 'api_key'),
+        discovered('gpt-4o', 'openai', 'subscription'),
+      ];
+      expect(subscriptionPreferredRoute('gpt-4o', list)).toEqual(
+        route('openai', 'subscription', 'gpt-4o'),
+      );
+    });
+    it('matches provider case-insensitively', () => {
+      const list = [
+        discovered('gpt-4o', 'OpenAI', 'subscription'),
+        discovered('gpt-4o', 'openai', 'api_key'),
+      ];
+      expect(subscriptionPreferredRoute('gpt-4o', list)).toEqual(
+        route('OpenAI', 'subscription', 'gpt-4o'),
+      );
+    });
+    it('returns null for a single match', () => {
+      expect(
+        subscriptionPreferredRoute('gpt-4o', [discovered('gpt-4o', 'openai', 'subscription')]),
+      ).toBeNull();
+    });
+    it('returns null for three or more matches', () => {
+      const list = [
+        discovered('gpt-4o', 'openai', 'api_key'),
+        discovered('gpt-4o', 'openai', 'subscription'),
+        discovered('gpt-4o', 'openai', 'local'),
+      ];
+      expect(subscriptionPreferredRoute('gpt-4o', list)).toBeNull();
+    });
+    it('returns null when the pair is not subscription + api_key', () => {
+      const list = [
+        discovered('gpt-4o', 'openai', 'subscription'),
+        discovered('gpt-4o', 'openai', 'local'),
+      ];
+      expect(subscriptionPreferredRoute('gpt-4o', list)).toBeNull();
+    });
+    it('returns null for two matches of the same auth type', () => {
+      const list = [
+        discovered('gpt-4o', 'openai', 'api_key'),
+        discovered('gpt-4o', 'azure', 'api_key'),
+      ];
+      expect(subscriptionPreferredRoute('gpt-4o', list)).toBeNull();
+    });
+    it('returns null for a cross-provider collision', () => {
+      const list = [
+        discovered('gpt-4o', 'openai', 'subscription'),
+        discovered('gpt-4o', 'azure', 'api_key'),
+      ];
+      expect(subscriptionPreferredRoute('gpt-4o', list)).toBeNull();
+    });
+    it('ignores matches without an authType', () => {
+      const list = [
+        discovered('gpt-4o', 'openai', undefined as never),
+        discovered('gpt-4o', 'openai', 'subscription'),
+      ];
+      expect(subscriptionPreferredRoute('gpt-4o', list)).toBeNull();
     });
   });
 

--- a/packages/backend/src/routing/routing-core/route-helpers.ts
+++ b/packages/backend/src/routing/routing-core/route-helpers.ts
@@ -72,6 +72,35 @@ export function unambiguousRoute(
 }
 
 /**
+ * Resolve a bare model name carried by exactly two (provider, authType) route
+ * classes of the SAME provider — one subscription, one api_key — to the
+ * subscription route. A flat-fee subscription already covers the request, so
+ * silently metering a key (or refusing outright) would charge the user for
+ * traffic their subscription serves.
+ *
+ * Matches count route classes, not connections: discovery collapses multiple
+ * api_key connections of one provider into a single api_key row, and the
+ * subscription still wins over any number of metered keys — the same rationale
+ * applies whether one key or several would otherwise be billed.
+ *
+ * Returns null for every other multi-match shape (single match, cross-provider
+ * collision, three or more route classes, a `local` route involved) — those
+ * stay ambiguous and keep M302, exactly as unambiguousRoute treated them.
+ */
+export function subscriptionPreferredRoute(
+  model: string,
+  available: DiscoveredModel[],
+): ModelRoute | null {
+  const matches = available.filter((m) => m.id === model && m.authType);
+  if (matches.length !== 2) return null;
+  const subscription = matches.find((m) => m.authType === 'subscription');
+  const apiKey = matches.find((m) => m.authType === 'api_key');
+  if (!subscription || !apiKey) return null;
+  if (subscription.provider.toLowerCase() !== apiKey.provider.toLowerCase()) return null;
+  return { provider: subscription.provider, authType: 'subscription', model: subscription.id };
+}
+
+/**
  * Strict equality on (provider, authType, model, keyLabel). Used for tier-card
  * dedup where the same model with two different keys must NOT collide.
  *


### PR DESCRIPTION
### ✨ What changed

An explicit bare model id (e.g. `claude-fable-5-1`) that is served by both a subscription and an api_key connection of the same provider now routes strictly to the subscription connection. Previously the two catalog entries made the match ambiguous, and the request could silently resolve to the metered api_key.

- `subscriptionPreferredRoute()` in `route-helpers.ts` resolves the exact shape: two matches, same provider, one `subscription` + one `api_key`.
- `proxy.service.ts` calls it in `resolveExplicitModel` before the ambiguity check, for unqualified ids only.
- No fallback: if the subscription credentials fail, the caller gets the real error (M102) instead of a silent switch to the key.

### 💭 Why

Claude Code sends the bare model id and cannot append the `-subscription` suffix. With both connections active, the bare id matched both and the router picked the api_key path, billing dollars ($1.15 observed) for traffic the flat-fee subscription already covers. The caller pinned the model on purpose; the subscription is the connection they pay for.

### 👤 For users

Requests naming a model covered by your subscription now use the subscription, not your metered key. A subscription auth failure is surfaced to you rather than quietly charged to the key.

### 📝 Notes

Every other multi-match shape is untouched and keeps M302: cross-provider collisions, three or more connections, `local` involvement, same-auth duplicates. Backend suite: 8630 tests green, patch coverage 100%.