### PR TITLE
fix(frontend): adapt provider connection page and header to phone screens

### DIFF
--- a/.changeset/mobile-provider-connection-view.md
+++ b/.changeset/mobile-provider-connection-view.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Adapt the provider connection page, the Overview KPI cards, and the app header to phone-sized screens

--- a/design-system/registry/components.json
+++ b/design-system/registry/components.json
@@ -888,6 +888,21 @@
         "routing-providers.css"
       ]
     },
+    "connection-detail": {
+      "classes": [
+        "connection-detail__badge",
+        "connection-detail__badges",
+        "connection-detail__controls",
+        "connection-detail__header",
+        "connection-detail__identity",
+        "connection-detail__meta",
+        "connection-detail__title",
+        "connection-detail__title-row"
+      ],
+      "files": [
+        "connection-detail.css"
+      ]
+    },
     "connection-label-cell": {
       "classes": [
         "connection-label-cell",
@@ -1072,6 +1087,7 @@
         "custom-select__value"
       ],
       "files": [
+        "connection-detail.css",
         "custom-select.css",
         "discovery.css",
         "routing-providers.css"
@@ -1485,7 +1501,9 @@
         "header__avatar-btn",
         "header__breadcrumb-current",
         "header__breadcrumb-icon",
+        "header__breadcrumb-label",
         "header__breadcrumb-link",
+        "header__breadcrumb-provider-icon",
         "header__docs-link",
         "header__dropdown",
         "header__dropdown-divider",
@@ -2397,7 +2415,8 @@
     },
     "overview-stats": {
       "classes": [
-        "overview-stats"
+        "overview-stats",
+        "overview-stats--5"
       ],
       "files": [
         "analytics-overview.css"
@@ -2413,6 +2432,7 @@
       ],
       "files": [
         "analytics-overview.css",
+        "connection-detail.css",
         "layout.css",
         "theme.css"
       ]
@@ -4313,7 +4333,7 @@
       "prop": "color",
       "value": "hsl(var(--foreground))",
       "file": "analytics-overview.css",
-      "line": 170
+      "line": 206
     },
     {
       "selector": ".custom-select__option--top > svg",
@@ -4565,35 +4585,59 @@
       "prop": "align-items",
       "value": "flex-start",
       "file": "toast.css",
-      "line": 16
+      "line": 25
     },
     {
       "selector": ".toast",
       "prop": "gap",
       "value": "var(--gap-sm)",
       "file": "toast.css",
-      "line": 17
+      "line": 26
     },
     {
       "selector": ".toast",
       "prop": "padding",
       "value": "12px var(--gap-md)",
       "file": "toast.css",
-      "line": 18
+      "line": 27
     },
     {
       "selector": ".toast",
       "prop": "box-shadow",
       "value": "0 4px 6px -1px rgb(0 0 0 / 0.1),\n    0 2px 4px -2px rgb(0 0 0 / 0.1)",
       "file": "toast.css",
-      "line": 22
+      "line": 31
     },
     {
       "selector": ".toast",
       "prop": "animation",
       "value": "toastSlideIn 200ms ease-out",
       "file": "toast.css",
-      "line": 26
+      "line": 35
+    },
+    {
+      "selector": ".toast-container",
+      "media": "(max-width: 480px)",
+      "prop": "left",
+      "value": "var(--gap-sm)",
+      "file": "toast.css",
+      "line": 98
+    },
+    {
+      "selector": ".toast-container",
+      "media": "(max-width: 480px)",
+      "prop": "right",
+      "value": "var(--gap-sm)",
+      "file": "toast.css",
+      "line": 99
+    },
+    {
+      "selector": ".toast-container",
+      "media": "(max-width: 480px)",
+      "prop": "bottom",
+      "value": "var(--gap-sm)",
+      "file": "toast.css",
+      "line": 100
     },
     {
       "selector": ".welcome__progress-header span",
@@ -4686,7 +4730,7 @@
       "value": "hsl(var(--muted-foreground))",
       "file": "cards.css",
       "line": 72,
-      "losesTo": "analytics-overview.css:170"
+      "losesTo": "analytics-overview.css:206"
     },
     {
       "selector": ".chart-card",
@@ -4750,7 +4794,7 @@
       "value": "center",
       "file": "controls.css",
       "line": 172,
-      "losesTo": "toast.css:16"
+      "losesTo": "toast.css:25"
     },
     {
       "selector": ".toast",
@@ -4758,7 +4802,7 @@
       "value": "10px",
       "file": "controls.css",
       "line": 173,
-      "losesTo": "toast.css:17"
+      "losesTo": "toast.css:26"
     },
     {
       "selector": ".toast",
@@ -4766,7 +4810,7 @@
       "value": "12px 16px",
       "file": "controls.css",
       "line": 174,
-      "losesTo": "toast.css:18"
+      "losesTo": "toast.css:27"
     },
     {
       "selector": ".toast",
@@ -4774,7 +4818,7 @@
       "value": "0 4px 16px rgb(0 0 0 / 0.15)",
       "file": "controls.css",
       "line": 177,
-      "losesTo": "toast.css:22"
+      "losesTo": "toast.css:31"
     },
     {
       "selector": ".toast",
@@ -4782,7 +4826,7 @@
       "value": "toast-in 200ms ease-out",
       "file": "controls.css",
       "line": 180,
-      "losesTo": "toast.css:26"
+      "losesTo": "toast.css:35"
     },
     {
       "selector": ".sidebar",
@@ -4961,6 +5005,33 @@
       "losesTo": "syntax-highlight.css:41"
     },
     {
+      "selector": ".toast-container",
+      "media": "(max-width: 480px)",
+      "prop": "left",
+      "value": "var(--gap-md)",
+      "file": "toast.css",
+      "line": 16,
+      "losesTo": "toast.css:98"
+    },
+    {
+      "selector": ".toast-container",
+      "media": "(max-width: 480px)",
+      "prop": "right",
+      "value": "var(--gap-md)",
+      "file": "toast.css",
+      "line": 17,
+      "losesTo": "toast.css:99"
+    },
+    {
+      "selector": ".toast-container",
+      "media": "(max-width: 480px)",
+      "prop": "bottom",
+      "value": "var(--gap-md)",
+      "file": "toast.css",
+      "line": 18,
+      "losesTo": "toast.css:100"
+    },
+    {
       "selector": ".welcome__progress-header span",
       "prop": "letter-spacing",
       "value": "0.09em",
@@ -5010,6 +5081,9 @@
       "pages/GlobalOverview.tsx",
       "pages/providers/ConnectionDetail.tsx",
       "pages/providers/ProviderConnectionsPage.tsx"
+    ],
+    "connection-detail.css": [
+      "pages/providers/ConnectionDetail.tsx"
     ],
     "discovery.css": [
       "pages/Discovery.tsx"
@@ -5079,9 +5153,9 @@
   "stats": {
     "tokens": 79,
     "darkOverrides": 38,
-    "blocks": 314,
-    "classes": 1696,
-    "canonicalRules": 46,
-    "ghostRules": 46
+    "blocks": 315,
+    "classes": 1707,
+    "canonicalRules": 49,
+    "ghostRules": 49
   }
 }

--- a/design-system/registry/components.json
+++ b/design-system/registry/components.json
@@ -2416,6 +2416,7 @@
     "overview-stats": {
       "classes": [
         "overview-stats",
+        "overview-stats--3",
         "overview-stats--5"
       ],
       "files": [
@@ -4333,7 +4334,7 @@
       "prop": "color",
       "value": "hsl(var(--foreground))",
       "file": "analytics-overview.css",
-      "line": 206
+      "line": 213
     },
     {
       "selector": ".custom-select__option--top > svg",
@@ -4585,59 +4586,35 @@
       "prop": "align-items",
       "value": "flex-start",
       "file": "toast.css",
-      "line": 25
+      "line": 16
     },
     {
       "selector": ".toast",
       "prop": "gap",
       "value": "var(--gap-sm)",
       "file": "toast.css",
-      "line": 26
+      "line": 17
     },
     {
       "selector": ".toast",
       "prop": "padding",
       "value": "12px var(--gap-md)",
       "file": "toast.css",
-      "line": 27
+      "line": 18
     },
     {
       "selector": ".toast",
       "prop": "box-shadow",
       "value": "0 4px 6px -1px rgb(0 0 0 / 0.1),\n    0 2px 4px -2px rgb(0 0 0 / 0.1)",
       "file": "toast.css",
-      "line": 31
+      "line": 22
     },
     {
       "selector": ".toast",
       "prop": "animation",
       "value": "toastSlideIn 200ms ease-out",
       "file": "toast.css",
-      "line": 35
-    },
-    {
-      "selector": ".toast-container",
-      "media": "(max-width: 480px)",
-      "prop": "left",
-      "value": "var(--gap-sm)",
-      "file": "toast.css",
-      "line": 98
-    },
-    {
-      "selector": ".toast-container",
-      "media": "(max-width: 480px)",
-      "prop": "right",
-      "value": "var(--gap-sm)",
-      "file": "toast.css",
-      "line": 99
-    },
-    {
-      "selector": ".toast-container",
-      "media": "(max-width: 480px)",
-      "prop": "bottom",
-      "value": "var(--gap-sm)",
-      "file": "toast.css",
-      "line": 100
+      "line": 26
     },
     {
       "selector": ".welcome__progress-header span",
@@ -4730,7 +4707,7 @@
       "value": "hsl(var(--muted-foreground))",
       "file": "cards.css",
       "line": 72,
-      "losesTo": "analytics-overview.css:206"
+      "losesTo": "analytics-overview.css:213"
     },
     {
       "selector": ".chart-card",
@@ -4794,7 +4771,7 @@
       "value": "center",
       "file": "controls.css",
       "line": 172,
-      "losesTo": "toast.css:25"
+      "losesTo": "toast.css:16"
     },
     {
       "selector": ".toast",
@@ -4802,7 +4779,7 @@
       "value": "10px",
       "file": "controls.css",
       "line": 173,
-      "losesTo": "toast.css:26"
+      "losesTo": "toast.css:17"
     },
     {
       "selector": ".toast",
@@ -4810,7 +4787,7 @@
       "value": "12px 16px",
       "file": "controls.css",
       "line": 174,
-      "losesTo": "toast.css:27"
+      "losesTo": "toast.css:18"
     },
     {
       "selector": ".toast",
@@ -4818,7 +4795,7 @@
       "value": "0 4px 16px rgb(0 0 0 / 0.15)",
       "file": "controls.css",
       "line": 177,
-      "losesTo": "toast.css:31"
+      "losesTo": "toast.css:22"
     },
     {
       "selector": ".toast",
@@ -4826,7 +4803,7 @@
       "value": "toast-in 200ms ease-out",
       "file": "controls.css",
       "line": 180,
-      "losesTo": "toast.css:35"
+      "losesTo": "toast.css:26"
     },
     {
       "selector": ".sidebar",
@@ -5005,33 +4982,6 @@
       "losesTo": "syntax-highlight.css:41"
     },
     {
-      "selector": ".toast-container",
-      "media": "(max-width: 480px)",
-      "prop": "left",
-      "value": "var(--gap-md)",
-      "file": "toast.css",
-      "line": 16,
-      "losesTo": "toast.css:98"
-    },
-    {
-      "selector": ".toast-container",
-      "media": "(max-width: 480px)",
-      "prop": "right",
-      "value": "var(--gap-md)",
-      "file": "toast.css",
-      "line": 17,
-      "losesTo": "toast.css:99"
-    },
-    {
-      "selector": ".toast-container",
-      "media": "(max-width: 480px)",
-      "prop": "bottom",
-      "value": "var(--gap-md)",
-      "file": "toast.css",
-      "line": 18,
-      "losesTo": "toast.css:100"
-    },
-    {
       "selector": ".welcome__progress-header span",
       "prop": "letter-spacing",
       "value": "0.09em",
@@ -5154,8 +5104,8 @@
     "tokens": 79,
     "darkOverrides": 38,
     "blocks": 315,
-    "classes": 1707,
-    "canonicalRules": 49,
-    "ghostRules": 49
+    "classes": 1708,
+    "canonicalRules": 46,
+    "ghostRules": 46
   }
 }

--- a/design-system/registry/llms.txt
+++ b/design-system/registry/llms.txt
@@ -96,7 +96,7 @@
 --z-toast: 8000
 --z-tooltip: 9999
 
-## Blocks (315 BEM blocks, 1707 classes)
+## Blocks (315 BEM blocks, 1708 classes)
 account-back-btn (agents.css): account-back-btn
 account-email-footer (agents.css): account-email-footer
 account-email-toggle (agents.css): account-email-toggle--disabled
@@ -276,7 +276,7 @@ overview (agents.css): overview__platform-icon
 overview-discovery-banner (overview.css): overview-discovery-banner overview-discovery-banner__cta overview-discovery-banner__dismiss overview-discovery-banner__inner overview-discovery-banner__text
 overview-split (analytics-overview.css): overview-split
 overview-stat-card (analytics-overview.css): overview-stat-card overview-stat-card--autofix overview-stat-card--destructive overview-stat-card--fallback overview-stat-card__label overview-stat-card__value overview-stat-card__value-row
-overview-stats (analytics-overview.css): overview-stats overview-stats--5
+overview-stats (analytics-overview.css): overview-stats overview-stats--3 overview-stats--5
 page-header (analytics-overview.css, connection-detail.css, layout.css, theme.css): page-header page-header--wrap page-header__intro page-header__subtitle page-header__title
 pagination (data.css): pagination pagination__btn pagination__controls pagination__summary
 panel (analytics-overview.css, cards.css, charts.css, limits.css, request-drawer.css, routing-providers.css, routing-tabs.css, theme.css, welcome.css, wizard.css): panel panel--disabled panel__header panel__tab panel__tab--active panel__tab-icon panel__tabs panel__title
@@ -419,8 +419,8 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
 ## Migration map — legacy component → primitive to use instead (0)
 (empty until primitives exist)
 
-## Canonical rules — same selector+property declared twice with different values; the winner renders (49)
-.view-more-link { color: hsl(var(--foreground)) }  ← analytics-overview.css:206
+## Canonical rules — same selector+property declared twice with different values; the winner renders (46)
+.view-more-link { color: hsl(var(--foreground)) }  ← analytics-overview.css:213
 .custom-select__option--top > svg { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
 .setup-modal__header { align-items: center }  ← overview.css:15
@@ -457,29 +457,26 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
     0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1102
 .modal__close { width: 2rem }  ← theme.css:1127
 .modal__close { height: 2rem }  ← theme.css:1128
-.toast { align-items: flex-start }  ← toast.css:25
-.toast { gap: var(--gap-sm) }  ← toast.css:26
-.toast { padding: 12px var(--gap-md) }  ← toast.css:27
+.toast { align-items: flex-start }  ← toast.css:16
+.toast { gap: var(--gap-sm) }  ← toast.css:17
+.toast { padding: 12px var(--gap-md) }  ← toast.css:18
 .toast { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1),
-    0 2px 4px -2px rgb(0 0 0 / 0.1) }  ← toast.css:31
-.toast { animation: toastSlideIn 200ms ease-out }  ← toast.css:35
-.toast-container { left: var(--gap-sm) }  ← toast.css:98  [@media (max-width: 480px)]
-.toast-container { right: var(--gap-sm) }  ← toast.css:99  [@media (max-width: 480px)]
-.toast-container { bottom: var(--gap-sm) }  ← toast.css:100  [@media (max-width: 480px)]
+    0 2px 4px -2px rgb(0 0 0 / 0.1) }  ← toast.css:22
+.toast { animation: toastSlideIn 200ms ease-out }  ← toast.css:26
 .welcome__progress-header span { letter-spacing: 0.02em }  ← welcome.css:554
 .welcome__text-link:focus-visible { outline: 2px solid hsl(var(--ring)) }  ← welcome.css:865
 .welcome__text-link:focus-visible { outline-offset: 3px }  ← welcome.css:866
 .welcome__route-test-heading { align-items: center }  ← welcome.css:903
 .welcome__route-test-heading { gap: 10px }  ← welcome.css:904
 
-## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (49)
+## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (46)
 .summary-card { box-shadow: var(--card-shadow) }  at cards.css:7 loses to theme.css:197
 .trend--up { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:238
 .trend--down { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:243
 .trend--up { background: hsl(var(--muted)) }  at cards.css:49 loses to theme.css:239
 .trend--down { background: hsl(var(--muted)) }  at cards.css:49 loses to theme.css:244
 .panel { box-shadow: var(--card-shadow) }  at cards.css:59 loses to theme.css:269
-.view-more-link { color: hsl(var(--muted-foreground)) }  at cards.css:72 loses to analytics-overview.css:206
+.view-more-link { color: hsl(var(--muted-foreground)) }  at cards.css:72 loses to analytics-overview.css:213
 .chart-card { box-shadow: var(--card-shadow) }  at cards.css:86 loses to theme.css:285
 .chart-card__header { align-items: stretch }  at cards.css:92 loses to theme.css:291
 .chart-card__value-row { align-items: center }  at cards.css:160 loses to theme.css:323
@@ -487,11 +484,11 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
 .expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1045
 .expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1046
 .expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1051
-.toast { align-items: center }  at controls.css:172 loses to toast.css:25
-.toast { gap: 10px }  at controls.css:173 loses to toast.css:26
-.toast { padding: 12px 16px }  at controls.css:174 loses to toast.css:27
-.toast { box-shadow: 0 4px 16px rgb(0 0 0 / 0.15) }  at controls.css:177 loses to toast.css:31
-.toast { animation: toast-in 200ms ease-out }  at controls.css:180 loses to toast.css:35
+.toast { align-items: center }  at controls.css:172 loses to toast.css:16
+.toast { gap: 10px }  at controls.css:173 loses to toast.css:17
+.toast { padding: 12px 16px }  at controls.css:174 loses to toast.css:18
+.toast { box-shadow: 0 4px 16px rgb(0 0 0 / 0.15) }  at controls.css:177 loses to toast.css:22
+.toast { animation: toast-in 200ms ease-out }  at controls.css:180 loses to toast.css:26
 .sidebar { padding: var(--gap-md) 0 }  at controls.css:261 loses to theme.css:785
 .custom-select__option--top > svg { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
@@ -515,9 +512,6 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
 .request-tool { border-radius: var(--radius) }  at request-drawer.css:647 loses to request-drawer.css:875
 .request-tool { background: hsl(var(--card)) }  at request-drawer.css:648 loses to request-drawer.css:876
 .hljs-attr { color: hsl(187 60% 38%) }  at request-drawer.css:1054 loses to syntax-highlight.css:41
-.toast-container { left: var(--gap-md) }  at toast.css:16 loses to toast.css:98
-.toast-container { right: var(--gap-md) }  at toast.css:17 loses to toast.css:99
-.toast-container { bottom: var(--gap-md) }  at toast.css:18 loses to toast.css:100
 .welcome__progress-header span { letter-spacing: 0.09em }  at welcome.css:548 loses to welcome.css:554
 .welcome__text-link:focus-visible { outline: 3px solid hsl(var(--ring)) }  at welcome.css:726 loses to welcome.css:865
 .welcome__text-link:focus-visible { outline-offset: 2px }  at welcome.css:727 loses to welcome.css:866

--- a/design-system/registry/llms.txt
+++ b/design-system/registry/llms.txt
@@ -96,7 +96,7 @@
 --z-toast: 8000
 --z-tooltip: 9999
 
-## Blocks (314 BEM blocks, 1696 classes)
+## Blocks (315 BEM blocks, 1707 classes)
 account-back-btn (agents.css): account-back-btn
 account-email-footer (agents.css): account-email-footer
 account-email-toggle (agents.css): account-email-toggle--disabled
@@ -150,6 +150,7 @@ cloud-email-info (notifications.css): cloud-email-info cloud-email-info__desc cl
 complexity-empty (routing.css): complexity-empty complexity-empty__desc complexity-empty__title
 confirm-modal (limits.css): confirm-modal__confirm-row confirm-modal__footer confirm-modal__warning
 connection-delete-confirmation (routing-providers.css): connection-delete-confirmation connection-delete-confirmation__copy connection-delete-confirmation__footer connection-delete-confirmation__label connection-delete-confirmation__title connection-delete-confirmation__warning
+connection-detail (connection-detail.css): connection-detail__badge connection-detail__badges connection-detail__controls connection-detail__header connection-detail__identity connection-detail__meta connection-detail__title connection-detail__title-row
 connection-label-cell (routing-providers.css): connection-label-cell connection-label-cell__edit
 connections-panel (routing-providers.css): connections-panel connections-panel--collapsed connections-panel__body connections-panel__chevron connections-panel__toggle connections-panel__viewport
 container (layout.css, theme.css): container--full container--lg container--md container--sm
@@ -164,7 +165,7 @@ count-link (theme.css): count-link
 custom-provider-item (routing-providers.css): custom-provider-item custom-provider-item__delete custom-provider-item__icon custom-provider-item__info custom-provider-item__meta custom-provider-item__name
 custom-provider-model-row (routing-providers.css): custom-provider-model-row custom-provider-model-row__name custom-provider-model-row__price custom-provider-model-row__remove
 custom-provider-models (routing-providers.css): custom-provider-models custom-provider-models__column custom-provider-models__column--name custom-provider-models__column--price custom-provider-models__column-spacer custom-provider-models__columns custom-provider-models__label
-custom-select (custom-select.css, discovery.css, routing-providers.css): custom-select custom-select__chevron custom-select__dropdown custom-select__dropdown--portal custom-select__dropdown--wide custom-select__option custom-select__option--disabled custom-select__option--selected custom-select__option--top custom-select__option-desc custom-select__option-text custom-select__option-text--inline custom-select__trigger custom-select__trigger--open custom-select__value
+custom-select (connection-detail.css, custom-select.css, discovery.css, routing-providers.css): custom-select custom-select__chevron custom-select__dropdown custom-select__dropdown--portal custom-select__dropdown--wide custom-select__option custom-select__option--disabled custom-select__option--selected custom-select__option--top custom-select__option-desc custom-select__option-text custom-select__option-text--inline custom-select__trigger custom-select__trigger--open custom-select__value
 dark (agent-type-select.css, agents.css, analytics-overview.css, auth.css, controls.css, data.css, modals.css, model-filter.css, overview.css, pivot.css, platform-icons.css, request-drawer.css, routing-deprecation.css, routing-providers.css, routing.css, syntax-highlight.css, tokens.css, welcome.css, wizard.css): dark
 data-table (data.css, feedback.css, theme.css): data-table data-table__sortable
 data-table-scroll (data.css): data-table-scroll
@@ -199,7 +200,7 @@ free-models-logo-dark (data.css): free-models-logo-dark
 free-models-logo-light (data.css): free-models-logo-light
 free-tag (theme.css): free-tag
 function_ (syntax-highlight.css): function_
-header (controls.css, theme.css): header header__avatar header__avatar-btn header__breadcrumb-current header__breadcrumb-icon header__breadcrumb-link header__docs-link header__dropdown header__dropdown-divider header__dropdown-email header__dropdown-header header__dropdown-item header__dropdown-item--danger header__dropdown-name header__gear header__gear-btn header__github-icon header__github-star header__github-star-action header__github-star-btn header__github-star-close header__github-star-count header__github-star-label header__left header__logo header__logo-img header__logo-img--dark header__logo-img--light header__mode-badge header__mode-badge--dev header__pro-badge header__right header__separator header__star-separator
+header (controls.css, theme.css): header header__avatar header__avatar-btn header__breadcrumb-current header__breadcrumb-icon header__breadcrumb-label header__breadcrumb-link header__breadcrumb-provider-icon header__docs-link header__dropdown header__dropdown-divider header__dropdown-email header__dropdown-header header__dropdown-item header__dropdown-item--danger header__dropdown-name header__gear header__gear-btn header__github-icon header__github-star header__github-star-action header__github-star-btn header__github-star-close header__github-star-count header__github-star-label header__left header__logo header__logo-img header__logo-img--dark header__logo-img--light header__mode-badge header__mode-badge--dev header__pro-badge header__right header__separator header__star-separator
 header-combo (routing-header-tiers.css): header-combo header-combo--invalid header-combo__error header-combo__input header-combo__menu header-combo__option header-combo__option--free header-combo__option--hover header-combo__option-group header-combo__option-label header-combo__option-row header-combo__option-sublabel
 header-controls (layout.css, theme.css): header-controls
 header-tier-card (routing-header-tiers.css): header-tier-card__actions header-tier-card__icon-btn header-tier-card__kebab header-tier-card__kebab-btn header-tier-card__menu header-tier-card__menu-item header-tier-card__menu-item--danger header-tier-card__name header-tier-card__ordinal header-tier-card__rule header-tier-card__title
@@ -275,8 +276,8 @@ overview (agents.css): overview__platform-icon
 overview-discovery-banner (overview.css): overview-discovery-banner overview-discovery-banner__cta overview-discovery-banner__dismiss overview-discovery-banner__inner overview-discovery-banner__text
 overview-split (analytics-overview.css): overview-split
 overview-stat-card (analytics-overview.css): overview-stat-card overview-stat-card--autofix overview-stat-card--destructive overview-stat-card--fallback overview-stat-card__label overview-stat-card__value overview-stat-card__value-row
-overview-stats (analytics-overview.css): overview-stats
-page-header (analytics-overview.css, layout.css, theme.css): page-header page-header--wrap page-header__intro page-header__subtitle page-header__title
+overview-stats (analytics-overview.css): overview-stats overview-stats--5
+page-header (analytics-overview.css, connection-detail.css, layout.css, theme.css): page-header page-header--wrap page-header__intro page-header__subtitle page-header__title
 pagination (data.css): pagination pagination__btn pagination__controls pagination__summary
 panel (analytics-overview.css, cards.css, charts.css, limits.css, request-drawer.css, routing-providers.css, routing-tabs.css, theme.css, welcome.css, wizard.css): panel panel--disabled panel__header panel__tab panel__tab--active panel__tab-icon panel__tabs panel__title
 plan-picker (auth.css): plan-picker plan-picker__amount plan-picker__badge plan-picker__card plan-picker__card--expanded plan-picker__card--pro plan-picker__cta plan-picker__details plan-picker__features plan-picker__name plan-picker__period plan-picker__price-inline plan-picker__radio plan-picker__radio-dot plan-picker__row plan-picker__section-header plan-picker__section-subtitle plan-picker__section-title plan-picker__usage
@@ -418,8 +419,8 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
 ## Migration map — legacy component → primitive to use instead (0)
 (empty until primitives exist)
 
-## Canonical rules — same selector+property declared twice with different values; the winner renders (46)
-.view-more-link { color: hsl(var(--foreground)) }  ← analytics-overview.css:170
+## Canonical rules — same selector+property declared twice with different values; the winner renders (49)
+.view-more-link { color: hsl(var(--foreground)) }  ← analytics-overview.css:206
 .custom-select__option--top > svg { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 14px) / 2) }  ← custom-select.css:142
 .setup-modal__header { align-items: center }  ← overview.css:15
@@ -456,26 +457,29 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
     0 25px 50px -12px rgb(0 0 0 / 0.25) }  ← theme.css:1102
 .modal__close { width: 2rem }  ← theme.css:1127
 .modal__close { height: 2rem }  ← theme.css:1128
