### PR TITLE
feat: sync manifest subscription model lists (2026-09-08)

### DIFF
--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -224,6 +224,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionKeyPlaceholder: 'Paste your Z.ai API key',
     knownModels: Object.freeze([
       'glm-5.3',
+      'glm-5.3-flash',
       'glm-5.2',
       'glm-5.1',
       'glm-5-turbo',


### PR DESCRIPTION
### ✨ What changed
- Adds `glm-5.3-flash` to subscription `knownModels` in configs.ts.

### 💭 Why
Discovery found these subscription models served by the provider but missing from the curated `knownModels` list.

### 📝 Notes
- Smoke could not verify (zai): `glm-5.3-flash` (HTTP 429: {"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}). Ids unverified by a live request.
- Not added: `muse-spark-1.3-contributor`, `omen-alpha`, `glm-5.3` (already curated, dynamically fetched, or a routing artifact).
- 143 new api_key models auto-discover at runtime, not listed here.
- Pricing (models.dev) and params (modelparams.dev) out of scope.
- Draft PR, auto-generated by the modelparams agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `glm-5.3-flash` to the subscription provider's `knownModels` list so the curated list matches what the provider serves.

- The model id was not verified via a live request because the provider returned HTTP 429.
- Other discovered models were not added because they're already curated, dynamically fetched, or routing artifacts.

<sup>Written for commit 7c575e5c3e325033145d78bc1ea6c3d912bcbb47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

