### PR TITLE
fix: give Kiro native tool calling

### DIFF
--- a/.changeset/kiro-tool-calling.md
+++ b/.changeset/kiro-tool-calling.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix Kiro tool calling. Forward OpenAI tool definitions as Kiro tool specifications, map assistant `tool_calls` and `tool` role messages into Kiro `toolUses`/`toolResults`, and return Kiro `toolUseEvent` frames as OpenAI `tool_calls` (with `finish_reason: tool_calls`) in both streaming and non-streaming responses.

--- a/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
@@ -305,6 +305,7 @@ describe('kiro-adapter', () => {
         messages: [{ role: 'user', content: 'go' }],
         tools: [
           { type: 'function', function: { name: 'my.tool', parameters: { type: 'object' } } },
+          { type: 'function', function: { name: '__a..b__', parameters: { type: 'object' } } },
         ],
       },
       'auto',
@@ -319,9 +320,10 @@ describe('kiro-adapter', () => {
     };
 
     expect(
-      request.conversationState.currentMessage.userInputMessage.userInputMessageContext.tools[0]
-        .toolSpecification.name,
-    ).toBe('my_tool');
+      request.conversationState.currentMessage.userInputMessage.userInputMessageContext.tools.map(
+        (tool) => tool.toolSpecification.name,
+      ),
+    ).toEqual(['my_tool', 'a_b']);
 
     const source = streamFrom([
       eventFrame('toolUseEvent', { toolUseId: 'c1', name: 'my_tool', input: '{}', stop: true }),

--- a/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
@@ -201,16 +201,11 @@ describe('kiro-adapter', () => {
         history: [
           { userInputMessage: { content: 'First question', origin: 'KIRO_CLI' } },
           { assistantResponseMessage: { content: 'First answer' } },
-          {
-            userInputMessage: {
-              content: 'Tool result tool-1:\n{"ok":true}',
-              origin: 'KIRO_CLI',
-            },
-          },
         ],
         currentMessage: {
           userInputMessage: {
-            content: 'System instructions:\nUse concise answers.\n\nUser:\nSecond question',
+            content:
+              'System instructions:\nUse concise answers.\n\nUser:\nSecond question\n\n[Tool result: {"ok":true}]',
             origin: 'KIRO_CLI',
             modelId: 'auto',
           },
@@ -219,6 +214,123 @@ describe('kiro-adapter', () => {
       },
       agentMode: 'SUPERVISED',
     });
+  });
+
+  it('maps OpenAI tools, tool calls, and tool results onto Kiro tool fields', () => {
+    const request = buildKiroChatRequest(
+      {
+        messages: [
+          { role: 'system', content: 'You can run commands.' },
+          { role: 'user', content: 'List the files.' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'bash', arguments: '{"command":"ls"}' },
+              },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_1', content: 'a.txt\nb.txt' },
+        ],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'bash',
+              description: 'Run a shell command.',
+              parameters: {
+                type: 'object',
+                properties: { command: { type: 'string' } },
+                required: ['command'],
+                additionalProperties: false,
+              },
+            },
+          },
+        ],
+      },
+      'auto',
+    ) as {
+      conversationState: {
+        history: Array<Record<string, unknown>>;
+        currentMessage: {
+          userInputMessage: {
+            content: string;
+            userInputMessageContext: {
+              tools: unknown[];
+              toolResults: unknown[];
+            };
+          };
+        };
+      };
+    };
+
+    expect(request.conversationState.history).toEqual([
+      { userInputMessage: { content: 'List the files.', origin: 'KIRO_CLI' } },
+      {
+        assistantResponseMessage: {
+          content: '...',
+          toolUses: [{ toolUseId: 'call_1', name: 'bash', input: { command: 'ls' } }],
+        },
+      },
+    ]);
+
+    const current = request.conversationState.currentMessage.userInputMessage;
+    expect(current.content).toBe('System instructions:\nYou can run commands.\n\nUser:\ncontinue');
+    expect(current.userInputMessageContext.toolResults).toEqual([
+      { toolUseId: 'call_1', status: 'success', content: [{ text: 'a.txt\nb.txt' }] },
+    ]);
+    expect(current.userInputMessageContext.tools).toEqual([
+      {
+        toolSpecification: {
+          name: 'bash',
+          description: 'Run a shell command.',
+          inputSchema: {
+            json: {
+              type: 'object',
+              properties: { command: { type: 'string' } },
+              required: ['command'],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('sanitizes invalid Kiro tool names and restores them on the response', async () => {
+    const request = buildKiroChatRequest(
+      {
+        messages: [{ role: 'user', content: 'go' }],
+        tools: [
+          { type: 'function', function: { name: 'my.tool', parameters: { type: 'object' } } },
+        ],
+      },
+      'auto',
+    ) as {
+      conversationState: {
+        currentMessage: {
+          userInputMessage: {
+            userInputMessageContext: { tools: Array<{ toolSpecification: { name: string } }> };
+          };
+        };
+      };
+    };
+
+    expect(
+      request.conversationState.currentMessage.userInputMessage.userInputMessageContext.tools[0]
+        .toolSpecification.name,
+    ).toBe('my_tool');
+
+    const source = streamFrom([
+      eventFrame('toolUseEvent', { toolUseId: 'c1', name: 'my_tool', input: '{}', stop: true }),
+    ]);
+    const response = new Response(
+      createKiroOpenAiStream(source, 'auto', new Map([['my_tool', 'my.tool']])),
+    );
+    const text = await response.text();
+    expect(text).toContain('"name":"my.tool"');
   });
 
   it('handles image parts, empty parts, and circular object content defensively', () => {
@@ -357,6 +469,109 @@ describe('kiro-adapter', () => {
     expect(text).toContain('"finish_reason":"stop"');
     expect(text).toContain('"prompt_tokens":7');
     expect(text).toContain('data: [DONE]');
+  });
+
+  it('converts Kiro toolUseEvent frames into OpenAI tool_calls', async () => {
+    const source = streamFrom([
+      eventFrame('toolUseEvent', { toolUseId: 'call_1', name: 'bash', input: '{"command":' }),
+      eventFrame('toolUseEvent', { toolUseId: 'call_1', name: 'bash', input: '"ls"}', stop: true }),
+      eventFrame('messageStopEvent', { stopReason: 'tool_use' }),
+    ]);
+
+    const response = new Response(createKiroOpenAiStream(source, 'auto'));
+    const text = await response.text();
+    const chunks = text
+      .split('\n')
+      .filter((line) => line.startsWith('data: ') && !line.includes('[DONE]'))
+      .map(
+        (line) =>
+          JSON.parse(line.slice(6)) as {
+            choices: Array<{
+              delta: {
+                tool_calls?: Array<{
+                  index: number;
+                  id: string;
+                  type: string;
+                  function: { name: string; arguments: string };
+                }>;
+              };
+              finish_reason: string | null;
+            }>;
+          },
+      );
+
+    const toolCalls = chunks.flatMap((chunk) => chunk.choices[0].delta.tool_calls ?? []);
+    expect(toolCalls).toEqual([
+      {
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'bash', arguments: '{"command":"ls"}' },
+      },
+    ]);
+    expect(chunks.at(-1)?.choices[0].finish_reason).toBe('tool_calls');
+    expect(text).toContain('data: [DONE]');
+  });
+
+  it('forwards tools and returns Kiro tool calls in the non-streaming completion', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        streamFrom([
+          eventFrame('toolUseEvent', {
+            toolUseId: 'call_1',
+            name: 'read',
+            input: '{"path":"a"}',
+            stop: true,
+          }),
+        ]),
+        { status: 200 },
+      ),
+    );
+
+    const response = await forwardKiroChat({
+      apiKey: 'ksk_test',
+      model: 'auto',
+      body: {
+        messages: [{ role: 'user', content: 'go' }],
+        tools: [{ type: 'function', function: { name: 'read', parameters: { type: 'object' } } }],
+      },
+      stream: false,
+      timeoutMs: 1000,
+    });
+    const json = await response.json();
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
+      conversationState: {
+        currentMessage: {
+          userInputMessage: { userInputMessageContext: { tools: unknown[] } };
+        };
+      };
+    };
+    expect(
+      sentBody.conversationState.currentMessage.userInputMessage.userInputMessageContext.tools,
+    ).toEqual([
+      {
+        toolSpecification: {
+          name: 'read',
+          description: 'Tool: read',
+          inputSchema: { json: { type: 'object', properties: {} } },
+        },
+      },
+    ]);
+
+    expect(json.choices[0]).toMatchObject({
+      finish_reason: 'tool_calls',
+      message: {
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'read', arguments: '{"path":"a"}' },
+          },
+        ],
+      },
+    });
   });
 
   it('forwards streaming Kiro chat as OpenAI-compatible SSE', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
@@ -130,6 +130,67 @@ function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   });
 }
 
