### PR TITLE
test: deflake proxy-fallback-auth e2e attempt polling

### DIFF
--- a/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
+++ b/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
@@ -222,18 +222,33 @@ describe('Proxy fallback success — auth_type/cost_usd attribution (#1173)', ()
       .send({ messages: [{ role: 'user', content: 'hello' }] })
       .expect(200);
 
-    // recordFallbackSuccess fires off the response — wait for it to flush.
-    await new Promise((r) => setTimeout(r, 200));
-
-    const rows = await ds.query(
-      `SELECT model, provider, auth_type, cost_usd, fallback_from_model, status, superseded
-         FROM agent_messages
-        WHERE agent_id = $1
-        ORDER BY timestamp DESC`,
-      [TEST_AGENT_ID],
-    );
-    const success = rows.find((r: { status: string }) => r.status === 'success');
+    // recordFallbackSuccess fires off the response — poll until it flushes
+    // (a fixed sleep was flaky on slow CI runners).
+    type AttemptRow = {
+      model: string;
+      provider: string;
+      auth_type: string;
+      cost_usd: string;
+      fallback_from_model: string | null;
+      status: string;
+      superseded: boolean;
+    };
+    const deadline = Date.now() + 10000;
+    let rows: AttemptRow[] = [];
+    let success: AttemptRow | undefined;
+    do {
+      rows = await ds.query(
+        `SELECT model, provider, auth_type, cost_usd, fallback_from_model, status, superseded
+           FROM agent_messages
+          WHERE agent_id = $1
+          ORDER BY timestamp DESC`,
+        [TEST_AGENT_ID],
+      );
+      success = rows.find((r) => r.status === 'success');
+      if (!success) await new Promise((r) => setTimeout(r, 100));
+    } while (!success && Date.now() < deadline);
     expect(success).toBeDefined();
+    if (!success) throw new Error('unreachable');
     // Without the fix, success.auth_type carried 'api_key' (the primary's)
     // and cost_usd was computed from token pricing — non-zero.
     expect(success.auth_type).toBe('subscription');
@@ -246,10 +261,10 @@ describe('Proxy fallback success — auth_type/cost_usd attribution (#1173)', ()
     // superseded primary now stores the canonical `failed` status; the
     // recovered-hop signal lives on `superseded`, not the old `fallback_error`.
     const primaryFailure = rows.find(
-      (r: { status: string; superseded: boolean; fallback_from_model: string | null }) =>
-        r.status === 'failed' && r.superseded === true && r.fallback_from_model === null,
+      (r) => r.status === 'failed' && r.superseded === true && r.fallback_from_model === null,
     );
     expect(primaryFailure).toBeDefined();
+    if (!primaryFailure) throw new Error('unreachable');
     expect(primaryFailure.auth_type).toBe('api_key');
     expect(primaryFailure.model).toBe(PRIMARY_MODEL);
   });


### PR DESCRIPTION
### ✨ What changed
- Replace the fixed 200ms sleep with a poll loop (100ms interval, 10s deadline) waiting for the recorded success attempt.
- Type the queried rows so the assertions no longer rely on inline callback casts.

### 💭 Why
`recordFallbackSuccess` flushes asynchronously after the response. On slow CI runners the row sometimes hadn't landed after 200ms, so `rows.find(r => r.status === 'success')` returned undefined and the suite failed. It hit main twice on 2026-09-02 (runs 33639672797 and 33668783309) on unrelated commits.

### 📝 Notes
Test-only change, no changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the fixed 200ms sleep in the proxy-fallback-auth e2e spec with a polling loop (100ms interval, 10s deadline) that waits for the recorded success attempt, fixing flaky failures on slow CI runners.

Test-only change, no changeset.

<sup>Written for commit bbb2e2038252f7b39599688a34f071c0aff29235. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

