### PR TITLE
fix(pricing): bill DeepSeek V4.1 Flash at published peak rates

### DIFF
--- a/.changeset/deepseek-v41-flash-pricing.md
+++ b/.changeset/deepseek-v41-flash-pricing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bill DeepSeek V4.1 Flash at the published peak/off-peak rates, and switch `deepseek-v4-pro` onto that card from 2026-09-14 04:00 UTC.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -402,11 +402,11 @@ describe('ModelsDevSyncService', () => {
         'https://models.dev/api.json',
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
-      // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 1,
-      // fireworks: 1, mistral: 6, xai: 3, bedrock: 8, groq: 2,
-      // nvidia: 1, opencode-go: 1, opencode: 1, cerebras: 1,
-      // ollama-cloud: 3 = 32
-      expect(count).toBe(32);
+      // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 2
+      // (deepseek-chat + deepseek-flash stub), fireworks: 1, mistral: 6, xai: 3,
+      // bedrock: 8, groq: 2, nvidia: 1, opencode-go: 1, opencode: 1, cerebras: 1,
+      // ollama-cloud: 3 = 33
+      expect(count).toBe(33);
     });
 
     it('should filter out non-text-output models', async () => {
@@ -1190,12 +1190,27 @@ describe('ModelsDevSyncService', () => {
       ]);
     });
 
