### PR TITLE
feat(routing): send x-opencode-session header on OpenCode Go/Zen requests

### DIFF
--- a/.changeset/opencode-session-header.md
+++ b/.changeset/opencode-session-header.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Send the `x-opencode-session` header on every OpenCode Go/Zen request — hashed per-conversation id when the caller provides `x-session-key`, stable per-agent fallback otherwise — ahead of OpenCode's 09/06 enforcement deadline.

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -993,4 +993,40 @@ describe('buildProviderExtraHeaders', () => {
     expect(buildProviderExtraHeaders('openai', 'sess-abc')).toBeUndefined();
     expect(buildProviderExtraHeaders('unknown', 'sess-abc')).toBeUndefined();
   });
+
+  it('returns x-opencode-session for opencode-go and opencode-zen', () => {
+    expect(buildProviderExtraHeaders('opencode-go', 'v1:scoped-session')).toEqual({
+      'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
+    });
+    expect(buildProviderExtraHeaders('opencode-zen', 'v1:scoped-session')).toEqual({
+      'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
+    });
+  });
+
+  it('falls back to the agent scope key for opencode when no session key exists', () => {
+    expect(buildProviderExtraHeaders('opencode-go', undefined, 'tenant-1 agent-1')).toEqual({
+      'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
+    });
+  });
+
+  it('prefers the per-conversation key over the agent scope fallback', () => {
+    const withSession = buildProviderExtraHeaders(
+      'opencode-go',
+      'v1:scoped-session',
+      'tenant-1 agent-1',
+    );
+    const fallbackOnly = buildProviderExtraHeaders('opencode-go', undefined, 'tenant-1 agent-1');
+    expect(withSession!['x-opencode-session']).not.toBe(fallbackOnly!['x-opencode-session']);
+    expect(withSession).toEqual(buildProviderExtraHeaders('opencode-go', 'v1:scoped-session'));
+  });
+
+  it('does not extend the agent scope fallback to xai or openrouter', () => {
+    expect(buildProviderExtraHeaders('xai', undefined, 'tenant-1 agent-1')).toBeUndefined();
+    expect(buildProviderExtraHeaders('openrouter', undefined, 'tenant-1 agent-1')).toBeUndefined();
+  });
+
+  it('returns undefined for opencode without any key', () => {
+    expect(buildProviderExtraHeaders('opencode-go')).toBeUndefined();
+    expect(buildProviderExtraHeaders('opencode-zen')).toBeUndefined();
+  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -1003,8 +1003,17 @@ describe('buildProviderExtraHeaders', () => {
     });
   });
 
