### PR TITLE
feat: let outreach find the users Autofix repaired

### DIFF
--- a/.changeset/crm-autofix-healed-feed.md
+++ b/.changeset/crm-autofix-healed-feed.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add an internal, secret-guarded feed of the users whose requests Autofix repaired, so outreach can reach them with their real repair counts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ packages/
 │   │   ├── error-pages/                     # Custom error-page config (internal + public)
 │   │   ├── waitlist/                        # Pivot waiting-list claims + legacy Autofix claim compatibility route
 │   │   ├── discovery/                       # Self-hosted discovery onboarding (forwarded to Peacock)
+│   │   ├── crm-metrics/                     # Internal feed: Autofix-healed user cohort + waitlist claims (secret-gated)
 │   │   ├── cors-csp-config.ts               # Wingman CORS/CSP origin allowlists
 │   │   ├── sentry/                          # Sentry init-options builder (SENTRY_DSN-gated)
 │   │   └── telemetry/                       # Anonymous self-hosted telemetry
@@ -386,6 +387,7 @@ Every resource belongs to a tenant; users only authenticate and (optionally) app
 | GET                       | `/api/v1/overview/autofix-*`                    | Session/API Key                     | Autofix analytics (stats, timeseries, per-agent/provider/model)                                             |
 | POST                      | `/api/v1/discovery/complete`                    | Session/API Key                     | Best-effort self-hosted discovery submission forwarded to Peacock                                           |
 | GET/POST/DELETE           | `/api/v1/internal/error-pages*`                 | Public (`x-internal-secret` header) | Custom error-page config (Peacock CMS push API)                                                             |
+| GET                       | `/api/v1/internal/crm-metrics*`                 | Public (`x-internal-secret` header) | Autofix-healed user cohort + pivot waitlist claims, for the outreach CRM (`CRM_METRICS_SECRET`)             |
 | GET/PUT/DELETE            | `/api/v1/agents/:agentName/enabled-providers*`  | Session/API Key                     | Per-agent provider enable/disable + impact preview                                                          |
 | GET/POST/PATCH/DELETE     | `/api/v1/notifications/*`                       | Session/API Key                     | Notification rules CRUD + email provider config                                                             |
 | GET/POST/PUT/PATCH/DELETE | `/api/v1/routing/:agentName/*`                  | Session/API Key                     | Routing config (tiers, providers, model-params, header-tiers, custom-providers, specificity, autofix, recording, etc.) |
@@ -448,6 +450,7 @@ See `packages/backend/.env.example` for all variables. Key ones:
 - `MANIFEST_TELEMETRY_DISABLED` — Set `1` to opt out of anonymous telemetry (self-hosted only).
 - `MANIFEST_UPDATE_CHECK_DISABLED` — Set `1` to stop the self-hosted dashboard's daily "new version available" check against GitHub Releases (`GET /api/v1/version`, `version/` module). Separate from the telemetry opt-out: air-gapped installs want no outbound calls at all. Never runs in cloud mode.
 - `MANIFEST_PUBLIC_STATS` — Set `true` to expose `/api/v1/public/*` aggregate stats without auth (cloud-only marketing use).