-    it('seeds DeepSeek V4 peak pricing when the catalog carries no time tiers', async () => {
+    const flashPeakTier = {
+      windows: ['01:00-04:00', '06:00-10:00'],
+      days: [1, 2, 3, 4, 5],
+      inputPricePerToken: 0.3 / 1_000_000,
+      outputPricePerToken: 1.2 / 1_000_000,
+      cacheReadPricePerToken: 0.006 / 1_000_000,
+      cacheWritePricePerToken: null,
+    };
+
+    it('seeds DeepSeek V4.1 Flash peak pricing when the catalog carries no time tiers', async () => {
       const response = {
         deepseek: {
           id: 'deepseek',
           name: 'DeepSeek',
           models: {
+            'deepseek-flash': {
+              id: 'deepseek-flash',
+              name: 'DeepSeek V4.1 Flash',
+              cost: { input: 0.14, output: 0.28, cache_read: 0.0028, cache_write: 0.35 },
+              modalities: { input: ['text', 'image'], output: ['text'] },
+            },
             'deepseek-v4-flash': {
               id: 'deepseek-v4-flash',
               name: 'DeepSeek V4 Flash',
@@ -1215,29 +1230,50 @@ describe('ModelsDevSyncService', () => {
 
       await service.refreshCache();
 
-      const flash = service.lookupModel('deepseek', 'deepseek-v4-flash');
-      // Stale catalog rates are replaced by the real off-peak base…
-      expect(flash!.inputPricePerToken).toBe(0.22 / 1_000_000);
-      expect(flash!.outputPricePerToken).toBe(0.66 / 1_000_000);
-      expect(flash!.cacheReadPricePerToken).toBe(0.007 / 1_000_000);
+      const flash = service.lookupModel('deepseek', 'deepseek-flash');
+      // Stale catalog rates are replaced by the V4.1 Flash off-peak base…
+      expect(flash!.inputPricePerToken).toBe(0.15 / 1_000_000);
+      expect(flash!.outputPricePerToken).toBe(0.6 / 1_000_000);
+      expect(flash!.cacheReadPricePerToken).toBe(0.003 / 1_000_000);
       // The stale catalog cache-write rate must not survive either: DeepSeek
       // bills cache writes at the input rate, which null falls back to.
       expect(flash!.cacheWritePricePerToken).toBeNull();
       // …plus the peak windows at double.
-      expect(flash!.timeTiers).toEqual([
-        {
-          windows: ['01:00-04:00', '06:00-10:00'],
-          days: [1, 2, 3, 4, 5],
-          inputPricePerToken: 0.44 / 1_000_000,
-          outputPricePerToken: 1.32 / 1_000_000,
-          cacheReadPricePerToken: 0.014 / 1_000_000,
-          cacheWritePricePerToken: null,
-        },
-      ]);
-      // Models outside the seed (legacy aliases) are untouched.
+      expect(flash!.timeTiers).toEqual([flashPeakTier]);
+      // Retired aliases still accepted by DeepSeek are billed on the same card.
+      const legacy = service.lookupModel('deepseek', 'deepseek-v4-flash');
+      expect(legacy!.inputPricePerToken).toBe(0.15 / 1_000_000);
+      expect(legacy!.timeTiers).toEqual([flashPeakTier]);
+      // Models outside the seed are untouched.
       const chat = service.lookupModel('deepseek', 'deepseek-chat');
       expect(chat!.inputPricePerToken).toBe(0.14 / 1_000_000);
       expect(chat!.timeTiers).toBeNull();
+    });
+
+    it('synthesizes deepseek-flash when the catalog has not listed it yet', async () => {
+      const response = {
+        deepseek: {
+          id: 'deepseek',
+          name: 'DeepSeek',
+          models: {
+            'deepseek-v4-flash': {
+              id: 'deepseek-v4-flash',
+              name: 'DeepSeek V4 Flash',
+              cost: { input: 0.14, output: 0.28, cache_read: 0.0028 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const ga = service.lookupModel('deepseek', 'deepseek-flash');
+      expect(ga).not.toBeNull();
+      expect(ga!.name).toBe('DeepSeek V4.1 Flash');
+      expect(ga!.inputPricePerToken).toBe(0.15 / 1_000_000);
+      expect(ga!.timeTiers).toEqual([flashPeakTier]);
     });
 
     it('seeds the vision preview on the Flash card', async () => {
@@ -1260,9 +1296,65 @@ describe('ModelsDevSyncService', () => {
       await service.refreshCache();
 
       const vision = service.lookupModel('deepseek', 'deepseek-v4-flash-vision-exp');
-      expect(vision!.inputPricePerToken).toBe(0.22 / 1_000_000);
-      expect(vision!.outputPricePerToken).toBe(0.66 / 1_000_000);
-      expect(vision!.timeTiers![0].days).toEqual([1, 2, 3, 4, 5]);
+      expect(vision!.inputPricePerToken).toBe(0.15 / 1_000_000);
+      expect(vision!.outputPricePerToken).toBe(0.6 / 1_000_000);
+      expect(vision!.timeTiers).toEqual([flashPeakTier]);
+    });
+
+    describe('deepseek-v4-pro Flash cutover', () => {
+      const proResponse = {
+        deepseek: {
+          id: 'deepseek',
+          name: 'DeepSeek',
+          models: {
+            'deepseek-v4-pro': {
+              id: 'deepseek-v4-pro',
+              name: 'DeepSeek V4 Pro',
+              cost: { input: 0.435, output: 0.87, cache_read: 0.003625 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      it('keeps the Pro card until 2026-09-14 04:00 UTC', async () => {
+        jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-09-14T03:59:59Z'));
+        fetchSpy.mockResolvedValue({ ok: true, json: async () => proResponse });
+
+        await service.refreshCache();
+
+        const pro = service.lookupModel('deepseek', 'deepseek-v4-pro');
+        expect(pro!.inputPricePerToken).toBe(0.66 / 1_000_000);
+        expect(pro!.outputPricePerToken).toBe(1.98 / 1_000_000);
+        expect(pro!.cacheReadPricePerToken).toBe(0.022 / 1_000_000);
+        expect(pro!.timeTiers).toEqual([
+          {
+            windows: ['01:00-04:00', '06:00-10:00'],
+            days: [1, 2, 3, 4, 5],
+            inputPricePerToken: 1.32 / 1_000_000,
+            outputPricePerToken: 3.96 / 1_000_000,
+            cacheReadPricePerToken: 0.044 / 1_000_000,
+            cacheWritePricePerToken: null,
+          },
+        ]);
+      });
+
+      it('bills Pro on the Flash card from 2026-09-14 04:00 UTC', async () => {
+        jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-09-14T04:00:00Z'));
+        fetchSpy.mockResolvedValue({ ok: true, json: async () => proResponse });
+
+        await service.refreshCache();
+
+        const pro = service.lookupModel('deepseek', 'deepseek-v4-pro');
+        expect(pro!.inputPricePerToken).toBe(0.15 / 1_000_000);
+        expect(pro!.outputPricePerToken).toBe(0.6 / 1_000_000);
+        expect(pro!.cacheReadPricePerToken).toBe(0.003 / 1_000_000);
+        expect(pro!.timeTiers).toEqual([flashPeakTier]);
+      });
     });
 
     it('carries a catalog day list through to the tier', async () => {
@@ -1690,7 +1782,7 @@ describe('ModelsDevSyncService', () => {
       fetchSpy.mockResolvedValue({ ok: true, json: async () => MOCK_API_RESPONSE });
       // Same total as refreshCache asserts: the kilo model is cached for
       // capabilities but never counted or priced.
-      expect(await service.refreshCache()).toBe(32);
+      expect(await service.refreshCache()).toBe(33);
     });
 
     it('should declare tool support for OpenRouter models', () => {

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -158,61 +158,76 @@ const FETCH_TIMEOUT_MS = 10000;
 const TIME_WINDOW_RE = /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/;
 
 /**
- * DeepSeek V4 moved to peak/off-peak billing on 2026-08-16: peak hours are
- * 01:00-04:00 and 06:00-10:00 UTC **Monday through Friday**, and every other
- * hour — including all 48 weekend hours — is off-peak at half the peak rate.
- * models.dev cannot express time-of-day pricing yet
- * (anomalyco/models.dev#4892 adds `cost.tiers[].tier.type = "time"`; #4891
- * corrects the flat numbers in the meantime), so until the catalog carries a
- * time tier for these models this seed replaces whatever flat rate the sync
- * returns with the real off-peak base plus a peak-window tier.
+ * DeepSeek bills peak/off-peak: peak hours are 01:00-04:00 and 06:00-10:00 UTC
+ * **Monday through Friday**, and every other hour — including all 48 weekend
+ * hours — is off-peak at half the peak rate. models.dev cannot express
+ * time-of-day pricing yet (anomalyco/models.dev#4892 adds
+ * `cost.tiers[].tier.type = "time"`), so until the catalog carries a time tier
+ * this seed replaces whatever flat rate the sync returns with the real
+ * off-peak base plus a peak-window tier.
  *
  * DELETE once models.dev serves time tiers for DeepSeek — the seed only
  * applies when `parseTimeTiers` finds nothing, so it retires itself, but the
  * dead constant should not outlive that. Prices are USD per 1M tokens from
- * https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17).
+ * https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-09-10).
  */
 const DEEPSEEK_PEAK_WINDOWS: readonly string[] = ['01:00-04:00', '06:00-10:00'];
 /** Monday–Friday: DeepSeek's peak schedule does not run on weekends. */
 const DEEPSEEK_PEAK_DAYS: readonly number[] = [1, 2, 3, 4, 5];
-const DEEPSEEK_V4_PEAK_SEED: ReadonlyMap<
-  string,
-  {
-    input: number;
-    output: number;
-    cacheRead: number;
-    peak: { input: number; output: number; cacheRead: number };
-  }
-> = new Map([
-  [
-    'deepseek-v4-flash',
-    {
-      input: 0.22,
-      output: 0.66,
-      cacheRead: 0.007,
-      peak: { input: 0.44, output: 1.32, cacheRead: 0.014 },
-    },
-  ],
-  [
-    'deepseek-v4-pro',
-    {
-      input: 0.66,
-      output: 1.98,
-      cacheRead: 0.022,
-      peak: { input: 1.32, output: 3.96, cacheRead: 0.044 },
-    },
-  ],
-  // The vision preview is billed on the Flash card, not a card of its own.
-  [
-    'deepseek-v4-flash-vision-exp',
-    {
-      input: 0.22,
-      output: 0.66,
-      cacheRead: 0.007,
-      peak: { input: 0.44, output: 1.32, cacheRead: 0.014 },
-    },
-  ],
+
+type DeepSeekRateCard = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  peak: { input: number; output: number; cacheRead: number };
+};
+
+/** V4.1 Flash, in effect from 2026-09-10 04:00 UTC. */
+const DEEPSEEK_FLASH_RATES: DeepSeekRateCard = {
+  input: 0.15,
+  output: 0.6,
+  cacheRead: 0.003,
+  peak: { input: 0.3, output: 1.2, cacheRead: 0.006 },
+};
+
+/** V4 Pro, unchanged until it starts routing to Flash. */
+const DEEPSEEK_PRO_RATES: DeepSeekRateCard = {
+  input: 0.66,
+  output: 1.98,
+  cacheRead: 0.022,
+  peak: { input: 1.32, output: 3.96, cacheRead: 0.044 },
+};
+
+/**
+ * 12:00 Beijing on 2026-09-14 = 04:00 UTC. From then, `deepseek-v4-pro` is
+ * served by V4.1 Flash and billed on the Flash card.
+ */
+const DEEPSEEK_PRO_FLASH_CUTOVER_MS = Date.parse('2026-09-14T04:00:00Z');
+
+/** GA id plus the retired aliases DeepSeek still accepts at Flash prices. */
+const DEEPSEEK_FLASH_MODEL_IDS: ReadonlySet<string> = new Set([
+  'deepseek-flash',
+  'deepseek-v4-flash',
+  'deepseek-v4-flash-vision-exp',
 ]);
+
+/** Stub used when the catalog has not listed `deepseek-flash` yet. */
+const DEEPSEEK_FLASH_CATALOG_STUB: RawModelsDevModel = {
+  id: 'deepseek-flash',
+  name: 'DeepSeek V4.1 Flash',
+  reasoning: true,
+  tool_call: true,
+  modalities: { input: ['text', 'image'], output: ['text'] },
+};
+
+function deepseekSeedRates(modelId: string, atMs = Date.now()): DeepSeekRateCard | undefined {
+  if (DEEPSEEK_FLASH_MODEL_IDS.has(modelId)) return DEEPSEEK_FLASH_RATES;
+  if (modelId === 'deepseek-v4-pro') {
+    return atMs >= DEEPSEEK_PRO_FLASH_CUTOVER_MS ? DEEPSEEK_FLASH_RATES : DEEPSEEK_PRO_RATES;
+  }
+  return undefined;
+}
+
 /** Matches trailing version suffixes like -001, -002 (Google API convention). */
 const VERSION_SUFFIX_RE = /-\d{3}$/;
 /** Matches trailing date suffixes like -20250514, -2025-04-14. */
@@ -318,6 +333,13 @@ export class ModelsDevSyncService implements OnModuleInit {
         if (!this.isChatCompatible(model)) continue;
         const entry = this.parseModel(ourId, modelId, model);
         modelMap.set(modelId, entry);
+        totalModels++;
+      }
+      if (ourId === 'deepseek' && !modelMap.has('deepseek-flash')) {
+        modelMap.set(
+          'deepseek-flash',
+          this.parseModel(ourId, 'deepseek-flash', DEEPSEEK_FLASH_CATALOG_STUB),
+        );
         totalModels++;
       }
 
@@ -718,10 +740,10 @@ export class ModelsDevSyncService implements OnModuleInit {
     let timeTiers = this.parseTimeTiers(raw);
 
     // Peak/off-peak seed for DeepSeek's own API until models.dev can carry
-    // the schedule itself (see DEEPSEEK_V4_PEAK_SEED). Catalog data wins the
+    // the schedule itself (see deepseekSeedRates). Catalog data wins the
     // moment it exists.
     if (providerId === 'deepseek' && !timeTiers) {
-      const seed = DEEPSEEK_V4_PEAK_SEED.get(modelId);
+      const seed = deepseekSeedRates(modelId);
       if (seed) {
         inputPerMillion = seed.input;
         outputPerMillion = seed.output;


### PR DESCRIPTION
### ✨ What changed
- Seed V4.1 Flash off-peak/peak rates (`0.15/0.6/0.003`, 2× peak) for `deepseek-flash` and the retired Flash aliases
- Switch `deepseek-v4-pro` onto that Flash card from 2026-09-14 04:00 UTC (12:00 Beijing)
- Stub `deepseek-flash` when models.dev has not listed it yet

### 💭 Why
V4.1 Flash GA'd 2026-09-10 at new rates. The seed still billed the old V4 Flash card (~2.3× high on cache reads). Pro stays on its own card until DeepSeek routes it to Flash.

### 👤 For users
DeepSeek first-party costs on Flash traffic now match the published card, including peak windows Mon–Fri 01:00–04:00 and 06:00–10:00 UTC.

### 📝 Notes
https://api-docs.deepseek.com/quick_start/pricing/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DeepSeek V4.1 Flash billing to use the published peak/off-peak rates instead of the old V4 Flash card, which overcharged cache reads by ~2.3x. Also switches `deepseek-v4-pro` to the Flash card from 2026-09-14 04:00 UTC and stubs `deepseek-flash` when models.dev hasn't listed it yet.

<sup>Written for commit 156abf37540a8df9b9b1ad31328a59efad58e252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

