### PR TITLE
feat: add alias for custom provider model ids

### DIFF
--- a/.changeset/custom-provider-alias.md
+++ b/.changeset/custom-provider-alias.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Custom providers now have an alias, the readable prefix their models are published under in `/v1/models` (`vercel-ai-gateway/alibaba/qwen-3-14b` instead of `custom:<uuid>/alibaba/qwen-3-14b`). The alias defaults to the provider name, is editable at creation and later, and the proxy accepts both the alias form and the internal `custom:<uuid>/…` form in the `model` field, so existing client configs keep working. Existing custom providers are backfilled on upgrade.

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -41,6 +41,7 @@ import { DropLegacyAutofixRolloutColumns1801600000000 } from './migrations/18016
 import { AddRequestApiMode1801720000000 } from './migrations/1801720000000-AddRequestApiMode';
 import { AddAutofixConsentToInstallMetadata1801900000000 } from './migrations/1801900000000-AddAutofixConsentToInstallMetadata';
 import { SlimTenantAgentModelIndex1802000000000 } from './migrations/1802000000000-SlimTenantAgentModelIndex';
+import { AddCustomProviderAlias1802100000000 } from './migrations/1802100000000-AddCustomProviderAlias';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -320,4 +321,5 @@ export const migrations = [
   AddRequestApiMode1801720000000,
   AddAutofixConsentToInstallMetadata1801900000000,
   SlimTenantAgentModelIndex1802000000000,
+  AddCustomProviderAlias1802100000000,
 ];

--- a/packages/backend/src/database/migrations/1802100000000-AddCustomProviderAlias.spec.ts
+++ b/packages/backend/src/database/migrations/1802100000000-AddCustomProviderAlias.spec.ts
@@ -1,0 +1,85 @@
+import { AddCustomProviderAlias1802100000000 } from './1802100000000-AddCustomProviderAlias';
+
+describe('AddCustomProviderAlias1802100000000', () => {
+  const migration = new AddCustomProviderAlias1802100000000();
+  let queries: string[];
+  let args: unknown[][];
+  let rows: { id: string; tenant_id: string; name: string; alias: string | null }[];
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string, ...params: unknown[]) => {
+      queries.push(sql);
+      args.push(params);
+      if (sql.startsWith('SELECT')) return Promise.resolve(rows);
+      return Promise.resolve([]);
+    }),
+  } as never;
+
+  const updates = () => args.filter((_, i) => queries[i].startsWith('UPDATE'));
+
+  beforeEach(() => {
+    queries = [];
+    args = [];
+    rows = [];
+    jest.clearAllMocks();
+  });
+
+  it('exposes the expected migration name', () => {
+    expect(migration.name).toBe('AddCustomProviderAlias1802100000000');
+  });
+
+  it('adds the nullable column and the case-insensitive partial unique index', async () => {
+    await migration.up(mockQueryRunner);
+    expect(queries[0]).toContain('ADD COLUMN IF NOT EXISTS "alias" varchar');
+    expect(queries[1]).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_custom_providers_tenant_alias"',
+    );
+    expect(queries[1]).toContain('("tenant_id", LOWER("alias")) WHERE "alias" IS NOT NULL');
+    expect(queries[2]).toMatch(/^SELECT .* ORDER BY "created_at" ASC, "id" ASC$/);
+  });
+
+  it('backfills each row from its name', async () => {
+    rows = [
+      { id: 'cp-1', tenant_id: 't1', name: 'Vercel AI Gateway', alias: null },
+      { id: 'cp-2', tenant_id: 't1', name: 'llama.cpp', alias: null },
+    ];
+    await migration.up(mockQueryRunner);
+    expect(updates()).toEqual([[['vercel-ai-gateway', 'cp-1']], [['llama.cpp', 'cp-2']]]);
+  });
+
+  it('skips rows whose name yields no usable or a reserved alias', async () => {
+    rows = [
+      { id: 'cp-1', tenant_id: 't1', name: '***', alias: null },
+      { id: 'cp-2', tenant_id: 't1', name: 'OpenAI', alias: null },
+    ];
+    await migration.up(mockQueryRunner);
+    expect(updates()).toEqual([]);
+  });
+
+  it('gives a contested alias to the oldest row only, per tenant', async () => {
+    rows = [
+      { id: 'cp-1', tenant_id: 't1', name: 'My Provider', alias: null },
+      { id: 'cp-2', tenant_id: 't1', name: 'My-Provider', alias: null },
+      { id: 'cp-3', tenant_id: 't2', name: 'my provider', alias: null },
+    ];
+    await migration.up(mockQueryRunner);
+    expect(updates()).toEqual([[['my-provider', 'cp-1']], [['my-provider', 'cp-3']]]);
+  });
+
+  it('leaves rows that already carry an alias alone and reserves their value', async () => {
+    rows = [
+      { id: 'cp-1', tenant_id: 't1', name: 'Something Else', alias: 'My-Provider' },
+      { id: 'cp-2', tenant_id: 't1', name: 'My Provider', alias: null },
+    ];
+    await migration.up(mockQueryRunner);
+    expect(updates()).toEqual([]);
+  });
+
+  it('drops the index and the column on down', async () => {
+    await migration.down(mockQueryRunner);
+    expect(queries).toEqual([
+      'DROP INDEX IF EXISTS "IDX_custom_providers_tenant_alias"',
+      'ALTER TABLE "custom_providers" DROP COLUMN IF EXISTS "alias"',
+    ]);
+  });
+});

--- a/packages/backend/src/database/migrations/1802100000000-AddCustomProviderAlias.ts
+++ b/packages/backend/src/database/migrations/1802100000000-AddCustomProviderAlias.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { deriveCustomProviderAlias, isReservedCustomProviderAlias } from 'manifest-shared';
+
+/**
+ * Adds `custom_providers.alias`: the public prefix of a custom provider's
+ * model ids in `/v1/models` (`<alias>/<model_name>`), replacing the internal
+ * `custom:<uuid>/<model_name>` key that chat clients truncate.
+ *
+ * Nullable — a null alias keeps publishing the internal key, which the proxy
+ * accepts forever. Uniqueness is case-insensitive per tenant, as for `name`,
+ * via a partial unique index that ignores null rows.
+ *
+ * Existing rows are backfilled from their name so every install gets readable
+ * ids on upgrade. The derivation is the same one `create` uses for a default.
+ * A row is skipped (alias stays null) when its name yields nothing usable, a
+ * reserved or built-in provider name, or an alias another row of the same
+ * tenant already took — oldest row wins, so a re-run is a no-op.
+ */
+export class AddCustomProviderAlias1802100000000 implements MigrationInterface {
+  name = 'AddCustomProviderAlias1802100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "custom_providers" ADD COLUMN IF NOT EXISTS "alias" varchar`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "IDX_custom_providers_tenant_alias" ON "custom_providers" ("tenant_id", LOWER("alias")) WHERE "alias" IS NOT NULL`,
+    );
+
+    const rows: { id: string; tenant_id: string; name: string; alias: string | null }[] =
+      await queryRunner.query(
+        `SELECT "id", "tenant_id", "name", "alias" FROM "custom_providers" ORDER BY "created_at" ASC, "id" ASC`,
+      );
+
+    const taken = new Set<string>();
+    for (const row of rows) {
+      if (row.alias) taken.add(`${row.tenant_id} ${row.alias.toLowerCase()}`);
+    }
+
+    for (const row of rows) {
+      if (row.alias) continue;
+      const alias = deriveCustomProviderAlias(row.name);
+      if (!alias || isReservedCustomProviderAlias(alias)) continue;
+      const key = `${row.tenant_id} ${alias}`;
+      if (taken.has(key)) continue;
+      taken.add(key);
+      await queryRunner.query(`UPDATE "custom_providers" SET "alias" = $1 WHERE "id" = $2`, [
+        alias,
+        row.id,
+      ]);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_custom_providers_tenant_alias"`);
+    await queryRunner.query(`ALTER TABLE "custom_providers" DROP COLUMN IF EXISTS "alias"`);
+  }
+}