+- `CRM_METRICS_SECRET` — Shared secret for `GET /api/v1/internal/crm-metrics*`, sent in the `x-internal-secret` header. Empty by default and anything under 32 chars counts as unset, because this is the only route that exports user email addresses across tenants. Separate from `ERROR_PAGE_PUSH_SECRET` on purpose: different consumer, different credential.
 - `TELEMETRY_ENDPOINT` — Where self-hosted installs POST the anonymous usage report. Default: `https://telemetry.manifest.build/v1/report`. See [Telemetry](#anonymous-usage-telemetry-self-hosted).
 - `DISCOVERY_ENDPOINT` — Optional override for the discovery submission endpoint. Default: `https://blue.manifest.build/v1/self-hosted/discovery`.
 - `SENTRY_DSN` / `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` — Opt-in Sentry error monitoring. Unset `SENTRY_DSN` disables Sentry entirely; `SENTRY_ENVIRONMENT` defaults to `NODE_ENV`. See [Error Monitoring](#error-monitoring-sentry-opt-in).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ packages/
 │   │   ├── error-pages/                     # Custom error-page config (internal + public)
 │   │   ├── waitlist/                        # Pivot waiting-list claims + legacy Autofix claim compatibility route
 │   │   ├── discovery/                       # Self-hosted discovery onboarding (forwarded to Peacock)
-│   │   ├── crm-metrics/                     # Internal feed: Autofix-healed user cohort + waitlist claims (secret-gated)
+│   │   ├── crm-metrics/                     # Cloud-only internal feed: Autofix-healed cohort + waitlist claims (secret-gated)
 │   │   ├── cors-csp-config.ts               # Wingman CORS/CSP origin allowlists
 │   │   ├── sentry/                          # Sentry init-options builder (SENTRY_DSN-gated)
 │   │   └── telemetry/                       # Anonymous self-hosted telemetry
@@ -387,7 +387,7 @@ Every resource belongs to a tenant; users only authenticate and (optionally) app
 | GET                       | `/api/v1/overview/autofix-*`                    | Session/API Key                     | Autofix analytics (stats, timeseries, per-agent/provider/model)                                             |
 | POST                      | `/api/v1/discovery/complete`                    | Session/API Key                     | Best-effort self-hosted discovery submission forwarded to Peacock                                           |
 | GET/POST/DELETE           | `/api/v1/internal/error-pages*`                 | Public (`x-internal-secret` header) | Custom error-page config (Peacock CMS push API)                                                             |
-| GET                       | `/api/v1/internal/crm-metrics*`                 | Public (`x-internal-secret` header) | Autofix-healed user cohort + pivot waitlist claims, for the outreach CRM (`CRM_METRICS_SECRET`)             |
+| GET                       | `/api/v1/internal/crm-metrics*`                 | Public (`x-internal-secret` header) | **Cloud only.** Autofix-healed user cohort + pivot waitlist claims, for the outreach CRM (`CRM_METRICS_SECRET`) |
 | GET/PUT/DELETE            | `/api/v1/agents/:agentName/enabled-providers*`  | Session/API Key                     | Per-agent provider enable/disable + impact preview                                                          |
 | GET/POST/PATCH/DELETE     | `/api/v1/notifications/*`                       | Session/API Key                     | Notification rules CRUD + email provider config                                                             |
 | GET/POST/PUT/PATCH/DELETE | `/api/v1/routing/:agentName/*`                  | Session/API Key                     | Routing config (tiers, providers, model-params, header-tiers, custom-providers, specificity, autofix, recording, etc.) |
@@ -450,7 +450,7 @@ See `packages/backend/.env.example` for all variables. Key ones:
 - `MANIFEST_TELEMETRY_DISABLED` — Set `1` to opt out of anonymous telemetry (self-hosted only).
 - `MANIFEST_UPDATE_CHECK_DISABLED` — Set `1` to stop the self-hosted dashboard's daily "new version available" check against GitHub Releases (`GET /api/v1/version`, `version/` module). Separate from the telemetry opt-out: air-gapped installs want no outbound calls at all. Never runs in cloud mode.
 - `MANIFEST_PUBLIC_STATS` — Set `true` to expose `/api/v1/public/*` aggregate stats without auth (cloud-only marketing use).
-- `CRM_METRICS_SECRET` — Shared secret for `GET /api/v1/internal/crm-metrics*`, sent in the `x-internal-secret` header. Empty by default and anything under 32 chars counts as unset, because this is the only route that exports user email addresses across tenants. Separate from `ERROR_PAGE_PUSH_SECRET` on purpose: different consumer, different credential.
+- `CRM_METRICS_SECRET` — Cloud only. Shared secret for `GET /api/v1/internal/crm-metrics*`, sent in the `x-internal-secret` header. Empty by default and anything under 32 chars counts as unset, because this is the only route that exports user email addresses across tenants. Separate from `ERROR_PAGE_PUSH_SECRET` on purpose: different consumer, different credential. Self-hosted installs never register the module and migration `1802200000000` skips its index there, so the feature leaves no trace on their schema or routes.
 - `TELEMETRY_ENDPOINT` — Where self-hosted installs POST the anonymous usage report. Default: `https://telemetry.manifest.build/v1/report`. See [Telemetry](#anonymous-usage-telemetry-self-hosted).
 - `DISCOVERY_ENDPOINT` — Optional override for the discovery submission endpoint. Default: `https://blue.manifest.build/v1/self-hosted/discovery`.
 - `SENTRY_DSN` / `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` — Opt-in Sentry error monitoring. Unset `SENTRY_DSN` disables Sentry entirely; `SENTRY_ENVIRONMENT` defaults to `NODE_ENV`. See [Error Monitoring](#error-monitoring-sentry-opt-in).

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -134,7 +134,7 @@ BETTER_AUTH_URL=http://localhost:3001
 # MANIFEST_FRONTEND_DIR=      # Custom path to frontend dist directory
 # MANIFEST_EMBEDDED=          # Set to skip auto-start (used by embedded server)
 # ERROR_PAGE_PUSH_SECRET=     # Shared secret for /api/v1/internal/error-pages (CMS push API)
-# CRM_METRICS_SECRET=         # Shared secret for /api/v1/internal/crm-metrics; min 32 chars, exports user emails
+# CRM_METRICS_SECRET=         # Cloud only. Secret for /api/v1/internal/crm-metrics; min 32 chars, exports user emails
 
 # ── Stripe Billing (cloud only) ─────────────────────
 # Enables the Free/Pro plan paywall. Cloud-only: billing no-ops when these are

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -133,6 +133,8 @@ BETTER_AUTH_URL=http://localhost:3001
 # ── Internal ────────────────────────────────────────
 # MANIFEST_FRONTEND_DIR=      # Custom path to frontend dist directory
 # MANIFEST_EMBEDDED=          # Set to skip auto-start (used by embedded server)
+# ERROR_PAGE_PUSH_SECRET=     # Shared secret for /api/v1/internal/error-pages (CMS push API)
+# CRM_METRICS_SECRET=         # Shared secret for /api/v1/internal/crm-metrics; min 32 chars, exports user emails
 
 # ── Stripe Billing (cloud only) ─────────────────────
 # Enables the Free/Pro plan paywall. Cloud-only: billing no-ops when these are

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -35,6 +35,7 @@ import { TelemetryModule } from './telemetry/telemetry.module';
 import { WaitlistModule } from './waitlist/waitlist.module';
 import { BillingModule } from './billing/billing.module';
 import { DiscoveryModule } from './discovery/discovery.module';
+import { CrmMetricsModule } from './crm-metrics/crm-metrics.module';
 import { DebugSentryController } from './sentry/debug-sentry.controller';
 
 const frontendPath = resolveFrontendDir();
@@ -106,6 +107,7 @@ const sentryDebugControllers =
     WaitlistModule,
     BillingModule,
     DiscoveryModule,
+    CrmMetricsModule,
   ],
   providers: [
     ...sentryProviders,

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -36,6 +36,7 @@ import { WaitlistModule } from './waitlist/waitlist.module';
 import { BillingModule } from './billing/billing.module';
 import { DiscoveryModule } from './discovery/discovery.module';
 import { CrmMetricsModule } from './crm-metrics/crm-metrics.module';
+import { isSelfHosted } from './common/utils/detect-self-hosted';
 import { DebugSentryController } from './sentry/debug-sentry.controller';
 
 const frontendPath = resolveFrontendDir();
@@ -67,6 +68,12 @@ const sentryProviders = sentryEnabled
   : [];
 const sentryDebugControllers =
   sentryEnabled && process.env['NODE_ENV'] !== 'production' ? [DebugSentryController] : [];
+
+// The CRM metrics feed drives Cloud outreach. Leaving it unregistered on
+// self-hosted means the routes do not exist there at all, rather than existing
+// and answering 401 forever, and pairs with migration 1802200000000 skipping
+// its index so a self-hosted install sees no trace of this feature.
+const crmMetricsImports = isSelfHosted() ? [] : [CrmMetricsModule];
 
 @Module({
   imports: [
@@ -107,7 +114,7 @@ const sentryDebugControllers =
     WaitlistModule,
     BillingModule,
     DiscoveryModule,
-    CrmMetricsModule,
+    ...crmMetricsImports,
   ],
   providers: [
     ...sentryProviders,

--- a/packages/backend/src/common/utils/crypto.util.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.spec.ts
@@ -8,6 +8,7 @@ import {
   isEncrypted,
   getDecryptionSecrets,
   decryptWithAny,
+  timingSafeCompare,
 } from './crypto.util';
 
 describe('getEncryptionSecret', () => {
@@ -281,5 +282,36 @@ describe('encryptBuffer / decryptBuffer', () => {
     expect(() => decryptBuffer(Buffer.from('MRE1short', 'ascii'), secret)).toThrow(
       'Invalid encrypted blob format',
     );
+  });
+});
+
+describe('timingSafeCompare', () => {
+  it('accepts identical strings', () => {
+    expect(timingSafeCompare('shared-secret', 'shared-secret')).toBe(true);
+  });
+
+  it('rejects a different string of the same length', () => {
+    expect(timingSafeCompare('aaaaaaaa', 'bbbbbbbb')).toBe(false);
+  });
+
+  it('rejects a length mismatch without throwing', () => {
+    expect(timingSafeCompare('short', 'much-longer-secret')).toBe(false);
+    expect(timingSafeCompare('much-longer-secret', 'short')).toBe(false);
+  });
+
+  it('treats two empty strings as equal', () => {
+    expect(timingSafeCompare('', '')).toBe(true);
+  });
+
+  it('compares by bytes, so multi-byte characters are handled', () => {
+    expect(timingSafeCompare('sécret', 'sécret')).toBe(true);
+    // Byte-length equal but different: the comparison itself has to reject
+    // these, not the length shortcut that catches 'sécret' vs 'secret'.
+    expect(Buffer.byteLength('é')).toBe(Buffer.byteLength('ab'));
+    expect(timingSafeCompare('é', 'ab')).toBe(false);
+    // Equal in characters, unequal in bytes: guarding on `String.length`
+    // instead would reach timingSafeEqual and make it throw.
+    expect(timingSafeCompare('é', 'a')).toBe(false);
+    expect(timingSafeCompare('sécret', 'secret')).toBe(false);
   });
 });

--- a/packages/backend/src/common/utils/crypto.util.ts
+++ b/packages/backend/src/common/utils/crypto.util.ts
@@ -1,5 +1,19 @@
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync, timingSafeEqual } from 'crypto';
 import { Logger as NestLogger } from '@nestjs/common';
+
+/**
+ * Constant-time string comparison for shared secrets sent in headers.
+ *
+ * `timingSafeEqual` requires equal-length inputs, and a length mismatch is a
+ * definite mismatch — the length of a configured secret is not itself worth
+ * hiding. Mirrors the logic in `ApiKeyGuard.safeCompare`.
+ */
+export function timingSafeCompare(actual: string, expected: string): boolean {
+  const actualBuf = Buffer.from(actual, 'utf8');
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  if (actualBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(actualBuf, expectedBuf);
+}
 
 const ALGORITHM = 'aes-256-gcm';
 // AES-GCM standard nonce length per NIST SP 800-38D §5.2.1.1. New ciphertexts

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -77,4 +77,11 @@ export const appConfig = registerAs('app', () => ({
   // `x-internal-secret` header to publish/unpublish curated error pages.
   // Empty by default — the endpoint rejects all writes until it is set.
   errorPagePushSecret: process.env['ERROR_PAGE_PUSH_SECRET'] ?? '',
+  // Shared secret guarding the internal CRM metrics feed
+  // (/api/v1/internal/crm-metrics), which the outreach CRM polls daily. Sent in
+  // the `x-internal-secret` header. Deliberately separate from
+  // errorPagePushSecret: different consumer, different credential. Empty by
+  // default, and anything shorter than 32 chars counts as unset — this route
+  // exports user email addresses across tenants.
+  crmMetricsSecret: process.env['CRM_METRICS_SECRET'] ?? '',
 }));

--- a/packages/backend/src/crm-metrics/crm-metrics.filters.spec.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.filters.spec.ts
@@ -1,0 +1,61 @@
+import { isExcludedEmail } from './crm-metrics.filters';
+
+describe('isExcludedEmail', () => {
+  it('keeps an ordinary user address', () => {
+    expect(isExcludedEmail('matheus@example.com')).toBe(false);
+    expect(isExcludedEmail('someone@gmail.com')).toBe(false);
+  });
+
+  it('excludes our own domains', () => {
+    expect(isExcludedEmail('bruno@buddyweb.fr')).toBe(true);
+    expect(isExcludedEmail('hello@manifest.build')).toBe(true);
+    expect(isExcludedEmail('x@mnfstinc.com')).toBe(true);
+  });
+
+  it('excludes team members signed up on a personal address', () => {
+    expect(isExcludedEmail('sebastien.conejo@gmail.com')).toBe(true);
+  });
+
+  it('excludes disposable and alias providers', () => {
+    expect(isExcludedEmail('improving_poison241@dralias.com')).toBe(true);
+    expect(isExcludedEmail('app.manifest.build@cryptidcloud.org')).toBe(true);
+    expect(isExcludedEmail('a@slmail.me')).toBe(true);
+  });
+
+  it('excludes shared role inboxes', () => {
+    expect(isExcludedEmail('info@realcompany.com')).toBe(true);
+    expect(isExcludedEmail('no-reply@realcompany.com')).toBe(true);
+    expect(isExcludedEmail('test@realcompany.com')).toBe(true);
+  });
+
+  it('matches a role inbox on the whole local part, not as a prefix', () => {
+    expect(isExcludedEmail('information@realcompany.com')).toBe(false);
+    expect(isExcludedEmail('admin.jones@realcompany.com')).toBe(false);
+    expect(isExcludedEmail('contact-us@realcompany.com')).toBe(false);
+  });
+
+  it('treats subdomains of a junk domain as junk', () => {
+    expect(isExcludedEmail('a@mail.dralias.com')).toBe(true);
+  });
+
+  it('does not match a domain that merely ends with the same letters', () => {
+    expect(isExcludedEmail('a@notdralias.com')).toBe(false);
+    expect(isExcludedEmail('a@notmanifest.build')).toBe(false);
+  });
+
+  it('normalises case and surrounding whitespace before matching', () => {
+    expect(isExcludedEmail('  Bruno@BuddyWeb.FR  ')).toBe(true);
+    expect(isExcludedEmail('INFO@Example.com')).toBe(true);
+  });
+
+  it('excludes anything that is not a routable address', () => {
+    expect(isExcludedEmail('no-at-sign')).toBe(true);
+    expect(isExcludedEmail('@nolocalpart.com')).toBe(true);
+    expect(isExcludedEmail('nodomain@')).toBe(true);
+    expect(isExcludedEmail('')).toBe(true);
+  });
+
+  it('uses the last @ so a quoted local part cannot smuggle a domain in', () => {
+    expect(isExcludedEmail('user@notjunk@dralias.com')).toBe(true);
+  });
+});

--- a/packages/backend/src/crm-metrics/crm-metrics.filters.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.filters.ts
@@ -1,0 +1,72 @@
+/**
+ * Deliverability filtering for the CRM feed.
+ *
+ * These run here rather than in the CRM so every consumer inherits them: an
+ * address excluded once is excluded everywhere, and the rules stay under test.
+ *
+ * The known bot-signup cluster (gibberish names on scraped corporate domains)
+ * deliberately has no rule. It never produced a successful heal, so the cohort
+ * predicate already excludes it — a domain list would be dead code that rots.
+ */
+
+/** Our own addresses. Emailing ourselves about our own launch is noise. */
+const INTERNAL_DOMAINS = ['manifest.build', 'buddyweb.fr', 'mnfstinc.com'];
+
+/** Team members signed up on a personal address, so the domain rule misses them. */
+const INTERNAL_EMAILS = ['sebastien.conejo@gmail.com'];
+
+/**
+ * Disposable/alias providers. Mirrors the list the CRM outreach function
+ * already carries, so both sides agree on what counts as junk.
+ */
+const JUNK_DOMAINS = [
+  'slmail.me',
+  'atomicmail.io',
+  'paytrust.cc',
+  'rapplo.com',
+  'joystill.com',
+  'abrdns.com',
+  'cryptidcloud.org',
+  'dralias.com',
+  'mail.cfw.262019.xyz',
+];
+
+/** Shared inboxes: nobody in particular reads these, and they skew reply rates. */
+const ROLE_LOCAL_PARTS = [
+  'info',
+  'admin',
+  'contact',
+  'support',
+  'sales',
+  'marketing',
+  'office',
+  'team',
+  'noreply',
+  'no-reply',
+  'test',
+];
+
+/**
+ * True when we should not email this address.
+ *
+ * Subdomains of a junk domain count as junk (`x.dralias.com`), but a domain
+ * that merely ends with the same letters does not (`notdralias.com`).
+ */
+export function isExcludedEmail(email: string): boolean {
+  const normalized = email.trim().toLowerCase();
+  const at = normalized.lastIndexOf('@');
+  // No '@' at all, or an empty local part / domain: not a routable address.
+  if (at <= 0 || at === normalized.length - 1) return true;
+
+  const local = normalized.slice(0, at);
+  const domain = normalized.slice(at + 1);
+
+  if (INTERNAL_EMAILS.includes(normalized)) return true;
+  if (matchesDomain(domain, INTERNAL_DOMAINS)) return true;
+  if (matchesDomain(domain, JUNK_DOMAINS)) return true;
+  return ROLE_LOCAL_PARTS.includes(local);
+}
+
+function matchesDomain(domain: string, list: string[]): boolean {
+  return list.some((entry) => domain === entry || domain.endsWith(`.${entry}`));
+}

--- a/packages/backend/src/crm-metrics/crm-metrics.module.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CrmMetricsService } from './crm-metrics.service';
+import { InternalCrmMetricsController } from './internal-crm-metrics.controller';
+
+/**
+ * Internal feed the CRM polls to drive Autofix product outreach. Queries run
+ * through the injected DataSource, so no `TypeOrmModule.forFeature` is needed.
+ */
+@Module({
+  controllers: [InternalCrmMetricsController],
+  providers: [CrmMetricsService],
+})
+export class CrmMetricsModule {}

--- a/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
@@ -525,12 +525,27 @@ describe('CrmMetricsService', () => {
 
     it('does not cache a failed scan, so the next call retries the database', async () => {
       setup({ cohort: [cohortRow()] });
-      query.mockRejectedValueOnce(new Error('canceling statement due to statement timeout'));
+      // Target the cohort scan itself, not whichever statement happens to run
+      // first: `mockRejectedValueOnce` would otherwise fail `SET LOCAL
+      // lock_timeout` and never reach the query this test is named after.
+      let failNextScan = true;
+      const scan = query.getMockImplementation()!;
+      query.mockImplementation((sql: string, ...params: unknown[]) => {
+        if (sql.includes('JOIN tenants t') && failNextScan) {
+          failNextScan = false;
+          return Promise.reject(new Error('canceling statement due to statement timeout'));
+        }
+        return scan(sql, ...params);
+      });
 
       await expect(service.getHealedCohort(7, NOW)).rejects.toThrow('statement timeout');
       const users = await service.getHealedCohort(7, NOW);
 
       expect(users.map((u) => u.email)).toEqual(['matheus@example.com']);
+      // Both calls reached the scan: the failure was not memoised.
+      expect(
+        query.mock.calls.filter(([sql]) => String(sql).includes('JOIN tenants t')),
+      ).toHaveLength(2);
     });
 
     it('does not cache a missing index either, so the feed recovers once it is rebuilt', async () => {

--- a/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
@@ -1,0 +1,602 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import type { DataSource } from 'typeorm';
+import { CrmMetricsService } from './crm-metrics.service';
+import { toLocalSqlTimestamp } from '../common/utils/postgres-sql';
+
+const NOW = new Date('2026-09-04T12:00:00.000Z');
+
+interface Scripted {
+  index?: unknown[];
+  cohort?: unknown[];
+  providers?: unknown[];
+  claims?: unknown[];
+}
+
+function cohortRow(over: Record<string, unknown> = {}) {
+  return {
+    email: 'matheus@example.com',
+    user_name: 'Matheus Vitorio',
+    tenant_id: 'tenant-a',
+    healed_recent: '260',
+    healed_all: '1241',
+    first_heal_at: '2026-07-30T15:17:31.000Z',
+    last_heal_at: '2026-09-04T09:47:30.000Z',
+    ...over,
+  };
+}
+
+describe('CrmMetricsService', () => {
+  let query: jest.Mock;
+  let commitTransaction: jest.Mock;
+  let rollbackTransaction: jest.Mock;
+  let release: jest.Mock;
+  let connect: jest.Mock;
+  let startTransaction: jest.Mock;
+  let service: CrmMetricsService;
+  let scripted: Scripted;
+
+  function setup(next: Scripted = {}): void {
+    scripted = { index: [{ '?column?': 1 }], ...next };
+    query = jest.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SET LOCAL')) return Promise.resolve([]);
+      if (sql.includes('pg_index')) return Promise.resolve(scripted.index ?? []);
+      if (sql.includes('JOIN tenants t')) return Promise.resolve(scripted.cohort ?? []);
+      if (sql.includes('JOIN agent_messages am')) return Promise.resolve(scripted.providers ?? []);
+      if (sql.includes('FROM waitlist_claims')) return Promise.resolve(scripted.claims ?? []);
+      throw new Error(`unexpected SQL: ${sql}`);
+    });
+    commitTransaction = jest.fn();
+    rollbackTransaction = jest.fn();
+    release = jest.fn();
+    connect = jest.fn();
+    startTransaction = jest.fn();
+    const runner = {
+      connect,
+      startTransaction,
+      commitTransaction,
+      rollbackTransaction,
+      release,
+      query,
+    };
+    service = new CrmMetricsService({ createQueryRunner: () => runner } as unknown as DataSource);
+  }
+
+  const sqlFor = (needle: string): string =>
+    query.mock.calls.map(([sql]) => String(sql)).find((sql) => sql.includes(needle)) ?? '';
+  const paramsFor = (needle: string): unknown[] =>
+    query.mock.calls.find(([sql]) => String(sql).includes(needle))?.[1] ?? [];
+
+  beforeEach(() => setup());
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('transaction handling', () => {
+    it('bounds the work with transaction-scoped timeouts', async () => {
+      await service.getHealedCohort(7, NOW);
+
+      expect(sqlFor('lock_timeout')).toBe(`SET LOCAL lock_timeout = '5000ms'`);
+      expect(sqlFor('statement_timeout')).toBe(`SET LOCAL statement_timeout = '1500ms'`);
+      expect(commitTransaction).toHaveBeenCalled();
+    });
+
+    it('rolls back and releases the runner when a query fails', async () => {
+      setup();
+      query.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(service.getHealedCohort(7, NOW)).rejects.toThrow('boom');
+      expect(rollbackTransaction).toHaveBeenCalled();
+      expect(commitTransaction).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalled();
+    });
+
+    it('releases the runner on the happy path too', async () => {
+      await service.getHealedCohort(7, NOW);
+
+      expect(release).toHaveBeenCalled();
+    });
+
+    it('opens the transaction before setting the timeouts, and commits after the work', async () => {
+      setup({ cohort: [cohortRow()] });
+
+      await service.getHealedCohort(7, NOW);
+
+      // `SET LOCAL` outside a transaction is silently a no-op, so hoisting
+      // these above startTransaction would disable both bounds without
+      // changing a single line of SQL text.
+      expect(connect.mock.invocationCallOrder[0]).toBeLessThan(
+        startTransaction.mock.invocationCallOrder[0],
+      );
+      expect(startTransaction.mock.invocationCallOrder[0]).toBeLessThan(
+        query.mock.invocationCallOrder[0],
+      );
+      expect(query.mock.calls.slice(0, 2).map(([sql]) => String(sql))).toEqual([
+        `SET LOCAL lock_timeout = '5000ms'`,
+        `SET LOCAL statement_timeout = '1500ms'`,
+      ]);
+      expect(commitTransaction.mock.invocationCallOrder[0]).toBeGreaterThan(
+        query.mock.invocationCallOrder[query.mock.invocationCallOrder.length - 1],
+      );
+    });
+  });
+
+  describe('index guard', () => {
+    it('refuses to run an unindexed scan when the index is missing or invalid', async () => {
+      setup({ index: [], cohort: [cohortRow()] });
+
+      const error = await service.getHealedCohort(7, NOW).then(
+        () => null,
+        (thrown: unknown) => thrown,
+      );
+
+      expect(error).toBeInstanceOf(ServiceUnavailableException);
+      expect((error as Error).message).toContain('IDX_requests_autofix_healed');
+      // Cohort rows were scripted, so an empty result here would mean the
+      // guard let the unindexed scan run and merely found nothing.
+      expect(sqlFor('JOIN tenants t')).toBe('');
+      expect(rollbackTransaction).toHaveBeenCalled();
+      expect(release).toHaveBeenCalled();
+    });
+
+    it('reports the outage as a rejection, never as an empty cohort', async () => {
+      setup({ cohort: [] });
+      await expect(service.getHealedCohort(7, NOW)).resolves.toEqual([]);
+
+      setup({ index: [] });
+      const outcome = await service.getHealedCohort(7, NOW).then(
+        (users) => ({ resolved: users }),
+        (error: unknown) => ({ error }),
+      );
+
+      // "Nobody was healed" and "the index is gone" must not look alike to the
+      // CRM: a `catch { return [] }` here would silently empty the feed.
+      expect(outcome).toEqual({ error: expect.any(ServiceUnavailableException) });
+    });
+
+    it('probes for the index by name', async () => {
+      await service.getHealedCohort(7, NOW);
+
+      expect(paramsFor('pg_index')).toEqual(['IDX_requests_autofix_healed']);
+    });
+  });
+
+  describe('cohort window', () => {
+    it('bounds both queries with a local wall-clock cutoff, not UTC', async () => {
+      setup({ cohort: [cohortRow()] });
+
+      await service.getHealedCohort(7, NOW);
+
+      const expected = toLocalSqlTimestamp(new Date(NOW.getTime() - 7 * 86_400_000));
+      expect(paramsFor('JOIN tenants t')).toEqual([expected]);
+      expect(paramsFor('JOIN agent_messages am')).toEqual([expected]);
+    });
+
+    it('defaults to the current time when no clock is injected', async () => {
+      setup({ cohort: [cohortRow()] });
+
+      await expect(service.getHealedCohort(7)).resolves.toHaveLength(1);
+      await expect(service.getConversions(90)).resolves.toEqual([]);
+
+      const cutoff = paramsFor('JOIN tenants t')[0] as string;
+      expect(cutoff).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('applies the canonical healed predicate, not autofix_status alone', async () => {
+      await service.getHealedCohort(7, NOW);
+
+      const sql = sqlFor('JOIN tenants t');
+      expect(sql).toContain(`r.autofix_status = 'retry_succeeded'`);
+      expect(sql).toContain('r.status IS NULL OR r.status IN');
+      expect(sql).toContain('u."emailVerified" = true');
+    });
+
+    it('counts every heal ever, but only surfaces people healed inside the window', async () => {
+      await service.getHealedCohort(7, NOW);
+
+      const sql = sqlFor('JOIN tenants t');
+      expect(sql).toContain('count(*) FILTER (WHERE r.timestamp > $1)');
+      expect(sql).toContain('HAVING count(*) FILTER (WHERE r.timestamp > $1) > 0');
+      // `healed_all` is deliberately unbounded. Narrowing the WHERE by the
+      // cutoff would collapse it onto `healed_recent` and quietly turn the
+      // "heals since Autofix shipped" number into a duplicate of the window.
+      expect(sql).not.toContain('AND r.timestamp >');
+    });
+
+    it('breaks providers down over patched attempts only, inside the window', async () => {
+      setup({ cohort: [cohortRow()] });
+
+      await service.getHealedCohort(7, NOW);
+
+      const sql = sqlFor('JOIN agent_messages am');
+      expect(sql).toContain('am.autofix_applied = true');
+      expect(sql).toContain('AND r.timestamp > $1');
+      // The status disjunction has to stay parenthesised: bare
+      // `A AND B OR C AND D` binds OR last and would let failed requests into
+      // the breakdown.
+      expect(sql).toContain(`(r.status IS NULL OR r.status IN ('ok', 'success'))`);
+    });
+  });
+
+  describe('cohort shaping', () => {
+    it('maps a single person with their provider breakdown', async () => {
+      setup({
+        cohort: [cohortRow()],
+        providers: [
+          { tenant_id: 'tenant-a', provider: 'openrouter', n: '200' },
+          { tenant_id: 'tenant-a', provider: 'anthropic', n: '60' },
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user).toEqual({
+        email: 'matheus@example.com',
+        name: 'Matheus Vitorio',
+        healed_recent: 260,
+        healed_all: 1241,
+        first_heal_at: '2026-07-30T15:17:31.000Z',
+        last_heal_at: '2026-09-04T09:47:30.000Z',
+        providers: ['openrouter', 'anthropic'],
+        top_provider: 'openrouter',
+      });
+    });
+
+    it('sums a person who owns more than one tenant', async () => {
+      setup({
+        cohort: [
+          cohortRow({ tenant_id: 'tenant-a', healed_recent: '10', healed_all: '20' }),
+          cohortRow({
+            tenant_id: 'tenant-b',
+            user_name: null,
+            healed_recent: '5',
+            healed_all: '7',
+            first_heal_at: '2026-07-01T00:00:00.000Z',
+            last_heal_at: '2026-09-05T00:00:00.000Z',
+          }),
+        ],
+        providers: [
+          { tenant_id: 'tenant-a', provider: 'openai', n: '4' },
+          { tenant_id: 'tenant-b', provider: 'openai', n: '6' },
+          { tenant_id: 'tenant-b', provider: 'gemini', n: '9' },
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user.healed_recent).toBe(15);
+      expect(user.healed_all).toBe(27);
+      expect(user.first_heal_at).toBe('2026-07-01T00:00:00.000Z');
+      expect(user.last_heal_at).toBe('2026-09-05T00:00:00.000Z');
+      // openai totals 10 across both tenants, so it outranks gemini's 9.
+      expect(user.providers).toEqual(['openai', 'gemini']);
+      expect(user.name).toBe('Matheus Vitorio');
+    });
+
+    it('keeps the first name seen when a later tenant carries a different one', async () => {
+      setup({
+        cohort: [
+          cohortRow({ tenant_id: 'tenant-a', user_name: 'First Name' }),
+          cohortRow({ tenant_id: 'tenant-b', user_name: 'Stale Name' }),
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      // First non-null wins; flipping the coalesce to `row.user_name ?? existing`
+      // would make the last tenant's copy of the name win instead.
+      expect(user.name).toBe('First Name');
+    });
+
+    it('leaves the name null when no row for the person ever carried one', async () => {
+      setup({
+        cohort: [
+          cohortRow({ tenant_id: 'tenant-a', user_name: null }),
+          cohortRow({ tenant_id: 'tenant-b', user_name: null }),
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user.name).toBeNull();
+      expect(user.email).toBe('matheus@example.com');
+    });
+
+    it('keeps a later name when the first row for a person had none', async () => {
+      setup({
+        cohort: [
+          cohortRow({ tenant_id: 'tenant-a', user_name: null }),
+          cohortRow({ tenant_id: 'tenant-b', user_name: 'Late Name' }),
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user.name).toBe('Late Name');
+    });
+
+    it('drops excluded addresses before they reach the payload', async () => {
+      setup({
+        cohort: [
+          cohortRow({ email: 'bruno@buddyweb.fr' }),
+          cohortRow({ email: 'improving_poison241@dralias.com' }),
+          cohortRow({ email: 'real@example.com' }),
+        ],
+      });
+
+      const users = await service.getHealedCohort(7, NOW);
+
+      expect(users.map((u) => u.email)).toEqual(['real@example.com']);
+    });
+
+    it('normalises case and whitespace on the grouping key', async () => {
+      setup({
+        cohort: [
+          cohortRow({ email: '  Matheus@Example.com ', tenant_id: 'tenant-a', healed_recent: '3' }),
+          cohortRow({ email: 'matheus@example.com', tenant_id: 'tenant-b', healed_recent: '4' }),
+        ],
+      });
+
+      const users = await service.getHealedCohort(7, NOW);
+
+      expect(users).toHaveLength(1);
+      expect(users[0].healed_recent).toBe(7);
+    });
+
+    it('orders people by heals in the window, most first', async () => {
+      setup({
+        cohort: [
+          cohortRow({ email: 'quiet@example.com', tenant_id: 't1', healed_recent: '2' }),
+          cohortRow({ email: 'loud@example.com', tenant_id: 't2', healed_recent: '99' }),
+        ],
+      });
+
+      const users = await service.getHealedCohort(7, NOW);
+
+      expect(users.map((u) => u.email)).toEqual(['loud@example.com', 'quiet@example.com']);
+    });
+
+    it('skips the provider query entirely when nobody qualifies', async () => {
+      setup({ cohort: [cohortRow({ email: 'bruno@buddyweb.fr' })] });
+
+      await expect(service.getHealedCohort(7, NOW)).resolves.toEqual([]);
+      expect(sqlFor('JOIN agent_messages am')).toBe('');
+    });
+
+    it('ranks providers by their numeric attempt count, not by concatenated strings', async () => {
+      setup({
+        cohort: [cohortRow({ tenant_id: 'tenant-a' }), cohortRow({ tenant_id: 'tenant-b' })],
+        providers: [
+          { tenant_id: 'tenant-a', provider: 'anthropic', n: '1' },
+          { tenant_id: 'tenant-b', provider: 'anthropic', n: '2' },
+          { tenant_id: 'tenant-a', provider: 'openai', n: '5' },
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      // pg returns bigint counts as strings: anthropic is 1 + 2 = 3 and loses
+      // to openai's 5. Dropping the Number() would make it '012' and win.
+      expect(user.providers).toEqual(['openai', 'anthropic']);
+      expect(user.top_provider).toBe('openai');
+    });
+
+    it('keeps both sides of a tie, in the order the database returned them', async () => {
+      setup({
+        cohort: [cohortRow()],
+        providers: [
+          { tenant_id: 'tenant-a', provider: 'openai', n: '5' },
+          { tenant_id: 'tenant-a', provider: 'anthropic', n: '5' },
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user.providers).toEqual(['openai', 'anthropic']);
+      expect(user.top_provider).toBe(user.providers[0]);
+    });
+
+    it('ignores provider rows belonging to a tenant this person does not own', async () => {
+      setup({
+        cohort: [cohortRow({ tenant_id: 'tenant-a' })],
+        providers: [
+          { tenant_id: 'tenant-a', provider: 'openai', n: '3' },
+          { tenant_id: 'someone-elses-tenant', provider: 'gemini', n: '900' },
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user.providers).toEqual(['openai']);
+      expect(user.top_provider).toBe('openai');
+    });
+
+    it('drops attempts with no provider instead of letting them top the ranking', async () => {
+      setup({
+        cohort: [cohortRow()],
+        providers: [
+          { tenant_id: 'tenant-a', provider: null, n: '99' },
+          { tenant_id: 'tenant-a', provider: 'openai', n: '3' },
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user.providers).toEqual(['openai']);
+      expect(user.top_provider).toBe('openai');
+    });
+
+    it('reports no providers when the attempts carry none', async () => {
+      setup({
+        cohort: [cohortRow()],
+        providers: [
+          { tenant_id: 'tenant-a', provider: null, n: '5' },
+          { tenant_id: 'other-tenant', provider: 'openai', n: '5' },
+        ],
+      });
+
+      const [user] = await service.getHealedCohort(7, NOW);
+
+      expect(user.providers).toEqual([]);
+      expect(user.top_provider).toBeNull();
+    });
+  });
+
+  describe('conversions', () => {
+    it('normalises claims and bounds the window in UTC', async () => {
+      setup({
+        claims: [
+          { email: 'Someone@Example.com', source: 'cloud', claimed_at: '2026-09-01T08:00:00.000Z' },
+        ],
+      });
+
+      const claims = await service.getConversions(90, NOW);
+
+      expect(claims).toEqual([
+        { email: 'someone@example.com', source: 'cloud', claimed_at: '2026-09-01T08:00:00.000Z' },
+      ]);
+      // claimed_at is `timestamp WITH time zone`, unlike requests.timestamp.
+      expect(paramsFor('FROM waitlist_claims')).toEqual([
+        new Date(NOW.getTime() - 90 * 86_400_000).toISOString(),
+      ]);
+    });
+
+    it('runs the claims query alone: no index probe, no cross-tenant scan', async () => {
+      setup({ claims: [] });
+
+      await service.getConversions(90, NOW);
+
+      expect(query.mock.calls.map(([sql]) => String(sql).trim().split('\n')[0])).toEqual([
+        `SET LOCAL lock_timeout = '5000ms'`,
+        `SET LOCAL statement_timeout = '1500ms'`,
+        'SELECT email, source, claimed_at',
+      ]);
+      expect(commitTransaction).toHaveBeenCalled();
+    });
+
+    it('reports every claim, including addresses the cohort filters out', async () => {
+      setup({
+        claims: [
+          {
+            email: 'bruno@buddyweb.fr',
+            source: 'self-hosted',
+            claimed_at: '2026-09-02T00:00:00.000Z',
+          },
+          {
+            email: 'info@realcompany.com',
+            source: 'cloud',
+            claimed_at: '2026-09-01T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const claims = await service.getConversions(90, NOW);
+
+      // Deliverability filtering is about who we may email; a conversion count
+      // that quietly drops our own signups would understate the campaign.
+      expect(claims.map((claim) => claim.email)).toEqual([
+        'bruno@buddyweb.fr',
+        'info@realcompany.com',
+      ]);
+    });
+  });
+
+  describe('caching', () => {
+    it('serves a repeated cohort request without touching the database', async () => {
+      setup({ cohort: [cohortRow()] });
+
+      const first = await service.getHealedCohort(7, NOW);
+      const callsAfterFirst = query.mock.calls.length;
+      const second = await service.getHealedCohort(7, NOW);
+
+      expect(second).toBe(first);
+      expect(query.mock.calls).toHaveLength(callsAfterFirst);
+    });
+
+    it('caches per window, so a different day count recomputes', async () => {
+      setup({ cohort: [cohortRow()] });
+
+      await service.getHealedCohort(7, NOW);
+      const callsAfterFirst = query.mock.calls.length;
+      await service.getHealedCohort(30, NOW);
+
+      expect(query.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+
+    it('does not cache a failed scan, so the next call retries the database', async () => {
+      setup({ cohort: [cohortRow()] });
+      query.mockRejectedValueOnce(new Error('canceling statement due to statement timeout'));
+
+      await expect(service.getHealedCohort(7, NOW)).rejects.toThrow('statement timeout');
+      const users = await service.getHealedCohort(7, NOW);
+
+      expect(users.map((u) => u.email)).toEqual(['matheus@example.com']);
+    });
+
+    it('does not cache a missing index either, so the feed recovers once it is rebuilt', async () => {
+      setup({ index: [], cohort: [cohortRow()] });
+
+      await expect(service.getHealedCohort(7, NOW)).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+      scripted.index = [{ '?column?': 1 }];
+
+      await expect(service.getHealedCohort(7, NOW)).resolves.toHaveLength(1);
+    });
+
+    it('caches an empty window too, so an idle feed stops re-scanning', async () => {
+      setup({ cohort: [] });
+
+      await expect(service.getHealedCohort(7, NOW)).resolves.toEqual([]);
+      const callsAfterFirst = query.mock.calls.length;
+      await service.getHealedCohort(7, NOW);
+
+      expect(query.mock.calls).toHaveLength(callsAfterFirst);
+    });
+
+    it('keeps the cohort and the conversion caches apart at the same window', async () => {
+      setup({
+        cohort: [cohortRow()],
+        claims: [
+          { email: 'someone@example.com', source: 'cloud', claimed_at: '2026-09-01T08:00:00.000Z' },
+        ],
+      });
+
+      const users = await service.getHealedCohort(7, NOW);
+      const claims = await service.getConversions(7, NOW);
+
+      // One cache keyed on `days` alone would hand the cohort array back here.
+      expect(users.map((u) => u.email)).toEqual(['matheus@example.com']);
+      expect(claims).toEqual([
+        { email: 'someone@example.com', source: 'cloud', claimed_at: '2026-09-01T08:00:00.000Z' },
+      ]);
+    });
+
+    it('recomputes once the 60s ttl lapses', async () => {
+      jest.useFakeTimers();
+      setup({ cohort: [cohortRow()] });
+
+      await service.getHealedCohort(7, NOW);
+      const callsAfterFirst = query.mock.calls.length;
+
+      jest.advanceTimersByTime(59_000);
+      await service.getHealedCohort(7, NOW);
+      expect(query.mock.calls).toHaveLength(callsAfterFirst);
+
+      jest.advanceTimersByTime(2_000);
+      await service.getHealedCohort(7, NOW);
+      expect(query.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+
+    it('caches conversions too', async () => {
+      setup({ claims: [] });
+
+      const first = await service.getConversions(90, NOW);
+      const callsAfterFirst = query.mock.calls.length;
+      const second = await service.getConversions(90, NOW);
+
+      expect(second).toBe(first);
+      expect(query.mock.calls).toHaveLength(callsAfterFirst);
+    });
+  });
+});

--- a/packages/backend/src/crm-metrics/crm-metrics.service.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.service.ts
@@ -1,0 +1,277 @@
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { DataSource, QueryRunner } from 'typeorm';
+import { TtlCache } from '../common/utils/ttl-cache';
+import { toLocalSqlTimestamp } from '../common/utils/postgres-sql';
+import { sqlIsSuccessStatus } from '../analytics/services/query-helpers';
+import { isExcludedEmail } from './crm-metrics.filters';
+import type { CohortRow, CrmHealedUser, CrmWaitlistClaim, ProviderRow } from './crm-metrics.types';
+
+/**
+ * Answers on the cheap: the requests Autofix repaired lately, grouped by the
+ * person who owns them, plus the waiting-list claims that measure whether the
+ * campaign worked.
+ *
+ * Read once a day by the CRM, so there is no snapshot table and no cron. A
+ * snapshot would need a cron running exactly the cross-tenant scan this is
+ * trying to avoid, plus leader election; once indexed, the live query is
+ * cheaper than that cron would be. Results sit behind a TTL cache.
+ */
+
+const HEALED_INDEX = 'IDX_requests_autofix_healed';
+
+/**
+ * Short on purpose. The cache exists to stop a retrying client from replaying
+ * the provider join (~80 MB of buffer reads) up to the throttler's 100/min, not
+ * to serve the expected traffic — a once-a-day poll misses either way. A long
+ * TTL would buy nothing and make the feed surprisingly stale after an operator
+ * fixes something and re-runs.
+ */
+const CACHE_TTL_MS = 60_000;
+
+/**
+ * Deliberately *below* the 2.4s the unindexed cohort scan takes. If the
+ * partial index is missing the query aborts instead of completing, because the
+ * damage from that plan is not latency but reading 6.6 GB through a ~128 MB
+ * shared_buffers and evicting everyone else's working set.
+ */
+const STATEMENT_TIMEOUT_MS = 1_500;
+const LOCK_TIMEOUT_MS = 5_000;
+
+/** The index is the entire point; without it, refuse rather than thrash prod. */
+const INDEX_READY_SQL = `
+  SELECT 1 FROM pg_index i
+  JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE c.relname = $1 AND i.indisvalid
+`;
+
+/**
+ * The canonical "healed" predicate, matching request-volume.service.ts. The
+ * status check is not redundant: a retry can return 2xx while the request still
+ * concludes failed, and quoting a repair count the dashboard disagrees with is
+ * worse than quoting none.
+ *
+ * No playground exclusion is needed here (every other cross-tenant aggregate
+ * carries one): playground.service.ts writes `autofix_status: null` on all of
+ * its request paths, so a playground row can never match this predicate.
+ */
+const IS_HEALED = `r.autofix_status = 'retry_succeeded' AND ${sqlIsSuccessStatus('r.status')}`;
+
+const COHORT_SQL = `
+  SELECT lower(u.email)                             AS email,
+         u.name                                     AS user_name,
+         r.tenant_id                                AS tenant_id,
+         count(*) FILTER (WHERE r.timestamp > $1)   AS healed_recent,
+         count(*)                                   AS healed_all,
+         min(r.timestamp)                           AS first_heal_at,
+         max(r.timestamp)                           AS last_heal_at
+  FROM requests r
+  JOIN tenants t ON t.id = r.tenant_id
+  JOIN "user" u ON u.id = t.owner_user_id
+  WHERE ${IS_HEALED}
+    AND u."emailVerified" = true
+  GROUP BY lower(u.email), u.name, r.tenant_id
+  HAVING count(*) FILTER (WHERE r.timestamp > $1) > 0
+`;
+
+/**
+ * Driven off the healed requests, not off "any autofix-touched attempt in the
+ * window". That is both cheaper (it rides the partial index, then ~1.6k
+ * request_id lookups, instead of scanning every tenant's whole window) and the
+ * question we actually mean: which providers were failing on the requests
+ * Autofix went on to repair.
+ */
+const PROVIDERS_SQL = `
+  SELECT r.tenant_id AS tenant_id, am.provider AS provider, count(*) AS n
+  FROM requests r
+  JOIN agent_messages am ON am.request_id = r.id
+  WHERE ${IS_HEALED}
+    AND r.timestamp > $1
+    AND am.autofix_applied = true
+  GROUP BY r.tenant_id, am.provider
+`;
+
+const CLAIMS_SQL = `
+  SELECT email, source, claimed_at
+  FROM waitlist_claims
+  WHERE claimed_at > $1
+  ORDER BY claimed_at DESC
+`;
+
+@Injectable()
+export class CrmMetricsService {
+  private readonly cohortCache = new TtlCache<number, CrmHealedUser[]>({
+    maxSize: 8,
+    ttlMs: CACHE_TTL_MS,
+  });
+  private readonly claimsCache = new TtlCache<number, CrmWaitlistClaim[]>({
+    maxSize: 8,
+    ttlMs: CACHE_TTL_MS,
+  });
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  /** Users whose requests Autofix repaired within `days`, one row per person. */
+  async getHealedCohort(days: number, now: Date = new Date()): Promise<CrmHealedUser[]> {
+    const cached = this.cohortCache.get(days);
+    if (cached) return cached;
+
+    const cutoff = cutoffFor(days, now);
+    const users = await this.withRunner(async (runner) => {
+      const ready = (await runner.query(INDEX_READY_SQL, [HEALED_INDEX])) as unknown[];
+      if (ready.length === 0) {
+        throw new ServiceUnavailableException(
+          `${HEALED_INDEX} is missing or invalid; refusing to run an unindexed scan`,
+        );
+      }
+      const merged = mergeByEmail((await runner.query(COHORT_SQL, [cutoff])) as CohortRow[]);
+      if (merged.size === 0) return [];
+      const providers = (await runner.query(PROVIDERS_SQL, [cutoff])) as ProviderRow[];
+      return buildUsers(merged, providers);
+    });
+
+    this.cohortCache.set(days, users);
+    return users;
+  }
+
+  /** Pivot waiting-list claims in the window: who converted, and from where. */
+  async getConversions(days: number, now: Date = new Date()): Promise<CrmWaitlistClaim[]> {
+    const cached = this.claimsCache.get(days);
+    if (cached) return cached;
+
+    // `waitlist_claims.claimed_at` is `timestamp WITH time zone`, unlike the
+    // naive `requests.timestamp` below — hence the UTC boundary here.
+    const cutoff = new Date(now.getTime() - days * 86_400_000).toISOString();
+    const claims = await this.withRunner(async (runner) => {
+      const rows = (await runner.query(CLAIMS_SQL, [cutoff])) as CrmWaitlistClaim[];
+      return rows.map((row) => ({
+        email: row.email.toLowerCase(),
+        source: row.source,
+        claimed_at: new Date(row.claimed_at).toISOString(),
+      }));
+    });
+
+    this.claimsCache.set(days, claims);
+    return claims;
+  }
+
+  /**
+   * `SET LOCAL` is transaction-scoped, which is the only form Railway's
+   * PgBouncer accepts (see the note in database.module.ts).
+   */
+  private async withRunner<T>(fn: (runner: QueryRunner) => Promise<T>): Promise<T> {
+    const runner = this.dataSource.createQueryRunner();
+    try {
+      await runner.connect();
+      await runner.startTransaction();
+      try {
+        await runner.query(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT_MS}ms'`);
+        await runner.query(`SET LOCAL statement_timeout = '${STATEMENT_TIMEOUT_MS}ms'`);
+        const result = await fn(runner);
+        await runner.commitTransaction();
+        return result;
+      } catch (error) {
+        await runner.rollbackTransaction();
+        throw error;
+      }
+    } finally {
+      await runner.release();
+    }
+  }
+}
+
+/** Accumulator for the rows belonging to one person. */
+interface Merged {
+  email: string;
+  name: string | null;
+  healed_recent: number;
+  healed_all: number;
+  first_heal_at: number;
+  last_heal_at: number;
+  tenantIds: string[];
+}
+
+/**
+ * Local wall clock, not UTC: `requests.timestamp` is `timestamp without time
+ * zone` and the pg driver writes JS Dates in the process timezone, so a UTC
+ * boundary would be offset by that amount and silently drop rows.
+ */
+function cutoffFor(days: number, now: Date): string {
+  return toLocalSqlTimestamp(new Date(now.getTime() - days * 86_400_000));
+}
+
+/**
+ * The SQL groups by (email, tenant) and the totals are summed here. Today a
+ * user owns at most one tenant (`uq_tenants_owner_user` is unique), so this is
+ * a no-op — but `owner_user_id` is nullable by design for future team
+ * workspaces, so the 1:1 is a current fact rather than an invariant.
+ *
+ * Excluded addresses are dropped before their tenants reach the payload.
+ */
+function mergeByEmail(rows: CohortRow[]): Map<string, Merged> {
+  const merged = new Map<string, Merged>();
+  for (const row of rows) {
+    const email = row.email.trim().toLowerCase();
+    if (isExcludedEmail(email)) continue;
+
+    const first = new Date(row.first_heal_at).getTime();
+    const last = new Date(row.last_heal_at).getTime();
+    const existing = merged.get(email);
+    if (!existing) {
+      merged.set(email, {
+        email,
+        name: row.user_name,
+        healed_recent: Number(row.healed_recent),
+        healed_all: Number(row.healed_all),
+        first_heal_at: first,
+        last_heal_at: last,
+        tenantIds: [row.tenant_id],
+      });
+      continue;
+    }
+    existing.healed_recent += Number(row.healed_recent);
+    existing.healed_all += Number(row.healed_all);
+    existing.first_heal_at = Math.min(existing.first_heal_at, first);
+    existing.last_heal_at = Math.max(existing.last_heal_at, last);
+    existing.name = existing.name ?? row.user_name;
+    existing.tenantIds.push(row.tenant_id);
+  }
+  return merged;
+}
+
+function buildUsers(merged: Map<string, Merged>, providerRows: ProviderRow[]): CrmHealedUser[] {
+  const byTenant = new Map<string, ProviderRow[]>();
+  for (const row of providerRows) {
+    if (!row.provider) continue;
+    const bucket = byTenant.get(row.tenant_id);
+    if (bucket) bucket.push(row);
+    else byTenant.set(row.tenant_id, [row]);
+  }
+
+  const users = [...merged.values()].map((entry) => {
+    const providers = rankProviders(entry.tenantIds, byTenant);
+    return {
+      email: entry.email,
+      name: entry.name,
+      healed_recent: entry.healed_recent,
+      healed_all: entry.healed_all,
+      first_heal_at: new Date(entry.first_heal_at).toISOString(),
+      last_heal_at: new Date(entry.last_heal_at).toISOString(),
+      providers,
+      top_provider: providers[0] ?? null,
+    };
+  });
+
+  return users.sort((a, b) => b.healed_recent - a.healed_recent);
+}
+
+/** Providers this person's tenants healed against, most-repaired first. */
+function rankProviders(tenantIds: string[], byTenant: Map<string, ProviderRow[]>): string[] {
+  const totals = new Map<string, number>();
+  for (const tenantId of tenantIds) {
+    for (const row of byTenant.get(tenantId) ?? []) {
+      const provider = row.provider as string;
+      totals.set(provider, (totals.get(provider) ?? 0) + Number(row.n));
+    }
+  }
+  return [...totals.entries()].sort((a, b) => b[1] - a[1]).map(([provider]) => provider);
+}

--- a/packages/backend/src/crm-metrics/crm-metrics.types.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.types.ts
@@ -1,0 +1,44 @@
+/** Shapes returned by the internal CRM metrics feed. */
+
+/** One Manifest user whose failing requests Autofix repaired. */
+export interface CrmHealedUser {
+  /** Lowercased primary address. The CRM dedupes people on this. */
+  email: string;
+  /** Display name from the auth record, or null when never set. */
+  name: string | null;
+  /** Heals inside the requested window — the number worth quoting to them. */
+  healed_recent: number;
+  /** Heals since Autofix shipped, across every tenant this user owns. */
+  healed_all: number;
+  first_heal_at: string;
+  last_heal_at: string;
+  /** Providers Autofix repaired against in the window, most-repaired first. */
+  providers: string[];
+  /** Convenience alias for `providers[0]`; null when no attempts were found. */
+  top_provider: string | null;
+}
+
+/** One pivot waiting-list claim: the conversion signal for the campaign. */
+export interface CrmWaitlistClaim {
+  email: string;
+  source: string;
+  claimed_at: string;
+}
+
+/** Raw cohort row, one per (user, tenant) pair, before merging. */
+export interface CohortRow {
+  email: string;
+  user_name: string | null;
+  tenant_id: string;
+  healed_recent: string | number;
+  healed_all: string | number;
+  first_heal_at: Date | string;
+  last_heal_at: Date | string;
+}
+
+/** Raw provider-breakdown row, one per (tenant, provider) pair. */
+export interface ProviderRow {
+  tenant_id: string;
+  provider: string | null;
+  n: string | number;
+}

--- a/packages/backend/src/crm-metrics/dto/crm-metrics-query.dto.spec.ts
+++ b/packages/backend/src/crm-metrics/dto/crm-metrics-query.dto.spec.ts
@@ -1,0 +1,39 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { CrmMetricsQueryDto } from './crm-metrics-query.dto';
+
+function parse(query: Record<string, unknown>): CrmMetricsQueryDto {
+  return plainToInstance(CrmMetricsQueryDto, query, { enableImplicitConversion: false });
+}
+
+describe('CrmMetricsQueryDto', () => {
+  it('coerces the query string into a number', () => {
+    const dto = parse({ days: '30' });
+
+    expect(dto.days).toBe(30);
+    expect(validateSync(dto)).toHaveLength(0);
+  });
+
+  it('allows the parameter to be omitted', () => {
+    const dto = parse({});
+
+    expect(dto.days).toBeUndefined();
+    expect(validateSync(dto)).toHaveLength(0);
+  });
+
+  it('accepts the window bounds', () => {
+    expect(validateSync(parse({ days: '1' }))).toHaveLength(0);
+    expect(validateSync(parse({ days: '365' }))).toHaveLength(0);
+  });
+
+  it('rejects a window outside the bounds', () => {
+    expect(validateSync(parse({ days: '0' }))).not.toHaveLength(0);
+    expect(validateSync(parse({ days: '366' }))).not.toHaveLength(0);
+  });
+
+  it('rejects a non-integer window', () => {
+    expect(validateSync(parse({ days: '7.5' }))).not.toHaveLength(0);
+    expect(validateSync(parse({ days: 'lots' }))).not.toHaveLength(0);
+  });
+});

--- a/packages/backend/src/crm-metrics/dto/crm-metrics-query.dto.ts
+++ b/packages/backend/src/crm-metrics/dto/crm-metrics-query.dto.ts
@@ -1,0 +1,22 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Window selector for both CRM metrics routes.
+ *
+ * The global ValidationPipe runs with `whitelist` + `forbidNonWhitelisted`, so
+ * anything not declared here makes the request 400. `@Type` is what coerces the
+ * query string into a number.
+ *
+ * A day count rather than an ISO `since`: this backend has no `@IsDateString`
+ * precedent, and the payload already carries `first_heal_at` / `last_heal_at`
+ * per user, so a consumer that wants a delta can compute one itself.
+ */
+export class CrmMetricsQueryDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(365)
+  @Type(() => Number)
+  days?: number;
+}

--- a/packages/backend/src/crm-metrics/internal-crm-metrics.controller.spec.ts
+++ b/packages/backend/src/crm-metrics/internal-crm-metrics.controller.spec.ts
@@ -1,7 +1,16 @@
-import { Logger, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
+import {
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import { InternalCrmMetricsController } from './internal-crm-metrics.controller';
 import type { CrmMetricsService } from './crm-metrics.service';
+import { isSelfHosted } from '../common/utils/detect-self-hosted';
+
+jest.mock('../common/utils/detect-self-hosted', () => ({ isSelfHosted: jest.fn() }));
+const mockedIsSelfHosted = jest.mocked(isSelfHosted);
 
 const SECRET = 'a'.repeat(32);
 const IP = '203.0.113.7';
@@ -19,6 +28,7 @@ describe('InternalCrmMetricsController', () => {
   beforeEach(() => {
     mockService = { getHealedCohort: jest.fn(), getConversions: jest.fn() };
     warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    mockedIsSelfHosted.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -167,6 +177,46 @@ describe('InternalCrmMetricsController', () => {
       await makeController(SECRET).conversions(SECRET, IP, { days: 14 });
 
       expect(mockService.getConversions).toHaveBeenCalledWith(14);
+    });
+  });
+
+  describe('self-hosted', () => {
+    // app.module.ts normally leaves the module unregistered, but that check
+    // runs before ConfigModule loads `.env`. This one resolves at construction,
+    // so a bare-metal install carrying MANIFEST_MODE only in `.env` is covered.
+    it('answers like an unmounted route on both endpoints', async () => {
+      mockedIsSelfHosted.mockReturnValue(true);
+      const controller = makeController(SECRET);
+
+      await expect(controller.cohort(SECRET, IP, {})).rejects.toBeInstanceOf(NotFoundException);
+      await expect(controller.conversions(SECRET, IP, {})).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(mockService.getHealedCohort).not.toHaveBeenCalled();
+      expect(mockService.getConversions).not.toHaveBeenCalled();
+    });
+
+    it('checks the mode before the secret, so it never reveals whether one is set', async () => {
+      mockedIsSelfHosted.mockReturnValue(true);
+
+      // No secret configured at all: a Cloud install would answer 401 here.
+      await expect(makeController(undefined).cohort('anything', IP, {})).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('resolves the mode once, at construction', async () => {
+      mockedIsSelfHosted.mockReturnValue(false);
+      const controller = makeController(SECRET);
+      mockService.getHealedCohort.mockResolvedValue([]);
+      const callsAfterConstruction = mockedIsSelfHosted.mock.calls.length;
+      mockedIsSelfHosted.mockReturnValue(true);
+
+      // A later flip must not change an already-built controller's behaviour,
+      // and serving a request must not re-read the mode.
+      await expect(controller.cohort(SECRET, IP, {})).resolves.toEqual([]);
+      expect(mockedIsSelfHosted.mock.calls).toHaveLength(callsAfterConstruction);
     });
   });
 });

--- a/packages/backend/src/crm-metrics/internal-crm-metrics.controller.spec.ts
+++ b/packages/backend/src/crm-metrics/internal-crm-metrics.controller.spec.ts
@@ -1,0 +1,172 @@
+import { Logger, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import { InternalCrmMetricsController } from './internal-crm-metrics.controller';
+import type { CrmMetricsService } from './crm-metrics.service';
+
+const SECRET = 'a'.repeat(32);
+const IP = '203.0.113.7';
+
+function makeConfig(secret: string | undefined): ConfigService {
+  return {
+    get: jest.fn((key: string) => (key === 'app.crmMetricsSecret' ? secret : undefined)),
+  } as unknown as ConfigService;
+}
+
+describe('InternalCrmMetricsController', () => {
+  let mockService: { getHealedCohort: jest.Mock; getConversions: jest.Mock };
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockService = { getHealedCohort: jest.fn(), getConversions: jest.fn() };
+    warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function makeController(secret: string | undefined): InternalCrmMetricsController {
+    return new InternalCrmMetricsController(
+      mockService as unknown as CrmMetricsService,
+      makeConfig(secret),
+    );
+  }
+
+  describe('secret rejection', () => {
+    it('rejects when the header is missing', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(
+        controller.cohort(undefined as unknown as string, IP, {}),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(mockService.getHealedCohort).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the header is wrong', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.cohort('b'.repeat(32), IP, {})).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockService.getHealedCohort).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the header is the right value but the wrong length', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.cohort('a'.repeat(31), IP, {})).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockService.getHealedCohort).not.toHaveBeenCalled();
+    });
+
+    it('leaks neither the configured nor the provided secret when it rejects', async () => {
+      // Same length on both sides, so the constant-time compare runs rather
+      // than the length shortcut.
+      const configured = 'configured-secret'.padEnd(40, 'x');
+      const provided = 'provided-secret'.padEnd(40, 'y');
+
+      const error = await makeController(configured)
+        .cohort(provided, IP, {})
+        .then(
+          () => null,
+          (thrown: unknown) => thrown as UnauthorizedException,
+        );
+
+      expect(error).toBeInstanceOf(UnauthorizedException);
+      expect(error?.message).toBe('Invalid or missing internal secret');
+      const surfaced = `${error?.message} ${JSON.stringify(error?.getResponse())}`;
+      expect(surfaced).not.toContain(configured);
+      expect(surfaced).not.toContain(provided);
+      // The rejection log is the other place a secret could end up.
+      const logged = JSON.stringify(warn.mock.calls);
+      expect(logged).not.toContain(configured);
+      expect(logged).not.toContain(provided);
+    });
+
+    it('rejects when no secret is configured', async () => {
+      await expect(makeController(undefined).cohort('anything', IP, {})).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      await expect(makeController('').cohort('', IP, {})).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockService.getHealedCohort).not.toHaveBeenCalled();
+    });
+
+    it('treats a secret shorter than 32 chars as unconfigured, even on an exact match', async () => {
+      const weak = 'short-secret';
+
+      await expect(makeController(weak).cohort(weak, IP, {})).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('guards the conversions route too', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.conversions('nope', IP, {})).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockService.getConversions).not.toHaveBeenCalled();
+    });
+
+    it('logs the source ip of a rejected attempt', async () => {
+      await expect(makeController(SECRET).cohort('nope', IP, {})).rejects.toThrow();
+
+      expect(warn).toHaveBeenCalledWith(`Rejected CRM metrics request from ${IP}`);
+    });
+  });
+
+  describe('cohort', () => {
+    it('defaults to a 7 day window', async () => {
+      const users = [{ email: 'a@b.com' }];
+      mockService.getHealedCohort.mockResolvedValue(users);
+
+      const result = await makeController(SECRET).cohort(SECRET, IP, {});
+
+      expect(result).toBe(users);
+      expect(mockService.getHealedCohort).toHaveBeenCalledWith(7);
+    });
+
+    it('passes an explicit window through', async () => {
+      mockService.getHealedCohort.mockResolvedValue([]);
+
+      await makeController(SECRET).cohort(SECRET, IP, { days: 30 });
+
+      expect(mockService.getHealedCohort).toHaveBeenCalledWith(30);
+    });
+
+    it('propagates an unavailable index instead of answering with an empty cohort', async () => {
+      mockService.getHealedCohort.mockRejectedValue(
+        new ServiceUnavailableException('IDX_requests_autofix_healed is missing or invalid'),
+      );
+
+      // A 503 is the signal the CRM needs to keep yesterday's list; a 200 with
+      // `[]` reads as "nobody was healed today".
+      await expect(makeController(SECRET).cohort(SECRET, IP, {})).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+    });
+  });
+
+  describe('conversions', () => {
+    it('defaults to a 90 day window', async () => {
+      const claims = [{ email: 'a@b.com', source: 'cloud', claimed_at: 'x' }];
+      mockService.getConversions.mockResolvedValue(claims);
+
+      const result = await makeController(SECRET).conversions(SECRET, IP, {});
+
+      expect(result).toBe(claims);
+      expect(mockService.getConversions).toHaveBeenCalledWith(90);
+    });
+
+    it('passes an explicit window through', async () => {
+      mockService.getConversions.mockResolvedValue([]);
+
+      await makeController(SECRET).conversions(SECRET, IP, { days: 14 });
+
+      expect(mockService.getConversions).toHaveBeenCalledWith(14);
+    });
+  });
+});

--- a/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
+++ b/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
@@ -1,7 +1,17 @@
-import { Controller, Get, Headers, Ip, Logger, Query, UnauthorizedException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Ip,
+  Logger,
+  NotFoundException,
+  Query,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Public } from '../common/decorators/public.decorator';
 import { timingSafeCompare } from '../common/utils/crypto.util';
+import { isSelfHosted } from '../common/utils/detect-self-hosted';
 import { CrmMetricsService } from './crm-metrics.service';
 import { CrmMetricsQueryDto } from './dto/crm-metrics-query.dto';
 import type { CrmHealedUser, CrmWaitlistClaim } from './crm-metrics.types';
@@ -18,6 +28,13 @@ import type { CrmHealedUser, CrmWaitlistClaim } from './crm-metrics.types';
  * modelled on: the comparison is constant-time, and a secret too short to be
  * worth anything counts as unconfigured rather than as a weak guard on a full
  * user list. Nothing here logs the payload.
+ *
+ * Cloud only. app.module.ts already leaves the module unregistered on
+ * self-hosted, but that check runs at import time, before ConfigModule reads
+ * `.env` — so a bare-metal install carrying `MANIFEST_MODE` only in its `.env`
+ * would look like Cloud there. Containers are unaffected (`/.dockerenv` is
+ * detected without any env), but this second check closes the gap: it resolves
+ * at construction, after configuration is loaded.
  */
 @Controller('api/v1/internal/crm-metrics')
 export class InternalCrmMetricsController {
@@ -28,10 +45,21 @@ export class InternalCrmMetricsController {
 
   private readonly logger = new Logger(InternalCrmMetricsController.name);
 
+  /** Resolved once at construction, which is after ConfigModule loads `.env`. */
+  private readonly selfHosted = isSelfHosted();
+
   constructor(
     private readonly service: CrmMetricsService,
     private readonly config: ConfigService,
   ) {}
+
+  /**
+   * Answer exactly as an unmounted route would. Checked before the secret so a
+   * self-hosted install never reveals whether one is configured.
+   */
+  private assertCloud(): void {
+    if (this.selfHosted) throw new NotFoundException();
+  }
 
   private assertSecret(provided: string | undefined, ip: string): void {
     const expected = this.config.get<string>('app.crmMetricsSecret') ?? '';
@@ -50,6 +78,7 @@ export class InternalCrmMetricsController {
     @Ip() ip: string,
     @Query() query: CrmMetricsQueryDto,
   ): Promise<CrmHealedUser[]> {
+    this.assertCloud();
     this.assertSecret(secret, ip);
     return this.service.getHealedCohort(
       query.days ?? InternalCrmMetricsController.DEFAULT_COHORT_DAYS,
@@ -64,6 +93,7 @@ export class InternalCrmMetricsController {
     @Ip() ip: string,
     @Query() query: CrmMetricsQueryDto,
   ): Promise<CrmWaitlistClaim[]> {
+    this.assertCloud();
     this.assertSecret(secret, ip);
     return this.service.getConversions(
       query.days ?? InternalCrmMetricsController.DEFAULT_CLAIM_DAYS,

--- a/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
+++ b/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
@@ -1,0 +1,72 @@
+import { Controller, Get, Headers, Ip, Logger, Query, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Public } from '../common/decorators/public.decorator';
+import { timingSafeCompare } from '../common/utils/crypto.util';
+import { CrmMetricsService } from './crm-metrics.service';
+import { CrmMetricsQueryDto } from './dto/crm-metrics-query.dto';
+import type { CrmHealedUser, CrmWaitlistClaim } from './crm-metrics.types';
+
+/**
+ * Internal read API for the CRM outreach pipeline.
+ *
+ * `@Public()` to skip the session/api-key guards, then gated by a shared secret
+ * in the `x-internal-secret` header. Lives under /api/* so the SPA static
+ * fallback never shadows it.
+ *
+ * This is the first Manifest endpoint that exports user email addresses across
+ * tenants, so it is deliberately stricter than the error-pages sibling it is
+ * modelled on: the comparison is constant-time, and a secret too short to be
+ * worth anything counts as unconfigured rather than as a weak guard on a full
+ * user list. Nothing here logs the payload.
+ */
+@Controller('api/v1/internal/crm-metrics')
+export class InternalCrmMetricsController {
+  /** Below this, a configured value is treated as absent. */
+  private static readonly MIN_SECRET_LENGTH = 32;
+  private static readonly DEFAULT_COHORT_DAYS = 7;
+  private static readonly DEFAULT_CLAIM_DAYS = 90;
+
+  private readonly logger = new Logger(InternalCrmMetricsController.name);
+
+  constructor(
+    private readonly service: CrmMetricsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  private assertSecret(provided: string | undefined, ip: string): void {
+    const expected = this.config.get<string>('app.crmMetricsSecret') ?? '';
+    const configured = expected.length >= InternalCrmMetricsController.MIN_SECRET_LENGTH;
+    if (!configured || !timingSafeCompare(provided ?? '', expected)) {
+      this.logger.warn(`Rejected CRM metrics request from ${ip}`);
+      throw new UnauthorizedException('Invalid or missing internal secret');
+    }
+  }
+
+  /** Users whose failing requests Autofix repaired inside the window. */
+  @Public()
+  @Get()
+  async cohort(
+    @Headers('x-internal-secret') secret: string,
+    @Ip() ip: string,
+    @Query() query: CrmMetricsQueryDto,
+  ): Promise<CrmHealedUser[]> {
+    this.assertSecret(secret, ip);
+    return this.service.getHealedCohort(
+      query.days ?? InternalCrmMetricsController.DEFAULT_COHORT_DAYS,
+    );
+  }
+
+  /** Pivot waiting-list claims — the campaign's conversion signal. */
+  @Public()
+  @Get('conversions')
+  async conversions(
+    @Headers('x-internal-secret') secret: string,
+    @Ip() ip: string,
+    @Query() query: CrmMetricsQueryDto,
+  ): Promise<CrmWaitlistClaim[]> {
+    this.assertSecret(secret, ip);
+    return this.service.getConversions(
+      query.days ?? InternalCrmMetricsController.DEFAULT_CLAIM_DAYS,
+    );
+  }
+}

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -42,6 +42,7 @@ import { AddRequestApiMode1801720000000 } from './migrations/1801720000000-AddRe
 import { AddAutofixConsentToInstallMetadata1801900000000 } from './migrations/1801900000000-AddAutofixConsentToInstallMetadata';
 import { SlimTenantAgentModelIndex1802000000000 } from './migrations/1802000000000-SlimTenantAgentModelIndex';
 import { AddCustomProviderAlias1802100000000 } from './migrations/1802100000000-AddCustomProviderAlias';
+import { AddRequestsAutofixHealedIndex1802200000000 } from './migrations/1802200000000-AddRequestsAutofixHealedIndex';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -322,4 +323,5 @@ export const migrations = [
   AddAutofixConsentToInstallMetadata1801900000000,
   SlimTenantAgentModelIndex1802000000000,
   AddCustomProviderAlias1802100000000,
+  AddRequestsAutofixHealedIndex1802200000000,
 ];

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
@@ -1,0 +1,46 @@
+import { AddRequestsAutofixHealedIndex1802200000000 } from './1802200000000-AddRequestsAutofixHealedIndex';
+
+describe('AddRequestsAutofixHealedIndex1802200000000', () => {
+  const migration = new AddRequestsAutofixHealedIndex1802200000000();
+  let queries: string[];
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve([]);
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('exposes the expected migration name', () => {
+    expect(migration.name).toBe('AddRequestsAutofixHealedIndex1802200000000');
+  });
+
+  it('runs outside a transaction so CONCURRENTLY is legal', () => {
+    expect(migration.transaction).toBe(false);
+  });
+
+  it('clears an INVALID shell, builds the partial index, then refreshes stats', async () => {
+    await migration.up(mockQueryRunner);
+
+    expect(queries).toHaveLength(3);
+    expect(queries[0]).toBe('DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"');
+    expect(queries[1]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_requests_autofix_healed"',
+    );
+    expect(queries[1]).toContain('ON "requests" ("tenant_id", "timestamp")');
+    expect(queries[1]).toContain('INCLUDE ("status")');
+    expect(queries[1]).toContain(`WHERE "autofix_status" = 'retry_succeeded'`);
+    expect(queries[2]).toBe('ANALYZE "requests"');
+  });
+
+  it('drops the index on rollback', async () => {
+    await migration.down(mockQueryRunner);
+
+    expect(queries).toEqual(['DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"']);
+  });
+});

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
@@ -3,16 +3,24 @@ import { AddRequestsAutofixHealedIndex1802200000000 } from './1802200000000-AddR
 describe('AddRequestsAutofixHealedIndex1802200000000', () => {
   const migration = new AddRequestsAutofixHealedIndex1802200000000();
   let queries: string[];
+  let args: unknown[][];
+  let invalidRows: unknown[];
 
   const mockQueryRunner = {
-    query: jest.fn().mockImplementation((sql: string) => {
+    query: jest.fn().mockImplementation((sql: string, ...params: unknown[]) => {
       queries.push(sql);
+      args.push(params);
+      if (sql.includes('NOT i.indisvalid')) {
+        return Promise.resolve(invalidRows);
+      }
       return Promise.resolve([]);
     }),
   } as never;
 
   beforeEach(() => {
     queries = [];
+    args = [];
+    invalidRows = [];
     jest.clearAllMocks();
   });
 
@@ -24,11 +32,12 @@ describe('AddRequestsAutofixHealedIndex1802200000000', () => {
     expect(migration.transaction).toBe(false);
   });
 
-  it('clears an INVALID shell, builds the partial index, then refreshes stats', async () => {
+  it('builds the partial index, then refreshes the planner stats', async () => {
     await migration.up(mockQueryRunner);
 
     expect(queries).toHaveLength(3);
-    expect(queries[0]).toBe('DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"');
+    expect(queries[0]).toContain('NOT i.indisvalid');
+    expect(args[0]).toEqual([['IDX_requests_autofix_healed']]);
     expect(queries[1]).toContain(
       'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_requests_autofix_healed"',
     );
@@ -36,6 +45,29 @@ describe('AddRequestsAutofixHealedIndex1802200000000', () => {
     expect(queries[1]).toContain('INCLUDE ("status")');
     expect(queries[1]).toContain(`WHERE "autofix_status" = 'retry_succeeded'`);
     expect(queries[2]).toBe('ANALYZE "requests"');
+  });
+
+  it('keeps a valid index instead of rebuilding it on a retried deploy', async () => {
+    // A deploy interrupted after the build succeeded but before TypeORM
+    // recorded the migration re-runs up(). Dropping unconditionally here would
+    // throw away a usable index and leave the feed 503ing while it rebuilt.
+    await migration.up(mockQueryRunner);
+
+    expect(queries.some((sql) => sql.startsWith('DROP INDEX'))).toBe(false);
+  });
+
+  it('drops an INVALID shell before rebuilding, since IF NOT EXISTS matches on name', async () => {
+    invalidRows = [{}];
+
+    await migration.up(mockQueryRunner);
+
+    expect(queries).toHaveLength(4);
+    expect(queries[0]).toContain('NOT i.indisvalid');
+    expect(queries[1]).toBe('DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"');
+    expect(queries[2]).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_requests_autofix_healed"',
+    );
+    expect(queries[3]).toBe('ANALYZE "requests"');
   });
 
   it('drops the index on rollback', async () => {

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
@@ -93,12 +93,14 @@ describe('AddRequestsAutofixHealedIndex1802200000000', () => {
       expect(queries).toEqual([]);
     });
 
-    it('touches nothing on the way down either', async () => {
+    it('still drops on the way down, so a cloud-built index is never orphaned', async () => {
+      // A database migrated in cloud mode can be reverted while the process
+      // looks self-hosted. DROP ... IF EXISTS is a no-op where it never existed.
       mockedIsSelfHosted.mockReturnValue(true);
 
       await migration.down(mockQueryRunner);
 
-      expect(queries).toEqual([]);
+      expect(queries).toEqual(['DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"']);
     });
   });
 });

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.spec.ts
@@ -1,4 +1,8 @@
 import { AddRequestsAutofixHealedIndex1802200000000 } from './1802200000000-AddRequestsAutofixHealedIndex';
+import { isSelfHosted } from '../../common/utils/detect-self-hosted';
+
+jest.mock('../../common/utils/detect-self-hosted', () => ({ isSelfHosted: jest.fn() }));
+const mockedIsSelfHosted = jest.mocked(isSelfHosted);
 
 describe('AddRequestsAutofixHealedIndex1802200000000', () => {
   const migration = new AddRequestsAutofixHealedIndex1802200000000();
@@ -22,6 +26,7 @@ describe('AddRequestsAutofixHealedIndex1802200000000', () => {
     args = [];
     invalidRows = [];
     jest.clearAllMocks();
+    mockedIsSelfHosted.mockReturnValue(false);
   });
 
   it('exposes the expected migration name', () => {
@@ -74,5 +79,26 @@ describe('AddRequestsAutofixHealedIndex1802200000000', () => {
     await migration.down(mockQueryRunner);
 
     expect(queries).toEqual(['DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"']);
+  });
+
+  describe('self-hosted', () => {
+    // The feed is Cloud-only and its module is not registered on self-hosted,
+    // so the index would be dead weight. Skipping also spares those upgrades a
+    // whole-table CONCURRENTLY scan during boot.
+    it('touches nothing on the way up', async () => {
+      mockedIsSelfHosted.mockReturnValue(true);
+
+      await migration.up(mockQueryRunner);
+
+      expect(queries).toEqual([]);
+    });
+
+    it('touches nothing on the way down either', async () => {
+      mockedIsSelfHosted.mockReturnValue(true);
+
+      await migration.down(mockQueryRunner);
+
+      expect(queries).toEqual([]);
+    });
   });
 });

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Partial index over the requests Autofix repaired, for the CRM metrics feed.
+ *
+ * `GET /api/v1/internal/crm-metrics` groups every healed request by tenant.
+ * No existing `requests` index mentions `autofix_status`, so the planner fell
+ * back to a sequential scan: measured on production, 7,016,836 rows discarded
+ * by the filter and 845,495 shared buffers (~6.6 GB) read to return 59 rows,
+ * in 2.4s. `shared_buffers` there is ~128 MB, so the damage is not the latency
+ * but the eviction — one call flushes the working set of every other query.
+ *
+ * Healed requests are a rounding error of the table (~8.3k of 7.0M), so a
+ * partial index costs almost nothing to store, and turns that scan into a read
+ * of a few hundred pages.
+ *
+ * `tenant_id` leads because the feed needs *every* healed row (the all-time
+ * count takes no time bound) grouped by tenant, and because the same index
+ * then serves `WHERE tenant_id = ANY(...)`. The timestamp-leading partial
+ * index added in 1795100000000 solved the opposite shape — a narrow window
+ * across all tenants — where a tenant-leading key forced a scan of every error
+ * row ever. Revisit if healed rows ever approach seven figures.
+ *
+ * `status` is INCLUDEd rather than filtered from the heap: the feed applies the
+ * canonical healed predicate (`sqlIsSuccessStatus` AND retry_succeeded, per
+ * request-volume.service.ts), and carrying `status` in the index keeps that
+ * check off the heap. `autofix_status` itself is deliberately absent — it is
+ * constant inside a partial index and would be pure waste.
+ *
+ * Write-path cost is negligible despite the predicate column blocking HOT
+ * updates: `status` is already indexed and already flips pending -> terminal on
+ * every request, so those upserts are non-HOT today regardless.
+ *
+ * Built CONCURRENTLY (so `transaction = false`) to avoid the ACCESS EXCLUSIVE
+ * lock that deadlocks against live writes during a deploy. Budget minutes for
+ * this one: two heap passes over ~6.6 GB, and it blocks autovacuum on
+ * `requests` while it runs.
+ *
+ * `npm run migration:revert` cannot run `down()` — TypeORM opens a transaction
+ * for reverts regardless of `transaction = false`, and Postgres rejects
+ * CONCURRENTLY inside one. Run the statement by hand and delete the row from
+ * `migrations`.
+ */
+export class AddRequestsAutofixHealedIndex1802200000000 implements MigrationInterface {
+  name = 'AddRequestsAutofixHealedIndex1802200000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Clear any invalid leftover from an interrupted CONCURRENTLY build, since
+    // CREATE ... IF NOT EXISTS matches on name and would skip over an INVALID
+    // shell, leaving the feed permanently unindexed.
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"`);
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_requests_autofix_healed" ON "requests" ("tenant_id", "timestamp") INCLUDE ("status") WHERE "autofix_status" = 'retry_succeeded'`,
+    );
+    // The planner only picks the index if it believes the predicate is
+    // selective; refresh the stats it reasons from before the first read.
+    await queryRunner.query(`ANALYZE "requests"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"`);
+  }
+}

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
@@ -79,8 +79,10 @@ export class AddRequestsAutofixHealedIndex1802200000000 implements MigrationInte
     await queryRunner.query(`ANALYZE "requests"`);
   }
 
+  // Deliberately ungated, unlike up(): a database migrated in cloud mode and
+  // reverted while MANIFEST_MODE=selfhosted would otherwise keep the index
+  // forever. DROP ... IF EXISTS is already a no-op where it was never created.
   public async down(queryRunner: QueryRunner): Promise<void> {
-    if (isSelfHosted()) return;
     await queryRunner.query(
       `DROP INDEX CONCURRENTLY IF EXISTS "${AddRequestsAutofixHealedIndex1802200000000.INDEX}"`,
     );

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
@@ -36,22 +36,29 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * this one: two heap passes over ~6.6 GB, and it blocks autovacuum on
  * `requests` while it runs.
  *
- * `npm run migration:revert` cannot run `down()` — TypeORM opens a transaction
- * for reverts regardless of `transaction = false`, and Postgres rejects
- * CONCURRENTLY inside one. Run the statement by hand and delete the row from
- * `migrations`.
+ * `npm run migration:revert` passes `--transaction none`, so `down()` runs
+ * outside a transaction as CONCURRENTLY requires. Under the default
+ * transaction mode Postgres would reject the statement.
  */
 export class AddRequestsAutofixHealedIndex1802200000000 implements MigrationInterface {
   name = 'AddRequestsAutofixHealedIndex1802200000000';
   transaction = false;
 
+  private static readonly INDEX = 'IDX_requests_autofix_healed';
+
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Clear any invalid leftover from an interrupted CONCURRENTLY build, since
-    // CREATE ... IF NOT EXISTS matches on name and would skip over an INVALID
-    // shell, leaving the feed permanently unindexed.
-    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"`);
+    const { INDEX } = AddRequestsAutofixHealedIndex1802200000000;
+    // A cancelled CONCURRENTLY build leaves an INVALID shell that
+    // `CREATE ... IF NOT EXISTS` would skip over by name, leaving the feed
+    // permanently unindexed. Drop only that shell: an unconditional drop would
+    // also destroy a *valid* index when a deploy is interrupted after the build
+    // succeeded but before TypeORM recorded the migration, costing minutes of
+    // 503s on the retry while it rebuilds.
+    if (await this.indexIsInvalid(queryRunner, INDEX)) {
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${INDEX}"`);
+    }
     await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_requests_autofix_healed" ON "requests" ("tenant_id", "timestamp") INCLUDE ("status") WHERE "autofix_status" = 'retry_succeeded'`,
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${INDEX}" ON "requests" ("tenant_id", "timestamp") INCLUDE ("status") WHERE "autofix_status" = 'retry_succeeded'`,
     );
     // The planner only picks the index if it believes the predicate is
     // selective; refresh the stats it reasons from before the first read.
@@ -59,6 +66,17 @@ export class AddRequestsAutofixHealedIndex1802200000000 implements MigrationInte
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_requests_autofix_healed"`);
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "${AddRequestsAutofixHealedIndex1802200000000.INDEX}"`,
+    );
+  }
+
+  /** True when an index of this name exists but is INVALID (interrupted build). */
+  private async indexIsInvalid(queryRunner: QueryRunner, indexName: string): Promise<boolean> {
+    const rows: unknown[] = await queryRunner.query(
+      `SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = $1 AND NOT i.indisvalid`,
+      [indexName],
+    );
+    return rows.length > 0;
   }
 }

--- a/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
+++ b/packages/backend/src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex.ts
@@ -1,4 +1,5 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
+import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 
 /**
  * Partial index over the requests Autofix repaired, for the CRM metrics feed.
@@ -39,6 +40,12 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * `npm run migration:revert` passes `--transaction none`, so `down()` runs
  * outside a transaction as CONCURRENTLY requires. Under the default
  * transaction mode Postgres would reject the statement.
+ *
+ * Cloud only, mirroring 1801300000000: a self-hosted install gets no schema
+ * change at all. Consequence to know about — an install that ran this while
+ * self-hosted and later switches `MANIFEST_MODE=cloud` will not re-run it,
+ * because TypeORM has already recorded it. The endpoint reports that state
+ * explicitly (503 naming the missing index) rather than silently scanning.
  */
 export class AddRequestsAutofixHealedIndex1802200000000 implements MigrationInterface {
   name = 'AddRequestsAutofixHealedIndex1802200000000';
@@ -47,6 +54,13 @@ export class AddRequestsAutofixHealedIndex1802200000000 implements MigrationInte
   private static readonly INDEX = 'IDX_requests_autofix_healed';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // The CRM feed is a Cloud outreach concern and its module is not even
+    // registered on self-hosted, so the index would be dead weight there.
+    // Skipping also spares self-hosted upgrades a CONCURRENTLY build, which
+    // scans the whole `requests` table however few rows match the predicate,
+    // and runs during boot where it would delay container startup.
+    if (isSelfHosted()) return;
+
     const { INDEX } = AddRequestsAutofixHealedIndex1802200000000;
     // A cancelled CONCURRENTLY build leaves an INVALID shell that
     // `CREATE ... IF NOT EXISTS` would skip over by name, leaving the feed
@@ -66,6 +80,7 @@ export class AddRequestsAutofixHealedIndex1802200000000 implements MigrationInte
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    if (isSelfHosted()) return;
     await queryRunner.query(
       `DROP INDEX CONCURRENTLY IF EXISTS "${AddRequestsAutofixHealedIndex1802200000000.INDEX}"`,
     );

--- a/packages/backend/test/crm-metrics.e2e-spec.ts
+++ b/packages/backend/test/crm-metrics.e2e-spec.ts
@@ -29,12 +29,14 @@ function localSqlTimestamp(d: Date): string {
 describe('Internal CRM metrics (e2e)', () => {
   let app: INestApplication;
   let ds: DataSource;
+  let previousMode: string | undefined;
 
   beforeAll(async () => {
     process.env['CRM_METRICS_SECRET'] = SECRET;
     // The migration and the module registration are both Cloud-only. Pin the
     // mode so this suite does not depend on whether the runner happens to look
     // containerised to `isSelfHosted()`.
+    previousMode = process.env['MANIFEST_MODE'];
     process.env['MANIFEST_MODE'] = 'cloud';
     app = await createTestApp();
     ds = app.get(DataSource);
@@ -73,7 +75,11 @@ describe('Internal CRM metrics (e2e)', () => {
   afterAll(async () => {
     await app.close();
     delete process.env['CRM_METRICS_SECRET'];
-    delete process.env['MANIFEST_MODE'];
+    // Restore rather than delete: e2e runs --runInBand, so every spec shares one
+    // process, and a shell that exports MANIFEST_MODE would otherwise lose it
+    // for every sibling suite that reads isSelfHosted().
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
   });
 
   beforeEach(async () => {

--- a/packages/backend/test/crm-metrics.e2e-spec.ts
+++ b/packages/backend/test/crm-metrics.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 import { createTestApp, TEST_TENANT_ID, TEST_AGENT_ID } from './helpers';
+import { AddRequestsAutofixHealedIndex1802200000000 } from '../src/database/migrations/1802200000000-AddRequestsAutofixHealedIndex';
 
 /**
  * Exercises the real SQL against real Postgres. The unit specs mock the
@@ -45,12 +46,24 @@ describe('Internal CRM metrics (e2e)', () => {
     );
 
     // The partial index lives in a migration, not on the entity, so
-    // synchronize() never creates it. Building it here also proves the exact
-    // definition the migration emits is valid Postgres.
-    await ds.query(
-      `CREATE INDEX IF NOT EXISTS "${HEALED_INDEX}" ON "requests" ("tenant_id", "timestamp") ` +
-        `INCLUDE ("status") WHERE "autofix_status" = 'retry_succeeded'`,
-    );
+    // synchronize() never creates it. Run the real migration rather than a
+    // copy of its DDL: a hand-copied index would keep passing even if the
+    // migration drifted, which is exactly the defect this suite exists to
+    // catch. CONCURRENTLY needs to be outside a transaction, and a bare
+    // queryRunner autocommits.
+    const runner = ds.createQueryRunner();
+    try {
+      await runner.connect();
+      await new AddRequestsAutofixHealedIndex1802200000000().up(runner);
+    } finally {
+      await runner.release();
+    }
+
+    const [built] = (await ds.query(`SELECT indexdef FROM pg_indexes WHERE indexname = $1`, [
+      HEALED_INDEX,
+    ])) as Array<{ indexdef: string }>;
+    expect(built?.indexdef).toContain('INCLUDE (status)');
+    expect(built?.indexdef).toContain(`WHERE ((autofix_status)::text = 'retry_succeeded'::text)`);
   });
 
   afterAll(async () => {

--- a/packages/backend/test/crm-metrics.e2e-spec.ts
+++ b/packages/backend/test/crm-metrics.e2e-spec.ts
@@ -32,6 +32,10 @@ describe('Internal CRM metrics (e2e)', () => {
 
   beforeAll(async () => {
     process.env['CRM_METRICS_SECRET'] = SECRET;
+    // The migration and the module registration are both Cloud-only. Pin the
+    // mode so this suite does not depend on whether the runner happens to look
+    // containerised to `isSelfHosted()`.
+    process.env['MANIFEST_MODE'] = 'cloud';
     app = await createTestApp();
     ds = app.get(DataSource);
 
@@ -69,6 +73,7 @@ describe('Internal CRM metrics (e2e)', () => {
   afterAll(async () => {
     await app.close();
     delete process.env['CRM_METRICS_SECRET'];
+    delete process.env['MANIFEST_MODE'];
   });
 
   beforeEach(async () => {

--- a/packages/backend/test/crm-metrics.e2e-spec.ts
+++ b/packages/backend/test/crm-metrics.e2e-spec.ts
@@ -1,0 +1,211 @@
+import request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { v4 as uuid } from 'uuid';
+import { createTestApp, TEST_TENANT_ID, TEST_AGENT_ID } from './helpers';
+
+/**
+ * Exercises the real SQL against real Postgres. The unit specs mock the
+ * DataSource entirely, so this is the only place a syntax error, a bad column
+ * name, or an invalid index definition would surface.
+ */
+
+const SECRET = 'e2e-crm-metrics-secret-at-least-32-chars';
+const HEALED_INDEX = 'IDX_requests_autofix_healed';
+
+const OWNER_ID = 'crm-owner-001';
+const OWNER_EMAIL = 'healed.user@example.com';
+
+/** Local wall clock, matching how the pg driver writes these naive columns. */
+function localSqlTimestamp(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  );
+}
+
+describe('Internal CRM metrics (e2e)', () => {
+  let app: INestApplication;
+  let ds: DataSource;
+
+  beforeAll(async () => {
+    process.env['CRM_METRICS_SECRET'] = SECRET;
+    app = await createTestApp();
+    ds = app.get(DataSource);
+
+    // Better Auth owns the `user` table and its migrations do not run in e2e.
+    await ds.query(
+      `CREATE TABLE IF NOT EXISTS "user" (
+         id VARCHAR PRIMARY KEY,
+         name VARCHAR,
+         email VARCHAR,
+         "emailVerified" BOOLEAN
+       )`,
+    );
+
+    // The partial index lives in a migration, not on the entity, so
+    // synchronize() never creates it. Building it here also proves the exact
+    // definition the migration emits is valid Postgres.
+    await ds.query(
+      `CREATE INDEX IF NOT EXISTS "${HEALED_INDEX}" ON "requests" ("tenant_id", "timestamp") ` +
+        `INCLUDE ("status") WHERE "autofix_status" = 'retry_succeeded'`,
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+    delete process.env['CRM_METRICS_SECRET'];
+  });
+
+  beforeEach(async () => {
+    await ds.query('DELETE FROM agent_messages');
+    await ds.query('DELETE FROM requests');
+    await ds.query('DELETE FROM waitlist_claims');
+    await ds.query('DELETE FROM "user"');
+    await ds.query(
+      `INSERT INTO "user" (id, name, email, "emailVerified") VALUES ($1, $2, $3, true)`,
+      [OWNER_ID, 'Healed User', OWNER_EMAIL],
+    );
+    await ds.query(`UPDATE tenants SET owner_user_id = $1 WHERE id = $2`, [
+      OWNER_ID,
+      TEST_TENANT_ID,
+    ]);
+  });
+
+  async function seedHealedRequest(
+    ageDays: number,
+    provider: string,
+    status = 'success',
+  ): Promise<void> {
+    const requestId = uuid();
+    const at = localSqlTimestamp(new Date(Date.now() - ageDays * 86_400_000));
+    await ds.query(
+      `INSERT INTO requests (id, tenant_id, agent_id, agent_name, timestamp, status, autofix_status)
+       VALUES ($1, $2, $3, 'demo-agent', $4, $5, 'retry_succeeded')`,
+      [requestId, TEST_TENANT_ID, TEST_AGENT_ID, at, status],
+    );
+    await ds.query(
+      `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, request_id, timestamp, provider, model, autofix_applied)
+       VALUES ($1, $2, $3, 'demo-agent', $4, $5, $6, 'some-model', true)`,
+      [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, requestId, at, provider],
+    );
+  }
+
+  const get = (path: string) =>
+    request(app.getHttpServer()).get(`/api/v1/internal/crm-metrics${path}`);
+
+  /**
+   * Results are memoised per window for 60s, which outlives this suite, so each
+   * cohort assertion asks for its own `days` value. They are all far shorter
+   * than the 40-day-old row seeded below, so the window itself never matters —
+   * only that the cache keys differ.
+   */
+  let windowDays = 6;
+  const nextWindow = () => `?days=${++windowDays}`;
+
+  describe('auth', () => {
+    it('rejects a request with no secret', async () => {
+      await get('').expect(401);
+    });
+
+    it('rejects a request with the wrong secret', async () => {
+      await get('').set('x-internal-secret', 'wrong').expect(401);
+    });
+
+    it('rejects the conversions route without the secret', async () => {
+      await get('/conversions').expect(401);
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects an out-of-range window', async () => {
+      await get('?days=0').set('x-internal-secret', SECRET).expect(400);
+      await get('?days=400').set('x-internal-secret', SECRET).expect(400);
+    });
+
+    it('rejects an undeclared query parameter', async () => {
+      await get('?nope=1').set('x-internal-secret', SECRET).expect(400);
+    });
+  });
+
+  describe('cohort', () => {
+    it('returns a healed user with their counts and providers', async () => {
+      await seedHealedRequest(1, 'openrouter');
+      await seedHealedRequest(2, 'openrouter');
+      await seedHealedRequest(3, 'anthropic');
+
+      const res = await get(nextWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0]).toMatchObject({
+        email: OWNER_EMAIL,
+        name: 'Healed User',
+        healed_recent: 3,
+        healed_all: 3,
+        providers: ['openrouter', 'anthropic'],
+        top_provider: 'openrouter',
+      });
+    });
+
+    it('counts older heals in the all-time total but not the window', async () => {
+      await seedHealedRequest(1, 'openai');
+      await seedHealedRequest(40, 'openai');
+
+      const res = await get(nextWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(res.body[0]).toMatchObject({ healed_recent: 1, healed_all: 2 });
+    });
+
+    it('ignores a retry that succeeded on a request which still failed', async () => {
+      await seedHealedRequest(1, 'openai', 'failed');
+
+      const res = await get(nextWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(res.body).toEqual([]);
+    });
+
+    it('omits users whose email is unverified', async () => {
+      await seedHealedRequest(1, 'openai');
+      await ds.query(`UPDATE "user" SET "emailVerified" = false WHERE id = $1`, [OWNER_ID]);
+
+      const res = await get(nextWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(res.body).toEqual([]);
+    });
+
+    it('omits internal addresses', async () => {
+      await seedHealedRequest(1, 'openai');
+      await ds.query(`UPDATE "user" SET email = 'bruno@buddyweb.fr' WHERE id = $1`, [OWNER_ID]);
+
+      const res = await get(nextWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(res.body).toEqual([]);
+    });
+
+    it('returns an empty list when nothing was healed', async () => {
+      const res = await get(nextWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(res.body).toEqual([]);
+    });
+  });
+
+  describe('conversions', () => {
+    it('returns waitlist claims in the window, lowercased', async () => {
+      await ds.query(
+        `INSERT INTO waitlist_claims (id, email, source, claimed_at) VALUES ($1, $2, $3, now())`,
+        [uuid(), 'Converted@Example.com', 'cloud'],
+      );
+      await ds.query(
+        `INSERT INTO waitlist_claims (id, email, source, claimed_at)
+         VALUES ($1, $2, $3, now() - interval '200 days')`,
+        [uuid(), 'ancient@example.com', 'cloud'],
+      );
+
+      const res = await get('/conversions?days=90').set('x-internal-secret', SECRET).expect(200);
+
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0]).toMatchObject({ email: 'converted@example.com', source: 'cloud' });
+    });
+  });
+});

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -53,6 +53,7 @@ import { CommonModule } from '../src/common/common.module';
 import { PublicStatsModule } from '../src/public-stats/public-stats.module';
 import { SetupModule } from '../src/setup/setup.module';
 import { WaitlistModule } from '../src/waitlist/waitlist.module';
+import { CrmMetricsModule } from '../src/crm-metrics/crm-metrics.module';
 import { ProviderModelFetcherService } from '../src/model-discovery/provider-model-fetcher.service';
 
 export const TEST_USER_ID = 'test-user-001';
@@ -238,6 +239,7 @@ export async function createTestApp(options: CreateTestAppOptions = {}): Promise
         PublicStatsModule,
         SetupModule,
         WaitlistModule,
+        CrmMetricsModule,
       ],
       providers: [{ provide: APP_GUARD, useClass: MockSessionGuard }],
     })


### PR DESCRIPTION
### 💭 Why

We want to tell the people whose requests Autofix actually repaired that it now works as a standalone product, and quote their real repair count. Nothing in the API could answer "who did Autofix help lately".

### ✨ What changed

- `GET /api/v1/internal/crm-metrics` returns healed users with their repair counts and the providers that were failing.
- `GET /api/v1/internal/crm-metrics/conversions` returns pivot waitlist claims, so the campaign can be measured.
- Partial index over the ~8.3k healed rows in `requests`.
- Provider breakdown joins through `request_id`, reusing an existing index instead of adding one to `agent_messages`.
- Internal, role, disposable and unverified addresses are filtered server side, so every consumer inherits the rules.
- CLAUDE.md: new route, new env var, new module in the structure tree.

### 🔧 For operators

- Set `CRM_METRICS_SECRET` to 32+ chars or the route rejects everything. This is the only endpoint that returns user emails across tenants, so it uses a constant-time compare and a separate secret from `ERROR_PAGE_PUSH_SECRET`.
- The migration runs `CREATE INDEX CONCURRENTLY` against a 7.0M row table. Budget minutes, and note it holds off autovacuum on `requests` while it builds. Do not ship it right before you need a hotfix out.

### 📝 Notes

Measured on production, the cohort query was a sequential scan: 7,016,836 rows discarded to return 59, reading ~6.6 GB through a 128 MB `shared_buffers`. The damage was cache eviction, not latency, and a 2.4s query survives any sane timeout. So the service probes for the index and returns 503 when it is missing or half-built rather than falling back to the scan.

Coverage on the new module is 100% across statements, branches, functions and lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal, secret-gated feed of the users Autofix repaired so outreach can quote real repair counts, plus pivot waitlist claims to measure conversions.

- `GET /api/v1/internal/crm-metrics` returns healed users with recent and all-time repair counts and the providers that were failing; `GET /api/v1/internal/crm-metrics/conversions` returns pivot waitlist claims.
- Cloud-only: self-hosted installs never register the module or the index migration, and the controller re-checks the mode after config loads so a bare-metal install carrying `MANIFEST_MODE` only in `.env` still 404s.
- A partial index over the ~8.3k healed rows in `requests` turns a 6.6 GB sequential scan into a small index read; the service 503s when that index is missing or half-built instead of falling back to the scan.
- The migration runs `CREATE INDEX CONCURRENTLY`, blocks autovacuum on `requests` while it builds, and drops only an INVALID index shell so a retried deploy keeps a valid one.
- Set `CRM_METRICS_SECRET` (min 32 chars, compared in constant time) or the route rejects all requests.

<sup>Written for commit a3d205b23b0a6387f7dba0a69a96579be81f3d10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

