### PR TITLE
fix: keep streaming success after caller close

### DIFF
--- a/.changeset/streaming-cancel-after-complete.md
+++ b/.changeset/streaming-cancel-after-complete.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Keep streaming requests as success when the caller closes after a terminal provider event.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -3036,6 +3036,96 @@ describe('ProxyController', () => {
       expect(headers['X-Manifest-Provider']).toBe('OpenAI');
     });
 
+    function makeAbortingSseResponse(firstChunk: string, onFirstChunk: () => void): Response {
+      const encoder = new TextEncoder();
+      let sentFirstChunk = false;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (!sentFirstChunk) {
+            sentFirstChunk = true;
+            controller.enqueue(encoder.encode(firstChunk));
+            onFirstChunk();
+            return;
+          }
+          controller.error(new Error('aborted'));
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }
+
+    it('records success when the caller closes after finish_reason but before upstream EOF', async () => {
+      let closeListener: (() => void) | undefined;
+      const successSpy = jest.spyOn(recorder, 'recordSuccessMessage');
+      const cancelledSpy = jest.spyOn(recorder, 'recordCancelledRequest');
+      proxyService.proxyRequest.mockResolvedValue({
+        forward: {
+          response: makeAbortingSseResponse(
+            'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n' +
+              'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+            () => closeListener?.(),
+          ),
+          wireFormat: 'openai_chat_completions',
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        },
+        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8 },
+      });
+
+      const req = mockRequest({
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      });
+      const { res, written } = mockResponse();
+      (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+        if (event === 'close') closeListener = cb;
+      });
+
+      await controller.chatCompletions(req as never, res as never);
+      await flushRecorderMicrotasks();
+
+      expect(written.join('')).toContain('"finish_reason":"stop"');
+      expect(cancelledSpy).not.toHaveBeenCalled();
+      expect(successSpy).toHaveBeenCalled();
+    });
+
+    it('records cancelled when the caller closes before a terminal provider event', async () => {
+      let closeListener: (() => void) | undefined;
+      const successSpy = jest.spyOn(recorder, 'recordSuccessMessage');
+      const cancelledSpy = jest.spyOn(recorder, 'recordCancelledRequest');
+      proxyService.proxyRequest.mockResolvedValue({
+        forward: {
+          response: makeAbortingSseResponse(
+            'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+            () => closeListener?.(),
+          ),
+          wireFormat: 'openai_chat_completions',
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        },
+        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8 },
+      });
+
+      const req = mockRequest({
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      });
+      const { res } = mockResponse();
+      (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+        if (event === 'close') closeListener = cb;
+      });
+
+      await controller.chatCompletions(req as never, res as never);
+      await flushRecorderMicrotasks();
+
+      expect(successSpy).not.toHaveBeenCalled();
+      expect(cancelledSpy).toHaveBeenCalled();
+    });
+
     it('should emit a terminal SSE error when the upstream dies after the first chunk', async () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -94,7 +94,10 @@ function makeDiscoveredModel(overrides: Partial<DiscoveredModel> = {}): Discover
   };
 }
 
