### PR TITLE
feat: show new-version badge on self-hosted dashboards

### DIFF
--- a/.changeset/self-hosted-update-check.md
+++ b/.changeset/self-hosted-update-check.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add `GET /api/v1/version` for self-hosted installs: reports the running version, the latest GitHub release, and changelog/upgrade links so the dashboard can show a "new version available" badge. Checks once a day, never in cloud mode, and can be turned off with `MANIFEST_UPDATE_CHECK_DISABLED=1`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,7 @@ Every resource belongs to a tenant; users only authenticate and (optionally) app
 | GET/POST/PATCH            | `/api/v1/playground/*`                          | Session/API Key                     | Playground runs (run, list, star, mark best)                                                                |
 | GET                       | `/api/v1/events`                                | Session                             | SSE real-time events                                                                                        |
 | GET                       | `/api/v1/github/stars`                          | Public                              | GitHub star count                                                                                           |
+| GET                       | `/api/v1/version`                               | Session/API Key                     | Running version + latest GitHub release for the self-hosted update badge (24h cache; off in cloud)          |
 
 ## Environment Variables
 
@@ -445,6 +446,7 @@ See `packages/backend/.env.example` for all variables. Key ones:
 - `SEED_DATA` — Set `true` to seed demo data on startup. Dev/test only — ignored when `NODE_ENV=production` (use the first-run setup wizard instead).
 - `MANIFEST_MODE` — `selfhosted` or `cloud` (default: `cloud`; auto-detected as `selfhosted` inside Docker via `/.dockerenv` or Podman via `/run/.containerenv`). Self-hosted mode allows custom-provider URLs with `http://` / private IPs. `local` is accepted as a legacy alias for `selfhosted`.
 - `MANIFEST_TELEMETRY_DISABLED` — Set `1` to opt out of anonymous telemetry (self-hosted only).
+- `MANIFEST_UPDATE_CHECK_DISABLED` — Set `1` to stop the self-hosted dashboard's daily "new version available" check against GitHub Releases (`GET /api/v1/version`, `version/` module). Separate from the telemetry opt-out: air-gapped installs want no outbound calls at all. Never runs in cloud mode.
 - `MANIFEST_PUBLIC_STATS` — Set `true` to expose `/api/v1/public/*` aggregate stats without auth (cloud-only marketing use).
 - `TELEMETRY_ENDPOINT` — Where self-hosted installs POST the anonymous usage report. Default: `https://telemetry.manifest.build/v1/report`. See [Telemetry](#anonymous-usage-telemetry-self-hosted).
 - `DISCOVERY_ENDPOINT` — Optional override for the discovery submission endpoint. Default: `https://blue.manifest.build/v1/self-hosted/discovery`.

--- a/design-system/registry/components.json
+++ b/design-system/registry/components.json
@@ -4132,7 +4132,10 @@
     },
     "version-indicator": {
       "classes": [
-        "version-indicator"
+        "version-indicator",
+        "version-indicator--update",
+        "version-indicator__dismiss",
+        "version-indicator__update"
       ],
       "files": [
         "version-indicator.css"
@@ -4291,7 +4294,8 @@
         "wingman-fab__label"
       ],
       "files": [
-        "controls.css"
+        "controls.css",
+        "version-indicator.css"
       ]
     },
     "workspace-table": {
@@ -5080,7 +5084,7 @@
     "tokens": 79,
     "darkOverrides": 38,
     "blocks": 314,
-    "classes": 1696,
+    "classes": 1699,
     "canonicalRules": 46,
     "ghostRules": 46
   }

--- a/design-system/registry/llms.txt
+++ b/design-system/registry/llms.txt
@@ -96,7 +96,7 @@
 --z-toast: 8000
 --z-tooltip: 9999
 
-## Blocks (314 BEM blocks, 1696 classes)
+## Blocks (314 BEM blocks, 1699 classes)
 account-back-btn (agents.css): account-back-btn
 account-email-footer (agents.css): account-email-footer
 account-email-toggle (agents.css): account-email-toggle--disabled
@@ -404,12 +404,12 @@ upgrade-success-modal (modals.css): upgrade-success-modal upgrade-success-modal_
 upgrade-terms (agents.css): upgrade-terms
 usage-limit-banner (modals.css): usage-limit-banner usage-limit-banner__actions usage-limit-banner__btn usage-limit-banner__text
 user-discovery-modal (modals.css): user-discovery-modal user-discovery-modal__banner user-discovery-modal__banner-img user-discovery-modal__body user-discovery-modal__close user-discovery-modal__cta user-discovery-modal__features user-discovery-modal__highlight user-discovery-modal__later user-discovery-modal__subtitle user-discovery-modal__title user-discovery-modal__title-logo
-version-indicator (version-indicator.css): version-indicator
+version-indicator (version-indicator.css): version-indicator version-indicator--update version-indicator__dismiss version-indicator__update
 view-more-link (analytics-overview.css, cards.css): view-more-link
 waiting-banner (overview.css): waiting-banner waiting-banner--success
 welcome (welcome.css): welcome welcome__actions welcome__actions--split welcome__actions--sticky welcome__actions-note welcome__agent-wait welcome__agent-wait--success welcome__agent-wait-heading welcome__autofix-details welcome__autofix-examples welcome__autofix-heading welcome__autofix-how welcome__autofix-section welcome__availability-note welcome__error welcome__eyebrow welcome__first-request welcome__form-panel welcome__harness-summary welcome__harness-summary-icon welcome__harness-summary-name welcome__harness-summary-type welcome__inline-code welcome__input-hint welcome__launch-orbit welcome__launch-rocket welcome__launch-rocket--complete welcome__launch-stack welcome__launch-stack--complete welcome__launch-stack-header welcome__launch-track welcome__legal welcome__liftoff welcome__liftoff-action welcome__liftoff-beacon welcome__liftoff-copy welcome__liftoff-description welcome__liftoff-earth welcome__liftoff-exit welcome__liftoff-flash welcome__liftoff-kicker welcome__liftoff-orbit welcome__liftoff-plume welcome__liftoff-plume-inner welcome__liftoff-rocket welcome__liftoff-smoke welcome__liftoff-stars welcome__liftoff-stars--far welcome__liftoff-stars--near welcome__liftoff-status welcome__liftoff-title welcome__liftoff-title--launch welcome__liftoff-title--orbit welcome__liftoff-titles welcome__logo-dark welcome__logo-light welcome__logo-mark welcome__main welcome__model-badge welcome__nav welcome__nav-btn welcome__nav-check welcome__nav-dot welcome__nav-hint welcome__nav-item welcome__nav-item--active welcome__nav-item--done welcome__nav-label welcome__nav-mobile-rocket welcome__nav-mobile-rocket--complete welcome__output welcome__panel welcome__panel--playground welcome__panel--setup welcome__panel-desc welcome__panel-header welcome__panel-title welcome__pending welcome__plan-heading welcome__plan-section welcome__playground welcome__playground-actions welcome__playground-link welcome__progress welcome__progress-header welcome__prompt-label welcome__provider-connected welcome__provider-list welcome__request-failure welcome__response welcome__rocket-flame welcome__route-test-heading welcome__route-test-section welcome__route-test-title welcome__section-desc welcome__section-heading welcome__setup-snippets welcome__sidebar welcome__sidebar-footer welcome__sidebar-top welcome__skip-row welcome__spinner welcome__stats welcome__success-icon welcome__text-link welcome__textarea
 wingman-drawer (controls.css): wingman-drawer wingman-drawer--resizing wingman-drawer__actions wingman-drawer__frame wingman-drawer__head wingman-drawer__icon-btn wingman-drawer__resizer wingman-drawer__sub wingman-drawer__title
