### PR TITLE
fix: normalize repeated Responses call ids from chat

### DIFF
--- a/.changeset/responses-duplicate-call-ids-chat.md
+++ b/.changeset/responses-duplicate-call-ids-chat.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Give repeated tool call ids unique values when converting a Chat Completions request to Responses, so reused ids no longer trip a strict Responses provider's "Duplicate function_call_output for call_id".

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-request-tools.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-request-tools.spec.ts
@@ -156,4 +156,123 @@ describe('ChatGPT Adapter – toResponsesRequest (tool calls)', () => {
 
     expect(result.tools).toEqual([{ type: 'code_interpreter' }]);
   });
+
+  describe('duplicate call_id normalization', () => {
+    const call = (callId: string, args: string) => ({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        { id: callId, type: 'function', function: { name: 'terminal', arguments: args } },
+      ],
+    });
+    const output = (callId: string, text: string) => ({
+      role: 'tool',
+      tool_call_id: callId,
+      content: text,
+    });
+
+    it('gives repeated call/output pairs unique ids without touching the payloads', () => {
+      const result = toResponsesRequest(
+        {
+          messages: [
+            { role: 'user', content: 'run it' },
+            call('terminal:0', '{"cmd":"ls"}'),
+            output('terminal:0', 'one'),
+            call('terminal:0', '{"cmd":"pwd"}'),
+            output('terminal:0', 'two'),
+            call('terminal:0', '{"cmd":"whoami"}'),
+            output('terminal:0', 'three'),
+          ],
+        },
+        'gpt-5',
+      );
+
+      expect(result.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'run it' }] },
+        {
+          type: 'function_call',
+          call_id: 'terminal:0',
+          name: 'terminal',
+          arguments: '{"cmd":"ls"}',
+        },
+        { type: 'function_call_output', call_id: 'terminal:0', output: 'one' },
+        {
+          type: 'function_call',
+          call_id: 'terminal:0-mnfst-2',
+          name: 'terminal',
+          arguments: '{"cmd":"pwd"}',
+        },
+        { type: 'function_call_output', call_id: 'terminal:0-mnfst-2', output: 'two' },
+        {
+          type: 'function_call',
+          call_id: 'terminal:0-mnfst-3',
+          name: 'terminal',
+          arguments: '{"cmd":"whoami"}',
+        },
+        { type: 'function_call_output', call_id: 'terminal:0-mnfst-3', output: 'three' },
+      ]);
+    });
+
+    it('leaves unique and ambiguous histories untouched', () => {
+      const unique = [
+        call('terminal:0', '{}'),
+        output('terminal:0', 'one'),
+        call('terminal:1', '{}'),
+        output('terminal:1', 'two'),
+      ];
+      const uniqueInput = toResponsesRequest({ messages: unique }, 'gpt-5').input as Record<
+        string,
+        unknown
+      >[];
+      expect(uniqueInput.map((item) => item.call_id)).toEqual([
+        'terminal:0',
+        'terminal:0',
+        'terminal:1',
+        'terminal:1',
+      ]);
+
+      // Two calls in a row: which output belongs to which call is a guess.
+      const unpaired = [
+        call('terminal:0', '{}'),
+        call('terminal:0', '{}'),
+        output('terminal:0', 'one'),
+        output('terminal:0', 'two'),
+      ];
+      const unpairedInput = toResponsesRequest({ messages: unpaired }, 'gpt-5').input as Record<
+        string,
+        unknown
+      >[];
+      expect(unpairedInput.map((item) => item.call_id)).toEqual([
+        'terminal:0',
+        'terminal:0',
+        'terminal:0',
+        'terminal:0',
+      ]);
+    });
+
+    it('extends a replacement id that the history already uses', () => {
+      const result = toResponsesRequest(
+        {
+          messages: [
+            call('terminal:0', '{}'),
+            output('terminal:0', 'one'),
+            call('terminal:0-mnfst-2', '{}'),
+            output('terminal:0-mnfst-2', 'other tool'),
+            call('terminal:0', '{}'),
+            output('terminal:0', 'two'),
+          ],
+        },
+        'gpt-5',
+      );
+
+      expect((result.input as Record<string, unknown>[]).map((item) => item.call_id)).toEqual([
+        'terminal:0',
+        'terminal:0',
+        'terminal:0-mnfst-2',
+        'terminal:0-mnfst-2',
+        'terminal:0-mnfst-2-x',
+        'terminal:0-mnfst-2-x',
+      ]);
+    });
+  });
 });

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -18,6 +18,7 @@ import {
   safeParse,
 } from './chatgpt-helpers';
 import { OpenAIMessage } from './proxy-types';