+  it('resolves registry aliases (opencodego / opencodezen) to the canonical builder', () => {
+    expect(buildProviderExtraHeaders('opencodego', 'v1:scoped-session')).toEqual({
+      'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
+    });
+    expect(buildProviderExtraHeaders('opencodezen', 'v1:scoped-session')).toEqual({
+      'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
+    });
+  });
+
   it('falls back to the agent scope key for opencode when no session key exists', () => {
-    expect(buildProviderExtraHeaders('opencode-go', undefined, 'tenant-1 agent-1')).toEqual({
+    expect(buildProviderExtraHeaders('opencode-go', undefined, 'tenant-1\u0000agent-1')).toEqual({
       'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
     });
   });
@@ -1013,16 +1022,22 @@ describe('buildProviderExtraHeaders', () => {
     const withSession = buildProviderExtraHeaders(
       'opencode-go',
       'v1:scoped-session',
-      'tenant-1 agent-1',
+      'tenant-1\u0000agent-1',
     );
-    const fallbackOnly = buildProviderExtraHeaders('opencode-go', undefined, 'tenant-1 agent-1');
+    const fallbackOnly = buildProviderExtraHeaders(
+      'opencode-go',
+      undefined,
+      'tenant-1\u0000agent-1',
+    );
     expect(withSession!['x-opencode-session']).not.toBe(fallbackOnly!['x-opencode-session']);
     expect(withSession).toEqual(buildProviderExtraHeaders('opencode-go', 'v1:scoped-session'));
   });
 
   it('does not extend the agent scope fallback to xai or openrouter', () => {
-    expect(buildProviderExtraHeaders('xai', undefined, 'tenant-1 agent-1')).toBeUndefined();
-    expect(buildProviderExtraHeaders('openrouter', undefined, 'tenant-1 agent-1')).toBeUndefined();
+    expect(buildProviderExtraHeaders('xai', undefined, 'tenant-1\u0000agent-1')).toBeUndefined();
+    expect(
+      buildProviderExtraHeaders('openrouter', undefined, 'tenant-1\u0000agent-1'),
+    ).toBeUndefined();
   });
 
   it('returns undefined for opencode without any key', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -915,11 +915,8 @@ describe('ProxyFallbackService', () => {
         sessionKey: 'default',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith(
-        expect.objectContaining({
-          extraHeaders: expect.not.objectContaining({ 'x-opencode-session': expect.any(String) }),
-        }),
-      );
+      const forwardArgs = providerClient.forward.mock.calls[0][0];
+      expect(forwardArgs.extraHeaders?.['x-opencode-session']).toBeUndefined();
     });
 
     it('exchanges copilot token before forwarding', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -841,6 +841,85 @@ describe('ProxyFallbackService', () => {
       );
     });
 
+    it('adds x-opencode-session header for opencode-go with a scoped session key', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'opencode-go',
+        apiKey: 'sk-oc',
+        model: 'opencode-go/deepseek-v4-flash',
+        body,
+        stream: false,
+        sessionKey: 'my-session',
+        providerCacheKey: 'v1:scoped-session',
+      });
+
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extraHeaders: {
+            'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
+          },
+        }),
+      );
+    });
+
+    it('adds a stable agent-scoped x-opencode-session when the caller sent no session key', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      const forwardTwice = async () =>
+        service.tryForwardToProvider({
+          provider: 'opencode-go',
+          apiKey: 'sk-oc',
+          model: 'opencode-go/deepseek-v4-flash',
+          body,
+          stream: false,
+          sessionKey: 'default',
+          tenantId: 'tenant-1',
+          agentId: 'agent-1',
+        });
+      await forwardTwice();
+      await forwardTwice();
+
+      const calls = providerClient.forward.mock.calls.map(
+        ([opts]: [{ extraHeaders?: Record<string, string> }]) =>
+          opts.extraHeaders?.['x-opencode-session'],
+      );
+      expect(calls[0]).toMatch(/^manifest-[a-f0-9]{32}$/);
+      expect(calls[1]).toBe(calls[0]);
+    });
+
+    it('omits x-opencode-session without a session key or agent identity', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'opencode-go',
+        apiKey: 'sk-oc',
+        model: 'opencode-go/deepseek-v4-flash',
+        body,
+        stream: false,
+        sessionKey: 'default',
+      });
+
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({ extraHeaders: undefined }),
+      );
+    });
+
     it('exchanges copilot token before forwarding', async () => {
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -916,7 +916,9 @@ describe('ProxyFallbackService', () => {
       });
 
       expect(providerClient.forward).toHaveBeenCalledWith(
-        expect.objectContaining({ extraHeaders: undefined }),
+        expect.objectContaining({
+          extraHeaders: expect.not.objectContaining({ 'x-opencode-session': expect.any(String) }),
+        }),
       );
     });
 

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -33,26 +33,51 @@ export function resolveSubscriptionEndpointKey(endpointKey: string): string | un
 }
 
 /**
+ * Keys available to an extra-header builder, both already hashed into
+ * opaque `manifest-*` identifiers.
+ */
+interface ExtraHeaderKeys {
+  /** Per-conversation key; absent when the caller sent no x-session-key. */
+  sessionKey?: string;
+  /** Per-agent key; absent when the forward carries no tenant/agent identity. */
+  agentKey?: string;
+}
+
+// OpenCode Go/Zen pin a session to one upstream provider via
+// x-opencode-session and reject some models without it, so unlike the
+// observability-only hints above the header must ride on every request:
+// fall back to the per-agent key when the caller sent no x-session-key.
+const opencodeSessionHeader = ({ sessionKey, agentKey }: ExtraHeaderKeys) => {
+  const id = sessionKey ?? agentKey;
+  return id ? { 'x-opencode-session': id } : undefined;
+};
+
+/**
  * Extra HTTP headers that must be attached at forward-time for specific
  * providers (typically for observability on the provider side).
  */
 const PROVIDER_EXTRA_HEADER_BUILDERS: Record<
   string,
