### PR TITLE
Fix pivot announcement article link

### DIFF
--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -21,7 +21,7 @@
 >
 > **This open-source gateway stays available and maintained.**
 >
-> **[Read about the new direction →](https://manifest.build/blog/introducing-paid-plans/)**
+> **[Read more](https://manifest.build/blog/manifest-is-taking-a-new-direction/)**
 
 ## What is Manifest?
 

--- a/packages/frontend/src/components/PivotAnnouncement.tsx
+++ b/packages/frontend/src/components/PivotAnnouncement.tsx
@@ -11,7 +11,8 @@ import { checkIsSelfHosted } from '../services/setup-status.js';
 import { useFocusTrap } from '../services/use-focus-trap.js';
 import { hasPivotJoined, markPivotJoined, submitPivotClaim } from '../services/waitlist.js';
 
-export const PIVOT_ARTICLE_URL = 'https://manifest.build/blog/introducing-paid-plans/';
+export const PIVOT_ARTICLE_URL =
+  'https://manifest.build/blog/manifest-is-taking-a-new-direction/';
 const PIVOT_CARD_DISMISSED_KEY = 'pivot-card-dismissed';
 
 /**
@@ -212,7 +213,7 @@ const PivotAnnouncement: Component = () => {
                       rel="noopener noreferrer"
                       class="modal-card__field-link"
                     >
-                      Read about the new direction →
+                      Read more
                     </a>
                     <button type="submit" class="btn btn--primary btn--sm" disabled={busy()}>
                       {busy() ? <span class="spinner" /> : 'Join the waiting list'}
@@ -228,7 +229,7 @@ const PivotAnnouncement: Component = () => {
                     rel="noopener noreferrer"
                     class="modal-card__field-link"
                   >
-                    Read about the new direction →
+                    Read more
                   </a>
                   <button
                     ref={closeBtnRef}

--- a/packages/frontend/tests/components/PivotAnnouncement.test.tsx
+++ b/packages/frontend/tests/components/PivotAnnouncement.test.tsx
@@ -107,6 +107,7 @@ describe('PivotAnnouncement', () => {
     expect(input.value).toBe('test@test.com');
     const link = document.querySelector(`a[href="${PIVOT_ARTICLE_URL}"]`);
     expect(link).not.toBeNull();
+    expect(link?.textContent?.trim()).toBe('Read more');
     // The Manifest logotype sits above the title, in both theme variants.
     const logo = document.querySelector('.sidebar-pivot-modal__logo');
     expect(logo?.querySelector('img.auth-logo__img--light')).not.toBeNull();


### PR DESCRIPTION
## Summary
- point the pivot announcement modal to the new direction article
- shorten the article link label to `Read more` in both modal states
- assert the updated label in the component test

## Testing
- `git diff --check`
- Not run: `npm test --workspace=manifest-frontend -- tests/components/PivotAnnouncement.test.tsx` (`vitest` is not installed in this workspace)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points the pivot announcement and Docker README to the new direction article and shortens the link label to `Read more` in both modal states.

- Updates `PIVOT_ARTICLE_URL` and the Docker README link to `https://manifest.build/blog/manifest-is-taking-a-new-direction/`.
- Changes the link text from "Read about the new direction →" to `Read more` in the modal and README.
- Asserts the new label in the component test.

<sup>Written for commit ddb2dbfd3c096dc4d7d14b366e1e084c9a618e9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