+type BuiltKiroRequest = {
+  conversationState: {
+    history: Array<Record<string, unknown>>;
+    currentMessage: {
+      userInputMessage: {
+        content: string;
+        userInputMessageContext?: {
+          tools?: Array<{
+            toolSpecification: {
+              name: string;
+              description: string;
+              inputSchema: { json: Record<string, unknown> };
+            };
+          }>;
+          toolResults?: Array<{
+            toolUseId: string;
+            status: string;
+            content: Array<{ text: string }>;
+          }>;
+        };
+      };
+    };
+  };
+};
+
+function buildKiro(body: Record<string, unknown>): BuiltKiroRequest {
+  return buildKiroChatRequest(body, 'auto') as unknown as BuiltKiroRequest;
+}
+
+function kiroSpecs(request: BuiltKiroRequest) {
+  return (
+    request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.tools ?? []
+  ).map((tool) => tool.toolSpecification);
+}
+
+function kiroToolUses(request: BuiltKiroRequest) {
+  const assistant = request.conversationState.history.find(
+    (turn) => 'assistantResponseMessage' in turn,
+  ) as
+    | {
+        assistantResponseMessage: {
+          content: string;
+          toolUses?: Array<{ toolUseId: string; name: string; input: unknown }>;
+        };
+      }
+    | undefined;
+  return assistant?.assistantResponseMessage;
+}
+
+function sseToolCalls(text: string): Array<Record<string, unknown>> {
+  return text
+    .split('\n')
+    .filter((line) => line.startsWith('data: ') && !line.includes('[DONE]'))
+    .flatMap((line) => {
+      const chunk = JSON.parse(line.slice(6)) as {
+        choices: Array<{ delta: { tool_calls?: Array<Record<string, unknown>> } }>;
+      };
+      return chunk.choices[0].delta.tool_calls ?? [];
+    });
+}
+
 describe('kiro-adapter', () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -652,5 +713,267 @@ describe('kiro-adapter', () => {
 
     expect(response.status).toBe(403);
     expect(await response.text()).toBe('forbidden');
+  });
+
+  describe('tool mapping edge cases', () => {
+    it('normalizes tool names, defaults descriptions, and cleans schemas', () => {
+      const request = buildKiro({
+        messages: [{ role: 'user', content: 'go' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'a.b',
+              parameters: {
+                type: 'object',
+                properties: { x: { type: 'string' } },
+                required: ['x', 'missing'],
+                additionalProperties: false,
+              },
+            },
+          },
+          { type: 'function', function: { name: 'a..b', parameters: { type: 'object' } } },
+          { type: 'function', function: { name: '__' } },
+          { type: 'function', function: { name: 'a.b' } },
+          { type: 'function' },
+          null,
+          'nope',
+          { name: 'top.level', description: 'plain' },
+          { function: { name: 'desc', description: 42, parameters: [] } },
+        ],
+      });
+
+      const specs = kiroSpecs(request);
+      expect(specs.map((spec) => spec.name)).toEqual(['a_b', 'a_b_2', 'tool', 'top_level', 'desc']);
+      expect(specs[0].inputSchema.json).toEqual({
+        type: 'object',
+        properties: { x: { type: 'string' } },
+        required: ['x'],
+      });
+      expect(specs[3].description).toBe('plain');
+      expect(specs[4].description).toBe('Tool: desc');
+      expect(specs[4].inputSchema.json).toEqual({ type: 'object', properties: {} });
+    });
+
+    it('parses arguments from objects and JSON, generating missing ids', () => {
+      const request = buildKiro({
+        messages: [
+          { role: 'user', content: 'go' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              { id: 'c1', function: { name: 'x', arguments: { a: 1 } } },
+              { function: { name: 'y', arguments: '{"b":2}' } },
+              { function: { name: 'z', arguments: 'not json' } },
+              { function: { name: 'w', arguments: '42' } },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'c1', content: 'r1' },
+          { role: 'tool', tool_call_id: 'call_2', content: 'r2' },
+          { role: 'tool', tool_call_id: 'call_3', content: 'r3' },
+          { role: 'tool', tool_call_id: 'call_4', content: 'r4' },
+        ],
+        tools: [
+          { function: { name: 'x' } },
+          { function: { name: 'y' } },
+          { function: { name: 'z' } },
+          { function: { name: 'w' } },
+        ],
+      });
+
+      expect(kiroToolUses(request)?.toolUses).toEqual([
+        { toolUseId: 'c1', name: 'x', input: { a: 1 } },
+        { toolUseId: 'call_2', name: 'y', input: { b: 2 } },
+        { toolUseId: 'call_3', name: 'z', input: {} },
+        { toolUseId: 'call_4', name: 'w', input: {} },
+      ]);
+      expect(
+        request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.toolResults?.map(
+          (result) => result.toolUseId,
+        ),
+      ).toEqual(['c1', 'call_2', 'call_3', 'call_4']);
+    });
+
+    it('de-duplicates repeated tool-use ids and flattens leftover results', () => {
+      const request = buildKiro({
+        messages: [
+          { role: 'user', content: 'go' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              { id: 'dup', function: { name: 't', arguments: '{}' } },
+              { id: 'dup', function: { name: 't', arguments: '{}' } },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'dup', content: 'r1' },
+          { role: 'tool', tool_call_id: 'dup', content: 'r2' },
+          { role: 'tool', tool_call_id: 'dup', content: 'r3' },
+        ],
+        tools: [{ function: { name: 't' } }],
+      });
+
+      expect(kiroToolUses(request)?.toolUses?.map((use) => use.toolUseId)).toEqual([
+        'dup',
+        'dup_2',
+      ]);
+      expect(request.conversationState.currentMessage.userInputMessage.content).toContain(
+        '[Tool result: r3]',
+      );
+    });
+
+    it('falls back to a generated id when a tool-use id has no valid characters', () => {
+      const request = buildKiro({
+        messages: [
+          { role: 'user', content: 'go' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{ id: '***', function: { name: 't', arguments: '{}' } }],
+          },
+          { role: 'tool', tool_call_id: '***', content: 'r' },
+        ],
+        tools: [{ function: { name: 't' } }],
+      });
+
+      expect(kiroToolUses(request)?.toolUses?.[0].toolUseId).toBe('call_1_0');
+    });
+
+    it('merges consecutive assistant messages with their tool calls', () => {
+      const request = buildKiro({
+        messages: [
+          { role: 'user', content: 'go' },
+          { role: 'assistant', content: 'thinking' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{ id: 'c1', function: { name: 't', arguments: '{}' } }],
+          },
+          { role: 'tool', tool_call_id: 'c1', content: 'r' },
+        ],
+        tools: [{ function: { name: 't' } }],
+      });
+
+      expect(kiroToolUses(request)).toMatchObject({
+        content: 'thinking',
+        toolUses: [{ toolUseId: 'c1', name: 't', input: {} }],
+      });
+    });
+
+    it('flattens calls to undeclared tools and their results to text', () => {
+      const request = buildKiro({
+        messages: [
+          { role: 'user', content: 'go' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{ id: 'c1', function: { name: 'ghost', arguments: '{"a":1}' } }],
+          },
+          { role: 'tool', tool_call_id: 'c1', content: 'r' },
+        ],
+        tools: [{ function: { name: 'other' } }],
+      });
+
+      expect(kiroToolUses(request)?.content).toBe('...');
+      const current = request.conversationState.currentMessage.userInputMessage;
+      expect(current.content).toContain('[Tool call: ghost({"a":1})]');
+      expect(current.content).toContain('[Tool result: r]');
+      expect(current.userInputMessageContext?.toolResults).toBeUndefined();
+    });
+
+    it('synthesizes a current user turn for empty or assistant-bounded conversations', () => {
+      const empty = buildKiro({ messages: [] });
+      expect(empty.conversationState.history).toEqual([]);
+      expect(empty.conversationState.currentMessage.userInputMessage.content).toBe('continue');
+
+      const startsAssistant = buildKiro({
+        messages: [
+          { role: 'assistant', content: 'a' },
+          { role: 'user', content: 'q' },
+        ],
+      });
+      expect(startsAssistant.conversationState.history[0]).toEqual({
+        userInputMessage: { content: 'continue', origin: 'KIRO_CLI' },
+      });
+      expect(startsAssistant.conversationState.currentMessage.userInputMessage.content).toBe('q');
+
+      const endsAssistant = buildKiro({
+        messages: [
+          { role: 'user', content: 'q' },
+          { role: 'assistant', content: 'a' },
+        ],
+      });
+      expect(endsAssistant.conversationState.currentMessage.userInputMessage.content).toBe(
+        'continue',
+      );
+      expect(endsAssistant.conversationState.history).toEqual([
+        { userInputMessage: { content: 'q', origin: 'KIRO_CLI' } },
+        { assistantResponseMessage: { content: 'a' } },
+      ]);
+    });
+
+    it('folds developer instructions and string/array content parts', () => {
+      const request = buildKiro({
+        messages: [
+          { role: 'developer', content: 'dev rules' },
+          {
+            role: 'user',
+            content: ['line1', { type: 'text', text: 'line2' }, { type: 'image_url' }],
+          },
+        ],
+      });
+
+      expect(request.conversationState.currentMessage.userInputMessage.content).toBe(
+        'System instructions:\ndev rules\n\nUser:\nline1\nline2\n[image omitted]',
+      );
+    });
+
+    it('collects tool-use events from object input, arrays, and nested payloads', async () => {
+      const source = streamFrom([
+        eventFrame('toolUseEvent', { name: 'obj', input: { a: 1 } }),
+        eventFrame('toolUseEvent', { toolUseId: 'skip', input: '{}' }),
+        eventFrame('toolUseEvent', {
+          toolUseEvent: { toolUseId: 'n1', name: 'nested', input: '{"n":1}', stop: true },
+        }),
+        eventFrame('toolUseEvent', [
+          { toolUseId: 'a1', name: 'arr1', input: '{"x":1}' },
+          { toolUseId: 'a2', name: 'arr2', input: '{"y":2}' },
+        ]),
+      ]);
+
+      const response = new Response(createKiroOpenAiStream(source, 'auto'));
+      expect(sseToolCalls(await response.text())).toEqual([
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'obj', arguments: '{"a":1}' },
+        },
+        {
+          index: 1,
+          id: 'n1',
+          type: 'function',
+          function: { name: 'nested', arguments: '{"n":1}' },
+        },
+        { index: 2, id: 'a1', type: 'function', function: { name: 'arr1', arguments: '{"x":1}' } },
+        { index: 3, id: 'a2', type: 'function', function: { name: 'arr2', arguments: '{"y":2}' } },
+      ]);
+    });
+
+    it('surfaces Kiro exception payload variants', async () => {
+      const cases: Array<[Record<string, unknown>, string]> = [
+        [{ errorMessage: 'via-errorMessage' }, 'via-errorMessage'],
+        [{ error: 'via-error' }, 'via-error'],
+        [{}, 'Kiro returned an exception event'],
+      ];
+
+      for (const [payload, message] of cases) {
+        const response = new Response(
+          createKiroOpenAiStream(streamFrom([eventFrame('boom', payload, 'exception')]), 'auto'),
+        );
+        await expect(response.text()).rejects.toThrow(message);
+      }
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { ProviderClient } from '../provider-client';
 import { ManifestError } from '../../../common/errors/manifest-error';
 import { buildCustomEndpoint, buildEndpointOverride } from '../provider-endpoints';
@@ -7,6 +8,35 @@ import type { ProviderModelRegistryService } from '../../../model-discovery/prov
 
 const mockFetch = jest.fn();
 (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
+
+function kiroStringHeader(name: string, value: string): Buffer {
+  const nameBytes = Buffer.from(name);
+  const valueBytes = Buffer.from(value);
+  const valueLength = Buffer.alloc(2);
+  valueLength.writeUInt16BE(valueBytes.length, 0);
+  return Buffer.concat([
+    Buffer.from([nameBytes.length]),
+    nameBytes,
+    Buffer.from([7]),
+    valueLength,
+    valueBytes,
+  ]);
+}
+
+function kiroEventFrame(eventType: string, payload: unknown, messageType = 'event'): Uint8Array {
+  const headers = Buffer.concat([
+    kiroStringHeader(':message-type', messageType),
+    kiroStringHeader(':event-type', eventType),
+  ]);
+  const payloadBytes = Buffer.from(JSON.stringify(payload));
+  const totalLength = 12 + headers.length + payloadBytes.length + 4;
+  const frame = Buffer.alloc(totalLength);
+  frame.writeUInt32BE(totalLength, 0);
+  frame.writeUInt32BE(headers.length, 4);
+  headers.copy(frame, 12);
+  payloadBytes.copy(frame, 12 + headers.length);
+  return frame;
+}
 
 describe('ProviderClient', () => {
   const previousMode = process.env['MANIFEST_MODE'];
@@ -2991,6 +3021,99 @@ describe('ProviderClient', () => {
         'Hello from Responses',
       );
       expect(resolveChatBody).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards tools and returns Kiro tool calls end to end', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                kiroEventFrame('toolUseEvent', {
+                  toolUseId: 'call_1',
+                  name: 'bash',
+                  input: '{"command":"ls"}',
+                  stop: true,
+                }),
+              );
+              controller.close();
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await client.forward({
+        provider: 'kiro',
+        apiKey: 'ksk_test',
+        model: 'kiro/auto',
+        body: {
+          messages: [
+            { role: 'user', content: 'List files' },
+            {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'bash', arguments: '{"command":"ls"}' },
+                },
+              ],
+            },
+            { role: 'tool', tool_call_id: 'call_1', content: 'a.txt' },
+          ],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'bash',
+                parameters: {
+                  type: 'object',
+                  properties: { command: { type: 'string' } },
+                  additionalProperties: false,
+                },
+              },
+            },
+          ],
+        },
+        stream: true,
+        authType: 'subscription',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.conversationState.history).toEqual([
+        { userInputMessage: { content: 'List files', origin: 'KIRO_CLI' } },
+        {
+          assistantResponseMessage: {
+            content: '...',
+            toolUses: [{ toolUseId: 'call_1', name: 'bash', input: { command: 'ls' } }],
+          },
+        },
+      ]);
+      const current = sentBody.conversationState.currentMessage.userInputMessage;
+      expect(current.userInputMessageContext.tools).toEqual([
+        {
+          toolSpecification: {
+            name: 'bash',
+            description: 'Tool: bash',
+            inputSchema: {
+              json: {
+                type: 'object',
+                properties: { command: { type: 'string' } },
+              },
+            },
+          },
+        },
+      ]);
+      expect(current.userInputMessageContext.toolResults).toEqual([
+        { toolUseId: 'call_1', status: 'success', content: [{ text: 'a.txt' }] },
+      ]);
+
+      const text = await result.response.text();
+      expect(text).toContain('"id":"call_1"');
+      expect(text).toContain('"name":"bash"');
+      expect(text).toContain('"finish_reason":"tool_calls"');
     });
   });
 

