### PR TITLE
fix: give repeated Responses call ids unique values

### DIFF
--- a/.changeset/responses-duplicate-call-ids.md
+++ b/.changeset/responses-duplicate-call-ids.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Give repeated tool call ids unique values before forwarding a Responses history, so strict Responses providers stop rejecting resubmitted turns with "Duplicate function_call_output for call_id".

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -479,6 +479,157 @@ describe('Responses adapter', () => {
     expect(result.top_p).toBe(0.5);
   });
 
+  describe('duplicate call_id normalization', () => {
+    const call = (callId: string, name: string, args: string) => ({
+      type: 'function_call',
+      call_id: callId,
+      name,
+      arguments: args,
+    });
+    const output = (callId: string, text: string) => ({
+      type: 'function_call_output',
+      call_id: callId,
+      output: text,
+    });
+
+    it('gives repeated call/output pairs unique ids without touching the payloads', () => {
+      const result = toNativeResponsesRequest(
+        {
+          input: [
+            { role: 'user', content: 'run it' },
+            call('terminal:0', 'terminal', '{"cmd":"ls"}'),
+            output('terminal:0', 'one'),
+            call('vision_analyze:0', 'vision_analyze', '{"id":1}'),
+            output('vision_analyze:0', 'first look'),
+            call('terminal:0', 'terminal', '{"cmd":"pwd"}'),
+            output('terminal:0', 'two'),
+            call('vision_analyze:0', 'vision_analyze', '{"id":2}'),
+            output('vision_analyze:0', 'second look'),
+            call('terminal:0', 'terminal', '{"cmd":"whoami"}'),
+            output('terminal:0', 'three'),
+          ],
+        },
+        'muse-spark-1.3-contributor',
+      );
+
+      expect(result.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'run it' }] },
+        call('terminal:0', 'terminal', '{"cmd":"ls"}'),
+        output('terminal:0', 'one'),
+        call('vision_analyze:0', 'vision_analyze', '{"id":1}'),
+        output('vision_analyze:0', 'first look'),
+        call('terminal:0-mnfst-2', 'terminal', '{"cmd":"pwd"}'),
+        output('terminal:0-mnfst-2', 'two'),
+        call('vision_analyze:0-mnfst-2', 'vision_analyze', '{"id":2}'),
+        output('vision_analyze:0-mnfst-2', 'second look'),
+        call('terminal:0-mnfst-3', 'terminal', '{"cmd":"whoami"}'),
+        output('terminal:0-mnfst-3', 'three'),
+      ]);
+    });
+
+    it('extends a replacement id that the history already uses', () => {
+      const result = toNativeResponsesRequest(
+        {
+          input: [
+            call('terminal:0', 'terminal', '{}'),
+            output('terminal:0', 'one'),
+            call('terminal:0-mnfst-2', 'terminal', '{}'),
+            output('terminal:0-mnfst-2', 'other tool'),
+            call('terminal:0', 'terminal', '{}'),
+            output('terminal:0', 'two'),
+          ],
+        },
+        'muse-spark-1.3-contributor',
+      );
+
+      expect(result.input).toEqual([
+        call('terminal:0', 'terminal', '{}'),
+        output('terminal:0', 'one'),
+        call('terminal:0-mnfst-2', 'terminal', '{}'),
+        output('terminal:0-mnfst-2', 'other tool'),
+        call('terminal:0-mnfst-2-x', 'terminal', '{}'),
+        output('terminal:0-mnfst-2-x', 'two'),
+      ]);
+    });
+
+    it('leaves unique, ambiguous, and id-less histories untouched', () => {
+      const unique = [
+        call('terminal:0', 'terminal', '{}'),
+        output('terminal:0', 'one'),
+        call('terminal:1', 'terminal', '{}'),
+        output('terminal:1', 'two'),
+      ];
+      expect(toNativeResponsesRequest({ input: unique }, 'gpt-5.4').input).toEqual(unique);
+
+      // Two calls in a row: which output belongs to which call is a guess.
+      const unpaired = [
+        call('terminal:0', 'terminal', '{}'),
+        call('terminal:0', 'terminal', '{}'),
+        output('terminal:0', 'one'),
+        output('terminal:0', 'two'),
+      ];
+      expect(toNativeResponsesRequest({ input: unpaired }, 'gpt-5.4').input).toEqual(unpaired);
+
+      // An output with no matching call leaves an odd number of entries.
+      const orphan = [
+        output('terminal:0', 'one'),
+        call('terminal:0', 'terminal', '{}'),
+        output('terminal:0', 'two'),
+      ];
+      expect(toNativeResponsesRequest({ input: orphan }, 'gpt-5.4').input).toEqual(orphan);
+
+      const idLess = ['plain', { type: 'reasoning', id: 'rs_1' }, { type: 'function_call' }];
+      expect(toNativeResponsesRequest({ input: idLess }, 'gpt-5.4').input).toEqual(idLess);
+    });
+
+    it('leaves ids alone when the provider holds the earlier turns', () => {
+      const input = [
+        call('terminal:0', 'terminal', '{}'),
+        output('terminal:0', 'one'),
+        call('terminal:0', 'terminal', '{}'),
+        output('terminal:0', 'two'),
+      ];
+
+      expect(
+        toNativeResponsesRequest({ input, previous_response_id: 'resp_123' }, 'gpt-5.4').input,
+      ).toEqual(input);
+      expect(
+        toNativeResponsesRequest({ input, previous_response_id: '' }, 'gpt-5.4').input,
+      ).toEqual([
+        call('terminal:0', 'terminal', '{}'),
+        output('terminal:0', 'one'),
+        call('terminal:0-mnfst-2', 'terminal', '{}'),
+        output('terminal:0-mnfst-2', 'two'),
+      ]);
+    });
+
+    it('normalizes ids on backends that require input lists', () => {
+      const result = toNativeResponsesRequest(
+        {
+          input: [
+            call('terminal:0', 'terminal', '{}'),
+            output('terminal:0', 'one'),
+            call('terminal:0', 'terminal', '{}'),
+            output('terminal:0', 'two'),
+          ],
+        },
+        'gpt-5.4',
+        { inputList: true },
+      );
+
+      expect((result.input as Record<string, unknown>[]).map((item) => item.call_id)).toEqual([
+        'terminal:0',
+        'terminal:0',
+        'terminal:0-mnfst-2',
+        'terminal:0-mnfst-2',
+      ]);
+    });
+
+    it('keeps a non-list input as it was sent', () => {
+      expect(toNativeResponsesRequest({ input: 'hi' }, 'gpt-5.4').input).toBe('hi');
+    });
+  });
+
   describe('fromChatCompletionResponse', () => {
     it('converts text, tool calls, and usage to a Response object', () => {
       const result = fromChatCompletionResponse(

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -225,6 +225,14 @@ export function toNativeResponsesRequest(
   } else if (body.input !== undefined) {
     request.input = normalizeNativeResponsesInput(body.input);
   }
+  // `previous_response_id` means the provider holds the earlier turns, so the
+  // ids in this request can pair with items we cannot see. Leave them alone.
+  if (
+    Array.isArray(request.input) &&
+    (typeof request.previous_response_id !== 'string' || !request.previous_response_id)
+  ) {
+    request.input = deduplicateCallIds(request.input);
+  }
   if (
     opts?.defaultInstructions &&
     (typeof request.instructions !== 'string' || !request.instructions.trim())
@@ -232,6 +240,73 @@ export function toNativeResponsesRequest(
     request.instructions = DEFAULT_INSTRUCTIONS;
   }
   return request;
+}
+
+interface CallIdItem {
+  index: number;
+  type: string;
+}
+
+/**
+ * Some agents and adapters mint turn-local tool ids such as `terminal:0`. When
+ * the caller resubmits its accumulated Responses history, the same id then
+ * carries several `function_call` / `function_call_output` pairs, and a strict
+ * Responses provider rejects the request with `Duplicate function_call_output
+ * for call_id '...'` before the model runs.
+ *
+ * Give every repeated pair a request-unique `call_id`. Only ids whose calls and
+ * outputs alternate one for one are rewritten: an unmatched call, an output
+ * before its call, or two calls in a row is ambiguous, so that id is left as
+ * the caller sent it. Item order, tool names, arguments and outputs never
+ * change, and a history whose ids are already unique is returned untouched.
+ */
+function deduplicateCallIds(input: unknown[]): unknown[] {
+  const byCallId = new Map<string, CallIdItem[]>();
+  const takenCallIds = new Set<string>();
+
+  input.forEach((item, index) => {
+    if (!isRecord(item)) return;
+    const callId = typeof item.call_id === 'string' ? item.call_id : '';
+    if (!callId) return;
+    takenCallIds.add(callId);
+    if (item.type !== 'function_call' && item.type !== 'function_call_output') return;
+    const items = byCallId.get(callId) ?? [];
+    items.push({ index, type: item.type });
+    byCallId.set(callId, items);
+  });
+
+  const rewrites = new Map<number, string>();
+  for (const [callId, items] of byCallId) {
+    // Two entries are a single call/output pair, so there is nothing to split.
+    if (items.length <= 2 || !isAlternatingPairs(items)) continue;
+    for (let pair = 1; pair * 2 < items.length; pair += 1) {
+      const replacement = uniqueCallId(callId, pair, takenCallIds);
+      rewrites.set(items[pair * 2].index, replacement);
+      rewrites.set(items[pair * 2 + 1].index, replacement);
+    }
+  }
+  if (rewrites.size === 0) return input;
+
+  return input.map((item, index) => {
+    const replacement = rewrites.get(index);
+    return replacement === undefined ? item : { ...(item as JsonRecord), call_id: replacement };
+  });
+}
+
+/** True when the items read `function_call`, `function_call_output`, repeated. */
+function isAlternatingPairs(items: CallIdItem[]): boolean {
+  if (items.length % 2 !== 0) return false;
+  return items.every((item, position) =>
+    position % 2 === 0 ? item.type === 'function_call' : item.type === 'function_call_output',
+  );
+}
+
+/** Deterministic replacement id, extended until it collides with nothing. */
+function uniqueCallId(callId: string, pair: number, taken: Set<string>): string {
+  let candidate = `${callId}-mnfst-${pair + 1}`;
+  while (taken.has(candidate)) candidate += '-x';
+  taken.add(candidate);
+  return candidate;
 }
 
 function normalizeNativeResponsesInput(input: unknown): unknown {


### PR DESCRIPTION
## Problem

An agent that mints turn-local tool ids (`terminal:0`, `vision_analyze:0`) reuses those ids across turns. When it resubmits its accumulated Responses history and Manifest forwards it to a strict Responses provider, the provider rejects the request before the model runs:

```text
Duplicate function_call_output for call_id 'terminal:0'. Each function_call must have exactly one matching function_call_output
```

Each individual call and output pair is valid. The accumulated request is not, because the ids collide.

## Fix

`toNativeResponsesRequest` is the single place where Manifest builds the Responses body it forwards, so the normalization happens there, after the existing input normalization and before the request goes out.

`deduplicateCallIds` walks the input in order, groups `function_call` / `function_call_output` items by their `call_id`, and rewrites every repeat after the first pair to a request-unique id. The replacement is derived from the original (`terminal:0-mnfst-2`) and is extended until it collides with no id already in the request, so it stays deterministic.

Deliberately conservative, per the acceptance criteria:

- Only ids whose items alternate call, output, call, output are rewritten. Two calls in a row, an output with no call, or any odd count is ambiguous, so that id is left exactly as the caller sent it.
- A history whose ids are already unique is returned untouched, same array, no copies.
- Order, tool names, arguments, outputs and every other field are never modified. Only `call_id` changes, and both halves of a pair get the same new value.
- A request carrying `previous_response_id` is skipped entirely. The provider holds the earlier turns there, so ids in this request can pair with items Manifest cannot see, and rewriting them would break that pairing.

Items of other types that happen to carry the same id (for example `computer_call`) are not touched.

## Tests

Six specs in `responses-adapter.spec.ts`, including the reported shape: `terminal:0` used three times and `vision_analyze:0` twice, interleaved, each call followed by its own output. Four of the six fail on unmodified `main` and pass with this change. The other two pin the "leave it alone" behavior and pass either way, which is the point of them.

Checks run locally: `npx jest src/routing/proxy` 2379 passing. Full backend `npx jest` 8827 of 8828 passing; the one failure is `notification-cron.service.edge-cases.spec.ts`, which asserts two timestamps fall in different local hours and so fails in a UTC+5:30 timezone regardless of this change. `npx eslint`, `npx tsc --noEmit` and `npx prettier --check` on the changed files are clean. Coverage on `responses-adapter.ts` shows no new uncovered lines. Patch changeset added targeting `manifest`.

Fixes #2851


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops strict Responses providers from rejecting resubmitted histories when agents reuse turn-local tool ids like `terminal:0`, by rewriting repeated call ids to request-unique values before forwarding.

**Bug Fixes**
- Deduplicates `function_call` / `function_call_output` pairs in `toNativeResponsesRequest` after input normalization.
- Rewrites only ids whose calls and outputs alternate one for one; ambiguous patterns and requests with `previous_response_id` are left untouched.
- Preserves order, tool names, arguments, outputs, and returns already-unique histories unchanged.
- Adds six specs covering the reported shape and the leave-it-alone cases. Fixes #2851.

<sup>Written for commit 8945dacd09f41f71bb583b46782721672994a43e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