-.toast { align-items: flex-start }  ← toast.css:16
-.toast { gap: var(--gap-sm) }  ← toast.css:17
-.toast { padding: 12px var(--gap-md) }  ← toast.css:18
+.toast { align-items: flex-start }  ← toast.css:25
+.toast { gap: var(--gap-sm) }  ← toast.css:26
+.toast { padding: 12px var(--gap-md) }  ← toast.css:27
 .toast { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1),
-    0 2px 4px -2px rgb(0 0 0 / 0.1) }  ← toast.css:22
-.toast { animation: toastSlideIn 200ms ease-out }  ← toast.css:26
+    0 2px 4px -2px rgb(0 0 0 / 0.1) }  ← toast.css:31
+.toast { animation: toastSlideIn 200ms ease-out }  ← toast.css:35
+.toast-container { left: var(--gap-sm) }  ← toast.css:98  [@media (max-width: 480px)]
+.toast-container { right: var(--gap-sm) }  ← toast.css:99  [@media (max-width: 480px)]
+.toast-container { bottom: var(--gap-sm) }  ← toast.css:100  [@media (max-width: 480px)]
 .welcome__progress-header span { letter-spacing: 0.02em }  ← welcome.css:554
 .welcome__text-link:focus-visible { outline: 2px solid hsl(var(--ring)) }  ← welcome.css:865
 .welcome__text-link:focus-visible { outline-offset: 3px }  ← welcome.css:866
 .welcome__route-test-heading { align-items: center }  ← welcome.css:903
 .welcome__route-test-heading { gap: 10px }  ← welcome.css:904
 
-## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (46)
+## Ghost rules — declared but always losing; edit the canonical rule instead, delete these in the refactor project (49)
 .summary-card { box-shadow: var(--card-shadow) }  at cards.css:7 loses to theme.css:197
 .trend--up { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:238
 .trend--down { color: hsl(var(--muted-foreground)) }  at cards.css:48 loses to theme.css:243
 .trend--up { background: hsl(var(--muted)) }  at cards.css:49 loses to theme.css:239
 .trend--down { background: hsl(var(--muted)) }  at cards.css:49 loses to theme.css:244
 .panel { box-shadow: var(--card-shadow) }  at cards.css:59 loses to theme.css:269
-.view-more-link { color: hsl(var(--muted-foreground)) }  at cards.css:72 loses to analytics-overview.css:170
+.view-more-link { color: hsl(var(--muted-foreground)) }  at cards.css:72 loses to analytics-overview.css:206
 .chart-card { box-shadow: var(--card-shadow) }  at cards.css:86 loses to theme.css:285
 .chart-card__header { align-items: stretch }  at cards.css:92 loses to theme.css:291
 .chart-card__value-row { align-items: center }  at cards.css:160 loses to theme.css:323
@@ -483,11 +487,11 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
 .expandable-card__fade { height: 80px }  at charts.css:110 loses to theme.css:1045
 .expandable-card__fade { background: linear-gradient(transparent, hsl(var(--card)) 60%) }  at charts.css:111 loses to theme.css:1046
 .expandable-card__fade { padding-bottom: 16px }  at charts.css:116 loses to theme.css:1051
-.toast { align-items: center }  at controls.css:172 loses to toast.css:16
-.toast { gap: 10px }  at controls.css:173 loses to toast.css:17
-.toast { padding: 12px 16px }  at controls.css:174 loses to toast.css:18
-.toast { box-shadow: 0 4px 16px rgb(0 0 0 / 0.15) }  at controls.css:177 loses to toast.css:22
-.toast { animation: toast-in 200ms ease-out }  at controls.css:180 loses to toast.css:26
+.toast { align-items: center }  at controls.css:172 loses to toast.css:25
+.toast { gap: 10px }  at controls.css:173 loses to toast.css:26
+.toast { padding: 12px 16px }  at controls.css:174 loses to toast.css:27
+.toast { box-shadow: 0 4px 16px rgb(0 0 0 / 0.15) }  at controls.css:177 loses to toast.css:31
+.toast { animation: toast-in 200ms ease-out }  at controls.css:180 loses to toast.css:35
 .sidebar { padding: var(--gap-md) 0 }  at controls.css:261 loses to theme.css:785
 .custom-select__option--top > svg { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
 .custom-select__option--top > img { margin-top: calc((18px - 13px) / 2) }  at custom-select.css:137 loses to custom-select.css:142
@@ -511,15 +515,19 @@ workspace-table (agents.css): workspace-table__actions workspace-table__icon wor
 .request-tool { border-radius: var(--radius) }  at request-drawer.css:647 loses to request-drawer.css:875
 .request-tool { background: hsl(var(--card)) }  at request-drawer.css:648 loses to request-drawer.css:876
 .hljs-attr { color: hsl(187 60% 38%) }  at request-drawer.css:1054 loses to syntax-highlight.css:41
+.toast-container { left: var(--gap-md) }  at toast.css:16 loses to toast.css:98
+.toast-container { right: var(--gap-md) }  at toast.css:17 loses to toast.css:99
+.toast-container { bottom: var(--gap-md) }  at toast.css:18 loses to toast.css:100
 .welcome__progress-header span { letter-spacing: 0.09em }  at welcome.css:548 loses to welcome.css:554
 .welcome__text-link:focus-visible { outline: 3px solid hsl(var(--ring)) }  at welcome.css:726 loses to welcome.css:865
 .welcome__text-link:focus-visible { outline-offset: 2px }  at welcome.css:727 loses to welcome.css:866
 .welcome__route-test-heading { align-items: flex-start }  at welcome.css:873 loses to welcome.css:903
 .welcome__route-test-heading { gap: 14px }  at welcome.css:875 loses to welcome.css:904
 
-## Component-loaded sheets — imported by components, not theme.css; they load after the global styles (19)
+## Component-loaded sheets — imported by components, not theme.css; they load after the global styles (20)
 agent-chart-tooltip.css ← components/ChartHoverTooltip.tsx
 analytics-overview.css ← components/AutofixKpiCards.tsx, pages/GlobalOverview.tsx, pages/providers/ConnectionDetail.tsx, pages/providers/ProviderConnectionsPage.tsx
+connection-detail.css ← pages/providers/ConnectionDetail.tsx
 discovery.css ← pages/Discovery.tsx
 filter-select.css ← components/FilterSelect.tsx
 model-filter.css ← components/ModelPricesFilterBar.tsx, pages/MessageLog.tsx

--- a/packages/frontend/src/components/AutofixKpiCards.tsx
+++ b/packages/frontend/src/components/AutofixKpiCards.tsx
@@ -105,7 +105,7 @@ const AutofixKpiCards: Component<AutofixKpiCardsProps> = (props) => {
   return (
     <Show when={props.stats}>
       {(s) => (
-        <div class="overview-stats" style="grid-template-columns: repeat(5, 1fr);">
+        <div class="overview-stats overview-stats--5">
           <div class="overview-stat-card">
             <span class="overview-stat-card__label">
               Success rate

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -160,10 +160,7 @@ const Header: Component<HeaderProps> = (props) => {
         </Show>
         <Show when={getAgentName()}>
           <span class="header__separator">/</span>
-          <A
-            href="/harnesses"
-            style="color: hsl(var(--muted-foreground)); text-decoration: none; font-size: var(--font-size-sm); font-weight: 500;"
-          >
+          <A href="/harnesses" class="header__breadcrumb-link" style="font-weight: 500;">
             Harnesses
           </A>
           <span class="header__separator">/</span>
@@ -251,22 +248,23 @@ const Header: Component<HeaderProps> = (props) => {
           <span class="header__separator">/</span>
           <A
             href={connectionBreadcrumbBackLink()}
-            style="color: hsl(var(--muted-foreground)); text-decoration: none; font-size: var(--font-size-sm); font-weight: 500;"
+            class="header__breadcrumb-link"
+            style="font-weight: 500;"
           >
             {connectionBreadcrumbBackLabel()}
           </A>
           <span class="header__separator">/</span>
-          <span style="display: inline-flex; align-items: center; gap: 6px; font-size: var(--font-size-sm); font-weight: 500; color: hsl(var(--foreground));">
+          {/* Same classes as the harness crumb so the phone breakpoint hides the
+              parent link and truncates the name instead of wrapping it. */}
+          <span class="header__breadcrumb-current">
             <Show when={connectionBreadcrumbProviderId()}>
-              <span style="display: inline-flex; align-items: center; flex-shrink: 0;">
+              <span class="header__breadcrumb-provider-icon">
                 {providerIcon(connectionBreadcrumbProviderId()!, 14)}
               </span>
             </Show>
-            {connectionBreadcrumbName()}
+            <span>{connectionBreadcrumbName()}</span>
             <Show when={connectionBreadcrumbLabel()}>
-              <span style="color: hsl(var(--muted-foreground)); font-weight: 400;">
-                {connectionBreadcrumbLabel()}
-              </span>
+              <span class="header__breadcrumb-label">{connectionBreadcrumbLabel()}</span>
             </Show>
           </span>
         </Show>

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -51,6 +51,7 @@ import { setConnectionBreadcrumb } from '../../services/connection-breadcrumb-st
 import { toast } from '../../services/toast-store.js';
 import '../../styles/charts.css';
 import '../../styles/analytics-overview.css';
+import '../../styles/connection-detail.css';
 import { getModelDisplayName } from '../../services/model-display.js';
 import CustomProviderForm from '../../components/CustomProviderForm.jsx';
 import '../../styles/routing.css';
@@ -702,62 +703,72 @@ const ConnectionDetail: Component = () => {
               </div>
 
               {/* Header */}
-              <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 24px;">
-                <div>
-                  <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 8px;">
-                    <span style="display: flex; align-items: center; width: 32px; height: 32px;">
+              <div class="connection-detail__header">
+                <div class="connection-detail__identity">
+                  <div class="connection-detail__title-row">
+                    <div class="connection-detail__title">
+                      <span style="display: flex; align-items: center; flex-shrink: 0; width: 32px; height: 32px;">
+                        <Show
+                          when={providerIcon(c.provider, 32)}
+                          fallback={
+                            <span
+                              style={{
+                                display: 'inline-flex',
+                                'align-items': 'center',
+                                'justify-content': 'center',
+                                width: '32px',
+                                height: '32px',
+                                'border-radius': '8px',
+                                'font-size': '16px',
+                                'font-weight': '700',
+                                color: 'white',
+                                background: customProviderColor(providerDisplayName()),
+                              }}
+                            >
+                              {providerDisplayName().charAt(0).toUpperCase()}
+                            </span>
+                          }
+                        >
+                          {providerIcon(c.provider, 32)}
+                        </Show>
+                      </span>
+                      <h1 class="page-header__title">
+                        {providerDisplayName()}
+                        <span style="font-size: var(--font-size-sm); font-weight: 400; color: hsl(var(--muted-foreground));">
+                          {c.label}
+                        </span>
+                      </h1>
+                    </div>
+                    <div class="connection-detail__badges">
+                      <Show when={isCustomProvider()}>
+                        <span
+                          class="connection-detail__badge"
+                          style="padding: 2px 8px; border: 1px solid hsl(var(--border)); color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs); font-weight: 500;"
+                        >
+                          Custom
+                        </span>
+                      </Show>
                       <Show
-                        when={providerIcon(c.provider, 32)}
+                        when={c.is_active}
                         fallback={
                           <span
-                            style={{
-                              display: 'inline-flex',
-                              'align-items': 'center',
-                              'justify-content': 'center',
-                              width: '32px',
-                              height: '32px',
-                              'border-radius': '8px',
-                              'font-size': '16px',
-                              'font-weight': '700',
-                              color: 'white',
-                              background: customProviderColor(providerDisplayName()),
-                            }}
+                            class="connection-detail__badge"
+                            style="padding: 4px 12px; background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); font-weight: 500;"
                           >
-                            {providerDisplayName().charAt(0).toUpperCase()}
+                            Inactive
                           </span>
                         }
                       >
-                        {providerIcon(c.provider, 32)}
-                      </Show>
-                    </span>
-                    <h1
-                      class="page-header__title"
-                      style="margin: 0; display: flex; align-items: baseline; gap: 8px;"
-                    >
-                      {providerDisplayName()}
-                      <span style="font-size: var(--font-size-sm); font-weight: 400; color: hsl(var(--muted-foreground));">
-                        {c.label}
-                      </span>
-                    </h1>
-                    <Show when={isCustomProvider()}>
-                      <span style="display: inline-flex; align-items: center; padding: 2px 8px; border-radius: var(--radius-sm); border: 1px solid hsl(var(--border)); color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs); font-weight: 500;">
-                        Custom
-                      </span>
-                    </Show>
-                    <Show
-                      when={c.is_active}
-                      fallback={
-                        <span style="display: inline-flex; align-items: center; padding: 4px 12px; border-radius: var(--radius-sm); background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); font-weight: 500;">
-                          Inactive
+                        <span
+                          class="connection-detail__badge"
+                          style="padding: 4px 12px; background: hsl(var(--success)); color: white; font-size: var(--font-size-sm); font-weight: 600;"
+                        >
+                          Active
                         </span>
-                      }
-                    >
-                      <span style="display: inline-flex; align-items: center; padding: 4px 12px; border-radius: var(--radius-sm); background: hsl(var(--success)); color: white; font-size: var(--font-size-sm); font-weight: 600;">
-                        Active
-                      </span>
-                    </Show>
+                      </Show>
+                    </div>
                   </div>
-                  <div style="display: flex; gap: 24px; font-size: var(--font-size-sm);">
+                  <div class="connection-detail__meta">
                     <span>
                       <span style="font-weight: 600; color: hsl(var(--foreground));">
                         Connection name:
@@ -788,7 +799,7 @@ const ConnectionDetail: Component = () => {
                     </span>
                   </div>
                 </div>
-                <div style="display: flex; align-items: center; gap: 8px; flex-shrink: 0;">
+                <div class="connection-detail__controls">
                   <Show when={allAgents().length > 1}>
                     <FilterSelect
                       noun="harnesses"
@@ -817,10 +828,7 @@ const ConnectionDetail: Component = () => {
               {/* Attempt world cards: the connection's own numbers on the
                   filtered period. Fallback retries exist for everyone;
                   autofixed attempts only exist with the Doctor version. */}
-              <div
-                class="overview-stats"
-                style="grid-template-columns: repeat(5, 1fr); margin-bottom: 16px;"
-              >
+              <div class="overview-stats overview-stats--5" style="margin-bottom: 16px;">
                 <div class="overview-stat-card">
                   <span class="overview-stat-card__label">
                     Success rate

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -554,7 +554,8 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
       <Show when={connectedRows().length > 0}>
         <div
           class="overview-stats"
-          style={`grid-template-columns: repeat(${showMetricCard() ? 4 : 3}, 1fr); margin-bottom: 24px;`}
+          classList={{ 'overview-stats--3': !showMetricCard() }}
+          style="margin-bottom: 24px;"
         >
           <Show when={showMetricCard()}>
             <div class="overview-stat-card">

--- a/packages/frontend/src/styles/analytics-overview.css
+++ b/packages/frontend/src/styles/analytics-overview.css
@@ -35,12 +35,17 @@
   grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
+.overview-stats--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 /* Stat cards collapse toward one column as the viewport narrows. The
    modifier and the base share the same breakpoints so a five-card row
    never stays wider than the screen. */
 @media (max-width: 1024px) {
   .overview-stats,
-  .overview-stats--5 {
+  .overview-stats--5,
+  .overview-stats--3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 16px;
   }
@@ -48,7 +53,8 @@
 
 @media (max-width: 768px) {
   .overview-stats,
-  .overview-stats--5 {
+  .overview-stats--5,
+  .overview-stats--3 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 12px;
   }
@@ -62,7 +68,8 @@
 
 @media (max-width: 480px) {
   .overview-stats,
-  .overview-stats--5 {
+  .overview-stats--5,
+  .overview-stats--3 {
     grid-template-columns: 1fr;
   }
 }

--- a/packages/frontend/src/styles/analytics-overview.css
+++ b/packages/frontend/src/styles/analytics-overview.css
@@ -26,9 +26,45 @@
 /* ── Summary stat cards ──────────────────────────── */
 .overview-stats {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 24px;
   margin-bottom: 24px;
+}
+
+.overview-stats--5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+/* Stat cards collapse toward one column as the viewport narrows. The
+   modifier and the base share the same breakpoints so a five-card row
+   never stays wider than the screen. */
+@media (max-width: 1024px) {
+  .overview-stats,
+  .overview-stats--5 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+  }
+}
+
+@media (max-width: 768px) {
+  .overview-stats,
+  .overview-stats--5 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+  /* Two-up cards are narrow: let the trend pill / "View more" drop under
+     the big value instead of pushing past the card edge. */
+  .overview-stat-card__value-row {
+    flex-wrap: wrap;
+    row-gap: 2px;
+  }
+}
+
+@media (max-width: 480px) {
+  .overview-stats,
+  .overview-stats--5 {
+    grid-template-columns: 1fr;
+  }
 }
 
 .overview-stat-card {
@@ -270,6 +306,9 @@
 .scroll-panel__body {
   max-height: 480px;
   overflow-y: auto;
+  /* Wide tables (the 7-column Harnesses breakdown) scroll inside the
+     panel on narrow screens instead of widening the page. */
+  overflow-x: auto;
   padding-bottom: 32px;
 }
 

--- a/packages/frontend/src/styles/connection-detail.css
+++ b/packages/frontend/src/styles/connection-detail.css
@@ -65,6 +65,13 @@
   font-size: var(--font-size-sm);
 }
 
+/* A label with no break opportunity must not hold the row at its own
+   min-content width on a phone. */
+.connection-detail__meta > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .connection-detail__controls {
   display: flex;
   align-items: center;

--- a/packages/frontend/src/styles/connection-detail.css
+++ b/packages/frontend/src/styles/connection-detail.css
@@ -1,0 +1,112 @@
+/* ── Provider connection detail (/providers/connections/:id) ──────────
+   Layout for the page header block: provider identity on the left,
+   range/harness filters + Manage on the right, and the metadata row
+   underneath the title. Desktop keeps the one-row side-by-side header;
+   the shared 768px breakpoint stacks it so nothing overflows a phone
+   viewport. Imported by ConnectionDetail.tsx only. */
+
+.connection-detail__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.connection-detail__identity {
+  min-width: 0;
+}
+
+.connection-detail__title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+/* Icon + title travel together as one flex item, so on a narrow screen the
+   title wraps beside the icon and the badges drop to the next line as a
+   group instead of squeezing the title into a column. */
+.connection-detail__title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.connection-detail__title .page-header__title {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* Custom + status travel together so a narrow row wraps them as a pair. */
+.connection-detail__badges {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.connection-detail__badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+}
+
+.connection-detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 24px;
+  font-size: var(--font-size-sm);
+}
+
+.connection-detail__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .connection-detail__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .connection-detail__title-row,
+  .connection-detail__badges {
+    gap: 8px 10px;
+  }
+
+  .connection-detail__title .page-header__title {
+    font-size: var(--font-size-xl);
+    letter-spacing: 0;
+  }
+
+  /* The badges shrink to a matched pair of compact tags rather than two
+     differently sized pills. `!important` beats the per-badge inline
+     padding/font-size, which is the desktop sizing. */
+
+  .connection-detail__badge {
+    padding: 2px 8px !important;
+    font-size: var(--font-size-xs) !important;
+    line-height: 1.6;
+  }
+
+  .connection-detail__controls {
+    flex-wrap: wrap;
+  }
+
+  /* The range picker becomes the row's flexible item; the harness filter
+     and Manage keep their natural width beside or below it. */
+  .connection-detail__controls > .custom-select {
+    flex: 1 1 160px;
+    min-width: 0;
+  }
+}

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -365,6 +365,10 @@
   border-radius: var(--radius);
   background: hsl(var(--success) / 0.15);
   color: hsl(var(--success));
+  /* The header's left group shrinks around the breadcrumb on small screens;
+     the badge must stay one line rather than break "SELF-" / "HOSTED". */
+  white-space: nowrap;
+  flex-shrink: 0;
   line-height: 1;
   user-select: none;
 }
@@ -403,6 +407,17 @@
 .header__breadcrumb-icon {
   width: 14px;
   height: 14px;
+}
+
+.header__breadcrumb-provider-icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.header__breadcrumb-label {
+  color: hsl(var(--muted-foreground));
+  font-weight: 400;
 }
 
 .dark .header__breadcrumb-icon[src*='openai'],

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -1233,6 +1233,9 @@ h6 {
 @media (max-width: 768px) {
   .header {
     padding: 0 var(--gap-md);
+    /* The left group grows to fill the row here, so without a gap the
+       truncated breadcrumb would butt against the nav toggle. */
+    gap: var(--gap-md);
   }
   .header__left {
     flex: 1;
@@ -1251,12 +1254,34 @@ h6 {
   }
   .header__breadcrumb-current {
     max-width: min(38vw, 180px);
+    /* Also shrink below the natural width when the logo + badge leave less
+       room than that cap, so the name ellipsizes instead of being clipped
+       by the left group's overflow. */
+    min-width: 0;
+    flex: 0 1 auto;
   }
   .header__breadcrumb-current > span {
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .header__breadcrumb-current > .header__breadcrumb-provider-icon,
+  .header__breadcrumb-current > .header__breadcrumb-label {
+    display: none;
+  }
+  /* Tab bars (harness detail, routing layers, …) are inline-flex pills that
+     never shrink: when the tabs outgrow a phone screen the bar scrolls
+     sideways inside its own box instead of widening the whole page. The
+     pill is only 2.25rem tall, so the scrollbar is hidden rather than
+     squeezed in. */
+  .panel__tabs {
+    max-width: 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .panel__tabs::-webkit-scrollbar {
+    display: none;
   }
   .header__gear {
     flex-shrink: 0;

--- a/packages/frontend/src/styles/toast.css
+++ b/packages/frontend/src/styles/toast.css
@@ -11,15 +11,6 @@
   width: 420px;
 }
 
-@media (max-width: 480px) {
-  .toast-container {
-    left: var(--gap-md);
-    right: var(--gap-md);
-    bottom: var(--gap-md);
-    width: auto;
-  }
-}
-
 .toast {
   display: flex;
   align-items: flex-start;

--- a/packages/frontend/src/styles/toast.css
+++ b/packages/frontend/src/styles/toast.css
@@ -11,6 +11,15 @@
   width: 420px;
 }
 
+@media (max-width: 480px) {
+  .toast-container {
+    left: var(--gap-md);
+    right: var(--gap-md);
+    bottom: var(--gap-md);
+    width: auto;
+  }
+}
+
 .toast {
   display: flex;
   align-items: flex-start;

--- a/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
+++ b/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
@@ -347,6 +347,11 @@ describe('analytics chart surface components', () => {
     expect(screen.getByText('5')).toBeDefined();
     expect(screen.getByText('Recovered by Fallback')).toBeDefined();
     expect(screen.getByText('3')).toBeDefined();
+    // The five-card row relies on the responsive `overview-stats--5` modifier;
+    // an inline grid-template-columns would override the phone breakpoints.
+    const grid = screen.getByText('Success rate').closest('.overview-stats') as HTMLElement;
+    expect(grid.classList.contains('overview-stats--5')).toBe(true);
+    expect(grid.style.gridTemplateColumns).toBe('');
     unmount();
 
     // Trends: previous window present → percentage badges.

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -1,22 +1,26 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
 
 const mockSignOut = vi.fn().mockResolvedValue(undefined);
 const mockNavigate = vi.fn();
-const mockGetBillingStatus = vi.fn().mockResolvedValue({ enabled: false, plan: "free" });
+const mockGetBillingStatus = vi.fn().mockResolvedValue({ enabled: false, plan: 'free' });
 const mockLocationReplace = vi.fn();
-let mockPathname = "/";
+let mockPathname = '/';
 
-vi.mock("@solidjs/router", () => ({
-  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+vi.mock('@solidjs/router', () => ({
+  A: (props: any) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
   useNavigate: () => mockNavigate,
   useLocation: () => ({ pathname: mockPathname }),
 }));
 
-vi.mock("../../src/services/auth-client.js", () => ({
+vi.mock('../../src/services/auth-client.js', () => ({
   authClient: {
     useSession: () => () => ({
-      data: { user: { id: "u1", name: "Alice", email: "alice@test.com" } },
+      data: { user: { id: 'u1', name: 'Alice', email: 'alice@test.com' } },
       isPending: false,
     }),
     signOut: (...args: unknown[]) => mockSignOut(...args),
@@ -24,56 +28,56 @@ vi.mock("../../src/services/auth-client.js", () => ({
 }));
 
 let mockAgentName: string | null = null;
-vi.mock("../../src/services/routing.js", () => ({
+vi.mock('../../src/services/routing.js', () => ({
   useAgentName: () => () => mockAgentName,
 }));
 
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   duplicateAgent: vi.fn(),
   getDuplicatePreview: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock("../../src/services/recent-agents.js", () => ({
+vi.mock('../../src/services/recent-agents.js', () => ({
   markAgentCreated: vi.fn(),
 }));
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
 }));
 
 let mockAgentDisplayName: string | null = null;
-vi.mock("../../src/services/agent-display-name.js", () => ({
+vi.mock('../../src/services/agent-display-name.js', () => ({
   agentDisplayName: () => mockAgentDisplayName,
 }));
 
 const mockCheckIsSelfHosted = vi.fn().mockResolvedValue(false);
-vi.mock("../../src/services/setup-status.js", () => ({
+vi.mock('../../src/services/setup-status.js', () => ({
   checkIsSelfHosted: () => mockCheckIsSelfHosted(),
 }));
 
-vi.mock("../../src/services/api/billing.js", () => ({
+vi.mock('../../src/services/api/billing.js', () => ({
   getBillingStatus: (...args: unknown[]) => mockGetBillingStatus(...args),
 }));
 
-vi.mock("../../src/components/NotificationBell.jsx", () => ({
+vi.mock('../../src/components/NotificationBell.jsx', () => ({
   default: () => null,
 }));
 
-import Header from "../../src/components/Header";
-import { setConnectionBreadcrumb } from "../../src/services/connection-breadcrumb-store";
+import Header from '../../src/components/Header';
+import { setConnectionBreadcrumb } from '../../src/services/connection-breadcrumb-store';
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  vi.spyOn(window, "location", "get").mockReturnValue({
+  vi.spyOn(window, 'location', 'get').mockReturnValue({
     ...window.location,
     replace: mockLocationReplace,
   });
   sessionStorage.clear();
-  mockPathname = "/";
+  mockPathname = '/';
   mockAgentName = null;
   mockAgentDisplayName = null;
   mockGetBillingStatus.mockReset();
-  mockGetBillingStatus.mockResolvedValue({ enabled: false, plan: "free" });
+  mockGetBillingStatus.mockResolvedValue({ enabled: false, plan: 'free' });
   mockLocationReplace.mockReset();
   mockCheckIsSelfHosted.mockReset();
   mockCheckIsSelfHosted.mockResolvedValue(false);
@@ -82,83 +86,83 @@ beforeEach(() => {
   setConnectionBreadcrumb(null);
 });
 
-describe("Header", () => {
-  it("renders logo", () => {
+describe('Header', () => {
+  it('renders logo', () => {
     const { container } = render(() => <Header />);
-    const imgs = container.querySelectorAll("img");
+    const imgs = container.querySelectorAll('img');
     expect(imgs.length).toBe(2);
   });
 
-  it("shows user initials", () => {
+  it('shows user initials', () => {
     render(() => <Header />);
-    expect(screen.getByText("A")).toBeDefined();
+    expect(screen.getByText('A')).toBeDefined();
   });
 
-  it("shows user menu button", () => {
+  it('shows user menu button', () => {
     render(() => <Header />);
-    expect(screen.getByLabelText("User menu")).toBeDefined();
+    expect(screen.getByLabelText('User menu')).toBeDefined();
   });
 
-  it("opens dropdown on click", async () => {
+  it('opens dropdown on click', async () => {
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("User menu"));
-    expect(screen.getByText("Alice")).toBeDefined();
-    expect(screen.getByText("alice@test.com")).toBeDefined();
+    await fireEvent.click(screen.getByLabelText('User menu'));
+    expect(screen.getByText('Alice')).toBeDefined();
+    expect(screen.getByText('alice@test.com')).toBeDefined();
   });
 
-  it("shows Account Preferences link in dropdown", async () => {
+  it('shows Account Preferences link in dropdown', async () => {
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("User menu"));
-    expect(screen.getByText("Account Preferences")).toBeDefined();
+    await fireEvent.click(screen.getByLabelText('User menu'));
+    expect(screen.getByText('Account Preferences')).toBeDefined();
   });
 
-  it("shows Log out button in dropdown", async () => {
+  it('shows Log out button in dropdown', async () => {
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("User menu"));
-    expect(screen.getByText("Log out")).toBeDefined();
+    await fireEvent.click(screen.getByLabelText('User menu'));
+    expect(screen.getByText('Log out')).toBeDefined();
   });
 
-  it("calls signOut when Log out clicked", async () => {
+  it('calls signOut when Log out clicked', async () => {
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("User menu"));
-    await fireEvent.click(screen.getByText("Log out"));
+    await fireEvent.click(screen.getByLabelText('User menu'));
+    await fireEvent.click(screen.getByText('Log out'));
     expect(mockSignOut).toHaveBeenCalled();
   });
 
-  it("navigates to login after signOut", async () => {
+  it('navigates to login after signOut', async () => {
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("User menu"));
-    await fireEvent.click(screen.getByText("Log out"));
+    await fireEvent.click(screen.getByLabelText('User menu'));
+    await fireEvent.click(screen.getByText('Log out'));
     await vi.waitFor(() => {
-      expect(mockLocationReplace).toHaveBeenCalledWith("/login");
+      expect(mockLocationReplace).toHaveBeenCalledWith('/login');
     });
   });
 
-  it("closes dropdown when clicking outside", async () => {
+  it('closes dropdown when clicking outside', async () => {
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("User menu"));
-    expect(screen.getByText("Alice")).toBeDefined();
+    await fireEvent.click(screen.getByLabelText('User menu'));
+    expect(screen.getByText('Alice')).toBeDefined();
     await fireEvent.click(document.body);
-    expect(screen.queryByText("Alice")).toBeNull();
+    expect(screen.queryByText('Alice')).toBeNull();
   });
 
-  it("renders the closed mobile navigation toggle", () => {
+  it('renders the closed mobile navigation toggle', () => {
     render(() => <Header showMobileNavToggle mobileNavOpen={false} />);
 
-    const toggle = screen.getByLabelText("Open navigation menu");
-    expect(toggle.getAttribute("aria-controls")).toBe("agent-navigation");
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    const toggle = screen.getByLabelText('Open navigation menu');
+    expect(toggle.getAttribute('aria-controls')).toBe('agent-navigation');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it("renders the open mobile navigation toggle and handles clicks", async () => {
+  it('renders the open mobile navigation toggle and handles clicks', async () => {
     const onMobileNavToggle = vi.fn();
 
     render(() => (
       <Header showMobileNavToggle mobileNavOpen onMobileNavToggle={onMobileNavToggle} />
     ));
 
-    const toggle = screen.getByLabelText("Close navigation menu");
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    const toggle = screen.getByLabelText('Close navigation menu');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
 
     await fireEvent.click(toggle);
 
@@ -166,330 +170,333 @@ describe("Header", () => {
   });
 });
 
-describe("Header - GitHub star button", () => {
-  it("renders the star button with link to GitHub repo", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 1234 }))
+describe('Header - GitHub star button', () => {
+  it('renders the star button with link to GitHub repo', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 1234 })),
     );
     const { container } = render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("Star")).toBeDefined();
+      expect(screen.getByText('Star')).toBeDefined();
     });
-    const link = container.querySelector(".header__github-star-btn") as HTMLAnchorElement;
+    const link = container.querySelector('.header__github-star-btn') as HTMLAnchorElement;
     expect(link).toBeDefined();
-    expect(link.href).toContain("github.com/mnfst/manifest");
-    expect(link.target).toBe("_blank");
-    expect(link.rel).toBe("noopener noreferrer");
+    expect(link.href).toContain('github.com/mnfst/manifest');
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toBe('noopener noreferrer');
   });
 
-  it("fetches and displays the star count", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 5678 }))
+  it('fetches and displays the star count', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 5678 })),
     );
     render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("5,678")).toBeDefined();
+      expect(screen.getByText('5,678')).toBeDefined();
     });
   });
 
-  it("formats large star counts with locale separators", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 12345 }))
+  it('formats large star counts with locale separators', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 12345 })),
     );
     render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("12,345")).toBeDefined();
+      expect(screen.getByText('12,345')).toBeDefined();
     });
   });
 
-  it("renders star button without count when API returns non-numeric value", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: "not a number" }))
+  it('renders star button without count when API returns non-numeric value', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 'not a number' })),
     );
     const { container } = render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("Star")).toBeDefined();
+      expect(screen.getByText('Star')).toBeDefined();
     });
-    expect(container.querySelector(".header__github-star-count")).toBeNull();
+    expect(container.querySelector('.header__github-star-count')).toBeNull();
   });
 
-  it("renders star button without count when fetch fails", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network error"));
+  it('renders star button without count when fetch fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Network error'));
     const { container } = render(() => <Header />);
     // Star label should still appear
     await vi.waitFor(() => {
-      expect(screen.getByText("Star")).toBeDefined();
+      expect(screen.getByText('Star')).toBeDefined();
     });
-    expect(container.querySelector(".header__github-star-count")).toBeNull();
+    expect(container.querySelector('.header__github-star-count')).toBeNull();
   });
 
-  it("shows dismiss button", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 100 }))
+  it('shows dismiss button', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 100 })),
     );
     render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByLabelText("Dismiss GitHub star button")).toBeDefined();
+      expect(screen.getByLabelText('Dismiss GitHub star button')).toBeDefined();
     });
   });
 
-  it("hides star button when dismiss is clicked", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 100 }))
+  it('hides star button when dismiss is clicked', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 100 })),
     );
     const { container } = render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("Star")).toBeDefined();
+      expect(screen.getByText('Star')).toBeDefined();
     });
-    await fireEvent.click(screen.getByLabelText("Dismiss GitHub star button"));
-    expect(container.querySelector(".header__github-star")).toBeNull();
+    await fireEvent.click(screen.getByLabelText('Dismiss GitHub star button'));
+    expect(container.querySelector('.header__github-star')).toBeNull();
   });
 
-  it("persists dismiss state in sessionStorage", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 100 }))
+  it('persists dismiss state in sessionStorage', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 100 })),
     );
     render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("Star")).toBeDefined();
+      expect(screen.getByText('Star')).toBeDefined();
     });
-    await fireEvent.click(screen.getByLabelText("Dismiss GitHub star button"));
-    expect(sessionStorage.getItem("github-star-dismissed")).toBe("true");
+    await fireEvent.click(screen.getByLabelText('Dismiss GitHub star button'));
+    expect(sessionStorage.getItem('github-star-dismissed')).toBe('true');
   });
 
-  it("does not render star button if previously dismissed", async () => {
-    sessionStorage.setItem("github-star-dismissed", "true");
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 100 }))
-    );
+  it('does not render star button if previously dismissed', async () => {
+    sessionStorage.setItem('github-star-dismissed', 'true');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ stars: 100 })));
     const { container } = render(() => <Header />);