-wingman-fab (controls.css): wingman-fab wingman-fab__label
+wingman-fab (controls.css, version-indicator.css): wingman-fab wingman-fab__label
 workspace-table (agents.css): workspace-table__actions workspace-table__icon workspace-table__name
 
 ## Primitives (0)

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -314,6 +314,8 @@ docker compose up -d
 
 Database migrations run automatically on boot, no manual steps. Your data in the `pgdata` volume is preserved across upgrades. Pin to a specific major version (e.g. `manifestdotbuild/manifest:6`) in `docker-compose.yml` if you want control over when major upgrades happen.
 
+The dashboard checks GitHub once a day for the latest release and shows a "new version available" badge linking to the [changelog](https://manifest.build/changelog/). The check only reads the public release list and sends nothing about your install. To turn it off (for example on an air-gapped host), set `MANIFEST_UPDATE_CHECK_DISABLED=1` in `.env`.
+
 ## Backup & persistence
 
 PostgreSQL state lives in the `mnfst_pgdata` named volume mounted at `/var/lib/postgresql/data` in the `postgres` service. The Compose install also stores local request recordings in the `mnfst_recordings` volume mounted at `/data/request-recordings`; those recordings are not included in a PostgreSQL dump. For ephemeral hosts or multiple instances, configure durable S3-compatible storage instead.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -151,6 +151,10 @@ services:
       # https://manifest.build/docs/self-hosted#telemetry for the payload shape.
       - MANIFEST_TELEMETRY_DISABLED=${MANIFEST_TELEMETRY_DISABLED:-0}
       - TELEMETRY_ENDPOINT=${TELEMETRY_ENDPOINT:-}
+      # Update check (opt-out). Once a day the dashboard asks GitHub for the
+      # latest Manifest release so it can show a "new version available"
+      # badge. Set MANIFEST_UPDATE_CHECK_DISABLED=1 on air-gapped installs.
+      - MANIFEST_UPDATE_CHECK_DISABLED=${MANIFEST_UPDATE_CHECK_DISABLED:-0}
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -125,6 +125,11 @@ BETTER_AUTH_URL=http://localhost:3001
 # ── Data Seeding ────────────────────────────────────
 # SEED_DATA=true              # Seed demo data + admin user on startup (self-hosted first boot)
 
+# ── Update Check (self-hosted) ──────────────────────
+# Once a day the dashboard asks GitHub for the latest Manifest release and
+# shows a "new version available" badge. Never runs in cloud mode.
+# MANIFEST_UPDATE_CHECK_DISABLED=1   # Opt out (air-gapped installs)
+
 # ── Internal ────────────────────────────────────────
 # MANIFEST_FRONTEND_DIR=      # Custom path to frontend dist directory
 # MANIFEST_EMBEDDED=          # Set to skip auto-start (used by embedded server)

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { PlaygroundModule } from './playground/playground.module';
 import { CommonModule } from './common/common.module';
 import { SseModule } from './sse/sse.module';
 import { GithubModule } from './github/github.module';
+import { VersionModule } from './version/version.module';
 import { PublicStatsModule } from './public-stats/public-stats.module';
 import { ErrorPagesModule } from './error-pages/error-pages.module';
 import { SetupModule } from './setup/setup.module';
@@ -95,6 +96,7 @@ const sentryDebugControllers =
     PlaygroundModule,
     SseModule,
     GithubModule,
+    VersionModule,
     PublicStatsModule,
     ErrorPagesModule,
     SetupModule,

--- a/packages/backend/src/version/version-check.config.spec.ts
+++ b/packages/backend/src/version/version-check.config.spec.ts
@@ -1,0 +1,182 @@
+import { isSelfHosted } from '../common/utils/detect-self-hosted';
+import { readManifestVersion } from '../telemetry/telemetry.config';
+import {
+  buildVersionCheckConfig,
+  changelogUrlFor,
+  compareVersions,
+  githubReleaseUrlFor,
+  parseReleaseTag,
+  summarizeReleases,
+  UPGRADE_COMMAND,
+  UPGRADE_DOCS_URL,
+} from './version-check.config';
+
+jest.mock('../common/utils/detect-self-hosted', () => ({
+  isSelfHosted: jest.fn(),
+}));
+jest.mock('../telemetry/telemetry.config', () => ({
+  readManifestVersion: jest.fn(),
+  UNKNOWN_VERSION: 'unknown',
+}));
+
+const mockIsSelfHosted = isSelfHosted as jest.MockedFunction<typeof isSelfHosted>;
+const mockReadVersion = readManifestVersion as jest.MockedFunction<typeof readManifestVersion>;
+
+describe('compareVersions', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareVersions('6.21.1', '6.21.1')).toBe(0);
+  });
+
+  it('returns a negative number when the first version is older', () => {
+    expect(compareVersions('6.21.1', '6.22.0')).toBeLessThan(0);
+    expect(compareVersions('6.21.1', '7.0.0')).toBeLessThan(0);
+    expect(compareVersions('6.21.1', '6.21.2')).toBeLessThan(0);
+  });
+
+  it('returns a positive number when the first version is newer', () => {
+    expect(compareVersions('6.22.0', '6.21.9')).toBeGreaterThan(0);
+  });
+
+  it('compares numerically, not lexically', () => {
+    expect(compareVersions('6.9.0', '6.10.0')).toBeLessThan(0);
+  });
+
+  it('returns null when either side is not a strict X.Y.Z version', () => {
+    expect(compareVersions('unknown', '6.22.0')).toBeNull();
+    expect(compareVersions('6.22.0', '6.22')).toBeNull();
+    expect(compareVersions('6.22.0-beta.1', '6.22.0')).toBeNull();
+  });
+});
+
+describe('parseReleaseTag', () => {
+  it('extracts the version from a manifest@X.Y.Z release tag', () => {
+    expect(parseReleaseTag('manifest@6.22.0')).toBe('6.22.0');
+  });
+
+  it('returns null for tags that are not Manifest releases', () => {
+    expect(parseReleaseTag('n8n-nodes-manifest-v0.2.1')).toBeNull();
+    expect(parseReleaseTag('v5.0.5')).toBeNull();
+    expect(parseReleaseTag('manifest@6.22')).toBeNull();
+    expect(parseReleaseTag(undefined)).toBeNull();
+  });
+});
+
+describe('summarizeReleases', () => {
+  const release = (tag: string, extra: Record<string, unknown> = {}) => ({
+    tag_name: tag,
+    draft: false,
+    prerelease: false,
+    ...extra,
+  });
+
+  it('returns the newest version and how many releases are newer than current', () => {
+    const body = [
+      release('manifest@6.21.1'),
+      release('manifest@6.21.0'),
+      release('manifest@6.20.0'),
+      release('manifest@6.19.0'),
+    ];
+    expect(summarizeReleases(body, '6.19.0')).toEqual({ latest: '6.21.1', releasesBehind: 3 });
+  });
+
+  it('reports zero behind when current is the newest', () => {
+    const body = [release('manifest@6.21.1'), release('manifest@6.21.0')];
+    expect(summarizeReleases(body, '6.21.1')).toEqual({ latest: '6.21.1', releasesBehind: 0 });
+  });
+
+  it('ignores drafts, pre-releases, and non-Manifest tags', () => {
+    const body = [
+      release('manifest@7.0.0', { draft: true }),
+      release('manifest@6.22.0', { prerelease: true }),
+      release('n8n-nodes-manifest-v0.2.1'),
+      release('manifest@6.21.1'),
+    ];
+    expect(summarizeReleases(body, '6.21.0')).toEqual({ latest: '6.21.1', releasesBehind: 1 });
+  });
+
+  it('does not rely on the API ordering to find the newest', () => {
+    const body = [
+      release('manifest@6.20.0'),
+      release('manifest@6.21.1'),
+      release('manifest@6.21.0'),
+    ];
+    expect(summarizeReleases(body, '6.20.0')).toEqual({ latest: '6.21.1', releasesBehind: 2 });
+  });
+
+  it('returns null when the body holds no usable release', () => {
+    expect(summarizeReleases([release('v5.0.5')], '6.21.1')).toBeNull();
+    expect(summarizeReleases([], '6.21.1')).toBeNull();
+    expect(summarizeReleases({ message: 'rate limited' }, '6.21.1')).toBeNull();
+    expect(summarizeReleases(['not-an-object', null], '6.21.1')).toBeNull();
+  });
+
+  it('reports an unknown distance when current cannot be parsed', () => {
+    const body = [release('manifest@6.21.1'), release('manifest@6.21.0')];
+    expect(summarizeReleases(body, 'unknown')).toEqual({ latest: '6.21.1', releasesBehind: null });
+  });
+});
+
+describe('release URLs', () => {
+  it('points changelogUrlFor at the website anchor for that version', () => {
+    expect(changelogUrlFor('6.22.0')).toBe('https://manifest.build/changelog/#v6-22-0');
+  });
+
+  it('points githubReleaseUrlFor at the encoded GitHub release tag', () => {
+    expect(githubReleaseUrlFor('6.22.0')).toBe(
+      'https://github.com/mnfst/manifest/releases/tag/manifest%406.22.0',
+    );
+  });
+
+  it('exposes the documented upgrade instructions', () => {
+    expect(UPGRADE_DOCS_URL).toBe('https://manifest.build/docs/self-hosted#upgrading');
+    expect(UPGRADE_COMMAND).toBe('docker compose pull && docker compose up -d');
+  });
+});
+
+describe('buildVersionCheckConfig', () => {
+  beforeEach(() => {
+    mockIsSelfHosted.mockReset();
+    mockReadVersion.mockReset();
+    mockReadVersion.mockReturnValue('6.21.1');
+  });
+
+  it('enables the check on self-hosted installs by default', () => {
+    mockIsSelfHosted.mockReturnValue(true);
+    expect(buildVersionCheckConfig({})).toEqual({ enabled: true, currentVersion: '6.21.1' });
+  });
+
+  it('never checks in cloud mode', () => {
+    mockIsSelfHosted.mockReturnValue(false);
+    expect(buildVersionCheckConfig({}).enabled).toBe(false);
+  });
+
+  it('honours MANIFEST_UPDATE_CHECK_DISABLED as 1 or true', () => {
+    mockIsSelfHosted.mockReturnValue(true);
+    expect(buildVersionCheckConfig({ MANIFEST_UPDATE_CHECK_DISABLED: '1' }).enabled).toBe(false);
+    expect(buildVersionCheckConfig({ MANIFEST_UPDATE_CHECK_DISABLED: 'true' }).enabled).toBe(false);
+  });
+
+  it('treats an empty or 0 MANIFEST_UPDATE_CHECK_DISABLED as not disabled', () => {
+    mockIsSelfHosted.mockReturnValue(true);
+    expect(buildVersionCheckConfig({ MANIFEST_UPDATE_CHECK_DISABLED: '' }).enabled).toBe(true);
+    expect(buildVersionCheckConfig({ MANIFEST_UPDATE_CHECK_DISABLED: '0' }).enabled).toBe(true);
+  });
+
+  it('reads process.env when no environment is passed', () => {
+    mockIsSelfHosted.mockReturnValue(true);
+    const previous = process.env['MANIFEST_UPDATE_CHECK_DISABLED'];
+    process.env['MANIFEST_UPDATE_CHECK_DISABLED'] = '1';
+    try {
+      expect(buildVersionCheckConfig().enabled).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env['MANIFEST_UPDATE_CHECK_DISABLED'];
+      else process.env['MANIFEST_UPDATE_CHECK_DISABLED'] = previous;
+    }
+  });
+
+  it('disables the check when the running version cannot be read', () => {
+    mockIsSelfHosted.mockReturnValue(true);
+    mockReadVersion.mockReturnValue('unknown');
+    expect(buildVersionCheckConfig({})).toEqual({ enabled: false, currentVersion: 'unknown' });
+  });
+});