-  (sessionKey: string) => Record<string, string> | undefined
+  (keys: ExtraHeaderKeys) => Record<string, string> | undefined
 > = {
-  xai: (sessionKey) => ({ 'x-grok-conv-id': sessionKey }),
-  openrouter: (sessionKey) =>
-    sessionKey === 'default' ? undefined : { 'x-session-id': sessionKey },
+  xai: ({ sessionKey }) => (sessionKey ? { 'x-grok-conv-id': sessionKey } : undefined),
+  openrouter: ({ sessionKey }) =>
+    !sessionKey || sessionKey === 'default' ? undefined : { 'x-session-id': sessionKey },
+  'opencode-go': opencodeSessionHeader,
+  'opencode-zen': opencodeSessionHeader,
 };
 
 export function buildProviderExtraHeaders(
   provider: string,
   providerCacheKey?: string,
+  agentScopeKey?: string,
 ): Record<string, string> | undefined {
-  if (!providerCacheKey) return undefined;
   const builder = PROVIDER_EXTRA_HEADER_BUILDERS[provider.toLowerCase()];
   if (!builder) return undefined;
-  return builder(buildProviderPromptCacheKey(providerCacheKey));
+  return builder({
+    sessionKey: providerCacheKey ? buildProviderPromptCacheKey(providerCacheKey) : undefined,
+    agentKey: agentScopeKey ? buildProviderPromptCacheKey(agentScopeKey) : undefined,
+  });
 }
 
 function buildProviderPromptCacheKey(providerCacheKey: string): string {

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
 
 /**
  * Provider-specific hooks — data-driven lookups that replace scattered
@@ -72,7 +73,11 @@ export function buildProviderExtraHeaders(
   providerCacheKey?: string,
   agentScopeKey?: string,
 ): Record<string, string> | undefined {
-  const builder = PROVIDER_EXTRA_HEADER_BUILDERS[provider.toLowerCase()];
+  // Canonicalize through the registry so alias-keyed providers (e.g.
+  // `opencodego` → `opencode-go`) hit the same builder as their canonical id.
+  const lower = provider.toLowerCase();
+  const canonical = PROVIDER_BY_ID_OR_ALIAS.get(lower)?.id ?? lower;
+  const builder = PROVIDER_EXTRA_HEADER_BUILDERS[canonical];
   if (!builder) return undefined;
   return builder({
     sessionKey: providerCacheKey ? buildProviderPromptCacheKey(providerCacheKey) : undefined,

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -664,7 +664,12 @@ export class ProxyFallbackService {
       authType,
       opts.model,
     );
-    const extraHeaders = buildProviderExtraHeaders(provider, opts.providerCacheKey);
+    // Agent-scope fallback for providers (OpenCode) that need a session id on
+    // every request even when the caller sent no x-session-key. NUL-joined so
+    // distinct (tenant, agent) pairs can never collide before hashing.
+    const agentScopeKey =
+      opts.tenantId && opts.agentId ? `${opts.tenantId}\u0000${opts.agentId}` : undefined;
+    const extraHeaders = buildProviderExtraHeaders(provider, opts.providerCacheKey, agentScopeKey);
 
     // Copilot: exchange the stored GitHub OAuth token for a short-lived API token
     let effectiveKey = opts.apiKey;


### PR DESCRIPTION
## Why

OpenCode emailed operators that requests missing the `x-opencode-session` header (flagged user agent: "Node fetch" — i.e. Manifest's proxy forwards) may start erroring on **09/06**. OpenCode uses the header to pin a conversation to one upstream provider for prompt-cache affinity; some models already 400 without it (see e.g. sst/opencode-adjacent reports of `deepseek-v4-flash` → "Model is unavailable").

Manifest multiplexes many agent conversations over one OpenCode API key and sent only auth/content-type headers, so every forward was missing the header.

## What

Extends the existing data-driven extra-header mechanism (`PROVIDER_EXTRA_HEADER_BUILDERS` in `provider-hooks.ts`, same one xai/openrouter use) — no new provider `if` branches:

- **`opencode-go` + `opencode-zen` builder entries** emit `x-opencode-session: manifest-<sha256/32hex>`, reusing the existing `buildProviderPromptCacheKey` hashing so the id stays opaque (no tenant/agent/session data leaks upstream).
- **Per-conversation id when available**: when the calling agent sends Manifest's `x-session-key` header, the existing hashed `providerCacheKey` is used — a stable id per conversation, exactly what OpenCode asks for.
- **Per-agent fallback otherwise**: unlike the observability-only xai/openrouter headers, OpenCode may *reject* requests without the header, so when no session key exists the id falls back to a stable hash of `tenantId + NUL + agentId`. xai/openrouter behavior is unchanged (pinned by a test).
- The header merge in `provider-client.ts` applies to all wire formats, so the `opencode-go-anthropic`, `opencode-go-responses`, and `opencode-zen-google` endpoint variants are covered by the same two builder entries.

## Testing

- TDD: 8 new tests across `provider-endpoints.spec.ts` (builder behavior, fallback precedence, xai/openrouter non-extension) and `proxy-fallback.service.spec.ts` (header on the wire, stable across forwards, omitted without any identity), all watched fail first.
- Full backend suite: 8640 tests / 467 suites green; typecheck + lint clean.
- Changed lines at 100% coverage; `provider-hooks.ts` at 100% statements and branches.

## Changeset

Patch bump on `manifest`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `x-opencode-session` header to forwarded OpenCode Go/Zen requests so OpenCode can pin conversations to one upstream provider before its September 6 enforcement deadline. Previously every forwarded OpenCode request was missing the header, and some models already reject requests without it.

- Uses the hashed per-conversation key when the caller sends `x-session-key`.
- Falls back to a stable hash of tenant and agent IDs when there is no session key, so the header is present on requests with agent identity.
- Resolves `opencodego`/`opencodezen` aliases to the same header builder.
- Omits the header only when no session key or agent identity is available.
- Leaves `xai` and `openrouter` header behavior unchanged.

<sup>Written for commit a241d9506a1f23fcebb35f69d90d3f555c04af3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