-function makeInterruptedSseResponse(firstChunk: string): Response {
+function makeInterruptedSseResponse(
+  firstChunk: string,
+  options?: { onFirstChunk?: () => void; error?: Error },
+): Response {
   const encoder = new TextEncoder();
   let sentFirstChunk = false;
   const stream = new ReadableStream<Uint8Array>({
@@ -102,9 +105,10 @@ function makeInterruptedSseResponse(firstChunk: string): Response {
       if (!sentFirstChunk) {
         sentFirstChunk = true;
         controller.enqueue(encoder.encode(firstChunk));
+        options?.onFirstChunk?.();
         return;
       }
-      controller.error(new Error('mid-stream failure'));
+      controller.error(options?.error ?? new Error('mid-stream failure'));
     },
   });
   return new Response(stream, {
@@ -3036,36 +3040,16 @@ describe('ProxyController', () => {
       expect(headers['X-Manifest-Provider']).toBe('OpenAI');
     });
 
-    function makeAbortingSseResponse(firstChunk: string, onFirstChunk: () => void): Response {
-      const encoder = new TextEncoder();
-      let sentFirstChunk = false;
-      const stream = new ReadableStream<Uint8Array>({
-        pull(controller) {
-          if (!sentFirstChunk) {
-            sentFirstChunk = true;
-            controller.enqueue(encoder.encode(firstChunk));
-            onFirstChunk();
-            return;
-          }
-          controller.error(new Error('aborted'));
-        },
-      });
-      return new Response(stream, {
-        status: 200,
-        headers: { 'Content-Type': 'text/event-stream' },
-      });
-    }
-
     it('records success when the caller closes after finish_reason but before upstream EOF', async () => {
       let closeListener: (() => void) | undefined;
       const successSpy = jest.spyOn(recorder, 'recordSuccessMessage');
       const cancelledSpy = jest.spyOn(recorder, 'recordCancelledRequest');
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
-          response: makeAbortingSseResponse(
+          response: makeInterruptedSseResponse(
             'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n' +
               'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
-            () => closeListener?.(),
+            { onFirstChunk: () => closeListener?.(), error: new Error('aborted') },
           ),
           wireFormat: 'openai_chat_completions',
           isGoogle: false,
@@ -3098,9 +3082,9 @@ describe('ProxyController', () => {
       const cancelledSpy = jest.spyOn(recorder, 'recordCancelledRequest');
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
-          response: makeAbortingSseResponse(
+          response: makeInterruptedSseResponse(
             'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
-            () => closeListener?.(),
+            { onFirstChunk: () => closeListener?.(), error: new Error('aborted') },
           ),
           wireFormat: 'openai_chat_completions',
           isGoogle: false,

--- a/packages/backend/src/routing/proxy/__tests__/stream-protocol.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-protocol.spec.ts
@@ -18,11 +18,14 @@ function event(data: unknown, name = ''): EventSourceMessage {
 describe('StreamProtocolObserver', () => {
   it('accepts OpenAI Chat Completions terminal markers', () => {
     const done = new StreamProtocolObserver('openai_chat_completions');
+    expect(done.isComplete()).toBe(false);
     done.observe(event('[DONE]'));
+    expect(done.isComplete()).toBe(true);
     expect(() => done.assertComplete()).not.toThrow();
 
     const finishReason = new StreamProtocolObserver('openai_chat_completions');
     finishReason.observe(event({ choices: [{ finish_reason: 'stop' }, null] }));
+    expect(finishReason.isComplete()).toBe(true);
     expect(() => finishReason.assertComplete()).not.toThrow();
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/stream-protocol.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-protocol.spec.ts
@@ -91,10 +91,11 @@ describe('StreamProtocolObserver', () => {
   });
 
   it.each(['google_generate_content', 'google_code_assist'] as const)(
-    'treats clean EOF as terminal for %s',
+    'treats clean EOF as terminal for %s without marking a provider outcome',
     (protocol) => {
       const observer = new StreamProtocolObserver(protocol);
       observer.observe(event('not-json'));
+      expect(observer.isComplete()).toBe(false);
       expect(() => observer.assertComplete()).not.toThrow();
     },
   );

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -261,6 +261,31 @@ describe('pipeStream', () => {
     expect(res.end).toHaveBeenCalled();
   });
 
+  it('still fails a Google stream aborted after a content chunk', async () => {
+    const { res } = mockResponse();
+    const encoder = new TextEncoder();
+    let sentContent = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentContent) {
+          sentContent = true;
+          controller.enqueue(
+            encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}\n\n'),
+          );
+          return;
+        }
+        controller.error(new Error('aborted'));
+      },
+    });
+
+    await expect(
+      pipeStream(stream, res as never, undefined, undefined, undefined, {
+        protocol: 'google_generate_content',
+      }),
+    ).rejects.toBeInstanceOf(UpstreamStreamError);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
   it('still fails when an upstream abort happens before a terminal event', async () => {
     const { res } = mockResponse();
     const encoder = new TextEncoder();

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -232,6 +232,60 @@ describe('pipeStream', () => {
     expect(res.end).toHaveBeenCalled();
   });
 
+  it('treats an upstream abort after finish_reason as a completed stream', async () => {
+    const { res, written } = mockResponse();
+    const encoder = new TextEncoder();
+    let sentTerminal = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentTerminal) {
+          sentTerminal = true;
+          controller.enqueue(
+            encoder.encode(
+              'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n' +
+                'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+            ),
+          );
+          return;
+        }
+        controller.error(new Error('aborted'));
+      },
+    });
+
+    await expect(
+      pipeStream(stream, res as never, undefined, undefined, undefined, {
+        protocol: 'openai_chat_completions',
+      }),
+    ).resolves.toBeNull();
+    expect(written.join('')).toContain('"finish_reason":"stop"');
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('still fails when an upstream abort happens before a terminal event', async () => {
+    const { res } = mockResponse();
+    const encoder = new TextEncoder();
+    let sentContent = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentContent) {
+          sentContent = true;
+          controller.enqueue(
+            encoder.encode('data: {"choices":[{"delta":{"content":"hello"}}]}\n\n'),
+          );
+          return;
+        }
+        controller.error(new Error('aborted'));
+      },
+    });
+
+    await expect(
+      pipeStream(stream, res as never, undefined, undefined, undefined, {
+        protocol: 'openai_chat_completions',
+      }),
+    ).rejects.toBeInstanceOf(UpstreamStreamError);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
   function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
     const encoder = new TextEncoder();
     let index = 0;
@@ -1049,6 +1103,35 @@ describe('pipePassthrough', () => {
 
     expect(stream.locked).toBe(false);
     expect(res.end).not.toHaveBeenCalled();
+  });
+
+  it('treats an upstream abort after message_stop as a completed stream', async () => {
+    const { res, written } = mockResponse();
+    const encoder = new TextEncoder();
+    let sentTerminal = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentTerminal) {
+          sentTerminal = true;
+          controller.enqueue(
+            encoder.encode(
+              'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"hi"}}\n\n' +
+                'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ),
+          );
+          return;
+        }
+        controller.error(new Error('aborted'));
+      },
+    });
+
+    await expect(
+      pipePassthrough(stream, res as never, () => null, undefined, {
+        protocol: 'anthropic_messages',
+      }),
+    ).resolves.toBeNull();
+    expect(written.join('')).toContain('message_stop');
+    expect(res.end).toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/src/routing/proxy/stream-protocol.ts
+++ b/packages/backend/src/routing/proxy/stream-protocol.ts
@@ -142,7 +142,6 @@ export class StreamProtocolObserver {
     }
 
     // Google streams have no portable terminal event; clean EOF is terminal.
-    this.completed = true;
   }
 
   isComplete(): boolean {

--- a/packages/backend/src/routing/proxy/stream-protocol.ts
+++ b/packages/backend/src/routing/proxy/stream-protocol.ts
@@ -145,6 +145,10 @@ export class StreamProtocolObserver {
     this.completed = true;
   }
 
+  isComplete(): boolean {
+    return this.completed;
+  }
+
   assertComplete(): void {
     if (this.protocol === 'google_generate_content' || this.protocol === 'google_code_assist') {
       return;

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -78,6 +78,13 @@ function createProtocolParser(options: StreamRelayOptions): {
   };
 }
 
+function isAbortAfterProviderOutcome(
+  error: unknown,
+  observer: StreamProtocolObserver | null,
+): boolean {
+  return error instanceof UpstreamStreamError && observer?.isComplete() === true;
+}
+
 /**
  * Read a usage block in either OpenAI-compat (`prompt_tokens`/`completion_tokens`)
  * or Anthropic-native (`input_tokens`/`output_tokens`) shape and normalise it
@@ -337,6 +344,7 @@ export async function pipePassthrough(
     }
     protocol.observer?.assertComplete();
   } catch (error) {
+    if (isAbortAfterProviderOutcome(error, protocol.observer)) return capturedUsage;
     streamFailed = error instanceof StreamFailure;
     if (error instanceof StreamIdleTimeoutError) await reader.cancel(error).catch(() => undefined);
     throw error;
@@ -450,6 +458,7 @@ export async function pipeStream(
       }
     }
   } catch (error) {
+    if (isAbortAfterProviderOutcome(error, protocol.observer)) return capturedUsage;
     streamFailed = error instanceof StreamFailure;
     if (error instanceof StreamIdleTimeoutError) await reader.cancel(error).catch(() => undefined);
     throw error;


### PR DESCRIPTION
### ✨ What changed
- Treat a caller close after a terminal provider event as stream success
- Keep cancelled only when the caller disconnects before that event
- Add regression tests for both orderings

### 💭 Why
OpenClaw and similar clients close as soon as they see `finish_reason`. Manifest then aborted the upstream read and recorded a completed stream as `cancelled`.

### 👤 For users
Successful streaming replies stay marked successful in request history and dashboards.

### 📝 Notes
https://github.com/mnfst/llm-gateway/issues/2854

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a caller close after a terminal provider event as stream success, so completed streams are no longer recorded as cancelled in request history. Only closes before the terminal event (like `finish_reason` or `message_stop`) are marked cancelled. Fixes #2854.

**Changes**
- Adds `isComplete()` to `StreamProtocolObserver` to expose whether a terminal event was observed.
- `pipeStream` and `pipePassthrough` now return success when the upstream aborts after a terminal event.
- Google streams stay incomplete until EOF, so a mid-stream abort there still records as cancelled.
- Adds regression tests for both close orderings across OpenAI and Anthropic protocols.

<sup>Written for commit 4f6eea55fbc4913f76e4e6f678aa4092c610d514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