--- a/packages/backend/src/routing/proxy/kiro-adapter.ts
+++ b/packages/backend/src/routing/proxy/kiro-adapter.ts
@@ -11,6 +11,17 @@ const KIRO_AGENT_MODE = 'SUPERVISED';
 const DEFAULT_KIRO_CONTEXT_WINDOW = 200000;
 const AUTO_KIRO_CONTEXT_WINDOW = 1000000;
 
+/**
+ * Kiro's tool schema bounds. Names must match `[A-Za-z0-9_-]+`, tool-use ids are
+ * limited to the same character set, and descriptions are capped to keep the
+ * upstream request under CodeWhisperer's size limit.
+ */
+const KIRO_TOOL_NAME_MAX_LENGTH = 64;
+const KIRO_TOOL_DESCRIPTION_MAX_LENGTH = 10237;
+const KIRO_TOOL_ID_MAX_LENGTH = 64;
+const KIRO_TOOL_NAME_ILLEGAL = /[^a-zA-Z0-9_-]/g;
+const KIRO_TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
 export function buildKiroHeaders(apiKey: string, target: string): Record<string, string> {
   return {
     Authorization: `Bearer ${apiKey}`,
@@ -33,8 +44,7 @@ function readNumber(value: unknown): number | undefined {
 
 function readKiroContextWindow(entry: Record<string, unknown>, modelId: string): number {
   const tokenLimits = (entry.tokenLimits ?? entry.token_limits) as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   return (
     readNumber(entry.contextWindowTokens) ??
     readNumber(entry.context_window_tokens) ??
@@ -66,30 +76,72 @@ export function parseKiroModels(body: unknown, provider = 'kiro'): DiscoveredMod
         outputPricePerToken: 0,
         capabilityReasoning: false,
         capabilityCode: true,
+        capabilities: ['tools'] as const,
         qualityScore: 3,
       };
     });
 }
 
+type OpenAiToolCall = {
+  id?: unknown;
+  function?: { name?: unknown; arguments?: unknown };
+};
+
 type OpenAiMessage = {
   role?: string;
   content?: unknown;
-  tool_call_id?: string;
+  tool_call_id?: unknown;
+  tool_calls?: unknown;
 };
 
-type KiroMessage =
-  | {
-      userInputMessage: {
-        content: string;
-        origin: string;
-        modelId?: string;
-      };
-    }
-  | {
-      assistantResponseMessage: {
-        content: string;
-      };
-    };
+type KiroToolSpec = {
+  toolSpecification: {
+    name: string;
+    description?: string;
+    inputSchema: { json: Record<string, unknown> };
+  };
+};
+
+type KiroToolUse = {
+  toolUseId: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+
+type KiroToolResult = {
+  toolUseId: string;
+  status: 'success' | 'error';
+  content: Array<{ text: string }>;
+};
+
+type KiroUserContext = {
+  tools?: KiroToolSpec[];
+  toolResults?: KiroToolResult[];
+};
+
+type KiroUserMessage = {
+  userInputMessage: {
+    content: string;
+    origin: string;
+    modelId?: string;
+    userInputMessageContext?: KiroUserContext;
+  };
+};
+
+type KiroAssistantMessage = {
+  assistantResponseMessage: {
+    content: string;
+    toolUses?: KiroToolUse[];
+  };
+};
+
+type KiroMessage = KiroUserMessage | KiroAssistantMessage;
+
+export interface KiroConversation {
+  body: Record<string, unknown>;
+  /** Kiro-side sanitized tool name → the caller's original tool name. */
+  toolNameMap: Map<string, string>;
+}
 
 function stringifyContent(content: unknown): string {
   if (typeof content === 'string') return content;
@@ -114,28 +166,400 @@ function stringifyContent(content: unknown): string {
   }
 }
 
-function toUserMessage(content: string, modelId?: string): KiroMessage {
+function appendText(current: string, extra: string): string {
+  if (!extra) return current;
+  return current ? `${current}\n\n${extra}` : extra;
+}
+
+function trimToLength(value: string, max: number): string {
+  return [...value].slice(0, max).join('');
+}
+
+function isUserMessage(message: KiroMessage): message is KiroUserMessage {
+  return 'userInputMessage' in message;
+}
+
+function isAssistantMessage(message: KiroMessage): message is KiroAssistantMessage {
+  return 'assistantResponseMessage' in message;
+}
+
+function toUserMessage(
+  content: string,
+  options: { modelId?: string; toolResults?: KiroToolResult[] } = {},
+): KiroUserMessage {
+  const context: KiroUserContext | undefined = options.toolResults?.length
+    ? { toolResults: options.toolResults }
+    : undefined;
   return {
     userInputMessage: {
       content,
       origin: KIRO_ORIGIN,
-      ...(modelId ? { modelId } : {}),
+      ...(options.modelId ? { modelId: options.modelId } : {}),
+      ...(context ? { userInputMessageContext: context } : {}),
     },
   };
 }
 
-function toAssistantMessage(content: string): KiroMessage {
+function toAssistantMessage(content: string, toolUses?: KiroToolUse[]): KiroAssistantMessage {
   return {
     assistantResponseMessage: {
       content,
+      ...(toolUses && toolUses.length > 0 ? { toolUses } : {}),
     },
   };
 }
 
-export function buildKiroChatRequest(
-  body: Record<string, unknown>,
+/**
+ * Recursively drop schema keywords Kiro rejects. `additionalProperties` and an
+ * empty `required` array are valid JSON Schema but make CodeWhisperer answer the
+ * whole request with REQUEST_BODY_INVALID.
+ */
+function cleanSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(cleanSchemaValue);
+  if (!value || typeof value !== 'object') return value;
+
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (key === 'additionalProperties') continue;
+    if (key === 'required' && Array.isArray(child) && child.length === 0) continue;
+    cleaned[key] = cleanSchemaValue(child);
+  }
+  return cleaned;
+}
+
+function normalizeToolSchema(schema: unknown): Record<string, unknown> {
+  const cleaned =
+    schema && typeof schema === 'object' && !Array.isArray(schema)
+      ? (cleanSchemaValue(schema) as Record<string, unknown>)
+      : {};
+  cleaned.type = 'object';
+  if (
+    !cleaned.properties ||
+    typeof cleaned.properties !== 'object' ||
+    Array.isArray(cleaned.properties)
+  ) {
+    cleaned.properties = {};
+  }
+  if (Array.isArray(cleaned.required)) {
+    const properties = new Set(Object.keys(cleaned.properties as Record<string, unknown>));
+    const required = [
+      ...new Set(
+        cleaned.required.filter((name) => typeof name === 'string' && properties.has(name)),
+      ),
+    ];
+    if (required.length === 0) delete cleaned.required;
+    else cleaned.required = required;
+  }
+  return cleaned;
+}
+
+function uniqueToolName(rawName: string, used: Set<string>): string {
+  const cleaned = rawName
+    .trim()
+    .replace(KIRO_TOOL_NAME_ILLEGAL, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  const base = trimToLength(cleaned || 'tool', KIRO_TOOL_NAME_MAX_LENGTH);
+  let candidate = base;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    const tail = `_${suffix}`;
+    suffix += 1;
+    candidate = `${base.slice(0, KIRO_TOOL_NAME_MAX_LENGTH - tail.length)}${tail}`;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+function buildKiroToolSpecs(tools: unknown): {
+  specs: KiroToolSpec[];
+  toKiroName: Map<string, string>;
+  toolNameMap: Map<string, string>;
+} {
+  const specs: KiroToolSpec[] = [];
+  const toKiroName = new Map<string, string>();
+  const toolNameMap = new Map<string, string>();
+  const used = new Set<string>();
+  if (!Array.isArray(tools)) return { specs, toKiroName, toolNameMap };
+
+  for (const raw of tools) {
+    if (!raw || typeof raw !== 'object') continue;
+    const tool = raw as Record<string, unknown>;
+    const fn = (tool.function ?? {}) as Record<string, unknown>;
+    const rawName = fn.name ?? tool.name;
+    if (typeof rawName !== 'string' || !rawName.trim()) continue;
+    if (toKiroName.has(rawName)) continue;
+
+    const name = uniqueToolName(rawName, used);
+    toKiroName.set(rawName, name);
+    if (name !== rawName) toolNameMap.set(name, rawName);
+
+    const rawDescription = fn.description ?? tool.description;
+    const description = trimToLength(
+      typeof rawDescription === 'string' && rawDescription.trim()
+        ? rawDescription
+        : `Tool: ${rawName}`,
+      KIRO_TOOL_DESCRIPTION_MAX_LENGTH,
+    );
+    const schema = fn.parameters ?? tool.parameters ?? tool.input_schema;
+    specs.push({
+      toolSpecification: { name, description, inputSchema: { json: normalizeToolSchema(schema) } },
+    });
+  }
+
+  return { specs, toKiroName, toolNameMap };
+}
+
+function parseToolInput(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Malformed argument JSON carries no usable input.
+    }
+  }
+  return {};
+}
+
+function toolUsesFromAssistant(
+  message: OpenAiMessage,
+  toKiroName: Map<string, string>,
+): KiroToolUse[] {
+  if (!Array.isArray(message.tool_calls)) return [];
+
+  const uses: KiroToolUse[] = [];
+  message.tool_calls.forEach((raw, index) => {
+    if (!raw || typeof raw !== 'object') return;
+    const call = raw as OpenAiToolCall;
+    const name = call.function?.name;
+    if (typeof name !== 'string' || !name) return;
+    uses.push({
+      toolUseId: typeof call.id === 'string' && call.id ? call.id : `call_${index + 1}`,
+      name: toKiroName.get(name) ?? name,
+      input: parseToolInput(call.function?.arguments),
+    });
+  });
+  return uses;
+}
+
+function toolResultFromMessage(message: OpenAiMessage): KiroToolResult {
+  return {
+    toolUseId: typeof message.tool_call_id === 'string' ? message.tool_call_id : '',
+    status: 'success',
+    content: [{ text: stringifyContent(message.content) }],
+  };
+}
+
+/**
+ * Convert OpenAI chat messages into Kiro's strictly alternating user/assistant
+ * turns. Consecutive same-role messages merge because Kiro rejects two turns in
+ * a row; assistant `tool_calls` become `toolUses`, and `tool` role messages
+ * become `toolResults` on the following (merged) user turn.
+ */
+function buildKiroTurns(messages: OpenAiMessage[], toKiroName: Map<string, string>): KiroMessage[] {
+  const turns: KiroMessage[] = [];
+  let user: KiroUserMessage | null = null;
+  let assistant: KiroAssistantMessage | null = null;
+
+  const flushUser = (): void => {
+    if (user) {
+      turns.push(user);
+      user = null;
+    }
+  };
+  const flushAssistant = (): void => {
+    if (assistant) {
+      turns.push(assistant);
+      assistant = null;
+    }
+  };
+
+  for (const message of messages) {
+    if (message.role === 'system' || message.role === 'developer') continue;
+
+    if (message.role === 'assistant') {
+      flushUser();
+      const content = stringifyContent(message.content);
+      const toolUses = toolUsesFromAssistant(message, toKiroName);
+      if (!content && toolUses.length === 0) continue;
+
+      if (assistant) {
+        assistant.assistantResponseMessage.content = appendText(
+          assistant.assistantResponseMessage.content,
+          content,
+        );
+        if (toolUses.length > 0) {
+          assistant.assistantResponseMessage.toolUses = [
+            ...(assistant.assistantResponseMessage.toolUses ?? []),
+            ...toolUses,
+          ];
+        }
+      } else {
+        assistant = toAssistantMessage(content || '...', toolUses);
+      }
+      continue;
+    }
+
+    flushAssistant();
+    const result = message.role === 'tool' ? toolResultFromMessage(message) : null;
+    const content = result ? '' : stringifyContent(message.content);
+    if (user) {
+      user.userInputMessage.content = appendText(user.userInputMessage.content, content);
+      if (result) {
+        const context = (user.userInputMessage.userInputMessageContext ??= {});
+        context.toolResults = [...(context.toolResults ?? []), result];
+      }
+    } else {
+      user = toUserMessage(content, { toolResults: result ? [result] : undefined });
+    }
+  }
+
+  flushAssistant();
+  flushUser();
+  return turns;
+}
+
+function flattenToolUse(toolUse: KiroToolUse): string {
+  return `[Tool call: ${toolUse.name}(${JSON.stringify(toolUse.input)})]`;
+}
+
+function flattenToolResult(result: KiroToolResult): string {
+  const text = result.content.map((part) => part.text).join('\n');
+  return `[Tool result${result.status === 'error' ? ' (error)' : ''}: ${text}]`;
+}
+
+function deleteEmptyContext(message: KiroUserMessage): void {
+  const context = message.userInputMessage.userInputMessageContext;
+  if (!context) return;
+  if (!context.toolResults?.length) delete context.toolResults;
+  if (!context.tools?.length) delete context.tools;
+  if (Object.keys(context).length === 0) delete message.userInputMessage.userInputMessageContext;
+}
+
+function reserveToolUseId(rawId: string, fallback: string, used: Set<string>): string {
+  const sanitized = rawId.replace(KIRO_TOOL_NAME_ILLEGAL, '');
+  const base = trimToLength(
+    KIRO_TOOL_ID_PATTERN.test(sanitized) && sanitized ? sanitized : fallback,
+    KIRO_TOOL_ID_MAX_LENGTH,
+  );
+  let candidate = base;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    const tail = `_${suffix}`;
+    suffix += 1;
+    candidate = `${base.slice(0, KIRO_TOOL_ID_MAX_LENGTH - tail.length)}${tail}`;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+/**
+ * Kiro requires each assistant `toolUses` entry to have a matching `toolResults`
+ * entry in the very next user turn, and every called tool to be declared in the
+ * request's tool specs. When a caller has a broken history (missing result, an
+ * orphan result, or a call to an undeclared tool), inline it as text rather than
+ * sending a body Kiro answers with REQUEST_BODY_INVALID.
+ */
+function reconcileToolPairs(turns: KiroMessage[], specNames: Set<string>): void {
+  const usedIds = new Set<string>();
+
+  for (let index = 0; index < turns.length - 1; index += 1) {
+    const assistant = turns[index];
+    const user = turns[index + 1];
+    if (!isAssistantMessage(assistant) || !isUserMessage(user)) continue;
+
+    const calls = assistant.assistantResponseMessage.toolUses ?? [];
+    const context = user.userInputMessage.userInputMessageContext;
+    const results = context?.toolResults ?? [];
+
+    if (calls.length === 0) {
+      if (results.length > 0) {
+        user.userInputMessage.content = appendText(
+          user.userInputMessage.content,
+          results.map(flattenToolResult).join('\n\n'),
+        );
+        if (context) delete context.toolResults;
+        deleteEmptyContext(user);
+      }
+      continue;
+    }
+
+    const resultQueues = new Map<string, KiroToolResult[]>();
+    for (const result of results) {
+      const queue = resultQueues.get(result.toolUseId) ?? [];
+      queue.push(result);
+      resultQueues.set(result.toolUseId, queue);
+    }
+
+    const keptCalls: KiroToolUse[] = [];
+    const keptResults: KiroToolResult[] = [];
+    const flattened: string[] = [];
+
+    for (const call of calls) {
+      const result = resultQueues.get(call.toolUseId)?.shift();
+      if (result && specNames.has(call.name)) {
+        const toolUseId = reserveToolUseId(
+          call.toolUseId,
+          `call_${index}_${keptCalls.length}`,
+          usedIds,
+        );
+        keptCalls.push({ ...call, toolUseId });
+        keptResults.push({ ...result, toolUseId });
+      } else {
+        flattened.push(flattenToolUse(call));
+        if (result) flattened.push(flattenToolResult(result));
+      }
+    }
+
+    for (const queue of resultQueues.values()) {
+      for (const result of queue) flattened.push(flattenToolResult(result));
+    }
+
+    if (flattened.length > 0) {
+      user.userInputMessage.content = appendText(
+        user.userInputMessage.content,
+        flattened.join('\n\n'),
+      );
+    }
+    if (keptCalls.length > 0) assistant.assistantResponseMessage.toolUses = keptCalls;
+    else delete assistant.assistantResponseMessage.toolUses;
+    if (context && keptResults.length > 0) context.toolResults = keptResults;
+    else if (context) delete context.toolResults;
+    deleteEmptyContext(user);
+  }
+}
+
+function finalizeKiroConversation(
+  turns: KiroMessage[],
+  specs: KiroToolSpec[],
   model: string,
-): Record<string, unknown> {
+): { history: KiroMessage[]; currentMessage: KiroUserMessage } {
+  const working = [...turns];
+  if (working.length === 0) {
+    working.push(toUserMessage('continue', { modelId: model }));
+  }
+  if (isAssistantMessage(working[0])) {
+    working.unshift(toUserMessage('continue'));
+  }
+  if (isAssistantMessage(working[working.length - 1])) {
+    working.push(toUserMessage('continue'));
+  }
+
+  reconcileToolPairs(working, new Set(specs.map((spec) => spec.toolSpecification.name)));
+
+  let currentIndex = working.length - 1;
+  while (currentIndex >= 0 && !isUserMessage(working[currentIndex])) currentIndex -= 1;
+  const currentMessage = working[currentIndex] as KiroUserMessage;
+  return { history: working.slice(0, currentIndex), currentMessage };
+}
+
+function buildKiroConversation(body: Record<string, unknown>, model: string): KiroConversation {
   const messages = Array.isArray(body.messages) ? (body.messages as OpenAiMessage[]) : [];
   const systemText = messages
     .filter((message) => message.role === 'system' || message.role === 'developer')
@@ -143,46 +567,46 @@ export function buildKiroChatRequest(
     .filter(Boolean)
     .join('\n\n');
 
-  const lastUserIndex = messages.reduce(
-    (last, message, index) => (message.role === 'user' ? index : last),
-    -1,
+  const { specs, toKiroName, toolNameMap } = buildKiroToolSpecs(body.tools);
+  const { history, currentMessage } = finalizeKiroConversation(
+    buildKiroTurns(messages, toKiroName),
+    specs,
+    model,
   );
-  const currentIndex = lastUserIndex >= 0 ? lastUserIndex : messages.length - 1;
-  const history: KiroMessage[] = [];
 
-  for (let index = 0; index < currentIndex; index += 1) {
-    const message = messages[index];
-    if (message.role === 'system' || message.role === 'developer') continue;
-    const content = stringifyContent(message.content);
-    if (!content) continue;
-    if (message.role === 'assistant') {
-      history.push(toAssistantMessage(content));
-    } else if (message.role === 'tool') {
-      history.push(
-        toUserMessage(
-          `Tool result${message.tool_call_id ? ` ${message.tool_call_id}` : ''}:\n${content}`,
-        ),
-      );
-    } else {
-      history.push(toUserMessage(content));
-    }
+  if (specs.length > 0) {
+    const context = (currentMessage.userInputMessage.userInputMessageContext ??= {});
+    context.tools = specs;
   }
 
-  const currentMessage = currentIndex >= 0 ? messages[currentIndex] : undefined;
-  const currentText = currentMessage ? stringifyContent(currentMessage.content) : '';
-  const content = systemText
-    ? `System instructions:\n${systemText}\n\nUser:\n${currentText}`
-    : currentText;
+  const currentText = currentMessage.userInputMessage.content;
+  const fallbackText = currentMessage.userInputMessage.userInputMessageContext?.toolResults?.length
+    ? 'continue'
+    : 'Hello';
+  currentMessage.userInputMessage.content = systemText
+    ? `System instructions:\n${systemText}\n\nUser:\n${currentText || fallbackText}`
+    : currentText || fallbackText;
+  currentMessage.userInputMessage.modelId ??= model;
 
   return {
-    conversationState: {
-      conversationId: randomUUID(),
-      history,
-      currentMessage: toUserMessage(content || 'Hello', model),
-      chatTriggerType: 'MANUAL',
+    body: {
+      conversationState: {
+        conversationId: randomUUID(),
+        history,
+        currentMessage,
+        chatTriggerType: 'MANUAL',
+      },
+      agentMode: KIRO_AGENT_MODE,
     },
-    agentMode: KIRO_AGENT_MODE,
+    toolNameMap,
   };
+}
+
+export function buildKiroChatRequest(
+  body: Record<string, unknown>,
+  model: string,
+): Record<string, unknown> {
+  return buildKiroConversation(body, model).body;
 }
 
 export interface KiroEvent {
@@ -295,10 +719,22 @@ interface OpenAiUsage {
   total_tokens: number;
 }
 
+interface KiroToolCallState {
+  id: string;
+  name: string;
+  input: string;
+}
+
 interface KiroCollectState {
   content: string;
   reasoning: string;
   usage?: OpenAiUsage;
+  toolCalls: Map<string, KiroToolCallState>;
+  toolOrder: string[];
+}
+
+function createKiroCollectState(): KiroCollectState {
+  return { content: '', reasoning: '', toolCalls: new Map(), toolOrder: [] };
 }
 
 function eventPayload(event: KiroEvent): Record<string, unknown> {
@@ -344,6 +780,31 @@ function extractErrorMessage(event: KiroEvent): string | null {
   return typeof message === 'string' ? message : null;
 }
 
+/**
+ * Kiro streams tool calls as `toolUseEvent` frames whose `input` is a JSON
+ * fragment; fragments accumulate per `toolUseId` until the frame sets `stop`.
+ */
+function collectKiroToolUse(state: KiroCollectState, payload: Record<string, unknown>): void {
+  const name = typeof payload.name === 'string' ? payload.name.trim() : '';
+  if (!name) return;
+
+  const rawId = typeof payload.toolUseId === 'string' ? payload.toolUseId : '';
+  const id = rawId || `call_${state.toolOrder.length + 1}`;
+  let tool = state.toolCalls.get(id);
+  if (!tool) {
+    tool = { id, name, input: '' };
+    state.toolCalls.set(id, tool);
+    state.toolOrder.push(id);
+  }
+
+  const input = payload.input;
+  if (typeof input === 'string') {
+    tool.input += input;
+  } else if (input && typeof input === 'object') {
+    tool.input = JSON.stringify(input);
+  }
+}
+
 function applyKiroEvent(state: KiroCollectState, event: KiroEvent): Record<string, unknown> | null {
   const eventType = event.eventType?.toLowerCase() ?? '';
   const payload = eventPayload(event);
@@ -361,10 +822,36 @@ function applyKiroEvent(state: KiroCollectState, event: KiroEvent): Record<strin
     state.reasoning += text;
     return text ? { reasoning_content: text } : null;
   }
+  if (eventType.includes('tooluse')) {
+    const values = Array.isArray(payload) ? payload : [payload];
+    for (const value of values) {
+      if (value && typeof value === 'object') {
+        collectKiroToolUse(state, value as Record<string, unknown>);
+      }
+    }
+    return null;
+  }
   if (eventType.includes('metadata')) {
     state.usage = normalizeUsage(payload.tokenUsage ?? payload.token_usage);
   }
   return null;
+}
+
+interface KiroToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+function kiroToolCalls(state: KiroCollectState, toolNameMap?: Map<string, string>): KiroToolCall[] {
+  return state.toolOrder.map((id) => {
+    const tool = state.toolCalls.get(id) as KiroToolCallState;
+    return {
+      id: tool.id,
+      name: toolNameMap?.get(tool.name) ?? tool.name,
+      arguments: tool.input.trim() || '{}',
+    };
+  });
 }
 
 function openAiChunk(
@@ -386,10 +873,11 @@ function openAiChunk(
 export function createKiroOpenAiStream(
   source: ReadableStream<Uint8Array>,
   model: string,
+  toolNameMap?: Map<string, string>,
 ): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   const parser = new KiroEventStreamParser();
-  const state: KiroCollectState = { content: '', reasoning: '' };
+  const state = createKiroCollectState();
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -404,7 +892,27 @@ export function createKiroOpenAiStream(
           }
         }
         parser.finish();
-        controller.enqueue(encoder.encode(openAiChunk(model, {}, 'stop', state.usage)));
+
+        const toolCalls = kiroToolCalls(state, toolNameMap);
+        toolCalls.forEach((tool, index) => {
+          controller.enqueue(
+            encoder.encode(
+              openAiChunk(model, {
+                tool_calls: [
+                  {
+                    index,
+                    id: tool.id,
+                    type: 'function',
+                    function: { name: tool.name, arguments: tool.arguments },
+                  },
+                ],
+              }),
+            ),
+          );
+        });
+
+        const finishReason = toolCalls.length > 0 ? 'tool_calls' : 'stop';
+        controller.enqueue(encoder.encode(openAiChunk(model, {}, finishReason, state.usage)));
         controller.enqueue(encoder.encode('data: [DONE]\n\n'));
         controller.close();
       } catch (err) {
@@ -417,9 +925,10 @@ export function createKiroOpenAiStream(
 async function collectKiroCompletion(
   source: ReadableStream<Uint8Array>,
   model: string,
+  toolNameMap?: Map<string, string>,
 ): Promise<Record<string, unknown>> {
   const parser = new KiroEventStreamParser();
-  const state: KiroCollectState = { content: '', reasoning: '' };
+  const state = createKiroCollectState();
   const reader = source.getReader();
 
   for (;;) {
@@ -437,12 +946,27 @@ async function collectKiroCompletion(
   };
   if (state.reasoning) message.reasoning_content = state.reasoning;
 
+  const toolCalls = kiroToolCalls(state, toolNameMap);
+  if (toolCalls.length > 0) {
+    message.tool_calls = toolCalls.map((tool) => ({
+      id: tool.id,
+      type: 'function',
+      function: { name: tool.name, arguments: tool.arguments },
+    }));
+  }
+
   return {
     id: `chatcmpl-${randomUUID()}`,
     object: 'chat.completion',
     created: Math.floor(Date.now() / 1000),
     model,
-    choices: [{ index: 0, message, finish_reason: 'stop' }],
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: toolCalls.length > 0 ? 'tool_calls' : 'stop',
+      },
+    ],
     ...(state.usage ? { usage: state.usage } : {}),
   };
 }
@@ -463,23 +987,24 @@ export async function forwardKiroChat(opts: {
     'x-amzn-kiro-agent-mode': KIRO_AGENT_MODE,
     ...opts.extraHeaders,
   };
+  const { body, toolNameMap } = buildKiroConversation(opts.body, opts.model);
   const upstream = await fetch(KIRO_BASE_URL, {
     method: 'POST',
     headers,
-    body: JSON.stringify(buildKiroChatRequest(opts.body, opts.model)),
+    body: JSON.stringify(body),
     signal: fetchSignal,
     redirect: 'error',
   });
 
   if (!upstream.ok || !upstream.body) return upstream;
   if (opts.stream) {
-    return new Response(createKiroOpenAiStream(upstream.body, opts.model), {
+    return new Response(createKiroOpenAiStream(upstream.body, opts.model, toolNameMap), {
       status: 200,
       headers: { 'Content-Type': 'text/event-stream' },
     });
   }
 
-  const completion = await collectKiroCompletion(upstream.body, opts.model);
+  const completion = await collectKiroCompletion(upstream.body, opts.model, toolNameMap);
   return new Response(JSON.stringify(completion), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },

--- a/packages/backend/src/routing/proxy/kiro-adapter.ts
+++ b/packages/backend/src/routing/proxy/kiro-adapter.ts
@@ -20,6 +20,7 @@ const KIRO_TOOL_NAME_MAX_LENGTH = 64;
 const KIRO_TOOL_DESCRIPTION_MAX_LENGTH = 10237;
 const KIRO_TOOL_ID_MAX_LENGTH = 64;
 const KIRO_TOOL_NAME_ILLEGAL = /[^a-zA-Z0-9_-]/g;
+const KIRO_TOOL_NAME_ALLOWED = /^[a-zA-Z0-9_-]$/;
 const KIRO_TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 export function buildKiroHeaders(apiKey: string, target: string): Record<string, string> {
@@ -253,13 +254,34 @@ function normalizeToolSchema(schema: unknown): Record<string, unknown> {
   return cleaned;
 }
 
+/**
+ * Normalize a caller tool name to Kiro's `[A-Za-z0-9_-]+` alphabet in one
+ * linear pass. The obvious regex chain (`_+` with anchored alternatives) is a
+ * polynomial-time match on adversarial input, which CodeQL flags.
+ */
+function sanitizeToolName(rawName: string): string {
+  const chars: string[] = [];
+  let previousUnderscore = false;
+  for (const char of rawName.trim()) {
+    const sanitized = KIRO_TOOL_NAME_ALLOWED.test(char) ? char : '_';
+    if (sanitized === '_') {
+      if (previousUnderscore) continue;
+      previousUnderscore = true;
+    } else {
+      previousUnderscore = false;
+    }
+    chars.push(sanitized);
+  }
+
+  let start = 0;
+  let end = chars.length;
+  while (start < end && chars[start] === '_') start += 1;
+  while (end > start && chars[end - 1] === '_') end -= 1;
+  return chars.slice(start, end).join('');
+}
+
 function uniqueToolName(rawName: string, used: Set<string>): string {
-  const cleaned = rawName
-    .trim()
-    .replace(KIRO_TOOL_NAME_ILLEGAL, '_')
-    .replace(/_+/g, '_')
-    .replace(/^_+|_+$/g, '');
-  const base = trimToLength(cleaned || 'tool', KIRO_TOOL_NAME_MAX_LENGTH);
+  const base = trimToLength(sanitizeToolName(rawName) || 'tool', KIRO_TOOL_NAME_MAX_LENGTH);
   let candidate = base;
   let suffix = 2;
   while (used.has(candidate)) {


### PR DESCRIPTION
### ✨ What changed
- Send OpenAI `tools` as Kiro `toolSpecification` on the current turn.
- Map assistant `tool_calls` to `toolUses` and `tool` results to `toolResults`.
- Return Kiro `toolUseEvent` frames as OpenAI `tool_calls` (stream and JSON).
- Reconcile broken tool history into text so Kiro does not reject the body.
- Advertise `tools` for discovered Kiro models.

### 💭 Why
Kiro's CodeWhisperer API supports tools natively, but the adapter forwarded only message text, so tool-using agents got prose instead of `tool_calls`.

### 👤 For users
Agents routed to `kiro/*` (override or fallback) can call tools again.

### 📝 Notes
Closes #2866

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes tools through Kiro's native tool API so agents served by `kiro/*` models can call tools again. Previously the adapter forwarded only message text, so tool-using agents got prose instead of `tool_calls`; now tool definitions, calls, and results round-trip in both streaming and non-streaming responses.

- Sends OpenAI `tools` as Kiro `toolSpecification` on the current turn and advertises tool capability on discovered models.
- Maps assistant `tool_calls` to `toolUses`, `tool` role messages to `toolResults`, and Kiro `toolUseEvent` frames back into OpenAI `tool_calls`.
- Reconciles broken tool histories (missing results, orphan results, undeclared tools) into text so Kiro does not reject the request body.
- Sanitizes tool names and IDs to Kiro's allowed character set, drops schema keywords Kiro rejects, and restores original names on responses.
- Handles exception payload variants and edge cases like duplicate IDs, merged assistant turns, and empty conversations.

Closes #2866.

<sup>Written for commit b8ec6be0adead2349deff4c8b936f6415eeb0a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

