### PR TITLE
fix: keep Kiro tool-result turns empty so agents keep context

### DIFF
--- a/.changeset/kiro-tool-loop-context.md
+++ b/.changeset/kiro-tool-loop-context.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Fix Kiro agent loops. When a request ends on a tool result with no new user text, leave the current Kiro turn empty instead of synthesizing `continue` (or prepending the system prompt). Kiro read that fabricated text as a fresh instruction and dropped the in-flight task, so tool-calling agents (opencode et al.) lost context immediately after the first tool call.
+Fix Kiro agent loops. When a request ends on a tool result with no new user text, leave the current Kiro turn empty instead of synthesizing `continue` (or leaving the system prompt there). Kiro read that fabricated text as a fresh instruction and dropped the in-flight task, so tool-calling agents (opencode et al.) lost context immediately after the first tool call. The system prompt now rides the conversation's first user turn so it still reaches the model.

--- a/.changeset/kiro-tool-loop-context.md
+++ b/.changeset/kiro-tool-loop-context.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix Kiro agent loops. When a request ends on a tool result with no new user text, leave the current Kiro turn empty instead of synthesizing `continue` (or prepending the system prompt). Kiro read that fabricated text as a fresh instruction and dropped the in-flight task, so tool-calling agents (opencode et al.) lost context immediately after the first tool call.

--- a/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
@@ -329,7 +329,12 @@ describe('kiro-adapter', () => {
     };
 
     expect(request.conversationState.history).toEqual([
-      { userInputMessage: { content: 'List the files.', origin: 'KIRO_CLI' } },
+      {
+        userInputMessage: {
+          content: 'System instructions:\nYou can run commands.\n\nUser:\nList the files.',
+          origin: 'KIRO_CLI',
+        },
+      },
       {
         assistantResponseMessage: {
           content: '...',
@@ -340,7 +345,9 @@ describe('kiro-adapter', () => {
 
     const current = request.conversationState.currentMessage.userInputMessage;
     // A tool result with no new user text must stay empty: fabricating
-    // "continue" (or prepending the system prompt) makes Kiro drop the task.
+    // "continue" (or leaving the system prompt here) makes Kiro read a fresh,
+    // context-free instruction and drop the task. The system prompt moves to the
+    // first user turn (above) so it still reaches the model.
     expect(current.content).toBe('');
     expect(current.userInputMessageContext.toolResults).toEqual([
       { toolUseId: 'call_1', status: 'success', content: [{ text: 'a.txt\nb.txt' }] },
@@ -359,35 +366,6 @@ describe('kiro-adapter', () => {
           },
         },
       },
-    ]);
-  });
-
-  it('keeps the current turn empty when a tool result is the last message', () => {
-    // Agents (opencode, Claude Code, …) send the follow-up turn with only the
-    // tool result and no new user text. Kiro continues the pending task only
-    // when that turn's `content` is empty — a fabricated "continue" or a
-    // prepended system prompt is read as a fresh instruction and drops the
-    // conversation.
-    const request = buildKiro({
-      messages: [
-        { role: 'system', content: 'You can run commands.' },
-        { role: 'user', content: 'Run echo hi and report the output.' },
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [
-            { id: 'c1', function: { name: 'bash', arguments: '{"command":"echo hi"}' } },
-          ],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: 'hi' },
-      ],
-      tools: [{ function: { name: 'bash' } }],
-    });
-
-    const current = request.conversationState.currentMessage.userInputMessage;
-    expect(current.content).toBe('');
-    expect(current.userInputMessageContext?.toolResults).toEqual([
-      { toolUseId: 'c1', status: 'success', content: [{ text: 'hi' }] },
     ]);
   });
 
@@ -942,6 +920,22 @@ describe('kiro-adapter', () => {
         { userInputMessage: { content: 'q', origin: 'KIRO_CLI' } },
         { assistantResponseMessage: { content: 'a' } },
       ]);
+    });
+
+    it('falls back to a Hello turn for an empty user message', () => {
+      expect(
+        buildKiro({ messages: [{ role: 'user', content: '' }] }).conversationState.currentMessage
+          .userInputMessage.content,
+      ).toBe('Hello');
+
+      expect(
+        buildKiro({
+          messages: [
+            { role: 'system', content: 'Be terse.' },
+            { role: 'user', content: '' },
+          ],
+        }).conversationState.currentMessage.userInputMessage.content,
+      ).toBe('System instructions:\nBe terse.\n\nUser:\nHello');
     });
 
     it('folds developer instructions and string/array content parts', () => {

--- a/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
@@ -339,7 +339,9 @@ describe('kiro-adapter', () => {
     ]);
 
     const current = request.conversationState.currentMessage.userInputMessage;
-    expect(current.content).toBe('System instructions:\nYou can run commands.\n\nUser:\ncontinue');
+    // A tool result with no new user text must stay empty: fabricating
+    // "continue" (or prepending the system prompt) makes Kiro drop the task.
+    expect(current.content).toBe('');
     expect(current.userInputMessageContext.toolResults).toEqual([
       { toolUseId: 'call_1', status: 'success', content: [{ text: 'a.txt\nb.txt' }] },
     ]);
@@ -357,6 +359,35 @@ describe('kiro-adapter', () => {
           },
         },
       },
+    ]);
+  });
+
+  it('keeps the current turn empty when a tool result is the last message', () => {
+    // Agents (opencode, Claude Code, …) send the follow-up turn with only the
+    // tool result and no new user text. Kiro continues the pending task only
+    // when that turn's `content` is empty — a fabricated "continue" or a
+    // prepended system prompt is read as a fresh instruction and drops the
+    // conversation.
+    const request = buildKiro({
+      messages: [
+        { role: 'system', content: 'You can run commands.' },
+        { role: 'user', content: 'Run echo hi and report the output.' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            { id: 'c1', function: { name: 'bash', arguments: '{"command":"echo hi"}' } },
+          ],
+        },
+        { role: 'tool', tool_call_id: 'c1', content: 'hi' },
+      ],
+      tools: [{ function: { name: 'bash' } }],
+    });
+
+    const current = request.conversationState.currentMessage.userInputMessage;
+    expect(current.content).toBe('');
+    expect(current.userInputMessageContext?.toolResults).toEqual([
+      { toolUseId: 'c1', status: 'success', content: [{ text: 'hi' }] },
     ]);
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
@@ -369,6 +369,31 @@ describe('kiro-adapter', () => {
     ]);
   });
 
