### PR TITLE
chore: add changeset for fast-uri security bump

### DIFF
--- a/.changeset/security-fast-uri-bump.md
+++ b/.changeset/security-fast-uri-bump.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Security: bump fast-uri to 3.1.6 (fixes GHSA-5jgf-p345-68v8, GHSA-fph4-wmhf-6fwf, GHSA-f65p-4m7j-42xc, GHSA-jqff-g426-hqxp) and refresh Docker base images.


### PR DESCRIPTION
Adds a changeset so the fast-uri 3.1.6 security fix (#2690) and Docker base-image refreshes (#2593) appear in the release changelog. Dependabot PRs carry no changesets, so these were invisible to the pending `chore: version packages` PR (#2822).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a changeset so the `fast-uri` security fix and Docker base-image refreshes appear in the release changelog; without it, Dependabot-driven changes stayed invisible to the versioning PR. The changeset applies a patch bump to `manifest` and lists the affected GitHub Security Advisories.

<sup>Written for commit 0eaebd990a8027c6046e1b60bca5a4aedaa4788f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

