### PR TITLE
fix: close object schemas in Anthropic structured output

### DIFF
--- a/.changeset/anthropic-structured-output-schema.md
+++ b/.changeset/anthropic-structured-output-schema.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Close object schemas in Anthropic structured output. Every `type: object` node in `output_config.format.schema` now gets `additionalProperties: false` (unless the author set it), on both the chat-completions → Anthropic translation and the native `/v1/messages` pass-through, so Anthropic no longer rejects requests with "For 'object' type, 'additionalProperties' must be explicitly set to false".

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -327,7 +327,10 @@ describe('Anthropic Adapter', () => {
       expect(result.tool_choice).toBeUndefined();
       expect(result.tools).toBeUndefined();
       expect(result.output_config).toEqual({
-        format: { type: 'json_schema', schema: { type: 'object' } },
+        format: {
+          type: 'json_schema',
+          schema: { type: 'object', additionalProperties: false },
+        },
       });
     });
 
@@ -353,7 +356,7 @@ describe('Anthropic Adapter', () => {
       expect(result.output_config).toEqual({
         format: {
           type: 'json_schema',
-          schema: { type: 'object' },
+          schema: { type: 'object', additionalProperties: false },
         },
       });
       expect(result.tools).toEqual([
@@ -379,6 +382,47 @@ describe('Anthropic Adapter', () => {
       expect(result.output_config).toBeUndefined();
     });
 
+    it('closes object nodes in a structured-output schema recursively', () => {
+      const result = toAnthropicRequest(
+        {
+          messages: [{ role: 'user', content: 'Return structured data.' }],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              schema: {
+                type: 'object',
+                properties: {
+                  outer: { type: 'object', properties: { inner: { type: 'string' } } },
+                  list: { type: 'array', items: { type: 'object' } },
+                  open: { type: 'object', additionalProperties: true },
+                },
+              },
+            },
+          },
+        },
+        'claude-sonnet-4-20250514',
+      );
+
+      expect(result.output_config).toEqual({
+        format: {
+          type: 'json_schema',
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              outer: {
+                type: 'object',
+                additionalProperties: false,
+                properties: { inner: { type: 'string' } },
+              },
+              list: { type: 'array', items: { type: 'object', additionalProperties: false } },
+              open: { type: 'object', additionalProperties: true },
+            },
+          },
+        },
+      });
+    });
+
     it('preserves thinking when native structured output is requested', () => {
       const result = toAnthropicRequest(
         {
@@ -393,7 +437,7 @@ describe('Anthropic Adapter', () => {
       expect(result.output_config).toEqual({
         format: {
           type: 'json_schema',
-          schema: { type: 'object' },
+          schema: { type: 'object', additionalProperties: false },
         },
       });
       expect(result.thinking).toEqual({ type: 'enabled', budget_tokens: 1024 });
@@ -2224,6 +2268,23 @@ describe('Anthropic Adapter', () => {
   });
 
   describe('applyAnthropicMessagesMutations', () => {
+    it('closes object schemas on a native output_config without mutating the inbound body', () => {
+      const inbound = {
+        messages: [{ role: 'user', content: 'hi' }],
+        output_config: { format: { type: 'json_schema', schema: { type: 'object' } } },
+      };
+
+      const result = applyAnthropicMessagesMutations(inbound);
+
+      expect(result.output_config).toEqual({
+        format: {
+          type: 'json_schema',
+          schema: { type: 'object', additionalProperties: false },
+        },
+      });
+      expect(inbound.output_config.format.schema).toEqual({ type: 'object' });
+    });
+
     it('preserves the manual budget in native adaptive thinking', () => {
       const inbound = {
         messages: [{ role: 'user', content: 'hi' }],

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -459,7 +459,7 @@ describe('Anthropic Adapter', () => {
       });
     });
 
-    it('closes object schemas across every schema-valued keyword', () => {
+    it('closes object schemas across every category of schema-valued keyword', () => {
       const result = toAnthropicRequest(
         {
           messages: [{ role: 'user', content: 'Return structured data.' }],

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -1,6 +1,7 @@
 import {
   applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
+  closeAnthropicObjectSchemas,
   extractThinkingBlocksFromMessagesResponse,
   toAnthropicRequest,
   fromAnthropicResponse,
@@ -421,6 +422,54 @@ describe('Anthropic Adapter', () => {
           },
         },
       });
+    });
+
+    it('leaves enum/default data values untouched while closing schema nodes', () => {
+      const result = toAnthropicRequest(
+        {
+          messages: [{ role: 'user', content: 'Return structured data.' }],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              schema: {
+                type: 'object',
+                properties: {
+                  kind: { type: 'string', enum: ['a', { type: 'object' }] },
+                  fallback: { type: 'string', default: { type: 'object' } },
+                },
+              },
+            },
+          },
+        },
+        'claude-sonnet-4-20250514',
+      );
+
+      expect(result.output_config).toEqual({
+        format: {
+          type: 'json_schema',
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              kind: { type: 'string', enum: ['a', { type: 'object' }] },
+              fallback: { type: 'string', default: { type: 'object' } },
+            },
+          },
+        },
+      });
+    });
+
+    it('preserves a property literally named __proto__ without polluting the prototype', () => {
+      const schema = JSON.parse(
+        '{"type":"object","properties":{"__proto__":{"type":"object"}}}',
+      ) as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(schema.properties, '__proto__')).toBe(true);
+
+      const closed = closeAnthropicObjectSchemas(schema) as Record<string, unknown>;
+      const props = closed.properties as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(props, '__proto__')).toBe(true);
+      expect((props['__proto__'] as Record<string, unknown>).additionalProperties).toBe(false);
+      expect(({} as Record<string, unknown>).additionalProperties).toBeUndefined();
     });
 
     it('preserves thinking when native structured output is requested', () => {

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -459,6 +459,60 @@ describe('Anthropic Adapter', () => {
       });
     });
 
+    it('closes object schemas across every schema-valued keyword', () => {
+      const result = toAnthropicRequest(
+        {
+          messages: [{ role: 'user', content: 'Return structured data.' }],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              schema: {
+                // No `type`, but `properties` still describes an object.
+                properties: {
+                  a: { type: 'object' },
+                  b: { type: ['object', 'null'] },
+                },
+                // Tuple form of `items`.
+                items: [{ type: 'object' }, { type: 'string' }],
+                // Combinators are lists of subschemas.
+                anyOf: [{ type: 'object' }, { type: 'string' }],
+                // Maps of subschemas.
+                $defs: { node: { type: 'object' } },
+                dependencies: { a: { type: 'object' } },
+                patternProperties: { '^x': { type: 'object' } },
+                // Single-subschema applicators.
+                not: { type: 'object' },
+                if: { type: 'object' },
+                // `additionalProperties` may itself be a schema.
+                additionalProperties: { type: 'object' },
+              },
+            },
+          },
+        },
+        'claude-sonnet-4-20250514',
+      );
+
+      expect(result.output_config).toEqual({
+        format: {
+          type: 'json_schema',
+          schema: {
+            properties: {
+              a: { type: 'object', additionalProperties: false },
+              b: { type: ['object', 'null'], additionalProperties: false },
+            },
+            items: [{ type: 'object', additionalProperties: false }, { type: 'string' }],
+            anyOf: [{ type: 'object', additionalProperties: false }, { type: 'string' }],
+            $defs: { node: { type: 'object', additionalProperties: false } },
+            dependencies: { a: { type: 'object', additionalProperties: false } },
+            patternProperties: { '^x': { type: 'object', additionalProperties: false } },
+            not: { type: 'object', additionalProperties: false },
+            if: { type: 'object', additionalProperties: false },
+            additionalProperties: { type: 'object', additionalProperties: false },
+          },
+        },
+      });
+    });
+
     it('preserves a property literally named __proto__ without polluting the prototype', () => {
       const schema = JSON.parse(
         '{"type":"object","properties":{"__proto__":{"type":"object"}}}',
@@ -2332,6 +2386,20 @@ describe('Anthropic Adapter', () => {
         },
       });
       expect(inbound.output_config.format.schema).toEqual({ type: 'object' });
+    });
+
+    it('leaves an output_config that carries no format schema unchanged', () => {
+      const noFormat = applyAnthropicMessagesMutations({
+        messages: [{ role: 'user', content: 'hi' }],
+        output_config: { effort: 'high' },
+      });
+      expect(noFormat.output_config).toEqual({ effort: 'high' });
+
+      const noSchema = applyAnthropicMessagesMutations({
+        messages: [{ role: 'user', content: 'hi' }],
+        output_config: { format: { type: 'json_schema' } },
+      });
+      expect(noSchema.output_config).toEqual({ format: { type: 'json_schema' } });
     });
 
     it('preserves the manual budget in native adaptive thinking', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1420,7 +1420,14 @@ describe('ProviderClient', () => {
       const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sent.tool_choice).toBeUndefined();
       expect(sent.output_config).toEqual({
-        format: { type: 'json_schema', schema },
+        format: {
+          type: 'json_schema',
+          schema: {
+            type: 'object',
+            properties: { title: { type: 'string' } },
+            additionalProperties: false,
+          },
+        },
       });
       expect(result.structuredOutputToolName).toBeUndefined();
       expect(result.responsesTextFormat).toEqual({
@@ -1456,7 +1463,7 @@ describe('ProviderClient', () => {
       expect(sent.output_config).toEqual({
         format: {
           type: 'json_schema',
-          schema: { type: 'object' },
+          schema: { type: 'object', additionalProperties: false },
         },
       });
       expect(result.structuredOutputToolName).toBeUndefined();

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -273,31 +273,63 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
   return out.length > 0 ? out : undefined;
 }
 
+/**
+ * Anthropic structured outputs reject any object schema that omits
+ * `additionalProperties` ("For 'object' type, 'additionalProperties' must be
+ * explicitly set to false"). Clients and our own `json_object` fallback routinely
+ * emit a bare `{ type: 'object' }`, so close every object node while leaving an
+ * author's explicit value untouched. Recurses through the whole schema
+ * (properties, items, $defs, combinators) because the rule applies at every level.
+ */
+export function closeAnthropicObjectSchemas(schema: unknown): unknown {
+  if (Array.isArray(schema)) return schema.map(closeAnthropicObjectSchemas);
+  if (!isObjectRecord(schema)) return schema;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    result[key] = closeAnthropicObjectSchemas(value);
+  }
+  const type = result.type;
+  const isObjectType =
+    type === 'object' || (Array.isArray(type) && type.some((entry) => entry === 'object'));
+  // `properties` without an explicit `type` still describes an object.
+  const isObject = isObjectType || (result.properties !== undefined && type === undefined);
+  if (isObject && result.additionalProperties === undefined) {
+    result.additionalProperties = false;
+  }
+  return result;
+}
+
+/** Close object schemas on an Anthropic `output_config` (returns a new object). */
+function closeOutputConfigObjectSchemas(
+  outputConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const format = outputConfig.format;
+  if (!isObjectRecord(format) || !('schema' in format)) return outputConfig;
+  return {
+    ...outputConfig,
+    format: { ...format, schema: closeAnthropicObjectSchemas(format.schema) },
+  };
+}
+
 function toAnthropicOutputConfig(
   responseFormat: unknown,
   outputConfig: unknown,
 ): Record<string, unknown> | undefined {
   const out: Record<string, unknown> = isObjectRecord(outputConfig) ? { ...outputConfig } : {};
-  if (!isObjectRecord(responseFormat)) return Object.keys(out).length > 0 ? out : undefined;
-
-  if (responseFormat.type === 'json_object') {
-    // Anthropic has no `json_object` shorthand; use native JSON output with
-    // an unconstrained object schema instead of forcing tool use.
-    out.format = {
-      type: 'json_schema',
-      schema: { type: 'object' },
-    };
-    return out;
-  } else if (responseFormat.type === 'json_schema') {
-    const jsonSchema = isObjectRecord(responseFormat.json_schema) ? responseFormat.json_schema : {};
-    out.format = {
-      type: 'json_schema',
-      schema: jsonSchema.schema ?? { type: 'object' },
-    };
-    return out;
-  } else {
-    return Object.keys(out).length > 0 ? out : undefined;
+  if (isObjectRecord(responseFormat)) {
+    if (responseFormat.type === 'json_object') {
+      // Anthropic has no `json_object` shorthand; use native JSON output with
+      // an unconstrained object schema instead of forcing tool use.
+      out.format = { type: 'json_schema', schema: { type: 'object' } };
+    } else if (responseFormat.type === 'json_schema') {
+      const jsonSchema = isObjectRecord(responseFormat.json_schema)
+        ? responseFormat.json_schema
+        : {};
+      out.format = { type: 'json_schema', schema: jsonSchema.schema ?? { type: 'object' } };
+    }
   }
+  // Also closes an `output_config` that arrived already shaped on the inbound body.
+  return Object.keys(out).length > 0 ? closeOutputConfigObjectSchemas(out) : undefined;
 }
 
 /* ── Request conversion ── */
@@ -427,6 +459,12 @@ export function applyAnthropicMessagesMutations(
   const result: Record<string, unknown> = { ...body };
   result.max_tokens = resolveAnthropicMaxTokens(body);
   delete result.max_completion_tokens;
+  // Anthropic rejects structured-output schemas whose object nodes omit
+  // `additionalProperties`; native Messages clients pass `output_config` straight
+  // through, so close those schemas here too (not just on the translated path).
+  if (isObjectRecord(result.output_config)) {
+    result.output_config = closeOutputConfigObjectSchemas(result.output_config);
+  }
   const cacheBudget = {
     remaining: Math.max(0, MAX_CACHE_CONTROL_BLOCKS - countCacheControlBlocks(body)),
   };

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -299,6 +299,7 @@ const ANTHROPIC_SCHEMA_MAP_KEYWORDS = new Set([
   '$defs',
   'definitions',
   'dependentSchemas',
+  'dependencies',
 ]);
 
 /**

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -274,20 +274,65 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
 }
 
 /**
+ * JSON Schema keywords whose value is a subschema, an array of subschemas, or a
+ * map of subschemas. Only these recurse: `enum`/`default`/`examples`/`const` hold
+ * data values that can look like schemas and must pass through untouched.
+ */
+const ANTHROPIC_SCHEMA_KEYWORDS = new Set([
+  'items',
+  'contains',
+  'additionalProperties',
+  'additionalItems',
+  'unevaluatedProperties',
+  'unevaluatedItems',
+  'propertyNames',
+  'not',
+  'if',
+  'then',
+  'else',
+  'contentSchema',
+]);
+const ANTHROPIC_SCHEMA_LIST_KEYWORDS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+const ANTHROPIC_SCHEMA_MAP_KEYWORDS = new Set([
+  'properties',
+  'patternProperties',
+  '$defs',
+  'definitions',
+  'dependentSchemas',
+]);
+
+/**
  * Anthropic structured outputs reject any object schema that omits
  * `additionalProperties` ("For 'object' type, 'additionalProperties' must be
  * explicitly set to false"). Clients and our own `json_object` fallback routinely
  * emit a bare `{ type: 'object' }`, so close every object node while leaving an
- * author's explicit value untouched. Recurses through the whole schema
- * (properties, items, $defs, combinators) because the rule applies at every level.
+ * author's explicit value untouched. Only schema-valued keywords recurse, so data
+ * in `enum`/`default`/`examples` is never rewritten, and entries are copied with
+ * `Object.fromEntries` so a property literally named `__proto__` survives.
  */
 export function closeAnthropicObjectSchemas(schema: unknown): unknown {
   if (Array.isArray(schema)) return schema.map(closeAnthropicObjectSchemas);
   if (!isObjectRecord(schema)) return schema;
-  const result: Record<string, unknown> = {};
+
+  const entries: Array<[string, unknown]> = [];
   for (const [key, value] of Object.entries(schema)) {
-    result[key] = closeAnthropicObjectSchemas(value);
+    if (ANTHROPIC_SCHEMA_KEYWORDS.has(key)) {
+      entries.push([key, closeAnthropicObjectSchemas(value)]);
+    } else if (ANTHROPIC_SCHEMA_LIST_KEYWORDS.has(key) && Array.isArray(value)) {
+      entries.push([key, value.map(closeAnthropicObjectSchemas)]);
+    } else if (ANTHROPIC_SCHEMA_MAP_KEYWORDS.has(key) && isObjectRecord(value)) {
+      entries.push([
+        key,
+        Object.fromEntries(
+          Object.entries(value).map(([name, sub]) => [name, closeAnthropicObjectSchemas(sub)]),
+        ),
+      ]);
+    } else {
+      entries.push([key, value]);
+    }
   }
+
+  const result = Object.fromEntries(entries) as Record<string, unknown>;
   const type = result.type;
   const isObjectType =
     type === 'object' || (Array.isArray(type) && type.some((entry) => entry === 'object'));


### PR DESCRIPTION
### ✨ What changed
- Recursively set `additionalProperties: false` on every object node in an Anthropic structured-output schema
- Apply it on both the chat-completions to Anthropic translation and the native `/v1/messages` pass-through
- Leave an explicitly set `additionalProperties` value untouched

### 💭 Why
Anthropic rejects structured-output schemas whose object nodes omit `additionalProperties` (`For 'object' type, 'additionalProperties' must be explicitly set to false`). Clients and the gateway's own `json_object` fallback emit a bare `{ type: 'object' }`, so otherwise valid requests were failing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anthropic rejects structured-output schemas whose object nodes omit `additionalProperties`, so requests using a bare `{ type: 'object' }` failed. This PR recursively sets `additionalProperties: false` on every object node in the schema for both the chat-completions to Anthropic translation and the native `/v1/messages` pass-through, while leaving explicitly set values untouched.

- Applies to nested objects in `properties`, `items`, `$defs`, `dependencies`, and combinators; only schema-valued keywords recurse, so data in `enum`, `default`, and `examples` is untouched.
- The pass-through returns a new `output_config`; the inbound request body is not mutated.

<sup>Written for commit eb46d485dc3eb80efb3c7aeba5f708947d641e44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