--- a/packages/backend/src/entities/custom-provider.entity.ts
+++ b/packages/backend/src/entities/custom-provider.entity.ts
@@ -30,6 +30,16 @@ export class CustomProvider {
   @Column('varchar')
   name!: string;
 
+  /**
+   * Public prefix of this provider's model ids in `/v1/models`
+   * (`<alias>/<model_name>`). Null means the models publish under the
+   * internal `custom:<uuid>/<model_name>` key. Uniqueness is a
+   * case-insensitive partial index on (tenant_id, LOWER(alias)) owned by
+   * the migration, same as `name`.
+   */
+  @Column('varchar', { nullable: true })
+  alias!: string | null;
+
   @Column('varchar')
   base_url!: string;
 

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -840,6 +840,18 @@ describe('ModelDiscoveryService', () => {
       expect(result[1].id).toBe('custom:cp-1/custom-llm');
       expect(result[1].provider).toBe('custom:cp-1');
       expect(result[1].displayName).toBe('custom-llm');
+      expect(result[1].providerName).toBe('My Custom');
+      expect(result[1]).not.toHaveProperty('providerAlias');
+    });
+
+    it('carries the custom provider alias so /v1/models can publish it', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([makeCustomProvider({ alias: 'my-custom' })]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result[0].providerAlias).toBe('my-custom');
+      expect(result[0].providerName).toBe('My Custom');
     });
 
     it('should filter stale unsupported OpenAI subscription cached models', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1134,6 +1134,19 @@ describe('ModelDiscoveryService', () => {
       expect(providerRepo.find).toHaveBeenCalledTimes(2);
     });
 
+    it('invalidateTenant drops every agent of that tenant and no other', async () => {
+      await service.getModelsForAgent('tenant-1', 'agent-1');
+      await service.getModelsForAgent('tenant-1', 'agent-2');
+      await service.getModelsForAgent('tenant-2', 'agent-3');
+      service.invalidateTenant('tenant-1');
+
+      await service.getModelsForAgent('tenant-1', 'agent-1'); // refetch
+      await service.getModelsForAgent('tenant-1', 'agent-2'); // refetch
+      await service.getModelsForAgent('tenant-2', 'agent-3'); // still cached
+
+      expect(providerRepo.find).toHaveBeenCalledTimes(5);
+    });
+
     it('only invalidates the targeted agent', async () => {
       await service.getModelsForAgent('tenant-1', 'agent-1');
       await service.getModelsForAgent('tenant-1', 'agent-2');

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -617,6 +617,8 @@ export class ModelDiscoveryService {
           capabilityReasoning: false,
           capabilityCode: false,
           qualityScore: 2,
+          providerName: cp.name,
+          ...(cp.alias ? { providerAlias: cp.alias } : {}),
         });
       }
     }

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -83,6 +83,7 @@ function nonChatFilterKey(providerId: string, authType: AuthType): string {
 const MODELS_CACHE_TTL_MS = 120_000;
 
 interface ModelsCacheEntry {
+  tenantId: string;
   data: DiscoveredModel[];
   expiresAt: number;
 }
@@ -513,7 +514,11 @@ export class ModelDiscoveryService {
     for (const [key, entry] of this.modelsCache) {
       if (entry.expiresAt <= now) this.modelsCache.delete(key);
     }
-    this.modelsCache.set(agentId, { data: models, expiresAt: now + MODELS_CACHE_TTL_MS });
+    this.modelsCache.set(agentId, {
+      tenantId,
+      data: models,
+      expiresAt: now + MODELS_CACHE_TTL_MS,
+    });
     return models;
   }
 
@@ -523,6 +528,17 @@ export class ModelDiscoveryService {
    */
   invalidate(agentId: string): void {
     this.modelsCache.delete(agentId);
+  }
+
+  /**
+   * Drop the cached model list of every agent in a tenant. Custom providers
+   * are tenant-global, so their alias, name or model-list edits change what
+   * every agent publishes at once (bridged from RoutingCacheService).
+   */
+  invalidateTenant(tenantId: string): void {
+    for (const [agentId, entry] of this.modelsCache) {
+      if (entry.tenantId === tenantId) this.modelsCache.delete(agentId);
+    }
   }
 
   private async invalidateProviderAccess(provider: TenantProvider): Promise<void> {

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -43,6 +43,14 @@ export interface DiscoveredModel {
   supportedEndpoints?: readonly string[];
   qualityScore: number;
   authType?: AuthType;
+  /** Custom providers only: the display name the user gave the provider. */
+  providerName?: string;
+  /**
+   * Custom providers only: the alias `/v1/models` publishes the model under
+   * (`<providerAlias>/<model_name>`). Absent when the provider has no alias,
+   * in which case the internal `custom:<uuid>/<model_name>` id is published.
+   */
+  providerAlias?: string;
 }
 
 export interface FetcherConfig {

--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -77,6 +77,7 @@ describe('CustomProviderController', () => {
         {
           id: 'cp-1',
           name: 'Groq',
+          alias: 'groq',
           base_url: 'https://api.groq.com/v1',
           models: [{ model_name: 'llama' }],
           created_at: '2026-03-04',
@@ -92,6 +93,7 @@ describe('CustomProviderController', () => {
       expect(result[0]).toEqual({
         id: 'cp-1',
         name: 'Groq',
+        alias: 'groq',
         base_url: 'https://api.groq.com/v1',
         has_api_key: true,
         models: [{ model_name: 'llama' }],

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -39,6 +39,7 @@ export class CustomProviderController {
       return {
         id: cp.id,
         name: cp.name,
+        alias: cp.alias,
         base_url: cp.base_url,
         api_kind: cp.api_kind,
         has_api_key: !!up?.api_key_encrypted,
@@ -86,6 +87,7 @@ export class CustomProviderController {
     return {
       id: cp.id,
       name: cp.name,
+      alias: cp.alias,
       base_url: cp.base_url,
       api_kind: cp.api_kind,
       has_api_key: !!up?.api_key_encrypted,
@@ -111,6 +113,7 @@ export class CustomProviderController {
     return {
       id: cp.id,
       name: cp.name,
+      alias: cp.alias,
       base_url: cp.base_url,
       api_kind: cp.api_kind,
       has_api_key: !!up?.api_key_encrypted,

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -416,6 +416,29 @@ describe('CustomProviderService', () => {
           ConflictException,
         );
       });
+
+      it('turns a lost race on the alias unique index into a 409', async () => {
+        const { svc, insert } = makeDeps({ findOneResults: [null] });
+        insert.mockRejectedValueOnce(
+          Object.assign(new Error('duplicate key'), {
+            code: '23505',
+            constraint: 'IDX_custom_providers_tenant_alias',
+          }),
+        );
+        await expect(svc.create('tenant-1', { ...dto, alias: 'vercel' })).rejects.toBeInstanceOf(
+          ConflictException,
+        );
+      });
+
+      it('rethrows other insert failures untouched', async () => {
+        const { svc, insert } = makeDeps({ findOneResults: [null] });
+        const boom = Object.assign(new Error('other index'), {
+          code: '23505',
+          constraint: 'some_other_index',
+        });
+        insert.mockRejectedValueOnce(boom);
+        await expect(svc.create('tenant-1', dto)).rejects.toBe(boom);
+      });
     });
 
     it('tags the companion tenant_providers row as local when the name is LM Studio', async () => {
@@ -681,6 +704,28 @@ describe('CustomProviderService', () => {
         await expect(svc.update('cp1', 'tenant-1', { alias: 'gemini' })).rejects.toBeInstanceOf(
           BadRequestException,
         );
+      });
+
+      it('turns a lost race on the alias unique index into a 409', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: null } as CustomProvider;
+        const { svc, save } = makeDeps({ findOneResults: [existing] });
+        save.mockRejectedValueOnce(
+          Object.assign(new Error('duplicate key'), {
+            code: '23505',
+            constraint: 'IDX_custom_providers_tenant_alias',
+          }),
+        );
+        await expect(svc.update('cp1', 'tenant-1', { alias: 'fresh' })).rejects.toBeInstanceOf(
+          ConflictException,
+        );
+      });
+
+      it('rethrows other save failures untouched', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: null } as CustomProvider;
+        const { svc, save } = makeDeps({ findOneResults: [existing] });
+        const boom = new Error('connection reset');
+        save.mockRejectedValueOnce(boom);
+        await expect(svc.update('cp1', 'tenant-1', { alias: 'fresh' })).rejects.toBe(boom);
       });
 
       it('rejects an alias another provider of the tenant already uses, case-insensitively', async () => {

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -368,6 +368,56 @@ describe('CustomProviderService', () => {
       expect(reloadPricing).toHaveBeenCalledTimes(1);
     });
 
+    describe('alias', () => {
+      it('derives a default alias from the name when none is sent', async () => {
+        const { svc } = makeDeps({ findOneResults: [null] });
+        const cp = await svc.create('tenant-1', { ...dto, name: 'Vercel AI Gateway' });
+        expect(cp.alias).toBe('vercel-ai-gateway');
+      });
+
+      it('leaves the default alias empty when the name yields a reserved one', async () => {
+        const { svc } = makeDeps({ findOneResults: [null] });
+        const cp = await svc.create('tenant-1', { ...dto, name: 'OpenAI' });
+        expect(cp.alias).toBeNull();
+      });
+
+      it('leaves the default alias empty when another provider already took it', async () => {
+        const { svc } = makeDeps({
+          findResult: [{ id: 'other', name: 'Other', alias: 'My-Provider' } as CustomProvider],
+        });
+        const cp = await svc.create('tenant-1', { ...dto, name: 'My Provider' });
+        expect(cp.alias).toBeNull();
+      });
+
+      it('stores an explicit alias, normalised', async () => {
+        const { svc } = makeDeps({ findOneResults: [null] });
+        const cp = await svc.create('tenant-1', { ...dto, alias: ' Vercel ' });
+        expect(cp.alias).toBe('vercel');
+      });
+
+      it('honours an explicit null as "no alias" instead of deriving one', async () => {
+        const { svc } = makeDeps({ findOneResults: [null] });
+        const cp = await svc.create('tenant-1', { ...dto, alias: null });
+        expect(cp.alias).toBeNull();
+      });
+
+      it('rejects an explicit alias that shadows a built-in provider', async () => {
+        const { svc } = makeDeps({ findOneResults: [null] });
+        await expect(svc.create('tenant-1', { ...dto, alias: 'openai' })).rejects.toBeInstanceOf(
+          BadRequestException,
+        );
+      });
+
+      it('rejects an explicit alias another provider of the tenant already uses', async () => {
+        const { svc } = makeDeps({
+          findResult: [{ id: 'other', name: 'Other', alias: 'Vercel' } as CustomProvider],
+        });
+        await expect(svc.create('tenant-1', { ...dto, alias: 'vercel' })).rejects.toBeInstanceOf(
+          ConflictException,
+        );
+      });
+    });
+
     it('tags the companion tenant_providers row as local when the name is LM Studio', async () => {
       const { svc, upsertProvider, txManager } = makeDeps({ findOneResults: [null] });
       await svc.create('tenant-1', { ...dto, name: 'LM Studio' });
@@ -582,6 +632,67 @@ describe('CustomProviderService', () => {
       // A rename-only update cannot affect prices, so the shared pricing
       // cache should be left alone (reload is expensive for large installs).
       expect(reloadPricing).not.toHaveBeenCalled();
+    });
+
+    describe('alias', () => {
+      it('leaves the alias alone on a rename so client configs survive', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: 'old' } as CustomProvider;
+        const { svc, find } = makeDeps({ findOneResults: [existing] });
+        await svc.update('cp1', 'tenant-1', { name: 'new' });
+        expect(existing.alias).toBe('old');
+        // The rename fetched the tenant list once; no second lookup for an alias.
+        expect(find).toHaveBeenCalledTimes(1);
+      });
+
+      it('sets a new alias after checking the tenant for collisions', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: null } as CustomProvider;
+        const { svc, save, find } = makeDeps({
+          findOneResults: [existing],
+          findResult: [existing, { id: 'other', name: 'Other', alias: 'taken' } as CustomProvider],
+        });
+        await svc.update('cp1', 'tenant-1', { alias: 'Fresh' });
+        expect(existing.alias).toBe('fresh');
+        expect(save).toHaveBeenCalledWith(existing);
+        expect(find).toHaveBeenCalledTimes(1);
+      });
+
+      it('clears the alias on null or an empty string', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: 'old' } as CustomProvider;
+        const { svc, find } = makeDeps({ findOneResults: [existing, existing] });
+        await svc.update('cp1', 'tenant-1', { alias: '' });
+        expect(existing.alias).toBeNull();
+        existing.alias = 'old';
+        await svc.update('cp1', 'tenant-1', { alias: null });
+        expect(existing.alias).toBeNull();
+        expect(find).not.toHaveBeenCalled();
+      });
+
+      it('skips the collision lookup when the alias is unchanged', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: 'same' } as CustomProvider;
+        const { svc, find } = makeDeps({ findOneResults: [existing] });
+        await svc.update('cp1', 'tenant-1', { alias: 'SAME' });
+        expect(existing.alias).toBe('same');
+        expect(find).not.toHaveBeenCalled();
+      });
+
+      it('rejects an alias that shadows a built-in provider', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: null } as CustomProvider;
+        const { svc } = makeDeps({ findOneResults: [existing] });
+        await expect(svc.update('cp1', 'tenant-1', { alias: 'gemini' })).rejects.toBeInstanceOf(
+          BadRequestException,
+        );
+      });
+
+      it('rejects an alias another provider of the tenant already uses, case-insensitively', async () => {
+        const existing = { id: 'cp1', name: 'old', alias: null } as CustomProvider;
+        const { svc } = makeDeps({
+          findOneResults: [existing],
+          findResult: [existing, { id: 'other', name: 'Other', alias: 'Taken' } as CustomProvider],
+        });
+        await expect(svc.update('cp1', 'tenant-1', { alias: 'taken' })).rejects.toBeInstanceOf(
+          ConflictException,
+        );
+      });
     });
 
     it('validates and updates base_url when provided', async () => {

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -12,6 +12,9 @@ import { randomUUID } from 'crypto';
 import {
   CANONICAL_LOCAL_IDS,
   SHARED_PROVIDER_BY_ID_OR_ALIAS,
+  deriveCustomProviderAlias,
+  isReservedCustomProviderAlias,
+  normalizeCustomProviderAlias,
   normalizeProviderName,
 } from 'manifest-shared';
 import type { AuthType } from 'manifest-shared';
@@ -89,6 +92,31 @@ export class CustomProviderService {
    */
   private notifyChange(tenantId: string, actorUserId?: string | null): void {
     this.eventBus.emit(tenantId, 'routing', actorUserId);
+  }
+
+  /**
+   * Reject an explicit alias that would shadow a built-in provider route or
+   * another custom provider of the tenant (case-insensitive, like the name).
+   */
+  private assertAliasAvailable(
+    alias: string,
+    allForTenant: CustomProvider[],
+    excludeId?: string,
+  ): void {
+    if (isReservedCustomProviderAlias(alias)) {
+      throw new BadRequestException(`Alias "${alias}" is reserved for a built-in provider`);
+    }
+    const dup = allForTenant.find((r) => r.id !== excludeId && r.alias?.toLowerCase() === alias);
+    if (dup) {
+      throw new ConflictException(`Alias "${alias}" is already used by "${dup.name}"`);
+    }
+  }
+
+  /** Default alias for a new provider: derived from the name, or none when taken. */
+  private defaultAlias(name: string, allForTenant: CustomProvider[]): string | null {
+    const derived = deriveCustomProviderAlias(name);
+    if (!derived) return null;
+    return allForTenant.some((r) => r.alias?.toLowerCase() === derived) ? null : derived;
   }
 
   /** Provider key used in TenantProvider tables. */
@@ -210,6 +238,16 @@ export class CustomProviderService {
       throw new ConflictException(`Custom provider "${dto.name}" already exists`);
     }
 
+    // An omitted alias gets a default derived from the name, silently left
+    // empty when that default is unusable or taken — the user can set one
+    // later. An explicit alias (including null, meaning "none") is honoured
+    // as sent and validated like the name is.
+    const alias =
+      dto.alias === undefined
+        ? this.defaultAlias(dto.name, allForTenant)
+        : normalizeCustomProviderAlias(dto.alias);
+    if (alias && dto.alias !== undefined) this.assertAliasAvailable(alias, allForTenant);
+
     try {
       await validatePublicUrl(dto.base_url, { allowPrivate: isSelfHosted() });
     } catch (err) {
@@ -224,6 +262,7 @@ export class CustomProviderService {
       tenant_id: tenantId,
       created_by_user_id: createdByUserId ?? null,
       name: dto.name,
+      alias,
       base_url: dto.base_url,
       api_kind: dto.api_kind ?? 'openai',
       models: this.enrichCustomProviderModels(dto.name, dto.models),
@@ -290,6 +329,18 @@ export class CustomProviderService {
         throw new ConflictException(`Custom provider "${dto.name}" already exists`);
       }
       cp.name = dto.name;
+    }
+
+    // Renaming never touches the alias: client configs carry
+    // `<alias>/<model>` and must survive a display-name change. Only an
+    // explicit alias field changes it (null or '' clears it).
+    if (dto.alias !== undefined) {
+      const alias = normalizeCustomProviderAlias(dto.alias);
+      if (alias && alias !== cp.alias) {
+        const allForTenant = await this.repo.find({ where: { tenant_id: tenantId } });
+        this.assertAliasAvailable(alias, allForTenant, id);
+      }
+      cp.alias = alias;
     }
 
     if (dto.base_url !== undefined) {

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -69,6 +69,20 @@ function authTypeForCustomProvider(name: string): AuthType {
   return isLocalCustomProviderName(name) ? 'local' : 'api_key';
 }
 
+const ALIAS_UNIQUE_INDEX = 'IDX_custom_providers_tenant_alias';
+const PG_UNIQUE_VIOLATION = '23505';
+
+/**
+ * Two requests can both pass the in-memory alias check and race to the
+ * partial unique index. TypeORM copies the pg error's `code` and
+ * `constraint` onto the QueryFailedError it throws, so the loser is
+ * recognisable and gets the same 409 the pre-check would have produced.
+ */
+function isAliasUniqueViolation(err: unknown): boolean {
+  const pg = err as { code?: unknown; constraint?: unknown } | null;
+  return pg?.code === PG_UNIQUE_VIOLATION && pg.constraint === ALIAS_UNIQUE_INDEX;
+}
+
 @Injectable()
 export class CustomProviderService {
   constructor(
@@ -281,20 +295,27 @@ export class CustomProviderService {
     // messages carry the grey-house badge and the row shows up under the
     // Local tab. A null agentId tells the provider service the change is
     // tenant-global rather than tied to one agent.
-    await this.repo.manager.transaction(async (manager) => {
-      await manager.getRepository(CustomProvider).insert(cp);
-      await this.providerService.upsertProvider(
-        null,
-        tenantId,
-        provKey,
-        dto.apiKey,
-        authTypeForCustomProvider(dto.name),
-        undefined,
-        undefined,
-        createdByUserId,
-        manager,
-      );
-    });
+    try {
+      await this.repo.manager.transaction(async (manager) => {
+        await manager.getRepository(CustomProvider).insert(cp);
+        await this.providerService.upsertProvider(
+          null,
+          tenantId,
+          provKey,
+          dto.apiKey,
+          authTypeForCustomProvider(dto.name),
+          undefined,
+          undefined,
+          createdByUserId,
+          manager,
+        );
+      });
+    } catch (err) {
+      if (isAliasUniqueViolation(err)) {
+        throw new ConflictException(`Alias "${alias}" is already used by another provider`);
+      }
+      throw err;
+    }
 
     // Rebuild the shared pricing cache so the proxy can compute cost for
     // requests routed to this custom provider's models immediately (without
@@ -360,7 +381,16 @@ export class CustomProviderService {
       cp.models = this.enrichCustomProviderModels(cp.name, dto.models);
     }
 
-    await this.repo.save(cp);
+    try {
+      await this.repo.save(cp);
+    } catch (err) {
+      if (isAliasUniqueViolation(err)) {
+        throw new ConflictException(`Alias "${cp.alias}" is already used by another provider`);
+      }
+      throw err;
+    }
+    // Fans out to the discovered-model cache of every agent in the tenant, so
+    // an alias or model-list edit shows in /v1/models on the next request.
     this.routingCache.invalidateTenant(tenantId);
 
     // Reload pricing cache when the model list changes so explicit routes to

--- a/packages/backend/src/routing/dto/custom-provider.dto.spec.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.spec.ts
@@ -21,6 +21,54 @@ function makeModels(count: number): CustomProviderModelDto[] {
   return Array.from({ length: count }, (_, i) => ({ model_name: `model-${i + 1}` }));
 }
 
+describe('alias validation', () => {
+  const base = {
+    name: 'Vercel AI Gateway',
+    base_url: 'https://ai-gateway.vercel.sh/v1',
+    models: [{ model_name: 'alibaba/qwen-3-14b' }],
+  };
+
+  it('accepts a well-formed alias on create and update', async () => {
+    expect(await validate(toDto({ ...base, alias: 'vercel-ai.gw' }))).toHaveLength(0);
+    expect(await validate(toUpdateDto({ alias: 'vercel' }))).toHaveLength(0);
+  });
+
+  it('normalises the alias to trimmed lowercase before validating', async () => {
+    const dto = toDto({ ...base, alias: '  Vercel-GW ' });
+    expect(dto.alias).toBe('vercel-gw');
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('turns an empty alias into null so it reads as "clear"', async () => {
+    const dto = toUpdateDto({ alias: '   ' });
+    expect(dto.alias).toBeNull();
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('accepts an explicit null and an omitted alias', async () => {
+    expect(await validate(toDto({ ...base, alias: null }))).toHaveLength(0);
+    expect(await validate(toDto(base))).toHaveLength(0);
+  });
+
+  it('rejects separators in the wrong place and forbidden characters', async () => {
+    for (const alias of ['-vercel', 'vercel-', 'ver//cel', 'vercel gw', 'a--b']) {
+      const errors = await validate(toUpdateDto({ alias }));
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints?.matches).toContain('lowercase letters');
+    }
+  });
+
+  it('rejects an alias longer than 50 chars', async () => {
+    const errors = await validate(toUpdateDto({ alias: 'a'.repeat(51) }));
+    expect(errors[0].constraints?.maxLength).toBeDefined();
+  });
+
+  it('rejects a non-string alias untouched by normalisation', async () => {
+    const errors = await validate(toUpdateDto({ alias: 42 }));
+    expect(errors[0].constraints?.isString).toBeDefined();
+  });
+});
+
 describe('CreateCustomProviderDto', () => {
   it('accepts valid input', async () => {
     const dto = toDto({

--- a/packages/backend/src/routing/dto/custom-provider.dto.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.ts
@@ -15,7 +15,33 @@ import {
   Min,
   IsBoolean,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
+import {
+  CUSTOM_PROVIDER_ALIAS_MAX_LENGTH,
+  CUSTOM_PROVIDER_ALIAS_MESSAGE,
+  CUSTOM_PROVIDER_ALIAS_PATTERN,
+  normalizeCustomProviderAlias,
+} from 'manifest-shared';
+
+/**
+ * Public prefix of the provider's model ids (`<alias>/<model_name>`).
+ * Normalised to lowercase; an empty string clears it. Omitted on create
+ * derives one from the name; omitted on update leaves it untouched.
+ */
+function AliasField(): PropertyDecorator {
+  const decorators = [
+    IsOptional(),
+    Transform(({ value }) =>
+      typeof value === 'string' ? normalizeCustomProviderAlias(value) : value,
+    ),
+    IsString(),
+    MaxLength(CUSTOM_PROVIDER_ALIAS_MAX_LENGTH),
+    Matches(CUSTOM_PROVIDER_ALIAS_PATTERN, { message: CUSTOM_PROVIDER_ALIAS_MESSAGE }),
+  ];
+  return (target, propertyKey) => {
+    for (const decorator of decorators) decorator(target, propertyKey);
+  };
+}
 
 export const CUSTOM_PROVIDER_API_KINDS = ['openai', 'anthropic'] as const;
 export type CustomProviderApiKindDto = (typeof CUSTOM_PROVIDER_API_KINDS)[number];
@@ -59,6 +85,9 @@ export class CreateCustomProviderDto {
     message: 'Name can only contain letters, numbers, spaces, dots, hyphens, and underscores',
   })
   name!: string;
+
+  @AliasField()
+  alias?: string | null;
 
   @IsString()
   @IsNotEmpty()
@@ -111,6 +140,9 @@ export class UpdateCustomProviderDto {
     message: 'Name can only contain letters, numbers, spaces, dots, hyphens, and underscores',
   })
   name?: string;
+
+  @AliasField()
+  alias?: string | null;
 
   @IsOptional()
   @IsString()

--- a/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
@@ -61,7 +61,7 @@ describe('OpenAI model ids', () => {
     ).toBe('opencode-go/glm-5.1-subscription');
   });
 
-  it('leaves custom model ids unchanged', () => {
+  it('leaves custom model ids unchanged when the provider has no alias', () => {
     expect(
       openAiModelId(
         model({
@@ -70,6 +70,43 @@ describe('OpenAI model ids', () => {
         }),
       ),
     ).toBe('custom:provider-1/model-a');
+  });
+
+  it('publishes custom models under the provider alias', () => {
+    expect(
+      openAiModelId(
+        model({
+          id: 'custom:provider-1/alibaba/qwen-3-14b',
+          provider: 'custom:provider-1',
+          providerAlias: 'vercel-ai-gateway',
+        }),
+      ),
+    ).toBe('vercel-ai-gateway/alibaba/qwen-3-14b');
+  });
+
+  it('keeps a custom model id without the provider prefix intact under the alias', () => {
+    expect(
+      openAiModelId(
+        model({ id: 'bare-model', provider: 'custom:provider-1', providerAlias: 'gw' }),
+      ),
+    ).toBe('gw/bare-model');
+  });
+
+  it('resolves the alias form and the internal form of a custom model to the same route', () => {
+    const custom = model({
+      id: 'custom:provider-1/alibaba/qwen-3-14b',
+      provider: 'custom:provider-1',
+      providerAlias: 'vercel-ai-gateway',
+    });
+    const route = {
+      provider: 'custom:provider-1',
+      authType: 'api_key',
+      model: 'custom:provider-1/alibaba/qwen-3-14b',
+    };
+
+    expect(routeForOpenAiModelId('vercel-ai-gateway/alibaba/qwen-3-14b', [custom])).toEqual(route);
+    expect(routeForOpenAiModelId('custom:provider-1/alibaba/qwen-3-14b', [custom])).toEqual(route);
+    expect(routeForOpenAiModelId('alibaba/qwen-3-14b', [custom])).toBeNull();
   });
 
   it('resolves listed ids back to routable provider/auth/model triples', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -267,6 +267,13 @@ describe('ProxyController', () => {
         provider: 'custom:provider-1',
         authType: 'api_key',
       }),
+      makeDiscoveredModel({
+        id: 'custom:provider-2/alibaba/qwen-3-14b',
+        provider: 'custom:provider-2',
+        providerName: 'Vercel AI Gateway',
+        providerAlias: 'vercel-ai-gateway',
+        authType: 'api_key',
+      }),
       makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'api_key' }),
     ]);
 
@@ -293,6 +300,12 @@ describe('ProxyController', () => {
           object: 'model',
           created: 0,
           owned_by: 'custom:provider-1',
+        },
+        {
+          id: 'vercel-ai-gateway/alibaba/qwen-3-14b',
+          object: 'model',
+          created: 0,
+          owned_by: 'Vercel AI Gateway',
         },
       ],
     });

--- a/packages/backend/src/routing/proxy/openai-model-id.ts
+++ b/packages/backend/src/routing/proxy/openai-model-id.ts
@@ -25,9 +25,23 @@ export function subscriptionOpenAiModelId(provider: string, modelId: string): st
     : `${routeId}${SUBSCRIPTION_MODEL_SUFFIX}`;
 }
 
+/**
+ * Public id of a custom provider model. With an alias the model publishes as
+ * `<alias>/<model_name>`; without one it keeps the internal
+ * `custom:<uuid>/<model_name>` key. The internal key always resolves (see
+ * `routeForOpenAiModelId`), so client configs written before an alias was
+ * set keep working.
+ */
+function customOpenAiModelId(model: DiscoveredModel): string {
+  if (!model.providerAlias) return model.id;
+  const prefix = `${model.provider}/`;
+  const modelName = model.id.startsWith(prefix) ? model.id.slice(prefix.length) : model.id;
+  return `${model.providerAlias}/${modelName}`;
+}
+
 export function openAiModelId(model: DiscoveredModel): string {
   const provider = model.provider.toLowerCase();
-  if (provider.startsWith('custom:')) return model.id;
+  if (provider.startsWith('custom:')) return customOpenAiModelId(model);
 
   const prefix = `${provider}/`;
   const routeId = model.id.toLowerCase().startsWith(prefix) ? model.id : `${provider}/${model.id}`;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -181,7 +181,9 @@ export class ProxyController {
         id,
         object: 'model',
         created: MODEL_CREATED_UNKNOWN,
-        owned_by: model.provider,
+        // Custom providers own their models under the name the user gave
+        // them, not the internal `custom:<uuid>` key.
+        owned_by: model.providerName ?? model.provider,
       };
       if (includeRouteMetadata) {
         entry.provider_model_id = model.id;

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
@@ -137,7 +137,10 @@ describe('ResolveService — edge cases', () => {
       penaltyService as unknown as SpecificityPenaltyService,
       headerTierService as unknown as HeaderTierService,
       agentRepo as unknown as Repository<Agent>,
-      { addInvalidationListener: jest.fn() } as unknown as RoutingCacheService,
+      {
+        addInvalidationListener: jest.fn(),
+        addTenantInvalidationListener: jest.fn(),
+      } as unknown as RoutingCacheService,
     );
   });
 

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -60,12 +60,18 @@ describe('ResolveService', () => {
   let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
   let pricingCache: jest.Mocked<Pick<ModelPricingCacheService, 'getByModel'>>;
   let discoveryService: jest.Mocked<
-    Pick<ModelDiscoveryService, 'getModelForAgent' | 'getModelsForAgent' | 'invalidate'>
+    Pick<
+      ModelDiscoveryService,
+      'getModelForAgent' | 'getModelsForAgent' | 'invalidate' | 'invalidateTenant'
+    >
   >;
   let penaltyService: jest.Mocked<Pick<SpecificityPenaltyService, 'getPenaltiesForAgent'>>;
   let headerTierService: jest.Mocked<Pick<HeaderTierService, 'list'>>;
   let agentRepo: { findOne: jest.Mock };
-  let routingCache: { addInvalidationListener: jest.Mock };
+  let routingCache: {
+    addInvalidationListener: jest.Mock;
+    addTenantInvalidationListener: jest.Mock;
+  };
   let svc: ResolveService;
 
   beforeEach(() => {
@@ -88,13 +94,14 @@ describe('ResolveService', () => {
       getModelForAgent: jest.fn().mockResolvedValue(null),
       getModelsForAgent: jest.fn().mockResolvedValue([]),
       invalidate: jest.fn(),
+      invalidateTenant: jest.fn(),
     };
     penaltyService = { getPenaltiesForAgent: jest.fn().mockResolvedValue(new Map()) };
     headerTierService = { list: jest.fn().mockResolvedValue([]) };
     agentRepo = {
       findOne: jest.fn().mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: true }),
     };
-    routingCache = { addInvalidationListener: jest.fn() };
+    routingCache = { addInvalidationListener: jest.fn(), addTenantInvalidationListener: jest.fn() };
 
     // Defaults — each test overrides as needed.
     mockedScore.mockReturnValue({
@@ -131,6 +138,17 @@ describe('ResolveService', () => {
       listener('agent-42');
 
       expect(discoveryService.invalidate).toHaveBeenCalledWith('agent-42');
+    });
+
+    it('registers a tenant listener that drops the discovery cache tenant-wide', () => {
+      expect(routingCache.addTenantInvalidationListener).toHaveBeenCalledTimes(1);
+      const listener = routingCache.addTenantInvalidationListener.mock.calls[0][0] as (
+        tenantId: string,
+      ) => void;
+
+      listener('tenant-42');
+
+      expect(discoveryService.invalidateTenant).toHaveBeenCalledWith('tenant-42');
     });
   });
 

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -73,6 +73,9 @@ export class ResolveService {
     this.routingCache.addInvalidationListener((agentId) =>
       this.discoveryService.invalidate(agentId),
     );
+    this.routingCache.addTenantInvalidationListener((tenantId) =>
+      this.discoveryService.invalidateTenant(tenantId),
+    );
   }
 
   async resolve(

--- a/packages/backend/src/routing/routing-cache.service.spec.ts
+++ b/packages/backend/src/routing/routing-cache.service.spec.ts
@@ -424,4 +424,37 @@ describe('RoutingCacheService', () => {
       expect(() => service.invalidateAgent('agent-3')).not.toThrow();
     });
   });
+
+  describe('tenant invalidation listeners', () => {
+    it('fires registered listeners with the tenantId on invalidateTenant', () => {
+      const listener = jest.fn();
+      service.addTenantInvalidationListener(listener);
+
+      service.invalidateTenant('tenant-1');
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith('tenant-1');
+    });
+
+    it('keeps invalidating and reaches later listeners when one throws', () => {
+      const failing = jest.fn(() => {
+        throw new Error('boom');
+      });
+      const next = jest.fn();
+      service.addTenantInvalidationListener(failing);
+      service.addTenantInvalidationListener(next);
+
+      expect(() => service.invalidateTenant('tenant-2')).not.toThrow();
+      expect(next).toHaveBeenCalledWith('tenant-2');
+    });
+
+    it('does not fire agent listeners on a tenant invalidation', () => {
+      const agentListener = jest.fn();
+      service.addInvalidationListener(agentListener);
+
+      service.invalidateTenant('tenant-3');
+
+      expect(agentListener).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/backend/src/routing/routing-core/routing-cache.service.ts
+++ b/packages/backend/src/routing/routing-core/routing-cache.service.ts
@@ -40,6 +40,7 @@ function setWithEviction<T>(map: Map<string, CachedEntry<T>>, key: string, data:
 
 /** Notified with the agentId whenever that agent's routing cache is invalidated. */
 export type AgentInvalidationListener = (agentId: string) => void;
+export type TenantInvalidationListener = (tenantId: string) => void;
 
 @Injectable()
 export class RoutingCacheService {
@@ -56,6 +57,9 @@ export class RoutingCacheService {
   // subscribe without forming an import cycle — every provider mutation already
   // funnels through invalidateAgent(), so this is the one place to fan out.
   private readonly invalidationListeners: AgentInvalidationListener[] = [];
+  // Same idea for tenant-wide mutations (custom provider create/update/delete),
+  // which change the model list of every agent in the tenant at once.
+  private readonly tenantInvalidationListeners: TenantInvalidationListener[] = [];
 
   getTiers(agentId: string): TierAssignment[] | null {
     return getOrExpire(this.tiers, agentId) ?? null;
@@ -160,6 +164,15 @@ export class RoutingCacheService {
     this.invalidationListeners.push(listener);
   }
 
+  /**
+   * Register a callback fired (with the tenantId) on every invalidateTenant().
+   * Custom providers are tenant-global, so an alias or model-list change must
+   * drop every agent's discovered-model cache, not one agent's.
+   */
+  addTenantInvalidationListener(listener: TenantInvalidationListener): void {
+    this.tenantInvalidationListeners.push(listener);
+  }
+
   invalidateAgent(agentId: string): void {
     this.tiers.delete(agentId);
     this.specificity.delete(agentId);
@@ -193,5 +206,12 @@ export class RoutingCacheService {
     const prefix = `${tenantId}\u0000`;
     const toDelete = [...this.providerKeys.keys()].filter((k) => k.startsWith(prefix));
     for (const k of toDelete) this.providerKeys.delete(k);
+    for (const listener of this.tenantInvalidationListeners) {
+      try {
+        listener(tenantId);
+      } catch {
+        // Best-effort fan-out, as for agent listeners.
+      }
+    }
   }
 }

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -1,4 +1,5 @@
 import { createResource, createSignal, Index, Show, type Component } from 'solid-js';
+import { deriveCustomProviderAlias, normalizeCustomProviderAlias } from 'manifest-shared';
 import {
   createCustomProvider,
   deleteCustomProvider,
@@ -67,6 +68,16 @@ const CustomProviderForm: Component<Props> = (props) => {
   };
 
   const [name, setName] = createSignal(props.initialData?.name ?? props.prefill?.name ?? '');
+  // The alias follows the name while creating, until the user edits it by
+  // hand. In edit mode it is the stored value: a rename must never rewrite
+  // the model ids clients already use.
+  const [alias, setAlias] = createSignal(
+    props.initialData ? (props.initialData.alias ?? '') : (deriveCustomProviderAlias(name()) ?? ''),
+  );
+  const [aliasTouched, setAliasTouched] = createSignal(isEdit());
+  const normalizedAlias = () => normalizeCustomProviderAlias(alias());
+  const modelIdPreview = () =>
+    normalizedAlias() ? `${normalizedAlias()}/<model>` : 'custom:<provider-id>/<model>';
   const [baseUrl, setBaseUrl] = createSignal(
     props.initialData?.base_url ?? props.prefill?.baseUrl ?? '',
   );
@@ -156,6 +167,7 @@ const CustomProviderForm: Component<Props> = (props) => {
     try {
       await createCustomProvider(props.agentName, {
         name: name().trim(),
+        alias: normalizedAlias(),
         base_url: baseUrl().trim(),
         api_kind: apiKind(),
         apiKey: apiKey().trim() || undefined,
@@ -174,6 +186,7 @@ const CustomProviderForm: Component<Props> = (props) => {
     setError(null);
     const data: Record<string, unknown> = {
       name: name().trim(),
+      alias: normalizedAlias(),
       base_url: baseUrl().trim(),
       models: buildModels(),
     };
@@ -257,9 +270,32 @@ const CustomProviderForm: Component<Props> = (props) => {
             value={name()}
             onInput={(e) => {
               setName(e.currentTarget.value);
+              if (!aliasTouched()) setAlias(deriveCustomProviderAlias(e.currentTarget.value) ?? '');
               setError(null);
             }}
           />
+        </div>
+
+        <div class="provider-detail__field">
+          <label class="provider-detail__label" for="cp-alias">
+            Alias
+          </label>
+          <input
+            id="cp-alias"
+            class="provider-detail__input"
+            type="text"
+            placeholder="e.g. vercel-ai-gateway"
+            value={alias()}
+            onInput={(e) => {
+              setAlias(e.currentTarget.value);
+              setAliasTouched(true);
+              setError(null);
+            }}
+          />
+          <div class="provider-detail__hint" data-testid="cp-alias-hint">
+            Models are listed as <code>{modelIdPreview()}</code> in <code>/v1/models</code>.
+            <Show when={isEdit()}> Changing the alias changes the model ids your clients use.</Show>
+          </div>
         </div>
 
         <fieldset

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -439,6 +439,8 @@ export interface CustomProviderModel {
 export interface CustomProviderData {
   id: string;
   name: string;
+  /** Public prefix of the provider's model ids (`<alias>/<model>`); null = internal id. */
+  alias: string | null;
   base_url: string;
   api_kind: CustomProviderApiKind;
   has_api_key: boolean;
@@ -484,6 +486,7 @@ export function createCustomProvider(
   agentName: string,
   data: {
     name: string;
+    alias?: string | null;
     base_url: string;
     api_kind?: CustomProviderApiKind;
     apiKey?: string;
@@ -503,6 +506,7 @@ export function updateCustomProvider(
   id: string,
   data: {
     name?: string;
+    alias?: string | null;
     base_url?: string;
     api_kind?: CustomProviderApiKind;
     apiKey?: string;

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -107,6 +107,7 @@ describe("CustomProviderForm", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Groq",
+        alias: null,
         base_url: "https://api.groq.com/v1",
         api_kind: "openai",
         apiKey: undefined,
@@ -172,6 +173,7 @@ describe("CustomProviderForm", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Groq",
+        alias: null,
         base_url: "https://api.groq.com/v1",
         api_kind: "openai",
         apiKey: "gsk_test123",
@@ -206,6 +208,7 @@ describe("CustomProviderForm", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Groq",
+        alias: null,
         base_url: "https://api.groq.com/v1",
         api_kind: "openai",
         apiKey: undefined,
@@ -246,6 +249,7 @@ describe("CustomProviderForm", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Groq",
+        alias: null,
         base_url: "https://api.groq.com/v1",
         api_kind: "openai",
         apiKey: undefined,
@@ -426,6 +430,7 @@ describe("CustomProviderForm", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Test",
+        alias: "test",
         base_url: "https://api.example.com/v1",
         api_kind: "openai",
         apiKey: undefined,
@@ -635,6 +640,7 @@ describe("CustomProviderForm — Fetch models probe", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Mammouth AI",
+        alias: "mammouth-ai",
         base_url: "https://api.mammouth.ai/v1",
         api_kind: "openai",
         apiKey: undefined,
@@ -765,6 +771,7 @@ describe("CustomProviderForm — prefill from URL params", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Groq",
+        alias: null,
         base_url: "https://api.groq.com/v1",
         api_kind: "openai",
         apiKey: undefined,
@@ -895,6 +902,7 @@ describe("CustomProviderForm — edit mode", () => {
     await waitFor(() => {
       expect(mockUpdateCustomProvider).toHaveBeenCalledWith("test-agent", "cp-1", {
         name: "Updated Groq",
+        alias: null,
         base_url: "https://api.groq.com/openai/v1",
         models: [
           {
@@ -934,6 +942,7 @@ describe("CustomProviderForm — edit mode", () => {
     await waitFor(() => {
       expect(mockUpdateCustomProvider).toHaveBeenCalledWith("test-agent", "cp-1", {
         name: "Groq",
+        alias: null,
         base_url: "https://api.groq.com/openai/v1",
         apiKey: "new-key-123",
         models: [
@@ -1323,6 +1332,7 @@ describe("CustomProviderForm — API format selector", () => {
     await waitFor(() => {
       expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
         name: "Azure Claude",
+        alias: "azure-claude",
         base_url: "https://api.anthropic.com",
         api_kind: "anthropic",
         apiKey: undefined,
@@ -1442,6 +1452,7 @@ describe("CustomProviderForm — edit mode: extra API key + delete UI branches",
     await waitFor(() => {
       expect(mockUpdateCustomProvider).toHaveBeenCalledWith("test-agent", "cp-1", {
         name: "Groq",
+        alias: null,
         base_url: "https://api.groq.com/openai/v1",
         apiKey: undefined,
         models: [
@@ -1525,6 +1536,114 @@ describe("CustomProviderForm — edit mode: extra API key + delete UI branches",
 
     await waitFor(() => {
       expect(container.querySelector('[role="dialog"]')).toBeNull();
+    });
+  });
+});
+
+describe("CustomProviderForm — alias", () => {
+  const onCreated = vi.fn();
+  const onBack = vi.fn();
+
+  const aliasInput = () => screen.getByPlaceholderText("e.g. vercel-ai-gateway") as HTMLInputElement;
+  const nameInput = () => screen.getByPlaceholderText("e.g. Groq, Together, Azure");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateCustomProvider.mockResolvedValue({});
+    mockUpdateCustomProvider.mockResolvedValue({});
+  });
+
+  it("derives the alias from the name while creating and previews the model id", () => {
+    render(() => (
+      <CustomProviderForm agentName="test-agent" onCreated={onCreated} onBack={onBack} />
+    ));
+    expect(aliasInput().value).toBe("");
+    expect(screen.getByTestId("cp-alias-hint").textContent).toContain("custom:<provider-id>/<model>");
+
+    fireEvent.input(nameInput(), { target: { value: "Vercel AI Gateway" } });
+    expect(aliasInput().value).toBe("vercel-ai-gateway");
+    expect(screen.getByTestId("cp-alias-hint").textContent).toContain("vercel-ai-gateway/<model>");
+  });
+
+  it("stops following the name once the alias was edited by hand", () => {
+    render(() => (
+      <CustomProviderForm agentName="test-agent" onCreated={onCreated} onBack={onBack} />
+    ));
+    fireEvent.input(aliasInput(), { target: { value: "gw" } });
+    fireEvent.input(nameInput(), { target: { value: "Vercel AI Gateway" } });
+    expect(aliasInput().value).toBe("gw");
+  });
+
+  it("derives the alias from a prefilled name", () => {
+    render(() => (
+      <CustomProviderForm
+        agentName="test-agent"
+        onCreated={onCreated}
+        onBack={onBack}
+        prefill={{ name: "Mammouth AI", baseUrl: "https://api.mammouth.ai/v1", models: [] }}
+      />
+    ));
+    expect(aliasInput().value).toBe("mammouth-ai");
+  });
+
+  it("sends a null alias when the field is cleared", async () => {
+    render(() => (
+      <CustomProviderForm agentName="test-agent" onCreated={onCreated} onBack={onBack} />
+    ));
+    fireEvent.input(nameInput(), { target: { value: "Groq" } });
+    fireEvent.input(screen.getByPlaceholderText("https://api.example.com/v1"), {
+      target: { value: "https://api.groq.com/v1" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("Model name"), {
+      target: { value: "llama-3.1-70b" },
+    });
+    fireEvent.input(aliasInput(), { target: { value: "   " } });
+
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() => {
+      expect(mockCreateCustomProvider).toHaveBeenCalledWith(
+        "test-agent",
+        expect.objectContaining({ alias: null }),
+      );
+    });
+  });
+
+  it("shows the stored alias in edit mode, leaves it alone on rename, and sends it normalised", async () => {
+    render(() => (
+      <CustomProviderForm
+        agentName="test-agent"
+        onCreated={onCreated}
+        onBack={onBack}
+        initialData={{
+          id: "cp-1",
+          name: "Groq",
+          alias: "groq",
+          base_url: "https://api.groq.com/openai/v1",
+          api_kind: "openai",
+          has_api_key: true,
+          models: [{ model_name: "llama-3.1-70b" }],
+          created_at: "2026-03-04T00:00:00Z",
+        }}
+      />
+    ));
+    expect(aliasInput().value).toBe("groq");
+    expect(screen.getByTestId("cp-alias-hint").textContent).toContain(
+      "Changing the alias changes the model ids your clients use.",
+    );
+
+    fireEvent.input(nameInput(), { target: { value: "Groq Cloud" } });
+    expect(aliasInput().value).toBe("groq");
+
+    fireEvent.input(aliasInput(), { target: { value: " Groq-Cloud " } });
+    fireEvent.click(screen.getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(mockUpdateCustomProvider).toHaveBeenCalledWith(
+        "test-agent",
+        "cp-1",
+        expect.objectContaining({ name: "Groq Cloud", alias: "groq-cloud" }),
+      );
     });
   });
 });

--- a/packages/shared/__tests__/custom-provider-alias.spec.ts
+++ b/packages/shared/__tests__/custom-provider-alias.spec.ts
@@ -1,0 +1,89 @@
+import {
+  CUSTOM_PROVIDER_ALIAS_PATTERN,
+  deriveCustomProviderAlias,
+  isReservedCustomProviderAlias,
+  normalizeCustomProviderAlias,
+} from '../src/custom-provider-alias';
+
+describe('custom provider alias', () => {
+  describe('CUSTOM_PROVIDER_ALIAS_PATTERN', () => {
+    it.each(['vercel', 'vercel-ai-gateway', 'llama.cpp', 'gw2', 'a'])('accepts %s', (alias) => {
+      expect(CUSTOM_PROVIDER_ALIAS_PATTERN.test(alias)).toBe(true);
+    });
+
+    it.each(['', 'Vercel', 'vercel ai', 'vercel/ai', '-vercel', 'vercel-', 'a--b', 'a.-b', '.a'])(
+      'rejects %j',
+      (alias) => {
+        expect(CUSTOM_PROVIDER_ALIAS_PATTERN.test(alias)).toBe(false);
+      },
+    );
+  });
+
+  describe('normalizeCustomProviderAlias', () => {
+    it('trims and lowercases', () => {
+      expect(normalizeCustomProviderAlias('  Vercel-GW ')).toBe('vercel-gw');
+    });
+
+    it('maps empty, blank, null and undefined to null', () => {
+      expect(normalizeCustomProviderAlias('')).toBeNull();
+      expect(normalizeCustomProviderAlias('   ')).toBeNull();
+      expect(normalizeCustomProviderAlias(null)).toBeNull();
+      expect(normalizeCustomProviderAlias(undefined)).toBeNull();
+    });
+  });
+
+  describe('isReservedCustomProviderAlias', () => {
+    it('reserves the synthetic routes and the custom prefix', () => {
+      expect(isReservedCustomProviderAlias('auto')).toBe(true);
+      expect(isReservedCustomProviderAlias('manifest')).toBe(true);
+      expect(isReservedCustomProviderAlias('custom')).toBe(true);
+    });
+
+    it('reserves built-in provider ids and their aliases', () => {
+      expect(isReservedCustomProviderAlias('openai')).toBe(true);
+      expect(isReservedCustomProviderAlias('google')).toBe(true);
+      expect(isReservedCustomProviderAlias('ollama')).toBe(true);
+    });
+
+    it('leaves other names free', () => {
+      expect(isReservedCustomProviderAlias('vercel-ai-gateway')).toBe(false);
+    });
+
+    it('leaves tile-only local providers free, since they only exist as custom providers', () => {
+      expect(isReservedCustomProviderAlias('llama.cpp')).toBe(false);
+      expect(isReservedCustomProviderAlias('lmstudio')).toBe(false);
+      expect(isReservedCustomProviderAlias('lm-studio')).toBe(false);
+    });
+  });
+
+  describe('deriveCustomProviderAlias', () => {
+    it('slugifies a display name', () => {
+      expect(deriveCustomProviderAlias('Vercel AI Gateway')).toBe('vercel-ai-gateway');
+      expect(deriveCustomProviderAlias('  my_gateway  ')).toBe('my-gateway');
+    });
+
+    it('keeps dots so llama.cpp stays recognisable', () => {
+      expect(deriveCustomProviderAlias('llama.cpp')).toBe('llama.cpp');
+    });
+
+    it('collapses and strips separator runs', () => {
+      expect(deriveCustomProviderAlias('--My -- Provider..')).toBe('my-provider');
+      expect(deriveCustomProviderAlias('a.-b')).toBe('a.b');
+    });
+
+    it('caps the alias at the maximum length without a trailing separator', () => {
+      const long = `${'a'.repeat(49)}-bbbbbb`;
+      expect(deriveCustomProviderAlias(long)).toBe('a'.repeat(49));
+    });
+
+    it('returns null when nothing usable remains', () => {
+      expect(deriveCustomProviderAlias('***')).toBeNull();
+      expect(deriveCustomProviderAlias('')).toBeNull();
+    });
+
+    it('returns null for reserved names so built-in routes stay unambiguous', () => {
+      expect(deriveCustomProviderAlias('OpenAI')).toBeNull();
+      expect(deriveCustomProviderAlias('auto')).toBeNull();
+    });
+  });
+});

--- a/packages/shared/src/custom-provider-alias.ts
+++ b/packages/shared/src/custom-provider-alias.ts
@@ -39,16 +39,33 @@ export function isReservedCustomProviderAlias(alias: string): boolean {
  * provider keeps publishing under its internal `custom:<uuid>/…` id.
  */
 export function deriveCustomProviderAlias(name: string): string | null {
-  const derived = name
+  const collapsed = name
     .trim()
     .toLowerCase()
     .replace(/[\s_]+/g, '-')
     .replace(/[^a-z0-9.-]/g, '')
-    .replace(/[.-]{2,}/g, (run) => run[0])
-    .replace(/^[.-]+|[.-]+$/g, '')
-    .slice(0, CUSTOM_PROVIDER_ALIAS_MAX_LENGTH)
-    .replace(/[.-]+$/, '');
+    .replace(/[.-]{2,}/g, (run) => run[0]);
+  const derived = trimSeparators(
+    trimSeparators(collapsed).slice(0, CUSTOM_PROVIDER_ALIAS_MAX_LENGTH),
+  );
   if (!CUSTOM_PROVIDER_ALIAS_PATTERN.test(derived)) return null;
   if (isReservedCustomProviderAlias(derived)) return null;
   return derived;
+}
+
+/**
+ * Strip leading and trailing `.` / `-`. A loop rather than `/[.-]+$/`: that
+ * anchored-suffix regex backtracks polynomially on long separator runs, and
+ * the input here is a user-supplied name.
+ */
+function trimSeparators(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && isSeparator(value[start])) start++;
+  while (end > start && isSeparator(value[end - 1])) end--;
+  return value.slice(start, end);
+}
+
+function isSeparator(char: string): boolean {
+  return char === '.' || char === '-';
 }

--- a/packages/shared/src/custom-provider-alias.ts
+++ b/packages/shared/src/custom-provider-alias.ts
@@ -1,0 +1,54 @@
+import { SHARED_PROVIDER_BY_ID_OR_ALIAS } from './providers';
+
+/**
+ * A custom provider's alias is the first path segment of the model ids
+ * `/v1/models` publishes for it (`<alias>/<model_name>`), so it must be a
+ * valid segment: lowercase letters, digits, dots and hyphens, with no
+ * leading, trailing or doubled separators.
+ */
+export const CUSTOM_PROVIDER_ALIAS_MAX_LENGTH = 50;
+export const CUSTOM_PROVIDER_ALIAS_PATTERN = /^[a-z0-9]+(?:[.-][a-z0-9]+)*$/;
+export const CUSTOM_PROVIDER_ALIAS_MESSAGE =
+  'Alias can only contain lowercase letters, numbers, dots and hyphens, and cannot start or end with a separator';
+
+/**
+ * Aliases that would collide with another published route: the synthetic
+ * `auto` route, Manifest itself, the internal `custom:` prefix, and every
+ * built-in provider id or alias (`openai/gpt-4o` must keep meaning OpenAI).
+ * Tile-only local providers (llama.cpp, LM Studio) are exempt: they only
+ * ever exist as custom providers, so no native route can claim the name.
+ */
+const RESERVED_ALIASES: ReadonlySet<string> = new Set(['auto', 'manifest', 'custom']);
+
+/** Trim and lowercase user input; an empty value means "no alias". */
+export function normalizeCustomProviderAlias(input: string | null | undefined): string | null {
+  const normalized = input?.trim().toLowerCase() ?? '';
+  return normalized === '' ? null : normalized;
+}
+
+export function isReservedCustomProviderAlias(alias: string): boolean {
+  if (RESERVED_ALIASES.has(alias)) return true;
+  const entry = SHARED_PROVIDER_BY_ID_OR_ALIAS.get(alias);
+  return entry !== undefined && !entry.tileOnly;
+}
+
+/**
+ * Derive the default alias from a display name: `Vercel AI Gateway` →
+ * `vercel-ai-gateway`, `llama.cpp` → `llama.cpp`. Returns null when the
+ * name yields nothing usable or a reserved alias, in which case the
+ * provider keeps publishing under its internal `custom:<uuid>/…` id.
+ */
+export function deriveCustomProviderAlias(name: string): string | null {
+  const derived = name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9.-]/g, '')
+    .replace(/[.-]{2,}/g, (run) => run[0])
+    .replace(/^[.-]+|[.-]+$/g, '')
+    .slice(0, CUSTOM_PROVIDER_ALIAS_MAX_LENGTH)
+    .replace(/[.-]+$/, '');
+  if (!CUSTOM_PROVIDER_ALIAS_PATTERN.test(derived)) return null;
+  if (isReservedCustomProviderAlias(derived)) return null;
+  return derived;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -188,3 +188,11 @@ export {
   normalizeRole,
 } from './chat-message';
 export type { ChatMessage, ChatTool, RecordedResponseBody, Role, ToolCall } from './chat-message';
+export {
+  CUSTOM_PROVIDER_ALIAS_MAX_LENGTH,
+  CUSTOM_PROVIDER_ALIAS_MESSAGE,
+  CUSTOM_PROVIDER_ALIAS_PATTERN,
+  deriveCustomProviderAlias,
+  isReservedCustomProviderAlias,
+  normalizeCustomProviderAlias,
+} from './custom-provider-alias';


### PR DESCRIPTION
### ✨ What changed
- Custom providers get an `alias`, the prefix their models publish under in `/v1/models`.
- `/v1/models` lists custom models as `<alias>/<model_name>` with `owned_by` set to the provider name.
- The proxy resolves both the alias form and the internal `custom:<uuid>/<model_name>` form.
- Alias defaults to the provider name, is editable at creation and later, and survives renames.
- Reserved names (built-in provider ids, `auto`, `manifest`, `custom`) return 400; duplicates per tenant return 409.
- Migration adds the nullable column, a case-insensitive partial unique index, and backfills existing rows from their name.
- Custom provider form gains an Alias field that follows the name until edited, with a live model id preview.

### 💭 Why
`custom:ce53b261-…/alibaba/qwen-3-14b` is truncated by chat clients such as LibreChat, and the uuid prefix carries no meaning for the user. Closes #2829.

### 👤 For users
Custom provider models now show up as `vercel-ai-gateway/alibaba/qwen-3-14b` in `/v1/models` and can be requested by that id. Existing `custom:<uuid>/…` ids keep working, so current client configs are not affected.

### 🔧 For operators
One migration, `AddCustomProviderAlias1802100000000`. It backfills aliases for existing custom providers; a row whose derived alias would collide with a built-in provider or another row of the tenant is left without one and keeps the internal id.

### 📝 Notes
- Deviates from the issue's derived-only proposal: the alias is a stored, user-editable column so ids stay stable across renames.
- tile-only local providers (llama.cpp, LM Studio) are exempt from the reserved-name rule since they only exist as custom providers.
- Echoing the alias in the response `model` field, raised in the issue comments, is out of scope: Manifest does not rewrite response bodies for any provider today.
- Follow-up: show the effective public model id on the connection detail page and in the routing model picker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Custom provider models now publish under a readable alias (`vercel-ai-gateway/alibaba/qwen-3-14b`) instead of the internal `custom:<uuid>/…` key, which chat clients truncate, and `/v1/models` now reports the provider name as `owned_by`. The alias defaults to the provider name, is editable at creation and later, and the proxy keeps accepting the old internal form so existing client configs keep working. Closes #2829.

**Migration**
- `AddCustomProviderAlias1802100000000` adds the nullable column, a case-insensitive partial unique index, and backfills existing rows from their name.
- Rows whose derived alias collides with a built-in provider or another row of the tenant keep the internal id.

**Validation**
- Reserved names (`auto`, `manifest`, `custom`, built-in provider ids) return 400; duplicates per tenant return 409, including a lost race on the unique index.
- Renames never touch the alias, so client configs survive.
- Alias, name, or model-list edits drop the model cache for every agent in the tenant, so `/v1/models` reflects them without waiting for the cache TTL.

<sup>Written for commit 79e44ef416dd5bdefe4bd1cd83bf9d3d522594ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