+import { deduplicateCallIds } from './responses-call-ids';
 
 export class ResponsesSseError extends Error {
   constructor(
@@ -100,7 +101,7 @@ export function toResponsesRequest(
 
   const request: Record<string, unknown> = {
     model,
-    input,
+    input: deduplicateCallIds(input),
     stream: options.stream ?? body.stream !== false,
     store: false,
     instructions: extractInstructions(messages),

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 
 import { DEFAULT_INSTRUCTIONS } from './chatgpt-helpers';
 import { OpenAIMessage } from './proxy-types';
+import { deduplicateCallIds } from './responses-call-ids';
 import { chatToolName, chatTools, responsesToolNames, ResponsesToolNames } from './responses-tools';
 
 type JsonRecord = Record<string, unknown>;
@@ -240,73 +241,6 @@ export function toNativeResponsesRequest(
     request.instructions = DEFAULT_INSTRUCTIONS;
   }
   return request;
-}
-
-interface CallIdItem {
-  index: number;
-  type: string;
-}
-
-/**
- * Some agents and adapters mint turn-local tool ids such as `terminal:0`. When
- * the caller resubmits its accumulated Responses history, the same id then
- * carries several `function_call` / `function_call_output` pairs, and a strict
- * Responses provider rejects the request with `Duplicate function_call_output
- * for call_id '...'` before the model runs.
- *
- * Give every repeated pair a request-unique `call_id`. Only ids whose calls and
- * outputs alternate one for one are rewritten: an unmatched call, an output
- * before its call, or two calls in a row is ambiguous, so that id is left as
- * the caller sent it. Item order, tool names, arguments and outputs never
- * change, and a history whose ids are already unique is returned untouched.
- */
-function deduplicateCallIds(input: unknown[]): unknown[] {
-  const byCallId = new Map<string, CallIdItem[]>();
-  const takenCallIds = new Set<string>();
-
-  input.forEach((item, index) => {
-    if (!isRecord(item)) return;
-    const callId = typeof item.call_id === 'string' ? item.call_id : '';
-    if (!callId) return;
-    takenCallIds.add(callId);
-    if (item.type !== 'function_call' && item.type !== 'function_call_output') return;
-    const items = byCallId.get(callId) ?? [];
-    items.push({ index, type: item.type });
-    byCallId.set(callId, items);
-  });
-
-  const rewrites = new Map<number, string>();
-  for (const [callId, items] of byCallId) {
-    // Two entries are a single call/output pair, so there is nothing to split.
-    if (items.length <= 2 || !isAlternatingPairs(items)) continue;
-    for (let pair = 1; pair * 2 < items.length; pair += 1) {
-      const replacement = uniqueCallId(callId, pair, takenCallIds);
-      rewrites.set(items[pair * 2].index, replacement);
-      rewrites.set(items[pair * 2 + 1].index, replacement);
-    }
-  }
-  if (rewrites.size === 0) return input;
-
-  return input.map((item, index) => {
-    const replacement = rewrites.get(index);
-    return replacement === undefined ? item : { ...(item as JsonRecord), call_id: replacement };
-  });
-}
-
-/** True when the items read `function_call`, `function_call_output`, repeated. */
-function isAlternatingPairs(items: CallIdItem[]): boolean {
-  if (items.length % 2 !== 0) return false;
-  return items.every((item, position) =>
-    position % 2 === 0 ? item.type === 'function_call' : item.type === 'function_call_output',
-  );
-}
-
-/** Deterministic replacement id, extended until it collides with nothing. */
-function uniqueCallId(callId: string, pair: number, taken: Set<string>): string {
-  let candidate = `${callId}-mnfst-${pair + 1}`;
-  while (taken.has(candidate)) candidate += '-x';
-  taken.add(candidate);
-  return candidate;
 }
 
 function normalizeNativeResponsesInput(input: unknown): unknown {

--- a/packages/backend/src/routing/proxy/responses-call-ids.ts
+++ b/packages/backend/src/routing/proxy/responses-call-ids.ts
@@ -1,0 +1,72 @@
+type JsonRecord = Record<string, unknown>;
+
+interface CallIdItem {
+  index: number;
+  type: string;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Some agents and adapters mint turn-local tool ids such as `terminal:0`. When
+ * the caller resubmits its accumulated Responses history, the same id then
+ * carries several `function_call` / `function_call_output` pairs, and a strict
+ * Responses provider rejects the request with `Duplicate function_call_output
+ * for call_id '...'` before the model runs.
+ *
+ * Give every repeated pair a request-unique `call_id`. Only ids whose calls and
+ * outputs alternate one for one are rewritten: an unmatched call, an output
+ * before its call, or two calls in a row is ambiguous, so that id is left as
+ * the caller sent it. Item order, tool names, arguments and outputs never
+ * change, and a history whose ids are already unique is returned untouched.
+ */
+export function deduplicateCallIds(input: unknown[]): unknown[] {
+  const byCallId = new Map<string, CallIdItem[]>();
+  const takenCallIds = new Set<string>();
+
+  input.forEach((item, index) => {
+    if (!isRecord(item)) return;
+    const callId = typeof item.call_id === 'string' ? item.call_id : '';
+    if (!callId) return;
+    takenCallIds.add(callId);
+    if (item.type !== 'function_call' && item.type !== 'function_call_output') return;
+    const items = byCallId.get(callId) ?? [];
+    items.push({ index, type: item.type });
+    byCallId.set(callId, items);
+  });
+
+  const rewrites = new Map<number, string>();
+  for (const [callId, items] of byCallId) {
+    // Two entries are a single call/output pair, so there is nothing to split.
+    if (items.length <= 2 || !isAlternatingPairs(items)) continue;
+    for (let pair = 1; pair * 2 < items.length; pair += 1) {
+      const replacement = uniqueCallId(callId, pair, takenCallIds);
+      rewrites.set(items[pair * 2].index, replacement);
+      rewrites.set(items[pair * 2 + 1].index, replacement);
+    }
+  }
+  if (rewrites.size === 0) return input;
+
+  return input.map((item, index) => {
+    const replacement = rewrites.get(index);
+    return replacement === undefined ? item : { ...(item as JsonRecord), call_id: replacement };
+  });
+}
+
+/** True when the items read `function_call`, `function_call_output`, repeated. */
+function isAlternatingPairs(items: CallIdItem[]): boolean {
+  if (items.length % 2 !== 0) return false;
+  return items.every((item, position) =>
+    position % 2 === 0 ? item.type === 'function_call' : item.type === 'function_call_output',
+  );
+}
+
+/** Deterministic replacement id, extended until it collides with nothing. */
+function uniqueCallId(callId: string, pair: number, taken: Set<string>): string {
+  let candidate = `${callId}-mnfst-${pair + 1}`;
+  while (taken.has(candidate)) candidate += '-x';
+  taken.add(candidate);
+  return candidate;
+}


### PR DESCRIPTION
### ✨ What changed
- Apply the call-id dedup to the Chat Completions to Responses conversion.
- Move `deduplicateCallIds` into a shared `responses-call-ids` module.

### 💭 Why
A chat-completions client that reuses turn-local tool ids (`terminal:0`) hit the same strict-provider rejection the native path already fixes. `toResponsesRequest` copied caller ids through unchecked.

### 👤 For users
Reusing tool call ids across turns no longer 400s on strict Responses providers.

### 📝 Notes
Fixes #2851

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes repeated tool call ids when converting Chat Completions requests to Responses, so reused turn-local ids no longer get rejected by strict Responses providers.

- Moves `deduplicateCallIds` into a shared `responses-call-ids` module used by both the native and chat adapters.
- Only rewrites ids whose calls and outputs alternate one-for-one; ambiguous or already-unique histories are left untouched.

<sup>Written for commit 1d378249a79a2812f3dd5b8efc0f677b11a92f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