-    expect(container.querySelector(".header__github-star")).toBeNull();
+    expect(container.querySelector('.header__github-star')).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("does not fetch star count if dismissed", () => {
-    sessionStorage.setItem("github-star-dismissed", "true");
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 100 }))
-    );
+  it('does not fetch star count if dismissed', () => {
+    sessionStorage.setItem('github-star-dismissed', 'true');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ stars: 100 })));
     render(() => <Header />);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("uses cached star count from sessionStorage", async () => {
-    sessionStorage.setItem("github-star-count", "9999");
-    sessionStorage.setItem("github-star-ts", String(Date.now()));
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
+  it('uses cached star count from sessionStorage', async () => {
+    sessionStorage.setItem('github-star-count', '9999');
+    sessionStorage.setItem('github-star-ts', String(Date.now()));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
     render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("9,999")).toBeDefined();
+      expect(screen.getByText('9,999')).toBeDefined();
     });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("fetches fresh count when cache is expired", async () => {
-    sessionStorage.setItem("github-star-count", "9999");
-    sessionStorage.setItem("github-star-ts", String(Date.now() - 4000000));
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 5555 }))
+  it('fetches fresh count when cache is expired', async () => {
+    sessionStorage.setItem('github-star-count', '9999');
+    sessionStorage.setItem('github-star-ts', String(Date.now() - 4000000));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 5555 })),
     );
     render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("5,555")).toBeDefined();
