### PR TITLE
fix: hide OpenRouter :batch model variants from discovery

### DIFF
--- a/.changeset/openrouter-hide-batch-variants.md
+++ b/.changeset/openrouter-hide-batch-variants.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop listing OpenRouter `:batch` model variants in model discovery. These variants are only served through OpenRouter's asynchronous Batch API and always fail with a 404 on the synchronous chat completions proxy.

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -34,6 +34,17 @@ describe('buildFallbackModels', () => {
     expect(result.map((m) => m.id)).toEqual(['gpt-4o', 'gpt-4-turbo']);
   });
 
+  it('should filter out :batch variants (only served via the async Batch API)', () => {
+    const cache = new Map([
+      ['openai/gpt-5', { input: 0.01, output: 0.02 }],
+      ['openai/gpt-5:batch', { input: 0.005, output: 0.01 }],
+    ]);
+
+    const result = buildFallbackModels(makePricingSync(cache), 'openai');
+
+    expect(result.map((m) => m.id)).toEqual(['gpt-5']);
+  });
+
   it('should return empty when pricingSync is null', () => {
     expect(buildFallbackModels(null, 'openai')).toEqual([]);
   });

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -251,6 +251,9 @@ export function buildFallbackModels(
 
   for (const [fullId, entry] of pricingSync.getAll()) {
     if (!fullId.startsWith(`${orPrefix}/`)) continue;
+    // `:batch` variants are only served through OpenRouter's async Batch API,
+    // never through the synchronous chat completions proxy.
+    if (fullId.endsWith(':batch')) continue;
     const modelId = normalizeProviderModelId(providerId, fullId.substring(orPrefix.length + 1));
     if (seen.has(modelId)) continue;
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2071,6 +2071,32 @@ describe('ProviderModelFetcherService', () => {
       );
     });
 
+    it('should filter out :batch variants (only served via the async Batch API)', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'openai/gpt-5',
+              name: 'GPT-5',
+              context_length: 400000,
+              architecture: { output_modalities: ['text'] },
+            },
+            {
+              id: 'openai/gpt-5:batch',
+              name: 'GPT-5 (batch)',
+              context_length: 400000,
+              architecture: { output_modalities: ['text'] },
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openrouter', '');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('openai/gpt-5');
+    });
+
     it('should normalize OpenRouter input and output modalities', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -632,6 +632,10 @@ function parseOpenRouter(body: unknown, provider: string): DiscoveredModel[] {
     .filter((m: unknown) => {
       const entry = m as OpenRouterModelEntry;
       if (typeof entry.id !== 'string') return false;
+      // `:batch` variants are only served through OpenRouter's async Batch API,
+      // never through the synchronous chat completions proxy — listing them
+      // advertises models that are guaranteed to 404.
+      if (entry.id.endsWith(':batch')) return false;
       const output = entry.architecture?.output_modalities?.map((o) => o.toLowerCase());
       if (output && output.length > 0 && !output.every((o) => o === 'text')) {
         return false;


### PR DESCRIPTION
### ✨ What changed
- `parseOpenRouter` drops `:batch` model ids from the OpenRouter catalog
- `buildFallbackModels` skips `:batch` entries in the OpenRouter pricing-cache fallback

### 💭 Why
OpenRouter added 67 `:batch` variants to `/api/v1/models`. They are only served through its async Batch API (`/api/beta/batches`) and always 404 on the synchronous chat completions endpoint, so every call through the gateway fails. One tenant's model sweep produced 65 hard-failure issues in a single evening.

### 👤 For users
`:batch` models no longer appear in the model list. Selecting a batch variant was guaranteed to fail, so nothing that worked before changes.

### 📝 Notes
Batch API support (async job submission and polling) would be the alternative, but there is no demand yet. The only `:batch` traffic ever recorded was one automated probe sweep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops OpenRouter `:batch` model variants from appearing in model discovery so they no longer show up as selectable models that always fail.

These variants are only served through OpenRouter's async Batch API, not the synchronous chat completions proxy. They are now filtered out in both the OpenRouter catalog fetch and the pricing-cache fallback. No working model disappears; async Batch API support isn't added because there's no demand.

<sup>Written for commit a5de2f3542ebcff3eed4ef1c2729466b7ea7486d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

