### PR TITLE
fix(routing): show loading state while a fallback reorder saves

### DIFF
--- a/.changeset/heavy-donkeys-repeat.md
+++ b/.changeset/heavy-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show a loading state while a routing fallback reorder is saving, and block further drags on that tier until it lands

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -80,6 +80,13 @@ interface FallbackListProps {
     params: RequestParamDefaults | null,
   ) => Promise<unknown>;
   swappingIndex?: number | null;
+  /**
+   * Notified when a reorder-drop starts and finishes persisting. The parent
+   * uses it to lock its own drag sources (the primary chip) for the duration,
+   * so a second swap can't be started against a tier whose fallback order is
+   * still being written.
+   */
+  onReorderingChange?: (reordering: boolean) => void;
   modelParamsScope?: string;
 }
 
@@ -101,7 +108,23 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   const [removingIndex, setRemovingIndex] = createSignal<number | null>(null);
   const [dragIndex, setDragIndex] = createSignal<number | null>(null);
   const [dropSlot, setDropSlot] = createSignal<number | null>(null);
+  const [reorderingIndex, setReorderingIndex] = createSignal<number | null>(null);
   let listRef: HTMLDivElement | undefined;
+
+  /**
+   * A row whose new position is still being persisted. Covers both the
+   * primary/fallback swap driven by the parent (`swappingIndex`) and a
+   * reorder inside this list, which used to persist with no feedback at all.
+   */
+  const isPending = (index: number): boolean =>
+    props.swappingIndex === index || reorderingIndex() === index;
+
+  /**
+   * True while any drag-initiated update for this tier is in flight. Rows stay
+   * put until it resolves, so a retry-because-nothing-happened drag can't fire
+   * a second overlapping write against the same tier.
+   */
+  const dragLocked = (): boolean => props.swappingIndex != null || reorderingIndex() !== null;
 
   const modelLabel = (model: string): string => {
     const info = props.models.find((m) => m.model_name === model);
@@ -348,11 +371,16 @@ const FallbackList: Component<FallbackListProps> = (props) => {
     });
 
     props.onUpdate(reordered, reorderedRoutes);
+    setReorderingIndex(insertAt);
+    props.onReorderingChange?.(true);
     try {
       await persistSet(props.agentName, props.tier, reordered, reorderedRoutes ?? undefined);
       toast.success('Fallback order updated');
     } catch {
       props.onUpdate(original, originalRoutes);
+    } finally {
+      setReorderingIndex(null);
+      props.onReorderingChange?.(false);
     }
   };
 
@@ -399,7 +427,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                     class="fallback-list__card"
                     classList={{
                       'fallback-list__card--dragging': dragIndex() === i(),
-                      'fallback-list__card--swapping': props.swappingIndex === i(),
+                      'fallback-list__card--swapping': isPending(i()),
                       'fallback-list__card--skipped': skippedInStream(model(), i()),
                     }}
                     title={
@@ -407,7 +435,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                         ? 'Skipped while Stream mode is active'
                         : undefined
                     }
-                    draggable={true}
+                    draggable={!dragLocked()}
                     onDragStart={(e) => handleDragStart(i(), e)}
                     // Bind dragend on the draggable row itself rather than
                     // only on the container. When a fallback row is dropped
@@ -422,7 +450,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                     onDragEnd={handleDragEnd}
                   >
                     <Show
-                      when={props.swappingIndex !== i()}
+                      when={!isPending(i())}
                       fallback={
                         <>
                           <div

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -153,6 +153,9 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
   const [fallbackDragging, setFallbackDragging] = createSignal<number | null>(null);
   const [primaryDropTarget, setPrimaryDropTarget] = createSignal(false);
   const [swappingFbIndex, setSwappingFbIndex] = createSignal<number | null>(null);
+  // Set while FallbackList persists a reorder. The primary chip is a drag
+  // source into that same list, so it stays locked until the write lands.
+  const [fallbackReordering, setFallbackReordering] = createSignal(false);
 
   const handlePrimaryDragStart = (e: DragEvent) => {
     setPrimaryDragging(true);
@@ -454,7 +457,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                         'routing-card__model-chip--skipped': primarySkipped(),
                       }}
                       title={primarySkipped() ? 'Skipped while Stream mode is active' : undefined}