--- a/packages/backend/src/version/version-check.config.ts
+++ b/packages/backend/src/version/version-check.config.ts
@@ -1,0 +1,102 @@
+import { isSelfHosted } from '../common/utils/detect-self-hosted';
+import { readManifestVersion, UNKNOWN_VERSION } from '../telemetry/telemetry.config';
+
+/**
+ * The GitHub releases the Docker publish job creates for every version. They
+ * are the source of truth for "what is the latest Manifest?" — the website
+ * changelog is generated from them. One page of 100 is enough to both find
+ * the newest and count how far behind an install is (capped at 100).
+ */
+export const RELEASES_PAGE_SIZE = 100;
+export const RELEASES_URL = `https://api.github.com/repos/mnfst/manifest/releases?per_page=${RELEASES_PAGE_SIZE}`;
+export const UPGRADE_DOCS_URL = 'https://manifest.build/docs/self-hosted#upgrading';
+export const UPGRADE_COMMAND = 'docker compose pull && docker compose up -d';
+
+export interface VersionCheckConfig {
+  /** False in cloud mode, when opted out, or when the running version is unreadable. */
+  enabled: boolean;
+  currentVersion: string;
+}
+
+/**
+ * Opt-out with `MANIFEST_UPDATE_CHECK_DISABLED=1`. Deliberately separate from
+ * the telemetry opt-out: one is "don't send data about me", the other is
+ * "don't make outbound calls at all" (air-gapped installs). Cloud never
+ * checks — cloud users are always on the latest deploy.
+ */
+export function buildVersionCheckConfig(env: NodeJS.ProcessEnv = process.env): VersionCheckConfig {
+  const disabled = env['MANIFEST_UPDATE_CHECK_DISABLED'];
+  const isDisabled = disabled === '1' || disabled === 'true';
+  const currentVersion = readManifestVersion();
+  return {
+    enabled: isSelfHosted() && !isDisabled && currentVersion !== UNKNOWN_VERSION,
+    currentVersion,
+  };
+}
+
+const STRICT_SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
+const RELEASE_TAG = /^manifest@(\d+\.\d+\.\d+)$/;
+
+/**
+ * Numeric three-part compare. Changesets only ever emits strict `X.Y.Z`, so
+ * anything else (pre-releases, `unknown`) returns null rather than guessing.
+ */
+export function compareVersions(a: string, b: string): number | null {
+  const pa = STRICT_SEMVER.exec(a);
+  const pb = STRICT_SEMVER.exec(b);
+  if (!pa || !pb) return null;
+  for (let i = 1; i <= 3; i++) {
+    const diff = Number(pa[i]) - Number(pb[i]);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/** `manifest@6.22.0` → `6.22.0`; anything else → null. */
+export function parseReleaseTag(tag: unknown): string | null {
+  if (typeof tag !== 'string') return null;
+  const match = RELEASE_TAG.exec(tag);
+  return match ? match[1] : null;
+}
+
+export interface ReleaseSummary {
+  latest: string;
+  /** Releases newer than `current`; null when `current` is not a strict X.Y.Z. */
+  releasesBehind: number | null;
+}
+
+/**
+ * Reduces a GitHub release-list body to the newest published Manifest
+ * version and the number of releases newer than `current`. Drafts,
+ * pre-releases, and other tags in the repo (the n8n node) are ignored, and
+ * the API ordering is not trusted. Null when nothing usable is in the body.
+ */
+export function summarizeReleases(body: unknown, current: string): ReleaseSummary | null {
+  if (!Array.isArray(body)) return null;
+  const versions: string[] = [];
+  for (const entry of body) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const release = entry as { tag_name?: unknown; draft?: unknown; prerelease?: unknown };
+    if (release.draft === true || release.prerelease === true) continue;
+    const version = parseReleaseTag(release.tag_name);
+    if (version) versions.push(version);
+  }
+  if (versions.length === 0) return null;
+
+  let latest = versions[0];
+  let releasesBehind: number | null = STRICT_SEMVER.test(current) ? 0 : null;
+  for (const version of versions) {
+    if ((compareVersions(version, latest) ?? 0) > 0) latest = version;
+    if (releasesBehind !== null && (compareVersions(version, current) ?? 0) > 0) releasesBehind++;
+  }
+  return { latest, releasesBehind };
+}
+
+/** Website changelog, scrolled to that version's entry. */
+export function changelogUrlFor(version: string): string {
+  return `https://manifest.build/changelog/#v${version.replace(/\./g, '-')}`;
+}
+
+export function githubReleaseUrlFor(version: string): string {
+  return `https://github.com/mnfst/manifest/releases/tag/${encodeURIComponent(`manifest@${version}`)}`;
+}

--- a/packages/backend/src/version/version-check.service.spec.ts
+++ b/packages/backend/src/version/version-check.service.spec.ts
@@ -1,0 +1,239 @@
+import { Logger } from '@nestjs/common';
+import { VersionCheckService } from './version-check.service';
+import { RELEASES_URL, UPGRADE_COMMAND, UPGRADE_DOCS_URL } from './version-check.config';
+
+const fetchMock = jest.fn();
+(global as unknown as Record<string, unknown>).fetch = fetchMock;
+
+const HOUR_MS = 60 * 60 * 1000;
+const realDateNow = Date.now;
+
+/** A GitHub release-list body: newest first, like the real API. */
+function releasesResponse(...tagNames: unknown[]) {
+  const body = tagNames.map((tag_name) => ({ tag_name, draft: false, prerelease: false }));
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function make(enabled = true, currentVersion = '6.21.1') {
+  return new VersionCheckService({ enabled, currentVersion });
+}
+
+describe('VersionCheckService', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    Date.now = () => 1_800_000_000_000;
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    Date.now = realDateNow;
+    warnSpy.mockRestore();
+  });
+
+  it('makes no outbound call and reports check_enabled=false when disabled', async () => {
+    const info = await make(false).getVersionInfo();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(info).toEqual({
+      current: '6.21.1',
+      latest: null,
+      update_available: false,
+      releases_behind: null,
+      release_url: null,
+      github_release_url: null,
+      upgrade_docs_url: UPGRADE_DOCS_URL,
+      upgrade_command: UPGRADE_COMMAND,
+      check_enabled: false,
+      checked_at: null,
+    });
+  });
+
+  it('reports an available update with changelog and release links', async () => {
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.22.0', 'manifest@6.21.1'));
+
+    const info = await make().getVersionInfo();
+
+    expect(info).toEqual({
+      current: '6.21.1',
+      latest: '6.22.0',
+      update_available: true,
+      releases_behind: 1,
+      release_url: 'https://manifest.build/changelog/#v6-22-0',
+      github_release_url: 'https://github.com/mnfst/manifest/releases/tag/manifest%406.22.0',
+      upgrade_docs_url: UPGRADE_DOCS_URL,
+      upgrade_command: UPGRADE_COMMAND,
+      check_enabled: true,
+      checked_at: new Date(1_800_000_000_000).toISOString(),
+    });
+  });
+
+  it('counts how many releases sit between current and latest', async () => {
+    fetchMock.mockResolvedValue(
+      releasesResponse(
+        'manifest@6.22.0',
+        'manifest@6.21.1',
+        'manifest@6.21.0',
+        'manifest@6.20.0',
+        'manifest@6.19.0',
+      ),
+    );
+
+    const info = await make(true, '6.19.0').getVersionInfo();
+
+    expect(info.latest).toBe('6.22.0');
+    expect(info.releases_behind).toBe(4);
+  });
+
+  it('calls the GitHub release-list API with a JSON accept header and a timeout', async () => {
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.22.0'));
+
+    await make().getVersionInfo();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(RELEASES_URL);
+    expect(init.headers).toEqual({ Accept: 'application/vnd.github+json' });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('reports no update when already on the latest release', async () => {
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.21.1', 'manifest@6.21.0'));
+
+    const info = await make().getVersionInfo();
+
+    expect(info.latest).toBe('6.21.1');
+    expect(info.update_available).toBe(false);
+    expect(info.releases_behind).toBe(0);
+    expect(info.release_url).toBe('https://manifest.build/changelog/#v6-21-1');
+  });
+
+  it('reports no update when running a version newer than the latest release', async () => {
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.21.0'));
+
+    const info = await make().getVersionInfo();
+
+    expect(info.update_available).toBe(false);
+    expect(info.releases_behind).toBe(0);
+  });
+
+  it('serves the cached result for 24 hours, then refreshes', async () => {
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.22.0'));
+    const service = make();
+
+    await service.getVersionInfo();
+    Date.now = () => 1_800_000_000_000 + 23 * HOUR_MS;
+    await service.getVersionInfo();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    Date.now = () => 1_800_000_000_000 + 25 * HOUR_MS;
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.23.0'));
+    const info = await service.getVersionInfo();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(info.latest).toBe('6.23.0');
+  });
+
+  it('degrades to "unknown latest" when the network call throws, and warns once', async () => {
+    fetchMock.mockRejectedValue(new Error('ENETUNREACH'));
+
+    const info = await make().getVersionInfo();
+
+    expect(info.latest).toBeNull();
+    expect(info.update_available).toBe(false);
+    expect(info.releases_behind).toBeNull();
+    expect(info.release_url).toBeNull();
+    expect(info.github_release_url).toBeNull();
+    expect(info.check_enabled).toBe(true);
+    expect(info.checked_at).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('ENETUNREACH');
+  });
+
+  it('logs a non-Error rejection without crashing', async () => {
+    fetchMock.mockRejectedValue('socket hang up');
+
+    const info = await make().getVersionInfo();
+
+    expect(info.latest).toBeNull();
+    expect(warnSpy.mock.calls[0][0]).toContain('socket hang up');
+  });
+
+  it('treats a non-OK response as a failure', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403, json: async () => ({}) });
+
+    const info = await make().getVersionInfo();
+
+    expect(info.latest).toBeNull();
+    expect(warnSpy.mock.calls[0][0]).toContain('403');
+  });
+
+  it('treats a body without any Manifest release as a failure', async () => {
+    fetchMock.mockResolvedValue(releasesResponse('v5.0.5'));
+
+    const info = await make().getVersionInfo();
+
+    expect(info.latest).toBeNull();
+    expect(warnSpy.mock.calls[0][0]).toContain('no Manifest release');
+  });
+
+  it('backs off for an hour after a failure instead of retrying every request', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
+    const service = make();
+
+    await service.getVersionInfo();
+    Date.now = () => 1_800_000_000_000 + 30 * 60 * 1000;
+    await service.getVersionInfo();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    Date.now = () => 1_800_000_000_000 + 61 * 60 * 1000;
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.22.0'));
+    const info = await service.getVersionInfo();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(info.latest).toBe('6.22.0');
+  });
+
+  it('keeps serving the last good result when a refresh fails', async () => {
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.22.0'));
+    const service = make();
+    await service.getVersionInfo();
+
+    Date.now = () => 1_800_000_000_000 + 25 * HOUR_MS;
+    fetchMock.mockRejectedValue(new Error('boom'));
+    const info = await service.getVersionInfo();
+
+    expect(info.latest).toBe('6.22.0');
+    expect(info.update_available).toBe(true);
+    expect(info.releases_behind).toBe(1);
+    expect(info.checked_at).toBe(new Date(1_800_000_000_000).toISOString());
+  });
+
+  it('only warns once per outage, not on every failed refresh', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
+    const service = make();
+
+    await service.getVersionInfo();
+    Date.now = () => 1_800_000_000_000 + 2 * HOUR_MS;
+    await service.getVersionInfo();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns again after a recovery when a new outage starts', async () => {
+    const service = make();
+    fetchMock.mockRejectedValue(new Error('first'));
+    await service.getVersionInfo();
+
+    Date.now = () => 1_800_000_000_000 + 2 * HOUR_MS;
+    fetchMock.mockResolvedValue(releasesResponse('manifest@6.22.0'));
+    await service.getVersionInfo();
+
+    Date.now = () => 1_800_000_000_000 + 27 * HOUR_MS;
+    fetchMock.mockRejectedValue(new Error('second'));
+    await service.getVersionInfo();
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[1][0]).toContain('second');
+  });
+});