+  it('gives the system prompt its own turn when a tool result has no earlier user turn', () => {
+    const withSystem = buildKiro({
+      messages: [
+        { role: 'system', content: 'You can run commands.' },
+        { role: 'tool', tool_call_id: 'c1', content: 'hi' },
+      ],
+    });
+    expect(withSystem.conversationState.currentMessage.userInputMessage.content).toBe('');
+    expect(withSystem.conversationState.history).toEqual([
+      {
+        userInputMessage: {
+          content: 'System instructions:\nYou can run commands.',
+          origin: 'KIRO_CLI',
+        },
+      },
+      { assistantResponseMessage: { content: '...' } },
+    ]);
+
+    const withoutSystem = buildKiro({
+      messages: [{ role: 'tool', tool_call_id: 'c1', content: 'hi' }],
+    });
+    expect(withoutSystem.conversationState.currentMessage.userInputMessage.content).toBe('');
+    expect(withoutSystem.conversationState.history).toEqual([]);
+  });
+
   it('sanitizes invalid Kiro tool names and restores them on the response', async () => {
     const request = buildKiroChatRequest(
       {

--- a/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/kiro-adapter.spec.ts
@@ -369,29 +369,29 @@ describe('kiro-adapter', () => {
     ]);
   });
 
-  it('gives the system prompt its own turn when a tool result has no earlier user turn', () => {
+  it('inlines a lone tool result that has no assistant call to pair with', () => {
     const withSystem = buildKiro({
       messages: [
         { role: 'system', content: 'You can run commands.' },
         { role: 'tool', tool_call_id: 'c1', content: 'hi' },
       ],
     });
-    expect(withSystem.conversationState.currentMessage.userInputMessage.content).toBe('');
-    expect(withSystem.conversationState.history).toEqual([
-      {
-        userInputMessage: {
-          content: 'System instructions:\nYou can run commands.',
-          origin: 'KIRO_CLI',
-        },
-      },
-      { assistantResponseMessage: { content: '...' } },
-    ]);
+    expect(withSystem.conversationState.history).toEqual([]);
+    expect(withSystem.conversationState.currentMessage.userInputMessage.content).toBe(
+      'System instructions:\nYou can run commands.\n\nUser:\n[Tool result: hi]',
+    );
+    expect(
+      withSystem.conversationState.currentMessage.userInputMessage.userInputMessageContext
+        ?.toolResults,
+    ).toBeUndefined();
 
     const withoutSystem = buildKiro({
       messages: [{ role: 'tool', tool_call_id: 'c1', content: 'hi' }],
     });
-    expect(withoutSystem.conversationState.currentMessage.userInputMessage.content).toBe('');
     expect(withoutSystem.conversationState.history).toEqual([]);
+    expect(withoutSystem.conversationState.currentMessage.userInputMessage.content).toBe(
+      '[Tool result: hi]',
+    );
   });
 
   it('sanitizes invalid Kiro tool names and restores them on the response', async () => {

--- a/packages/backend/src/routing/proxy/kiro-adapter.ts
+++ b/packages/backend/src/routing/proxy/kiro-adapter.ts
@@ -613,8 +613,14 @@ function buildKiroConversation(body: Record<string, unknown>, model: string): Ki
     // conversation's first user turn to keep delivering it.
     currentMessage.userInputMessage.content = '';
     const firstUser = history.find(isUserMessage);
-    if (systemText && firstUser) {
+    if (firstUser && systemText) {
       firstUser.userInputMessage.content = `System instructions:\n${systemText}\n\nUser:\n${firstUser.userInputMessage.content}`;
+    } else if (!firstUser && systemText) {
+      // No earlier user turn to carry the prompt (a lone tool result). Give it
+      // its own user/assistant pair so it still reaches Kiro without text on the
+      // current turn; the assistant turn keeps the history alternating.
+      history.push(toUserMessage(`System instructions:\n${systemText}`));
+      history.push(toAssistantMessage('...'));
     }
   } else {
     currentMessage.userInputMessage.content = systemText

--- a/packages/backend/src/routing/proxy/kiro-adapter.ts
+++ b/packages/backend/src/routing/proxy/kiro-adapter.ts
@@ -602,8 +602,8 @@ function buildKiroConversation(body: Record<string, unknown>, model: string): Ki
   }
 
   const currentText = currentMessage.userInputMessage.content;
-  const hasToolResults =
-    !!currentMessage.userInputMessage.userInputMessageContext?.toolResults?.length;
+  const toolResults = currentMessage.userInputMessage.userInputMessageContext?.toolResults ?? [];
+  const hasToolResults = toolResults.length > 0;
   if (hasToolResults && !currentText) {
     // The latest turn is a tool result with no new user text: Kiro continues the
     // pending task only when `content` is empty. A fabricated "continue" (or the
@@ -613,14 +613,21 @@ function buildKiroConversation(body: Record<string, unknown>, model: string): Ki
     // conversation's first user turn to keep delivering it.
     currentMessage.userInputMessage.content = '';
     const firstUser = history.find(isUserMessage);
-    if (firstUser && systemText) {
-      firstUser.userInputMessage.content = `System instructions:\n${systemText}\n\nUser:\n${firstUser.userInputMessage.content}`;
-    } else if (!firstUser && systemText) {
-      // No earlier user turn to carry the prompt (a lone tool result). Give it
-      // its own user/assistant pair so it still reaches Kiro without text on the
-      // current turn; the assistant turn keeps the history alternating.
-      history.push(toUserMessage(`System instructions:\n${systemText}`));
-      history.push(toAssistantMessage('...'));
+    if (firstUser) {
+      if (systemText) {
+        firstUser.userInputMessage.content = `System instructions:\n${systemText}\n\nUser:\n${firstUser.userInputMessage.content}`;
+      }
+    } else {
+      // No earlier user turn: this tool result is the conversation's first turn
+      // and has no assistant tool-use to pair with, so Kiro rejects it as an
+      // orphan. Inline the result; the system prompt belongs on this first turn.
+      const context = currentMessage.userInputMessage.userInputMessageContext!;
+      const inlined = toolResults.map(flattenToolResult).join('\n\n');
+      currentMessage.userInputMessage.content = systemText
+        ? `System instructions:\n${systemText}\n\nUser:\n${inlined}`
+        : inlined;
+      delete context.toolResults;
+      deleteEmptyContext(currentMessage);
     }
   } else {
     currentMessage.userInputMessage.content = systemText

--- a/packages/backend/src/routing/proxy/kiro-adapter.ts
+++ b/packages/backend/src/routing/proxy/kiro-adapter.ts
@@ -602,12 +602,19 @@ function buildKiroConversation(body: Record<string, unknown>, model: string): Ki
   }
 
   const currentText = currentMessage.userInputMessage.content;
-  const fallbackText = currentMessage.userInputMessage.userInputMessageContext?.toolResults?.length
-    ? 'continue'
-    : 'Hello';
-  currentMessage.userInputMessage.content = systemText
-    ? `System instructions:\n${systemText}\n\nUser:\n${currentText || fallbackText}`
-    : currentText || fallbackText;
+  const hasToolResults =
+    !!currentMessage.userInputMessage.userInputMessageContext?.toolResults?.length;
+  if (hasToolResults && !currentText) {
+    // The latest turn is a tool result with no new user text: Kiro continues the
+    // pending task only when `content` is empty. Fabricating "continue" (or
+    // prepending the system prompt) reads as a fresh, context-free user message
+    // and makes the model drop the conversation.
+    currentMessage.userInputMessage.content = '';
+  } else {
+    currentMessage.userInputMessage.content = systemText
+      ? `System instructions:\n${systemText}\n\nUser:\n${currentText || 'Hello'}`
+      : currentText || 'Hello';
+  }
   currentMessage.userInputMessage.modelId ??= model;
 
   return {

--- a/packages/backend/src/routing/proxy/kiro-adapter.ts
+++ b/packages/backend/src/routing/proxy/kiro-adapter.ts
@@ -606,10 +606,16 @@ function buildKiroConversation(body: Record<string, unknown>, model: string): Ki
     !!currentMessage.userInputMessage.userInputMessageContext?.toolResults?.length;
   if (hasToolResults && !currentText) {
     // The latest turn is a tool result with no new user text: Kiro continues the
-    // pending task only when `content` is empty. Fabricating "continue" (or
-    // prepending the system prompt) reads as a fresh, context-free user message
-    // and makes the model drop the conversation.
+    // pending task only when `content` is empty. A fabricated "continue" (or the
+    // system prompt) reads as a fresh, context-free user message and makes the
+    // model drop the conversation. The system prompt has no dedicated Kiro field
+    // and lands on the current turn everywhere else, so move it onto the
+    // conversation's first user turn to keep delivering it.
     currentMessage.userInputMessage.content = '';
+    const firstUser = history.find(isUserMessage);
+    if (systemText && firstUser) {
+      firstUser.userInputMessage.content = `System instructions:\n${systemText}\n\nUser:\n${firstUser.userInputMessage.content}`;
+    }
   } else {
     currentMessage.userInputMessage.content = systemText
       ? `System instructions:\n${systemText}\n\nUser:\n${currentText || 'Hello'}`


### PR DESCRIPTION
## What

The Kiro adapter fabricates the current user turn when a request ends on a tool result. It replaced that turn with `System instructions:\n…\n\nUser:\ncontinue` (`kiro-adapter.ts`). Kiro reads that text as a **fresh** instruction and drops the in-flight task — so any tool-calling agent that sends its follow-up with only the tool result (opencode, Claude Code, …) loses context immediately after the first tool call.

Follow-up to #2867.

## Repro (live Kiro, 6.23.3)

Through Manifest with a Kiro subscription, opencode (`@ai-sdk/openai-compatible` → `/v1/chat/completions`) runs the tool, then answers:

> I need more context about what to continue. Could you clarify what task or conversation you'd like me to continue?

Replaying the adapter's exact upstream body against Kiro:

| current turn content | Kiro response |
|---|---|
| `…User:\ncontinue` (before) | "I'm ready to help. What would you like to work on?" |
| `""` + toolResults (after) | "The exact output is: `OPENCODE_TOOL_OK`" |

Empty content is accepted by Kiro; the fabricated text is the problem.

## Change

When the current turn carries tool results and has no new user text, leave `content` empty — no system-prompt prefix, no `continue`. Turns with genuine new user text keep the old behavior.

## Tests

- New case in `kiro-adapter.spec.ts`: a tool result as the last message produces an empty current turn.
- Updated the one assertion that encoded the old `continue` behavior.
- `kiro-adapter.spec.ts` (29) and the Kiro `provider-client.spec.ts` cases pass.

`.changeset/kiro-tool-loop-context.md` (patch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Kiro adapter so tool-calling agents keep context after the first tool call, and keeps the system prompt delivered. When a request ends on a tool result with no new user text, the adapter used to synthesize `continue` or prepend the system prompt; Kiro read that as a fresh instruction and dropped the in-flight task. The current turn now stays empty, which is the shape Kiro continues on.

- Turns with genuine new user text keep the old behavior.
- The system prompt has no dedicated Kiro field, so when the latest turn is a tool result it rides the conversation's first user turn.
- A lone tool result with no earlier user turn would be an orphan Kiro rejects, so it is inlined into the current turn as text.

<sup>Written for commit f92eed97aacebf9f024c7ec105476851c093da40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

