### PR TITLE
ci: add upgrade-path smoke test against a populated database

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -325,6 +325,156 @@ jobs:
             kill "$(cat /tmp/mock-openai-provider.pid)" || true
           fi
 
+  upgrade-smoke:
+    name: Upgrade smoke test (populated DB)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # The `smoke` job above always boots against a fresh, empty database, so
+    # it can never catch a dependency or migration change that only breaks
+    # when upgrading an existing install. That is exactly how the Better Auth
+    # 1.7 bump (#2757) shipped green and then crashed every populated
+    # deployment at auth startup (rolled back in #2801). This job replays the
+    # real upgrade path: boot the latest *published* image, populate the
+    # database through the actual setup + login flow, then swap in the
+    # PR-built image against the same Postgres volume and verify it comes up
+    # healthy with the existing data and session intact.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Pull the published baseline image
+        run: |
+          docker pull manifestdotbuild/manifest:latest
+          docker tag manifestdotbuild/manifest:latest \
+            manifestdotbuild/manifest:published-baseline
+
+      - name: Build the PR image as manifestdotbuild/manifest:pr-candidate
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: manifestdotbuild/manifest:pr-candidate
+          platforms: linux/amd64
+          cache-from: type=gha,scope=smoke-amd64
+          cache-to: type=gha,mode=max,scope=smoke-amd64
+
+      - name: Prepare .env from .env.example
+        working-directory: docker
+        run: |
+          cp .env.example .env
+          # Generate a real secret so BETTER_AUTH_SECRET=${VAR:?…} succeeds.
+          secret=$(openssl rand -hex 32)
+          # Replace the empty `BETTER_AUTH_SECRET=` line.
+          new=""
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            if [[ "$line" == "BETTER_AUTH_SECRET=" ]]; then
+              new+="BETTER_AUTH_SECRET=${secret}"$'\n'
+            else
+              new+="$line"$'\n'
+            fi
+          done < .env
+          printf '%s' "$new" > .env
+
+      - name: Boot the published baseline and populate the database
+        working-directory: docker
+        env:
+          MANIFEST_VERSION: published-baseline
+        run: |
+          docker compose up -d
+          for i in $(seq 1 60); do
+            if curl -sSf http://127.0.0.1:2099/api/v1/health >/dev/null; then
+              echo "baseline healthy after ${i} tries"
+              break
+            fi
+            if [[ "$i" -eq 60 ]]; then
+              echo "baseline never became healthy" >&2
+              docker compose logs manifest
+              exit 1
+            fi
+            sleep 2
+          done
+
+          base_url=http://127.0.0.1:2099
+          auth_origin=http://localhost:2099
+          cookie_jar=/tmp/upgrade-smoke.cookies
+
+          curl -sSf -X POST "$base_url/api/v1/setup/admin" \
+            -H 'Content-Type: application/json' \
+            -H "Origin: $auth_origin" \
+            --data '{"email":"upgrade-smoke@example.com","name":"Upgrade Smoke","password":"upgrade-smoke-password"}' \
+            >/dev/null
+          curl -sSf -c "$cookie_jar" -X POST "$base_url/api/auth/sign-in/email" \
+            -H 'Content-Type: application/json' \
+            -H "Origin: $auth_origin" \
+            --data '{"email":"upgrade-smoke@example.com","password":"upgrade-smoke-password"}' \
+            >/dev/null
+          test -s "$cookie_jar"
+
+          # Real application rows on top of the auth tables, so migrations
+          # in the PR run against populated app data too.
+          agent=$(curl -sSf -b "$cookie_jar" -X POST "$base_url/api/v1/agents" \
+            -H 'Content-Type: application/json' \
+            --data '{"name":"Upgrade Smoke Agent"}')
+          jq -er '.apiKey | select(startswith("mnfst_"))' <<<"$agent" >/dev/null
+
+      - name: Upgrade to the PR image on the same database
+        working-directory: docker
+        env:
+          MANIFEST_VERSION: pr-candidate
+        run: |
+          docker compose up -d --no-deps manifest
+          for i in $(seq 1 60); do
+            if curl -sSf http://127.0.0.1:2099/api/v1/health >/dev/null; then
+              echo "upgraded image healthy after ${i} tries"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "upgraded image never became healthy against the populated database" >&2
+          docker compose logs manifest
+          exit 1
+
+      - name: Verify existing data and auth survive the upgrade
+        run: |
+          base_url=http://127.0.0.1:2099
+          auth_origin=http://localhost:2099
+          cookie_jar=/tmp/upgrade-smoke.cookies
+
+          # The session minted on the baseline image must still validate.
+          curl -sSf -b "$cookie_jar" -H "Origin: $auth_origin" \
+            "$base_url/api/auth/get-session" |
+            jq -e '.user.email == "upgrade-smoke@example.com"' >/dev/null
+
+          # A fresh login through the upgraded image must work — this is the
+          # exact call that broke after the Better Auth 1.7 upgrade.
+          curl -sSf -c /tmp/upgrade-smoke-fresh.cookies \
+            -X POST "$base_url/api/auth/sign-in/email" \
+            -H 'Content-Type: application/json' \
+            -H "Origin: $auth_origin" \
+            --data '{"email":"upgrade-smoke@example.com","password":"upgrade-smoke-password"}' \
+            >/dev/null
+          test -s /tmp/upgrade-smoke-fresh.cookies
+
+          # Pre-upgrade application data is still readable.
+          curl -sSf -b "$cookie_jar" \
+            "$base_url/api/v1/agents/upgrade-smoke-agent" -o /tmp/upgrade-agent.json
+          grep -q 'Upgrade Smoke Agent' /tmp/upgrade-agent.json
+
+      - name: Dump backend logs on failure
+        if: failure()
+        working-directory: docker
+        run: |
+          docker compose logs manifest || true
+          docker compose logs postgres || true
+
+      - name: Tear down
+        if: always()
+        working-directory: docker
+        run: docker compose down -v
+
   install-script:
     name: install.sh end-to-end
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The compose smoke test always boots against a **fresh, empty database**, so it can never catch a change that only breaks when **upgrading an existing install**. That is exactly how the Better Auth 1.7 bump (#2757) shipped green and then crashed every populated deployment at auth startup (rolled back in #2801).

## What

New `upgrade-smoke` job in `docker-smoke.yml` that replays the real upgrade path:

1. Pull the latest **published** image from Docker Hub and boot the compose stack with it (`MANIFEST_VERSION=published-baseline` — the compose file already parameterizes the image tag).
2. Populate the database through the real flow: `POST /api/v1/setup/admin` → `POST /api/auth/sign-in/email` → create an agent, so both Better Auth tables and application tables carry real rows.
3. Swap in the **PR-built** image on the same Postgres volume (`docker compose up -d --no-deps manifest` with `MANIFEST_VERSION=pr-candidate`).
4. Assert: `/api/v1/health` comes up, the session minted on the old version still validates (`get-session`), a fresh login works (the exact call that broke after the Better Auth 1.7 upgrade), and pre-upgrade agent data is still readable.

Reuses the existing `smoke-amd64` build cache scope, so the PR image build is mostly cache hits. No changeset — CI-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an upgrade-path smoke test that boots the published image, populates the database through the real setup and login flow, then swaps in the PR-built image on the same Postgres volume and verifies health, session validity, fresh login, and pre-upgrade data. Catches breakages that only appear when upgrading an existing install, which the existing fresh-database smoke test cannot.

- Reuses the `smoke-amd64` build cache scope, so the PR image build is mostly cache hits.
- CI-only change; no changeset.

<sup>Written for commit 643a48e3b4ef092d9457fd046d7c43551445ecf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