--- a/packages/backend/src/version/version-check.service.spec.ts
+++ b/packages/backend/src/version/version-check.service.spec.ts
@@ -118,6 +118,42 @@ describe('VersionCheckService', () => {
     expect(info.releases_behind).toBe(0);
   });
 
+  it('coalesces concurrent callers into a single GitHub request', async () => {
+    let resolveFetch: (value: unknown) => void = () => undefined;
+    fetchMock.mockReturnValue(new Promise((resolve) => (resolveFetch = resolve)));
+    const service = make();
+
+    const first = service.getVersionInfo();
+    const second = service.getVersionInfo();
+    const third = service.getVersionInfo();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch(releasesResponse('manifest@6.22.0'));
+    const results = await Promise.all([first, second, third]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    for (const info of results) {
+      expect(info.latest).toBe('6.22.0');
+      expect(info.update_available).toBe(true);
+    }
+  });
+
+  it('lets a caller after a coalesced failure see the failure, not hang', async () => {
+    let rejectFetch: (reason: unknown) => void = () => undefined;
+    fetchMock.mockReturnValue(new Promise((_, reject) => (rejectFetch = reject)));
+    const service = make();
+
+    const first = service.getVersionInfo();
+    const second = service.getVersionInfo();
+    rejectFetch(new Error('boom'));
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a.latest).toBeNull();
+    expect(b.latest).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('serves the cached result for 24 hours, then refreshes', async () => {
     fetchMock.mockResolvedValue(releasesResponse('manifest@6.22.0'));
     const service = make();

--- a/packages/backend/src/version/version-check.service.ts
+++ b/packages/backend/src/version/version-check.service.ts
@@ -1,0 +1,122 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  changelogUrlFor,
+  compareVersions,
+  githubReleaseUrlFor,
+  RELEASES_URL,
+  summarizeReleases,
+  UPGRADE_COMMAND,
+  UPGRADE_DOCS_URL,
+  type ReleaseSummary,
+  type VersionCheckConfig,
+} from './version-check.config';
+
+export const VERSION_CHECK_CONFIG = Symbol('VERSION_CHECK_CONFIG');
+
+/** Successful checks are reused for a day; failures back off for an hour. */
+const SUCCESS_TTL_MS = 24 * 60 * 60 * 1000;
+const FAILURE_BACKOFF_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+export interface VersionInfo {
+  current: string;
+  latest: string | null;
+  update_available: boolean;
+  /**
+   * Releases published after `current`, capped at the 100 the check fetches.
+   * Null until the first successful check or when `current` is unreadable.
+   */
+  releases_behind: number | null;
+  /** Website changelog anchored at `latest`. */
+  release_url: string | null;
+  github_release_url: string | null;
+  upgrade_docs_url: string;
+  upgrade_command: string;
+  /** False in cloud mode or when `MANIFEST_UPDATE_CHECK_DISABLED` is set. */
+  check_enabled: boolean;
+  /** When `latest` was last confirmed; null until the first successful check. */
+  checked_at: string | null;
+}
+
+interface CachedCheck extends ReleaseSummary {
+  checkedAt: number;
+}
+
+/**
+ * Answers "is there a newer Manifest, and how far behind am I?" for
+ * self-hosted dashboards.
+ *
+ * One outbound call to GitHub per day per process, never on cloud, never when
+ * opted out, and never more than once an hour while GitHub is unreachable —
+ * the dashboard may poll this on every page load, and the unauthenticated
+ * GitHub API allows 60 requests an hour.
+ */
+@Injectable()
+export class VersionCheckService {
+  private readonly logger = new Logger(VersionCheckService.name);
+  private cached: CachedCheck | null = null;
+  private lastFailureAt: number | null = null;
+
+  constructor(@Inject(VERSION_CHECK_CONFIG) private readonly config: VersionCheckConfig) {}
+
+  async getVersionInfo(): Promise<VersionInfo> {
+    if (this.config.enabled) {
+      await this.refreshIfDue();
+    }
+    return this.buildInfo();
+  }
+
+  private async refreshIfDue(): Promise<void> {
+    const now = Date.now();
+    if (this.cached && now - this.cached.checkedAt < SUCCESS_TTL_MS) return;
+    if (this.lastFailureAt !== null && now - this.lastFailureAt < FAILURE_BACKOFF_MS) return;
+
+    try {
+      const summary = await this.fetchReleases();
+      this.cached = { ...summary, checkedAt: now };
+      this.lastFailureAt = null;
+    } catch (err) {
+      // Warn once per outage: the first failure after a success (or at boot)
+      // is worth a log line; repeating it every hour is noise.
+      if (this.lastFailureAt === null) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`Update check failed (${message}); will retry in an hour`);
+      }
+      this.lastFailureAt = now;
+    }
+  }
+
+  private async fetchReleases(): Promise<ReleaseSummary> {
+    const res = await fetch(RELEASES_URL, {
+      headers: { Accept: 'application/vnd.github+json' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`GitHub responded ${res.status}`);
+    }
+    const summary = summarizeReleases(await res.json(), this.config.currentVersion);
+    if (!summary) {
+      throw new Error('no Manifest release in the GitHub response');
+    }
+    return summary;
+  }
+
+  private buildInfo(): VersionInfo {
+    const current = this.config.currentVersion;
+    const cached = this.config.enabled ? this.cached : null;
+    const latest = cached?.latest ?? null;
+    const cmp = latest ? compareVersions(current, latest) : null;
+    return {
+      current,
+      latest,
+      update_available: cmp !== null && cmp < 0,
+      releases_behind: cached?.releasesBehind ?? null,
+      release_url: latest ? changelogUrlFor(latest) : null,
+      github_release_url: latest ? githubReleaseUrlFor(latest) : null,
+      upgrade_docs_url: UPGRADE_DOCS_URL,
+      upgrade_command: UPGRADE_COMMAND,
+      check_enabled: this.config.enabled,
+      checked_at: cached ? new Date(cached.checkedAt).toISOString() : null,
+    };
+  }
+}

--- a/packages/backend/src/version/version-check.service.ts
+++ b/packages/backend/src/version/version-check.service.ts
@@ -56,6 +56,8 @@ export class VersionCheckService {
   private readonly logger = new Logger(VersionCheckService.name);
   private cached: CachedCheck | null = null;
   private lastFailureAt: number | null = null;
+  /** The refresh in progress, so concurrent callers share one GitHub request. */
+  private inflight: Promise<void> | null = null;
 
   constructor(@Inject(VERSION_CHECK_CONFIG) private readonly config: VersionCheckConfig) {}
 
@@ -66,11 +68,22 @@ export class VersionCheckService {
     return this.buildInfo();
   }
 
-  private async refreshIfDue(): Promise<void> {
+  private refreshIfDue(): Promise<void> {
     const now = Date.now();
-    if (this.cached && now - this.cached.checkedAt < SUCCESS_TTL_MS) return;
-    if (this.lastFailureAt !== null && now - this.lastFailureAt < FAILURE_BACKOFF_MS) return;
+    if (this.cached && now - this.cached.checkedAt < SUCCESS_TTL_MS) return Promise.resolve();
+    if (this.lastFailureAt !== null && now - this.lastFailureAt < FAILURE_BACKOFF_MS) {
+      return Promise.resolve();
+    }
+    if (!this.inflight) {
+      this.inflight = this.refresh(now).finally(() => {
+        this.inflight = null;
+      });
+    }
+    return this.inflight;
+  }
 
+  /** Never rejects: a failure is recorded for backoff and the caller gets stale/null data. */
+  private async refresh(now: number): Promise<void> {
     try {
       const summary = await this.fetchReleases();
       this.cached = { ...summary, checkedAt: now };

--- a/packages/backend/src/version/version.controller.spec.ts
+++ b/packages/backend/src/version/version.controller.spec.ts
@@ -1,0 +1,34 @@
+import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
+import { VersionController } from './version.controller';
+import type { VersionCheckService, VersionInfo } from './version-check.service';
+
+describe('VersionController', () => {
+  const info: VersionInfo = {
+    current: '6.21.1',
+    latest: '6.22.0',
+    update_available: true,
+    releases_behind: 1,
+    release_url: 'https://manifest.build/changelog/#v6-22-0',
+    github_release_url: 'https://github.com/mnfst/manifest/releases/tag/manifest%406.22.0',
+    upgrade_docs_url: 'https://manifest.build/docs/self-hosted#upgrading',
+    upgrade_command: 'docker compose pull && docker compose up -d',
+    check_enabled: true,
+    checked_at: '2026-09-04T09:00:00.000Z',
+  };
+
+  it('returns the version info from the service', async () => {
+    const service = { getVersionInfo: jest.fn().mockResolvedValue(info) };
+    const controller = new VersionController(service as unknown as VersionCheckService);
+
+    await expect(controller.getVersion()).resolves.toEqual(info);
+  });
+
+  it('is served at GET /api/v1/version behind the normal session/API-key guards', () => {
+    const prefix = Reflect.getMetadata('path', VersionController);
+    const route = Reflect.getMetadata('path', VersionController.prototype.getVersion);
+    const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, VersionController.prototype.getVersion);
+
+    expect(`${prefix}/${route}`).toBe('api/v1/version');
+    expect(isPublic).toBeUndefined();
+  });
+});

--- a/packages/backend/src/version/version.controller.ts
+++ b/packages/backend/src/version/version.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from '@nestjs/common';
+import { VersionCheckService, type VersionInfo } from './version-check.service';
+
+/**
+ * Running version + latest release for the self-hosted dashboard's update
+ * badge. Session/API-key guarded like the rest of the dashboard API: the
+ * version an install runs is not something to hand to anonymous callers.
+ */
+@Controller('api/v1')
+export class VersionController {
+  constructor(private readonly versionCheck: VersionCheckService) {}
+
+  @Get('version')
+  getVersion(): Promise<VersionInfo> {
+    return this.versionCheck.getVersionInfo();
+  }
+}

--- a/packages/backend/src/version/version.module.ts
+++ b/packages/backend/src/version/version.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { buildVersionCheckConfig } from './version-check.config';
+import { VERSION_CHECK_CONFIG, VersionCheckService } from './version-check.service';
+import { VersionController } from './version.controller';
+
+@Module({
+  controllers: [VersionController],
+  providers: [
+    { provide: VERSION_CHECK_CONFIG, useFactory: buildVersionCheckConfig },
+    VersionCheckService,
+  ],
+})
+export class VersionModule {}

--- a/packages/frontend/src/components/VersionIndicator.tsx
+++ b/packages/frontend/src/components/VersionIndicator.tsx
@@ -1,13 +1,84 @@
-import { Show } from 'solid-js';
+import { createResource, createSignal, Show } from 'solid-js';
+import { getVersionInfo, type VersionInfo } from '../services/api/version.js';
 
+/**
+ * localStorage key holding the `latest` version the user dismissed. The
+ * notice stays hidden while the latest release is that version and comes
+ * back on its own once an even newer one is published.
+ */
+export const UPDATE_DISMISSED_STORAGE_KEY = 'manifest.update-dismissed';
+
+function readDismissed(): string | null {
+  try {
+    return localStorage.getItem(UPDATE_DISMISSED_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeDismissed(version: string): void {
+  try {
+    localStorage.setItem(UPDATE_DISMISSED_STORAGE_KEY, version);
+  } catch {
+    // Private mode or blocked storage: the in-memory signal still hides it
+    // for this page load.
+  }
+}
+
+/**
+ * Bottom-corner `vX.Y.Z` badge for self-hosted installs. When the backend
+ * reports a newer release, the badge grows a link to the changelog for that
+ * release, with a dismiss button. A failed check degrades to the plain badge.
+ */
 const VersionIndicator = () => {
   const isSelfHosted = import.meta.env.VITE_MANIFEST_SELFHOSTED === 'true';
   const version = __MANIFEST_VERSION__;
 
+  const [info] = createResource<VersionInfo | null, boolean>(
+    () => isSelfHosted && Boolean(version),
+    () => getVersionInfo().catch(() => null),
+  );
+  const [dismissed, setDismissed] = createSignal<string | null>(readDismissed());
+
+  const update = (): (VersionInfo & { latest: string }) | null => {
+    const v = info();
+    if (!v?.update_available || !v.latest) return null;
+    return dismissed() === v.latest ? null : { ...v, latest: v.latest };
+  };
+  const dismiss = (latest: string) => {
+    setDismissed(latest);
+    writeDismissed(latest);
+  };
+
   return (
     <Show when={isSelfHosted && version}>
-      <div class="version-indicator" aria-label={`Version ${version}`}>
+      <div
+        class="version-indicator"
+        classList={{ 'version-indicator--update': update() !== null }}
+        aria-label={
+          update()
+            ? `Version ${version}, update to ${update()?.latest} available`
+            : `Version ${version}`
+        }
+      >
         <span>v{version}</span>
+        <Show when={update()}>
+          {(u) => (
+            <span class="version-indicator__update">
+              <a href={u().release_url ?? undefined} target="_blank" rel="noopener noreferrer">
+                v{u().latest} available
+              </a>
+              <button
+                type="button"
+                class="version-indicator__dismiss"
+                aria-label="Dismiss update notice"
+                onClick={() => dismiss(u().latest)}
+              >
+                ×
+              </button>
+            </span>
+          )}
+        </Show>
       </div>
     </Show>
   );

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -10,6 +10,7 @@ export * from './api/oauth.js';
 export * from './api/free-models.js';
 export * from './api/model-params.js';
 export * from './api/playground.js';
+export * from './api/version.js';
 export {
   getProviders as getGlobalProviders,
   getProviderUsage as getGlobalProviderUsage,

--- a/packages/frontend/src/services/api/version.ts
+++ b/packages/frontend/src/services/api/version.ts
@@ -1,0 +1,22 @@
+import { fetchJson } from './core.js';
+
+/** Mirrors `VersionInfo` in `packages/backend/src/version/version-check.service.ts`. */
+export interface VersionInfo {
+  current: string;
+  latest: string | null;
+  update_available: boolean;
+  /** Releases published after `current` (capped at 100); null when unknown. */
+  releases_behind: number | null;
+  /** Website changelog anchored at `latest`. */
+  release_url: string | null;
+  github_release_url: string | null;
+  upgrade_docs_url: string;
+  upgrade_command: string;
+  /** False on cloud or when the install opted out of update checks. */
+  check_enabled: boolean;
+  checked_at: string | null;
+}
+
+export function getVersionInfo(): Promise<VersionInfo> {
+  return fetchJson<VersionInfo>('/version');
+}

--- a/packages/frontend/src/styles/version-indicator.css
+++ b/packages/frontend/src/styles/version-indicator.css
@@ -55,7 +55,10 @@ body:has(.wingman-fab) .version-indicator {
   appearance: none;
   border: 0;
   background: transparent;
-  padding: 0 4px;
+  /* 24px minimum hit area so the × is tappable on touch screens. */
+  padding: 0 6px;
+  min-width: 24px;
+  min-height: 24px;
   font: inherit;
   font-size: var(--font-size-sm);
   line-height: 1;

--- a/packages/frontend/src/styles/version-indicator.css
+++ b/packages/frontend/src/styles/version-indicator.css
@@ -5,10 +5,67 @@
   bottom: var(--gap-md);
   right: var(--gap-md);
   z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
   font-size: var(--font-size-xs);
   font-family: var(--font-mono);
   color: hsl(var(--muted-foreground));
   opacity: 0.5;
   cursor: default;
   user-select: none;
+}
+
+/* The dev-only Wingman FAB (44px tall, 22px from the corner) shares this
+   corner. Lift the badge above it while it is on the page; production
+   builds never render the FAB, so this rule never fires there. */
+body:has(.wingman-fab) .version-indicator {
+  bottom: calc(22px + 44px + var(--gap-sm));
+}
+
+/* A newer release exists: make the badge readable and clickable. */
+.version-indicator--update {
+  opacity: 1;
+  user-select: text;
+  padding: 4px 6px 4px 10px;
+  border-radius: var(--radius-sm);
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  box-shadow: var(--shadow-sm);
+}
+
+.version-indicator__update {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-sm);
+}
+
+.version-indicator__update a {
+  color: hsl(var(--primary));
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.version-indicator__update a:hover,
+.version-indicator__update a:focus-visible {
+  text-decoration: underline;
+}
+
+.version-indicator__dismiss {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0 4px;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.version-indicator__dismiss:hover,
+.version-indicator__dismiss:focus-visible {
+  color: hsl(var(--foreground));
+  background: hsl(var(--muted));
 }

--- a/packages/frontend/tests/components/VersionIndicator.test.tsx
+++ b/packages/frontend/tests/components/VersionIndicator.test.tsx
@@ -1,32 +1,180 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render } from "@solidjs/testing-library";
-import VersionIndicator from "../../src/components/VersionIndicator";
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { fireEvent, render, waitFor } from '@solidjs/testing-library';
+import VersionIndicator, {
+  UPDATE_DISMISSED_STORAGE_KEY,
+} from '../../src/components/VersionIndicator';
+import { getVersionInfo, type VersionInfo } from '../../src/services/api/version.js';
 
-describe("VersionIndicator", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
+vi.mock('../../src/services/api/version.js', () => ({
+  getVersionInfo: vi.fn(),
+}));
+
+const mockGetVersionInfo = vi.mocked(getVersionInfo);
+
+function info(overrides: Partial<VersionInfo> = {}): VersionInfo {
+  return {
+    current: __MANIFEST_VERSION__,
+    latest: __MANIFEST_VERSION__,
+    update_available: false,
+    releases_behind: 0,
+    release_url: `https://manifest.build/changelog/#v${__MANIFEST_VERSION__.replace(/\./g, '-')}`,
+    github_release_url: null,
+    upgrade_docs_url: 'https://manifest.build/docs/self-hosted#upgrading',
+    upgrade_command: 'docker compose pull && docker compose up -d',
+    check_enabled: true,
+    checked_at: '2026-09-04T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const newer = () =>
+  info({
+    latest: '9.9.9',
+    update_available: true,
+    releases_behind: 9,
+    release_url: 'https://manifest.build/changelog/#v9-9-9',
   });
 
-  it("renders nothing when not self-hosted", () => {
-    vi.stubEnv("VITE_MANIFEST_SELFHOSTED", "");
+describe('VersionIndicator', () => {
+  beforeEach(() => {
+    mockGetVersionInfo.mockReset();
+    mockGetVersionInfo.mockResolvedValue(info());
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when not self-hosted', () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', '');
     const { container } = render(() => <VersionIndicator />);
-    expect(container.querySelector(".version-indicator")).toBeNull();
+    expect(container.querySelector('.version-indicator')).toBeNull();
   });
 
   it("renders nothing when the flag is anything other than 'true'", () => {
-    vi.stubEnv("VITE_MANIFEST_SELFHOSTED", "false");
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'false');
     const { container } = render(() => <VersionIndicator />);
-    expect(container.querySelector(".version-indicator")).toBeNull();
+    expect(container.querySelector('.version-indicator')).toBeNull();
   });
 
-  it("renders v{version} when self-hosted", () => {
-    vi.stubEnv("VITE_MANIFEST_SELFHOSTED", "true");
+  it('does not ask the backend for version info when not self-hosted', () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', '');
+    render(() => <VersionIndicator />);
+    expect(mockGetVersionInfo).not.toHaveBeenCalled();
+  });
+
+  it('renders v{version} when self-hosted', () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
     const { container } = render(() => <VersionIndicator />);
-    const badge = container.querySelector(".version-indicator");
+    const badge = container.querySelector('.version-indicator');
     expect(badge).not.toBeNull();
     expect(badge?.textContent).toBe(`v${__MANIFEST_VERSION__}`);
-    expect(badge?.getAttribute("aria-label")).toBe(
-      `Version ${__MANIFEST_VERSION__}`,
+    expect(badge?.getAttribute('aria-label')).toBe(`Version ${__MANIFEST_VERSION__}`);
+  });
+
+  it('keeps the plain badge when already on the latest release', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    const { container } = render(() => <VersionIndicator />);
+    await waitFor(() => expect(mockGetVersionInfo).toHaveBeenCalledTimes(1));
+    expect(container.querySelector('.version-indicator__update')).toBeNull();
+    expect(container.querySelector('.version-indicator')?.textContent).toBe(
+      `v${__MANIFEST_VERSION__}`,
+    );
+  });
+
+  it('links to the changelog when a newer release exists', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    mockGetVersionInfo.mockResolvedValue(newer());
+    const { container, findByText } = render(() => <VersionIndicator />);
+
+    const changelog = (await findByText('v9.9.9 available')) as HTMLAnchorElement;
+    expect(changelog.tagName).toBe('A');
+    expect(changelog.href).toBe('https://manifest.build/changelog/#v9-9-9');
+    expect(changelog.target).toBe('_blank');
+    expect(changelog.rel).toContain('noopener');
+
+    const badge = container.querySelector('.version-indicator');
+    expect(badge?.classList.contains('version-indicator--update')).toBe(true);
+    expect(badge?.getAttribute('aria-label')).toBe(
+      `Version ${__MANIFEST_VERSION__}, update to 9.9.9 available`,
+    );
+  });
+
+  it('shows neither an upgrade link nor a releases-behind count', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    mockGetVersionInfo.mockResolvedValue(newer());
+    const { container, findByText } = render(() => <VersionIndicator />);
+
+    await findByText('v9.9.9 available');
+    expect(container.querySelector('.version-indicator__upgrade')).toBeNull();
+    expect(container.textContent).not.toContain('behind');
+    expect(container.textContent).not.toContain('How to upgrade');
+  });
+
+  it('hides the update notice when dismissed and remembers the dismissed version', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    mockGetVersionInfo.mockResolvedValue(newer());
+    const { container, findByLabelText } = render(() => <VersionIndicator />);
+
+    const close = await findByLabelText('Dismiss update notice');
+    expect(close.tagName).toBe('BUTTON');
+    fireEvent.click(close);
+
+    expect(container.querySelector('.version-indicator__update')).toBeNull();
+    expect(container.querySelector('.version-indicator')?.textContent).toBe(
+      `v${__MANIFEST_VERSION__}`,
+    );
+    expect(container.querySelector('.version-indicator--update')).toBeNull();
+    expect(localStorage.getItem(UPDATE_DISMISSED_STORAGE_KEY)).toBe('9.9.9');
+  });
+
+  it('stays dismissed on later loads while the latest version is unchanged', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    localStorage.setItem(UPDATE_DISMISSED_STORAGE_KEY, '9.9.9');
+    mockGetVersionInfo.mockResolvedValue(newer());
+    const { container } = render(() => <VersionIndicator />);
+
+    await waitFor(() => expect(mockGetVersionInfo).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(container.querySelector('.version-indicator__update')).toBeNull();
+  });
+
+  it('shows the notice again once an even newer version is released', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    localStorage.setItem(UPDATE_DISMISSED_STORAGE_KEY, '9.9.8');
+    mockGetVersionInfo.mockResolvedValue(newer());
+    const { findByText } = render(() => <VersionIndicator />);
+
+    await expect(findByText('v9.9.9 available')).resolves.toBeTruthy();
+  });
+
+  it('still works when localStorage is unavailable', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    mockGetVersionInfo.mockResolvedValue(newer());
+    const { container, findByLabelText, findByText } = render(() => <VersionIndicator />);
+
+    await findByText('v9.9.9 available');
+    fireEvent.click(await findByLabelText('Dismiss update notice'));
+    expect(container.querySelector('.version-indicator__update')).toBeNull();
+  });
+
+  it('keeps the plain badge when the version check fails', async () => {
+    vi.stubEnv('VITE_MANIFEST_SELFHOSTED', 'true');
+    mockGetVersionInfo.mockRejectedValue(new Error('network down'));
+    const { container } = render(() => <VersionIndicator />);
+    await waitFor(() => expect(mockGetVersionInfo).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(container.querySelector('.version-indicator__update')).toBeNull();
+    expect(container.querySelector('.version-indicator')?.textContent).toBe(
+      `v${__MANIFEST_VERSION__}`,
     );
   });
 });

--- a/packages/frontend/tests/services/version-api.test.ts
+++ b/packages/frontend/tests/services/version-api.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getVersionInfo, type VersionInfo } from '../../src/services/api/version.js';
+import * as api from '../../src/services/api.js';
+
+vi.mock('../../src/services/toast-store.js', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  vi.stubGlobal('location', { origin: 'http://localhost:3000' });
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('getVersionInfo', () => {
+  it('fetches GET /api/v1/version and returns the payload', async () => {
+    const payload: VersionInfo = {
+      current: '6.21.1',
+      latest: '6.22.0',
+      update_available: true,
+      releases_behind: 1,
+      release_url: 'https://manifest.build/changelog/#v6-22-0',
+      github_release_url: 'https://github.com/mnfst/manifest/releases/tag/manifest%406.22.0',
+      upgrade_docs_url: 'https://manifest.build/docs/self-hosted#upgrading',
+      upgrade_command: 'docker compose pull && docker compose up -d',
+      check_enabled: true,
+      checked_at: '2026-09-04T09:00:00.000Z',
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(payload),
+      text: () => Promise.resolve(JSON.stringify(payload)),
+    });
+
+    const result = await getVersionInfo();
+
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(String(mockFetch.mock.calls[0][0])).toBe('http://localhost:3000/api/v1/version');
+  });
+
+  it('is re-exported from the api barrel', () => {
+    expect(api.getVersionInfo).toBe(getVersionInfo);
+  });
+});


### PR DESCRIPTION
### ✨ What changed
- New `GET /api/v1/version`: running version, latest GitHub release, changelog link.
- One GitHub call per day per process, 1h backoff on failure, stale result kept during outages.
- No outbound call on cloud or with `MANIFEST_UPDATE_CHECK_DISABLED=1`.
- Self-hosted version badge links to the changelog when a newer release exists.
- Badge has a dismiss that stays hidden until an even newer release ships (localStorage).
- Dev-only: badge moves above the Wingman button so the two don't overlap.

### 💭 Why
Self-hosted installs had no way to learn a new Docker image existed. n8n, Immich, and Gitea show a "new version available" notice and leave the pull to the user. This does the same.

### 👤 For users
Self-hosted dashboards show `v6.21.1 · v6.22.0 available ×` in the bottom-right corner once a newer release is published. The link opens the changelog at that version. Cloud sees no change.

### 🔧 For operators
New optional env var `MANIFEST_UPDATE_CHECK_DISABLED=1` turns the check off (air-gapped hosts). Added to `docker-compose.yml`, `.env.example`, and the Docker README. Separate from the telemetry opt-out. No migration.

### 📝 Notes
Closes part of #2830. The badge is intentionally minimal; styling polish and moving the upgrade instructions onto the website changelog page are tracked there. The response also carries `releases_behind`, `upgrade_docs_url`, and `upgrade_command` for a future tooltip; the badge does not render them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-hosted dashboards now display a badge linking to the changelog when a newer GitHub release exists. Closes part of #2830.

- Adds `GET /api/v1/version`, which reports the running version, the latest release, and upgrade links.
- The check runs once a day per process, backs off for an hour on failure, keeps serving the last good result during GitHub outages, and concurrent requests share a single fetch.
- No outbound call happens on cloud installs, or on self-hosted installs with `MANIFEST_UPDATE_CHECK_DISABLED=1`; that opt-out is separate from the telemetry one.
- Dismissing the badge keeps it hidden (localStorage) until an even newer release ships; styling polish and moving upgrade instructions to the changelog page are tracked in #2830.
- The payload also carries `releases_behind`, `upgrade_docs_url`, and `upgrade_command` for a future tooltip; the badge only renders the update link.

<sup>Written for commit 719b93afcb5afe5533715e4378e1c7cdda985d12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

