### PR TITLE
fix(routing): send x-opencode-session on OpenCode playground and catalog requests

### DIFF
--- a/.changeset/opencode-session-playground-catalog.md
+++ b/.changeset/opencode-session-playground-catalog.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Send the `x-opencode-session` header on OpenCode Go/Zen playground forwards and model-catalog discovery (`/v1/models`), not just agent proxy traffic. OpenCode rejects requests without the header starting 09/06, so playground runs and live model discovery for `opencode-go`/`opencode-zen` now attach the same stable hashed session id used by the proxy (per-tenant Playground agent scope for the playground, per-credential scope for catalog fetches).

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2938,6 +2938,30 @@ describe('ProviderModelFetcherService', () => {
       expect(result[1].id).toBe('opencode-go/glm-5.1');
     });
 
+    it('sends a stable x-opencode-session header on the live /models fetch', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ id: 'glm-5.2', object: 'model', owned_by: 'opencode' }] }),
+      });
+
+      await service.fetch('opencode-go', 'og-token', 'subscription');
+      await service.fetch('opencode-go', 'og-token', 'subscription');
+      await service.fetch('opencode-go', 'other-token', 'subscription');
+
+      const [, firstInit] = fetchSpy.mock.calls[0];
+      const [, secondInit] = fetchSpy.mock.calls[1];
+      const [, thirdInit] = fetchSpy.mock.calls[2];
+      expect((firstInit.headers as Record<string, string>)['x-opencode-session']).toMatch(
+        /^manifest-[a-f0-9]{32}$/,
+      );
+      expect((secondInit.headers as Record<string, string>)['x-opencode-session']).toBe(
+        (firstInit.headers as Record<string, string>)['x-opencode-session'],
+      );
+      expect((thirdInit.headers as Record<string, string>)['x-opencode-session']).not.toBe(
+        (firstInit.headers as Record<string, string>)['x-opencode-session'],
+      );
+    });
+
     it('falls back to a refreshed docs catalog when live /models is empty', async () => {
       const catalog = {
         list: jest.fn().mockResolvedValue([]),
@@ -3119,7 +3143,10 @@ describe('ProviderModelFetcherService', () => {
       expect(fetchSpy).toHaveBeenCalledWith(
         'https://opencode.ai/zen/v1/models',
         expect.objectContaining({
-          headers: expect.objectContaining({ Authorization: 'Bearer oz-token' }),
+          headers: expect.objectContaining({
+            Authorization: 'Bearer oz-token',
+            'x-opencode-session': expect.stringMatching(/^manifest-[a-f0-9]{32}$/),
+          }),
         }),
       );
       expect(result).toHaveLength(3);

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -15,6 +15,7 @@ import {
   buildClaudeCodeSubscriptionHeaders,
 } from '../common/constants/subscription-clients';
 import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
+import { buildProviderExtraHeaders } from '../routing/proxy/provider-hooks';
 import { getQwenCompatibleBaseUrl, normalizeQwenCompatibleBaseUrl } from '../routing/qwen-region';
 import { getBedrockMantleBaseUrl, normalizeBedrockMantleBaseUrl } from '../routing/bedrock-region';
 import {
@@ -1078,7 +1079,10 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
   },
   'opencode-zen': {
     endpoint: 'https://opencode.ai/zen/v1/models',
-    buildHeaders: bearerHeaders,
+    buildHeaders: (key: string) => ({
+      ...bearerHeaders(key),
+      ...buildProviderExtraHeaders('opencode-zen', key),
+    }),
     parse: parseOpencodeZen,
   },
 };
@@ -1347,7 +1351,10 @@ export class ProviderModelFetcherService {
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
       const res = await fetch(OPENCODE_GO_MODELS_URL, {
-        headers: apiKey ? bearerHeaders(apiKey) : {},
+        headers: {
+          ...(apiKey ? bearerHeaders(apiKey) : {}),
+          ...buildProviderExtraHeaders('opencode-go', apiKey),
+        },
         signal: controller.signal,
       });
       if (!res.ok) {

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -1314,6 +1314,34 @@ describe('PlaygroundService.runStream', () => {
     expect(forwardArgs.stream).toBe(true);
   });
 
+  it('sends a stable agent-scoped x-opencode-session on OpenCode Go/Zen forwards', async () => {
+    const { service, mocks } = buildService();
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream(['data: {"usage":{"prompt_tokens":0,"completion_tokens":0}}\n\n']),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      CTX,
+      makeDto({ provider: 'opencode-go', authType: 'subscription' }),
+      asRes(res),
+    );
+    await service.runStream(
+      CTX,
+      makeDto({ provider: 'opencode-zen', model: 'opencode-zen/qwen3.6-plus' }),
+      asRes(mockRes()),
+    );
+
+    const goArgs = mocks.providerClient.forward.mock.calls[0][0];
+    const zenArgs = mocks.providerClient.forward.mock.calls[1][0];
+    expect(goArgs.extraHeaders['x-opencode-session']).toMatch(/^manifest-[a-f0-9]{32}$/);
+    expect(zenArgs.extraHeaders['x-opencode-session']).toMatch(/^manifest-[a-f0-9]{32}$/);
+    // Same tenant+agent scope, so both forwards pin to one stable session id.
+    expect(zenArgs.extraHeaders['x-opencode-session']).toBe(
+      goArgs.extraHeaders['x-opencode-session'],
+    );
+  });
+
   it('send() is a no-op once the response has ended (no write after end)', async () => {
     const { service, mocks } = buildService();
     // Stream that ends the response itself before the done event would be sent.

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -8,6 +8,7 @@ import { AgentMessage } from '../entities/agent-message.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderClient } from '../routing/proxy/provider-client';
 import { resolveForwardEndpoint } from '../routing/proxy/forward-endpoint-resolver';
+import { buildProviderExtraHeaders } from '../routing/proxy/provider-hooks';
 import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
 import {
   isRefreshableOAuthCredential,
@@ -177,7 +178,14 @@ export class PlaygroundService {
       return this.sendPreStreamError(res, status, message);
     }
 
-    const extraHeaders = sanitizeRequestHeaders(dto.requestHeaders);
+    // OpenCode Go/Zen pin the session via x-opencode-session and reject
+    // requests without it, so forward-time extras must ride here too — the
+    // per-tenant Playground agent provides the stable fallback scope.
+    const agentScopeKey = `${agent.tenant_id}\u0000${agent.id}`;
+    const extraHeaders = {
+      ...sanitizeRequestHeaders(dto.requestHeaders),
+      ...buildProviderExtraHeaders(dto.provider, undefined, agentScopeKey),
+    };
     const abort = new AbortController();
     res.on('close', () => abort.abort());
 


### PR DESCRIPTION
## Summary

OpenCode [announced](https://x.com/opencode/status/2095410501400289576) that tools using OpenCode Go missing the `x-opencode-session` header prevent prompt-cache optimization, and that **starting 09/06 requests missing this header may error**. The [Go docs](https://opencode.ai/docs/go/#where-can-i-use-it) list it as a requirement for tools (no abusive traffic, proper identification, `x-opencode-session` header).

#2827 already sends the header on proxy forwards. This closes the two forward paths that still bypassed the provider extra-header builders:

- **Playground forwards** carried only caller-supplied headers. They now merge `buildProviderExtraHeaders` with the same `tenant\0agent` scope key the proxy falls back to, so the per-tenant Playground agent pins one stable session id. Non-OpenCode providers are unaffected (the builder returns `undefined` for them).
- **Model-catalog discovery** hit `opencode.ai/zen/go/v1/models` (and the `opencode-zen` catalog fetch) with bearer auth only. Both now attach a per-credential hashed `x-opencode-session`.

## Notes

- The documented requirement targets Go; the Zen docs don't mention the header yet. We keep sending it on Zen too, consistent with #2827 — the official OpenCode CLI sends it for all `opencode*` providers, and the Zen gateway consumes it for sticky provider routing, so it's harmless-to-beneficial there.
- Includes a changeset (`manifest: patch`).

## Testing

- New specs: playground forwards send a stable agent-scoped header; `opencode-go` / `opencode-zen` catalog fetches send a stable per-credential header.
- `playground.service.spec.ts`, `provider-model-fetcher.service.spec.ts`, `provider-endpoints.spec.ts`, `proxy-fallback.service.spec.ts`: 418 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the `x-opencode-session` header on OpenCode Go/Zen playground forwards and model-catalog discovery, not just proxy traffic. OpenCode rejects requests without this header starting 09/06, so these paths now attach the same stable hashed session id the proxy already uses.

- Playground forwards merge the provider extra-header builders with the tenant/agent scope, pinning one stable session id per Playground agent.
- Live `/v1/models` fetches for `opencode-go` and `opencode-zen` attach a per-credential hashed session id.
- Non-OpenCode providers are unaffected since the builder returns `undefined` for them.

<sup>Written for commit 623ee7db6205cbca250a7a8da7ee776fa5d60191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