-                      draggable={true}
+                      draggable={!fallbackReordering()}
                       onDragStart={handlePrimaryDragStart}
                       onDragEnd={handlePrimaryDragEnd}
                       onDragOver={handlePrimaryDragOver}
@@ -633,6 +636,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
               getModelParams={props.getModelParams}
               setModelParams={props.setModelParams}
               swappingIndex={swappingFbIndex()}
+              onReorderingChange={setFallbackReordering}
               modelParamsScope={modelParamsScopeForTier(props.stage.id)}
               responseMode={props.tier()?.response_mode ?? 'buffered'}
             />

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1404,4 +1404,113 @@ describe('FallbackList', () => {
       expect(btn).toBeDefined();
     });
   });
+
+  // ── Reorder in-flight state (issue #1876) ──
+  describe('reorder in-flight state', () => {
+    /**
+     * Drags the first card past the last one and drops it. In jsdom every
+     * getBoundingClientRect is zeroed, so clientY=0 puts the drop slot after
+     * the last card — the same trick the existing drag/drop specs use.
+     */
+    const dropFirstCardLast = (container: HTMLElement) => {
+      const list = container.querySelector<HTMLElement>('.fallback-list__items')!;
+      const cards = list.querySelectorAll<HTMLElement>('.fallback-list__card');
+      fireEvent.dragStart(cards[0]!, { dataTransfer: { effectAllowed: '', setData: vi.fn() } });
+      fireEvent.dragOver(list, {
+        clientY: 0,
+        dataTransfer: { dropEffect: '' },
+        preventDefault: vi.fn(),
+      });
+      fireEvent.drop(list, { preventDefault: vi.fn() });
+    };
+
+    it('shows a skeleton on the moved row and locks dragging until the reorder persists', async () => {
+      let resolvePersist!: () => void;
+      mockSetFallbacks.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolvePersist = resolve;
+        }),
+      );
+      const onReorderingChange = vi.fn();
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={['model-a', 'model-b']}
+          onReorderingChange={onReorderingChange}
+        />
+      ));
+
+      dropFirstCardLast(container);
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('.fallback-list__card--swapping').length).toBe(1);
+      });
+      const cards = container.querySelectorAll<HTMLElement>('.fallback-list__card');
+      expect(Array.from(cards).every((c) => c.draggable === false)).toBe(true);
+      expect(onReorderingChange).toHaveBeenCalledWith(true);
+
+      resolvePersist();
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('.fallback-list__card--swapping').length).toBe(0);
+      });
+      expect(onReorderingChange).toHaveBeenLastCalledWith(false);
+      expect(
+        Array.from(container.querySelectorAll<HTMLElement>('.fallback-list__card')).every(
+          (c) => c.draggable === true,
+        ),
+      ).toBe(true);
+    });
+
+    it('clears the in-flight state when the reorder fails to persist', async () => {
+      mockSetFallbacks.mockRejectedValueOnce(new Error('nope'));
+      const onReorderingChange = vi.fn();
+      const onUpdate = vi.fn();
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={['model-a', 'model-b']}
+          onUpdate={onUpdate}
+          onReorderingChange={onReorderingChange}
+        />
+      ));
+
+      dropFirstCardLast(container);
+
+      await waitFor(() => {
+        expect(onReorderingChange).toHaveBeenLastCalledWith(false);
+      });
+      expect(container.querySelectorAll('.fallback-list__card--swapping').length).toBe(0);
+      // Optimistic move reverted, then the drag lock released.
+      expect(onUpdate).toHaveBeenLastCalledWith(['model-a', 'model-b'], null);
+    });
+
+    it('reorders without a parent listener when onReorderingChange is omitted', async () => {
+      const { container } = render(() => (
+        <FallbackList {...defaultProps} fallbacks={['model-a', 'model-b']} />
+      ));
+
+      dropFirstCardLast(container);
+
+      await waitFor(() => {
+        expect(mockSetFallbacks).toHaveBeenCalledWith(
+          'test-agent',
+          'tier-1',
+          ['model-b', 'model-a'],
+          undefined,
+        );
+      });
+      expect(container.querySelectorAll('.fallback-list__card--swapping').length).toBe(0);
+    });
+
+    it('locks every row while the parent reports a primary swap in flight', () => {
+      const { container } = render(() => (
+        <FallbackList {...defaultProps} fallbacks={['model-a', 'model-b']} swappingIndex={0} />
+      ));
+
+      const cards = container.querySelectorAll<HTMLElement>('.fallback-list__card');
+      expect(cards.length).toBe(2);
+      expect(Array.from(cards).every((c) => c.draggable === false)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1876.

## Problem

Dragging a fallback model into a new position on the Routing page persists the
new order with no visual feedback at all. The row sits unchanged for the ~1s
round trip, so users assume the drag didn't register and drag again, firing a
second overlapping write against the same tier's fallback list.

Half of what the issue asks for already exists: the primary/fallback swap
renders a skeleton on the affected row through `swappingIndex`. What has no
in-flight state is the reorder-within-the-fallback-list path in
`FallbackList.handleDrop` — it calls `onUpdate` optimistically, awaits the
persist, and shows nothing meanwhile. Nothing stops a second drag during either
operation either: during a swap, the rows that aren't the swapping one stay
draggable, and the primary chip is a drag source into the same list.

## Change

`packages/frontend/src/components/FallbackList.tsx`

- Track a `reorderingIndex` around the reorder persist, cleared in `finally` so
  the failure path releases it too.
- `isPending(index)` folds it together with the existing `swappingIndex`, so the
  reordered row gets the same skeleton treatment that a swapped row already
  gets. No new styling — this reuses `fallback-list__card--swapping`.
- `dragLocked()` makes every fallback row non-draggable while any drag-initiated
  write for the tier is in flight.
- New optional `onReorderingChange` prop reports the reorder in-flight state to
  the parent.

`packages/frontend/src/pages/RoutingTierCard.tsx`

- Consumes `onReorderingChange` and locks the primary chip while a reorder is
  saving. (The other direction is already covered: while `swappingFbIndex` is
  set, the primary chip renders as a skeleton and isn't a drag source.)

The issue also floats optimistic UI as an alternative. Both paths were already
optimistic; the missing piece was the in-flight feedback and the interaction
lock, so that's all this touches.

## Tests

Four new specs in `tests/components/FallbackList.test.tsx`. Three of them fail
on `main` and pass with the fix (verified by reverting only the two source
files and re-running):

- skeleton appears on the moved row, all rows go non-draggable, and
  `onReorderingChange(true)` fires — then all of it unwinds once the persist
  resolves
- the in-flight state clears and the optimistic move reverts when the persist
  rejects
- rows are locked while the parent reports a primary swap in flight
- (fourth, passing either way) the reorder still works when no parent listener
  is supplied

## Checks

- `npx vitest run` (frontend) — 4292/4292 passing, 219/219 files
- `npx vitest run --coverage` — `FallbackList.tsx` lines 98.72% → 98.76%; the
  remaining uncovered lines are the same pre-existing ones, just shifted
- `npx tsc --noEmit` — clean
- `npx eslint` on the changed source files — clean
- `npx prettier --check` — clean
- Changeset added targeting `manifest` (patch); `scripts/check-changesets.js` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a loading state while a fallback reorder saves on the Routing page, so the drag gives immediate feedback instead of a silent ~1s pause. While any drag-initiated write for the tier is in flight, all fallback rows and the primary chip are locked, so a second overlapping drag can't start.

- Reuses the existing skeleton treatment (`fallback-list__card--swapping`) on the moved row via a new `reorderingIndex` signal.
- Adds an optional `onReorderingChange` prop so the parent can lock the primary chip during a reorder.
- While a reorder is pending, the remove, key-pin, and Add fallback controls are also disabled, so their independent writes can't race the in-flight reorder persist.
- New tests cover persist success, failure (optimistic move reverts), primary swap lock, the no-listener case, and the control lockouts.
- Fixes #1876.

<sup>Written for commit 3fe77a9a606dd4fd5855cbd6b158ef501e5fa267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