+      expect(screen.getByText('5,555')).toBeDefined();
     });
   });
 
-  it("caches star count in sessionStorage after fetch", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stars: 4321 }))
+  it('caches star count in sessionStorage after fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 4321 })),
     );
     render(() => <Header />);
     await vi.waitFor(() => {
-      expect(screen.getByText("4,321")).toBeDefined();
+      expect(screen.getByText('4,321')).toBeDefined();
     });
-    expect(sessionStorage.getItem("github-star-count")).toBe("4321");
-    expect(sessionStorage.getItem("github-star-ts")).toBeDefined();
+    expect(sessionStorage.getItem('github-star-count')).toBe('4321');
+    expect(sessionStorage.getItem('github-star-ts')).toBeDefined();
   });
 });
 
-describe("Header - breadcrumb", () => {
-  it("logo links to /", () => {
+describe('Header - breadcrumb', () => {
+  it('logo links to /', () => {
     const { container } = render(() => <Header />);
-    const logoLink = container.querySelector(".header__logo") as HTMLAnchorElement;
-    expect(logoLink.getAttribute("href")).toBe("/");
+    const logoLink = container.querySelector('.header__logo') as HTMLAnchorElement;
+    expect(logoLink.getAttribute('href')).toBe('/');
   });
 
-  it("shows only the active agent breadcrumb when agent is active", () => {
-    mockAgentName = "my-agent";
+  it('shows only the active agent breadcrumb when agent is active', () => {
+    mockAgentName = 'my-agent';
     const { container } = render(() => <Header />);
-    expect(screen.queryByText("Workspace")).toBeNull();
-    expect(container.querySelector(".header__breadcrumb-current")?.textContent).toContain(
-      "my-agent",
+    expect(screen.queryByText('Workspace')).toBeNull();
+    expect(container.querySelector('.header__breadcrumb-current')?.textContent).toContain(
+      'my-agent',
     );
-    expect(container.querySelectorAll(".header__separator").length).toBe(2);
+    expect(container.querySelectorAll('.header__separator').length).toBe(2);
   });
 });
 
-describe("Header - docs link", () => {
+describe('Header - docs link', () => {
   const docsHref = (container: HTMLElement) =>
-    container.querySelector(".header__docs-link")?.getAttribute("href");
+    container.querySelector('.header__docs-link')?.getAttribute('href');
 
-  it("links agent routing pages to routing docs", () => {
-    mockPathname = "/harnesses/my-agent/routing";
+  it('links agent routing pages to routing docs', () => {
+    mockPathname = '/harnesses/my-agent/routing';
     const { container } = render(() => <Header />);
-    expect(docsHref(container)).toBe("https://manifest.build/docs/routing");
+    expect(docsHref(container)).toBe('https://manifest.build/docs/routing');
   });
 
-  it("links the current Limits route to limits docs", () => {
-    mockPathname = "/harnesses/my-agent/guardrails";
+  it('links the current Limits route to limits docs', () => {
+    mockPathname = '/harnesses/my-agent/guardrails';
     const { container } = render(() => <Header />);
-    expect(docsHref(container)).toBe("https://manifest.build/docs/set-limits");
+    expect(docsHref(container)).toBe('https://manifest.build/docs/set-limits');
   });
 
-  it("keeps the legacy Limits route mapped to limits docs", () => {
-    mockPathname = "/harnesses/my-agent/limits";
+  it('keeps the legacy Limits route mapped to limits docs', () => {
+    mockPathname = '/harnesses/my-agent/limits';
     const { container } = render(() => <Header />);
-    expect(docsHref(container)).toBe("https://manifest.build/docs/set-limits");
+    expect(docsHref(container)).toBe('https://manifest.build/docs/set-limits');
   });
 
-  it("links provider pages to matching provider docs", () => {
-    mockPathname = "/providers/subscriptions";
+  it('links provider pages to matching provider docs', () => {
+    mockPathname = '/providers/subscriptions';
     const subscriptions = render(() => <Header />);
     expect(docsHref(subscriptions.container)).toBe(
-      "https://manifest.build/docs/providers/subscription-based-providers",
+      'https://manifest.build/docs/providers/subscription-based-providers',
     );
 
-    mockPathname = "/providers/byok";
+    mockPathname = '/providers/byok';
     const byok = render(() => <Header />);
     expect(docsHref(byok.container)).toBe(
-      "https://manifest.build/docs/providers/api-key-providers",
+      'https://manifest.build/docs/providers/api-key-providers',
     );
 
-    mockPathname = "/providers/local";
+    mockPathname = '/providers/local';
     const local = render(() => <Header />);
-    expect(docsHref(local.container)).toBe("https://manifest.build/docs/providers/local-models");
+    expect(docsHref(local.container)).toBe('https://manifest.build/docs/providers/local-models');
   });
 
-  it("falls back to introduction docs for unmapped pages", () => {
-    mockPathname = "/messages";
+  it('falls back to introduction docs for unmapped pages', () => {
+    mockPathname = '/messages';
     const { container } = render(() => <Header />);
-    expect(docsHref(container)).toBe("https://manifest.build/docs/introduction");
+    expect(docsHref(container)).toBe('https://manifest.build/docs/introduction');
   });
 });
 
-describe("Header - gear dropdown", () => {
-  it("shows gear button when on an agent page", () => {
-    mockAgentName = "my-agent";
+describe('Header - gear dropdown', () => {
+  it('shows gear button when on an agent page', () => {
+    mockAgentName = 'my-agent';
     render(() => <Header />);
-    expect(screen.getByLabelText("Harness actions")).toBeDefined();
+    expect(screen.getByLabelText('Harness actions')).toBeDefined();
   });
 
-  it("does not show gear button when not on an agent page", () => {
+  it('does not show gear button when not on an agent page', () => {
     mockAgentName = null;
     render(() => <Header />);
-    expect(screen.queryByLabelText("Harness actions")).toBeNull();
+    expect(screen.queryByLabelText('Harness actions')).toBeNull();
   });
 
-  it("opens dropdown with Settings and Duplicate items", async () => {
-    mockAgentName = "my-agent";
+  it('opens dropdown with Settings and Duplicate items', async () => {
+    mockAgentName = 'my-agent';
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("Harness actions"));
-    expect(screen.getByText("Settings")).toBeDefined();
-    expect(screen.getByText("Duplicate harness")).toBeDefined();
+    await fireEvent.click(screen.getByLabelText('Harness actions'));
+    expect(screen.getByText('Settings')).toBeDefined();
+    expect(screen.getByText('Duplicate harness')).toBeDefined();
   });
 
-  it("Settings links to the agent settings page", async () => {
-    mockAgentName = "my-agent";
+  it('Settings links to the agent settings page', async () => {
+    mockAgentName = 'my-agent';
     const { container } = render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("Harness actions"));
+    await fireEvent.click(screen.getByLabelText('Harness actions'));
     const settingsLink = container.querySelector('a[href="/harnesses/my-agent/settings"]');
     expect(settingsLink).not.toBeNull();
   });
 
-  it("closes gear dropdown when clicking outside", async () => {
-    mockAgentName = "my-agent";
+  it('closes gear dropdown when clicking outside', async () => {
+    mockAgentName = 'my-agent';
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("Harness actions"));
-    expect(screen.getByText("Settings")).toBeDefined();
+    await fireEvent.click(screen.getByLabelText('Harness actions'));
+    expect(screen.getByText('Settings')).toBeDefined();
     await fireEvent.click(document.body);
-    expect(screen.queryByText("Duplicate harness")).toBeNull();
+    expect(screen.queryByText('Duplicate harness')).toBeNull();
   });
 });
 
-describe("Header - self-hosted badge", () => {
-  it("renders the Self-hosted badge when isSelfHosted is true", async () => {
+describe('Header - self-hosted badge', () => {
+  it('renders the Self-hosted badge when isSelfHosted is true', async () => {
     mockCheckIsSelfHosted.mockResolvedValue(true);
     const { container } = render(() => <Header />);
     await new Promise((r) => setTimeout(r, 0));
-    const badge = container.querySelector(
-      ".header__mode-badge:not(.header__mode-badge--dev)",
-    );
+    const badge = container.querySelector('.header__mode-badge:not(.header__mode-badge--dev)');
     expect(badge).not.toBeNull();
-    expect(badge?.textContent?.trim()).toBe("Self-hosted");
+    expect(badge?.textContent?.trim()).toBe('Self-hosted');
   });
 
-  it("does not render the Self-hosted badge in cloud mode", async () => {
+  it('does not render the Self-hosted badge in cloud mode', async () => {
     mockCheckIsSelfHosted.mockResolvedValue(false);
     const { container } = render(() => <Header />);
     await new Promise((r) => setTimeout(r, 0));
-    expect(
-      container.querySelector(".header__mode-badge:not(.header__mode-badge--dev)"),
-    ).toBeNull();
+    expect(container.querySelector('.header__mode-badge:not(.header__mode-badge--dev)')).toBeNull();
   });
 });
 
-describe("Header - connection breadcrumb", () => {
-  it("renders the connection breadcrumb (back link, provider icon, name, label) when no agent is active", () => {
+describe('Header - connection breadcrumb', () => {
+  it('renders the connection breadcrumb (back link, provider icon, name, label) when no agent is active', () => {
     // No :agentName route param → getAgentName() is falsy, so the agent
     // breadcrumb is hidden and the connection breadcrumb takes over.
     mockAgentName = null;
     setConnectionBreadcrumb(
-      "OpenAI Default",
-      "/providers/usage-based",
-      "Usage-based",
-      "openai",
-      "Default",
+      'OpenAI Default',
+      '/providers/usage-based',
+      'Usage-based',
+      'openai',
+      'Default',
     );
     const { container } = render(() => <Header />);
 
     // Back link points at the configured route and shows the back label.
     const backLink = container.querySelector('a[href="/providers/usage-based"]');
     expect(backLink).not.toBeNull();
-    expect(backLink!.textContent).toContain("Usage-based");
+    expect(backLink!.textContent).toContain('Usage-based');
 
     // The connection name renders.
-    expect(container.textContent).toContain("OpenAI Default");
+    expect(container.textContent).toContain('OpenAI Default');
 
     // providerId set → the provider icon (an inline SVG for 'openai') renders.
     expect(container.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
 
     // label set → the secondary label text renders.
-    expect(container.textContent).toContain("Default");
+    expect(container.textContent).toContain('Default');
+
+    // The crumb reuses the harness breadcrumb classes so the phone breakpoint
+    // can hide the parent link and truncate the name instead of wrapping it.
+    expect(backLink!.classList.contains('header__breadcrumb-link')).toBe(true);
+    const current = container.querySelector('.header__breadcrumb-current');
+    expect(current?.textContent).toContain('OpenAI Default');
+    expect(current?.querySelector('.header__breadcrumb-label')?.textContent).toBe('Default');
   });
 
-  it("renders the connection breadcrumb name without an icon or label when those are omitted", () => {
+  it('renders the connection breadcrumb name without an icon or label when those are omitted', () => {
     // providerId + label omitted → both the icon <Show> and label <Show>
     // fall through, but the name still renders.
     mockAgentName = null;
-    setConnectionBreadcrumb("Anthropic", "/providers/subscriptions", "Subscriptions");
+    setConnectionBreadcrumb('Anthropic', '/providers/subscriptions', 'Subscriptions');
     const { container } = render(() => <Header />);
 
     const backLink = container.querySelector('a[href="/providers/subscriptions"]');
     expect(backLink).not.toBeNull();
-    expect(backLink!.textContent).toContain("Subscriptions");
-    expect(container.textContent).toContain("Anthropic");
+    expect(backLink!.textContent).toContain('Subscriptions');
+    expect(container.textContent).toContain('Anthropic');
   });
 
-  it("hides the connection breadcrumb when an agent IS active", () => {
+  it('hides the connection breadcrumb when an agent IS active', () => {
     // getAgentName() truthy → the `!getAgentName()` guard fails, so even with a
     // breadcrumb set the connection block stays hidden.
-    mockAgentName = "my-agent";
+    mockAgentName = 'my-agent';
     setConnectionBreadcrumb(
-      "OpenAI Default",
-      "/providers/usage-based",
-      "Usage-based",
-      "openai",
-      "Default",
+      'OpenAI Default',
+      '/providers/usage-based',
+      'Usage-based',
+      'openai',
+      'Default',
     );
     const { container } = render(() => <Header />);
     expect(container.querySelector('a[href="/providers/usage-based"]')).toBeNull();

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -114,7 +114,8 @@ vi.mock('../../src/services/api/analytics.js', () => ({
   getConnectionAttemptsByAgentTimeseries: (...args: unknown[]) =>
     apiMocks.getConnectionAttemptsByAgentTimeseries(...args),
   getPerAgentCostTimeseries: (...args: unknown[]) => apiMocks.getPerAgentCostTimeseries(...args),
-  getWorkspaceAutofixStatus: () => Promise.resolve({ any_enabled: false, enabled_agents: [], consented: true }),
+  getWorkspaceAutofixStatus: () =>
+    Promise.resolve({ any_enabled: false, enabled_agents: [], consented: true }),
   getAutofixStats: () => Promise.resolve(null),
   getAutofixTimeseries: () =>
     Promise.resolve({ range: '7d', by: 'disposition', keys: [], buckets: [] }),
@@ -981,9 +982,7 @@ describe('ConnectionDetail (analytics)', () => {
     await waitFor(() => expect(screen.getAllByText('Default').length).toBeGreaterThan(0));
     expect(screen.getAllByText('Harnesses').length).toBeGreaterThan(0);
     expect(screen.getAllByText('gpt-5').length).toBeGreaterThan(0);
-    expect(screen.getByTestId('requests-info-tooltip').textContent).toContain(
-      'autofixed attempts',
-    );
+    expect(screen.getByTestId('requests-info-tooltip').textContent).toContain('autofixed attempts');
     // Recent messages table renders model and token data (description is no longer displayed).
     expect(screen.getByText('Recent Requests')).toBeDefined();
     // BYOK connection → cost columns present
@@ -1077,6 +1076,23 @@ describe('ConnectionDetail (analytics)', () => {
     fireEvent.click(screen.getAllByText('All harnesses (2)').at(-1)!);
     fireEvent.click(screen.getByText('beta'));
     await waitFor(() => expect(screen.getByTestId('msg-agents').textContent).toBe('alpha'));
+  });
+
+  it('lays out the header, meta row, controls and stat grid with responsive classes', async () => {
+    const { container } = render(() => <ConnectionDetail />);
+    await waitFor(() => expect(screen.getAllByText('Default').length).toBeGreaterThan(0));
+    // The mobile layout lives in connection-detail.css: every block that used
+    // to be a fixed inline flex row / 5-column grid now carries a class the
+    // 768px breakpoint can reflow.
+    expect(container.querySelector('.connection-detail__header')).not.toBeNull();
+    expect(container.querySelector('.connection-detail__meta')).not.toBeNull();
+    expect(container.querySelector('.connection-detail__controls')).not.toBeNull();
+    // The status pill (and the Custom tag on custom connections) share one
+    // badge class so the phone breakpoint can size them as a matched pair.
+    expect(container.querySelector('.connection-detail__badge')?.textContent).toBe('Active');
+    const stats = container.querySelector('.overview-stats');
+    expect(stats?.classList.contains('overview-stats--5')).toBe(true);
+    expect((stats as HTMLElement).style.gridTemplateColumns).toBe('');
   });
 
   it('shows the attempt cards row: rate, counts and both retry families', async () => {


### PR DESCRIPTION
### ✨ What changed
- Connection detail header, meta row, and controls stack below 768px instead of overflowing.
- Stat card grids collapse 5 → 3 → 2 → 1 columns; KPI cards drop their inline 5-column grid.
- Custom and status badges render as one compact tag pair on phones.
- App header: connection breadcrumb reuses the harness breadcrumb classes, so it truncates with an ellipsis.
- App header: gap between breadcrumb and buttons; SELF-HOSTED badge no longer wraps.
- Tab bars scroll sideways on phones instead of widening the page; toasts fit under 480px.
- Design-system registry regenerated for the new CSS.

### 💭 Why
The connection page and the top header were built from inline styles that the shared 768px breakpoint never matched, so they did not reflow on phones.

### 👤 For users
The provider connection page, Overview KPI cards, and app header are usable on a phone. No horizontal page scrolling on those screens.

### 📝 Notes
The chart card's date axis labels still overlap at phone width. That is in the shared chart component and left for a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the provider connection page, Overview KPI cards, and app header reflow on phone screens instead of overflowing horizontally.

**Changes**
- Connection detail header, meta row, and controls stack below 768px; stat cards collapse 5 → 3 → 2 → 1 columns.
- Tab bars scroll sideways on phones instead of widening the page; toasts fit under 480px.
- App header breadcrumb reuses harness breadcrumb classes so the connection name truncates with an ellipsis instead of wrapping.
- Known side effect: chart card date axis labels still overlap on phone width; that's left for a follow-up.

<sup>Written for commit 549baab0405b7bb01306dab42a2e6e53d2a81460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

