### PR TITLE
fix: replay reasoning_content for DeepSeek thinking mode in tool conversations

### DIFF
--- a/.changeset/deepseek-reasoning-replay-fix.md
+++ b/.changeset/deepseek-reasoning-replay-fix.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix DeepSeek thinking-mode 400s by replaying `reasoning_content` under the scoped session key and covering non-tool assistant turns in tool conversations.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -747,6 +747,45 @@ describe('ProxyFallbackService', () => {
       );
     });
 
+    it('reads the reasoning cache with the scoped key the response handler wrote with', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      const requestBody = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      await service.tryForwardToProvider({
+        provider: 'deepseek',
+        apiKey: 'sk-test',
+        model: 'deepseek-chat',
+        body: requestBody,
+        stream: false,
+        sessionKey: 'sess-1',
+        reasoningCacheKey: 'v1:scoped-digest',
+        authType: 'api_key',
+      });
+
+      // Stored entries live under the scoped key; reading with the raw caller
+      // session key misses every one of them and DeepSeek 400s on the empty
+      // replay it then receives.
+      expect(reasoningCache.prepareRequest).toHaveBeenCalledWith(
+        requestBody,
+        'v1:scoped-digest',
+        'deepseek',
+        'deepseek-chat',
+      );
+    });
+
     it('rethrows when signal is aborted', async () => {
       const ac = new AbortController();
       ac.abort();

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -168,6 +168,53 @@ describe('ReasoningContentCache', () => {
     expect((body.messages[0] as Record<string, unknown>).reasoning_content).toBeUndefined();
   });
 
+  it('replays an empty reasoning_content key onto non-tool assistant turns in a tool conversation', async () => {
+    const body = {
+      messages: [
+        { role: 'user', content: 'read the file' },
+        { role: 'assistant', content: 'on it' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+        { role: 'tool', tool_call_id: 'call_1', content: 'contents' },
+      ],
+    };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    // DeepSeek's thinking mode rejects the request when any assistant turn omits
+    // the key once tools are in play, so the plain turn is replayed empty too.
+    expect(messages[1].reasoning_content).toBe('');
+    expect(messages[2].reasoning_content).toBe('');
+    expect(messages[0].reasoning_content).toBeUndefined();
+    expect(messages[3].reasoning_content).toBeUndefined();
+  });
+
+  it('leaves an existing non-tool reasoning_content untouched in a tool conversation', async () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: 'on it',
+          reasoning_content: 'client thinking',
+        },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe('client thinking');
+  });
+
   it('leaves request bodies without messages unchanged', async () => {
     const body = { prompt: 'The answer is 42.' };
 

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -29,6 +29,13 @@ interface ForwardProviderOptions {
   resolveChatBody?: ResolveChatBody;
   stream: boolean;
   sessionKey: string;
+  /**
+   * Scoped replay-cache key (`sessionScope.cacheKey`). The reasoning replay
+   * cache must read with the same key the response handler wrote with; the raw
+   * caller `sessionKey` (`default` without an x-session-key) never matches a
+   * stored entry, so DeepSeek's thinking mode saw an empty replay and 400ed.
+   */
+  reasoningCacheKey?: string;
   providerCacheKey?: string;
   signal?: AbortSignal;
   authType?: string;
@@ -198,6 +205,7 @@ export class ProxyFallbackService {
     /** Dashboard URL embedded in mid-chain M100/M102 credential failure bodies. */
     credentialDashboardUrl?: string,
     providerCacheKey?: string,
+    reasoningCacheKey?: string,
   ): Promise<{
     success: {
       forward: ForwardResult;
@@ -313,6 +321,7 @@ export class ProxyFallbackService {
         resolveChatBody,
         stream,
         sessionKey,
+        reasoningCacheKey,
         providerCacheKey,
         signal,
         agentId,
@@ -721,7 +730,7 @@ export class ProxyFallbackService {
             );
             resolved = await this.reasoningCache.prepareRequest(
               resolved,
-              opts.sessionKey,
+              opts.reasoningCacheKey ?? opts.sessionKey,
               reasoningEndpointKey,
               forwardModel,
             );
@@ -732,7 +741,7 @@ export class ProxyFallbackService {
       : undefined;
     body = await this.reasoningCache.prepareRequest(
       body,
-      opts.sessionKey,
+      opts.reasoningCacheKey ?? opts.sessionKey,
       reasoningEndpointKey,
       forwardModel,
     );

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -30,10 +30,8 @@ interface ForwardProviderOptions {
   stream: boolean;
   sessionKey: string;
   /**
-   * Scoped replay-cache key (`sessionScope.cacheKey`). The reasoning replay
-   * cache must read with the same key the response handler wrote with; the raw
-   * caller `sessionKey` (`default` without an x-session-key) never matches a
-   * stored entry, so DeepSeek's thinking mode saw an empty replay and 400ed.
+   * Scoped replay-cache key (`sessionScope.cacheKey`). The reasoning cache must
+   * read with the same key the response handler wrote with.
    */
   reasoningCacheKey?: string;
   providerCacheKey?: string;

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -186,6 +186,7 @@ interface HealedReforwardContext {
   tenantId: string;
   apiMode: ProxyApiMode;
   sessionKey: string;
+  sessionCacheKey?: string;
   providerCacheKey?: string;
   sessionMomentumKey?: string;
   signal?: AbortSignal;
@@ -395,6 +396,7 @@ export class ProxyService {
           resolveChatBody,
           stream,
           sessionKey,
+          sessionCacheKey,
           providerCacheKey,
           sessionMomentumKey,
           signal,
@@ -426,6 +428,7 @@ export class ProxyService {
       resolveChatBody,
       stream,
       sessionKey,
+      reasoningCacheKey: sessionCacheKey,
       providerCacheKey,
       signal,
       agentId,
@@ -473,6 +476,7 @@ export class ProxyService {
                 tenantId,
                 apiMode: autofixApiMode,
                 sessionKey,
+                sessionCacheKey,
                 providerCacheKey,
                 sessionMomentumKey,
                 signal,
@@ -516,6 +520,7 @@ export class ProxyService {
         resolveChatBody,
         stream,
         sessionKey,
+        sessionCacheKey,
         providerCacheKey,
         sessionMomentumKey,
         signal,
@@ -624,6 +629,7 @@ export class ProxyService {
           resolveChatBody,
           stream,
           sessionKey,
+          sessionCacheKey,
           providerCacheKey,
           sessionMomentumKey,
           signal,
@@ -801,6 +807,7 @@ export class ProxyService {
       resolveChatBody,
       stream: ctx.stream,
       sessionKey: ctx.sessionKey,
+      reasoningCacheKey: ctx.sessionCacheKey,
       providerCacheKey: ctx.providerCacheKey,
       signal: ctx.signal,
       agentId: ctx.agentId,
@@ -1161,6 +1168,7 @@ export class ProxyService {
     resolveChatBody?: ResolveChatBody;
     stream: boolean;
     sessionKey: string;
+    sessionCacheKey?: string;
     providerCacheKey?: string;
     sessionMomentumKey?: string;
     signal?: AbortSignal;
@@ -1187,6 +1195,7 @@ export class ProxyService {
       resolveChatBody,
       stream,
       sessionKey,
+      sessionCacheKey,
       providerCacheKey,
       sessionMomentumKey,
       signal,
@@ -1226,6 +1235,7 @@ export class ProxyService {
       args.startProviderAttempt,
       args.credentialDashboardUrl,
       providerCacheKey,
+      sessionCacheKey,
     );
 
     this.recordTierIfScoring(sessionMomentumKey, resolved.tier);

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -28,9 +28,13 @@ export const MAX_CACHE_ENTRIES = 10_000;
  * be replayed with the same `reasoning_content` they returned. Generic
  * OpenAI-compatible SDKs often drop that provider-specific field when they
  * rebuild conversation history, so Manifest caches tool turns by the first tool
- * call id. Normal assistant turns are intentionally not cached for replay:
- * DeepSeek does not require them, and content-based matching can attach
- * reasoning to the wrong visible turn.
+ * call id.
+ *
+ * Turns with no tool call are not cached: content-based matching can attach
+ * reasoning to the wrong visible turn. They are still replayed, using the
+ * empty-string fallback, once the conversation contains a tool call, because
+ * DeepSeek's thinking mode rejects the request when any assistant turn omits
+ * the key. A conversation without tool calls keeps its exact turn shape.
  */
 @Injectable()
 export class ReasoningContentCache {

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -30,11 +30,10 @@ export const MAX_CACHE_ENTRIES = 10_000;
  * rebuild conversation history, so Manifest caches tool turns by the first tool
  * call id.
  *
- * Turns with no tool call are not cached: content-based matching can attach
- * reasoning to the wrong visible turn. They are still replayed, using the
- * empty-string fallback, once the conversation contains a tool call, because
- * DeepSeek's thinking mode rejects the request when any assistant turn omits
- * the key. A conversation without tool calls keeps its exact turn shape.
+ * Turns with no tool call are never cached (content-based matching can attach
+ * reasoning to the wrong visible turn) but are still replayed, using the
+ * empty-string fallback, once the conversation contains a tool call: DeepSeek
+ * rejects the request when any assistant turn omits the key.
  */
 @Injectable()
 export class ReasoningContentCache {
@@ -137,9 +136,8 @@ export class ReasoningContentCache {
     const messages = body.messages;
     if (!Array.isArray(messages)) return body;
 
-    // DeepSeek's thinking mode only enforces the reasoning echo once tools are
-    // in play, so the wider candidate set is scoped to tool conversations and a
-    // plain chat thread keeps its exact turn shape.
+    // Only tool conversations enforce the echo; a plain chat thread keeps its
+    // exact turn shape.
     const includeNonToolTurns = messages.some(
       (message) =>
         !!message &&
@@ -274,11 +272,7 @@ function reasoningReplayCandidate(
   if (typeof record.reasoning_content === 'string' && record.reasoning_content) return null;
 
   if (!Array.isArray(record.tool_calls) || record.tool_calls.length === 0) {
-    // A non-tool assistant turn. Once tools are in play, DeepSeek's thinking
-    // mode requires the reasoning_content key on every assistant turn — an
-    // omitted key 400s exactly like a dropped tool-turn replay would, so these
-    // turns are replayed with the same empty-string fallback. Plain chat
-    // threads stay untouched.
+    // Once tools are in play DeepSeek wants the key on every assistant turn.
     return includeNonToolTurns ? { cacheKey: null } : null;
   }
 

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -133,7 +133,21 @@ export class ReasoningContentCache {
     const messages = body.messages;
     if (!Array.isArray(messages)) return body;
 
-    const candidates = messages.map(reasoningReplayCandidate);
+    // DeepSeek's thinking mode only enforces the reasoning echo once tools are
+    // in play, so the wider candidate set is scoped to tool conversations and a
+    // plain chat thread keeps its exact turn shape.
+    const includeNonToolTurns = messages.some(
+      (message) =>
+        !!message &&
+        typeof message === 'object' &&
+        !Array.isArray(message) &&
+        Array.isArray((message as Record<string, unknown>).tool_calls) &&
+        ((message as Record<string, unknown>).tool_calls as unknown[]).length > 0,
+    );
+
+    const candidates = messages.map((message) =>
+      reasoningReplayCandidate(message, includeNonToolTurns),
+    );
     if (!candidates.some(Boolean)) return body;
 
     const keys = candidates.flatMap((candidate) =>
@@ -246,11 +260,24 @@ interface ReasoningReplayCandidate {
   cacheKey: string | null;
 }
 
-function reasoningReplayCandidate(message: unknown): ReasoningReplayCandidate | null {
+function reasoningReplayCandidate(
+  message: unknown,
+  includeNonToolTurns: boolean,
+): ReasoningReplayCandidate | null {
   if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
   const record = message as Record<string, unknown>;
+  if (record.role !== 'assistant') return null;
   if (typeof record.reasoning_content === 'string' && record.reasoning_content) return null;
-  if (!Array.isArray(record.tool_calls) || record.tool_calls.length === 0) return null;
+
+  if (!Array.isArray(record.tool_calls) || record.tool_calls.length === 0) {
+    // A non-tool assistant turn. Once tools are in play, DeepSeek's thinking
+    // mode requires the reasoning_content key on every assistant turn — an
+    // omitted key 400s exactly like a dropped tool-turn replay would, so these
+    // turns are replayed with the same empty-string fallback. Plain chat
+    // threads stay untouched.
+    return includeNonToolTurns ? { cacheKey: null } : null;
+  }
+
   const firstToolCall = record.tool_calls[0];
   if (!firstToolCall || typeof firstToolCall !== 'object' || Array.isArray(firstToolCall)) {
     return { cacheKey: null };


### PR DESCRIPTION
## Problem

Requests routed to a DeepSeek thinking-mode model (reproduced with `opencode-go/deepseek-flash`) fail with:

```
Error from provider (Console Go): Upstream request failed: [invalid_request_error]
The `reasoning_content` in the thinking mode must be passed back to the API.
```

Two independent defects in `ReasoningContentCache` produce this.

### 1. The replay cache reads with a different key than it writes with

The response handlers store replayed `reasoning_content` under `sessionScope.cacheKey` (`v1:<sha256>`), while `prepareRequest` reads it back with the raw caller `sessionKey` — which is `default` whenever the client sends no `x-session-key` header. The two keys never match, so every lookup misses and the replay falls back to an empty string even when the exact turn is cached. The unit tests do not catch it because they pass the same literal on both sides.

### 2. Non-tool assistant turns are skipped in tool conversations

`reasoningReplayCandidate` only considers assistant turns that carry `tool_calls`. DeepSeek's thinking mode requires the `reasoning_content` key on **every** assistant turn once tools are in play; an omitted key is rejected exactly like a dropped tool-turn replay.

Captured request (ZCode harness; 1254 messages, 610 assistant turns): 573 carry `reasoning_content` and 564 of those are empty strings, all of them tool turns — while the trailing plain assistant turns omit the key entirely.

Isolating each half against the live upstream:

| variant | result |
| --- | --- |
| fill only the tool-call turns | 400 |
| strip `reasoning_content` from every assistant turn | 400 |
| fill only the non-tool assistant turns | **200** |

## Changes

- `reasoning-content-cache.ts` — treat non-tool assistant turns as replay candidates when the conversation contains tool calls. Scoped this way, a plain chat thread keeps its exact turn shape (the existing contract is preserved).
- `proxy-fallback.service.ts`, `proxy.service.ts` — thread the scoped session cache key through the forward and fallback paths so the replay cache reads with the key the response handler wrote with.
- Tests for both behaviours, plus a changeset.

## Verification

- Replaying the captured 1254-message request body against the live provider: 400 before, 200 after.
- `npm test --workspace=packages/backend`: 478 suites, 8831 tests pass.
- `eslint` and `prettier --check` clean on the touched files.

Related: #2219, #2047, #992 — same upstream error class; the earlier fixes covered tool-call turns only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DeepSeek thinking-mode 400s by aligning the reasoning replay cache key and covering non-tool assistant turns in tool conversations.

**Bug Fixes**

- The replay cache now reads with the scoped session key that response handlers write with, so cached `reasoning_content` is actually reused.
- Non-tool assistant turns are now replay candidates when the conversation contains tool calls, so missing `reasoning_content` keys are filled with empty strings.
- Plain chat threads without tool calls are unchanged.

<sup>Written for commit 0f5b0e7ee728e006725da0790971cded26a2f526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

