### PR TITLE
feat: let outreach reach the teams that signed up but never called the API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ packages/
 │   │   ├── error-pages/                     # Custom error-page config (internal + public)
 │   │   ├── waitlist/                        # Pivot waiting-list claims + legacy Autofix claim compatibility route
 │   │   ├── discovery/                       # Self-hosted discovery onboarding (forwarded to Peacock)
-│   │   ├── crm-metrics/                     # Cloud-only internal feed: Autofix-healed cohort + waitlist claims (secret-gated)
+│   │   ├── crm-metrics/                     # Cloud-only internal feed: Autofix-healed cohort + waitlist claims + corporate signups (secret-gated)
 │   │   ├── cors-csp-config.ts               # Wingman CORS/CSP origin allowlists
 │   │   ├── sentry/                          # Sentry init-options builder (SENTRY_DSN-gated)
 │   │   └── telemetry/                       # Anonymous self-hosted telemetry
@@ -387,7 +387,7 @@ Every resource belongs to a tenant; users only authenticate and (optionally) app
 | GET                       | `/api/v1/overview/autofix-*`                    | Session/API Key                     | Autofix analytics (stats, timeseries, per-agent/provider/model)                                             |
 | POST                      | `/api/v1/discovery/complete`                    | Session/API Key                     | Best-effort self-hosted discovery submission forwarded to Peacock                                           |
 | GET/POST/DELETE           | `/api/v1/internal/error-pages*`                 | Public (`x-internal-secret` header) | Custom error-page config (Peacock CMS push API)                                                             |
-| GET                       | `/api/v1/internal/crm-metrics*`                 | Public (`x-internal-secret` header) | **Cloud only.** Autofix-healed user cohort + pivot waitlist claims, for the outreach CRM (`CRM_METRICS_SECRET`) |
+| GET                       | `/api/v1/internal/crm-metrics*`                 | Public (`x-internal-secret` header) | **Cloud only.** Autofix-healed user cohort, pivot waitlist claims, and corporate signups, for the outreach CRM (`CRM_METRICS_SECRET`) |
 | GET/PUT/DELETE            | `/api/v1/agents/:agentName/enabled-providers*`  | Session/API Key                     | Per-agent provider enable/disable + impact preview                                                          |
 | GET/POST/PATCH/DELETE     | `/api/v1/notifications/*`                       | Session/API Key                     | Notification rules CRUD + email provider config                                                             |
 | GET/POST/PUT/PATCH/DELETE | `/api/v1/routing/:agentName/*`                  | Session/API Key                     | Routing config (tiers, providers, model-params, header-tiers, custom-providers, specificity, autofix, recording, etc.) |

--- a/packages/backend/src/crm-metrics/crm-metrics.filters.spec.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.filters.spec.ts
@@ -1,4 +1,10 @@
-import { isExcludedEmail } from './crm-metrics.filters';
+import {
+  domainOf,
+  isConsumerEmail,
+  isCorporateSignupEmail,
+  isExcludedEmail,
+  isSignupCluster,
+} from './crm-metrics.filters';
 
 describe('isExcludedEmail', () => {
   it('keeps an ordinary user address', () => {
@@ -57,5 +63,113 @@ describe('isExcludedEmail', () => {
 
   it('uses the last @ so a quoted local part cannot smuggle a domain in', () => {
     expect(isExcludedEmail('user@notjunk@dralias.com')).toBe(true);
+  });
+});
+
+describe('domainOf', () => {
+  it('returns the lowercased domain part', () => {
+    expect(domainOf('  Ada@Example.COM ')).toBe('example.com');
+  });
+
+  it('returns empty for an unroutable address', () => {
+    expect(domainOf('no-at-sign')).toBe('');
+    expect(domainOf('@leading.com')).toBe('');
+    expect(domainOf('trailing@')).toBe('');
+  });
+});
+
+describe('isConsumerEmail', () => {
+  it('flags mainstream consumer mailboxes', () => {
+    expect(isConsumerEmail('ada@gmail.com')).toBe(true);
+    expect(isConsumerEmail('ada@YAHOO.co.uk')).toBe(true);
+    expect(isConsumerEmail('ada@qq.com')).toBe(true);
+  });
+
+  it('flags privacy relays that read as custom domains', () => {
+    expect(isConsumerEmail('ada@duck.com')).toBe(true);
+    expect(isConsumerEmail('ada@pm.me')).toBe(true);
+    expect(isConsumerEmail('ada@simplelogin.io')).toBe(true);
+  });
+
+  it('treats subdomains of a consumer domain as consumer', () => {
+    expect(isConsumerEmail('ada@mail.duck.com')).toBe(true);
+  });
+
+  it('does not flag a domain that merely ends with the same letters', () => {
+    expect(isConsumerEmail('ada@notgmail.com')).toBe(false);
+  });
+
+  it('flags an unroutable address', () => {
+    expect(isConsumerEmail('nonsense')).toBe(true);
+  });
+
+  it('leaves real company domains alone', () => {
+    expect(isConsumerEmail('ada@stripe.com')).toBe(false);
+  });
+});
+
+describe('isCorporateSignupEmail', () => {
+  it('admits a company address', () => {
+    expect(isCorporateSignupEmail('ada@stripe.com')).toBe(true);
+  });
+
+  it('rejects consumer mail', () => {
+    expect(isCorporateSignupEmail('ada@gmail.com')).toBe(false);
+  });
+
+  it('rejects addresses the shared exclusion list already covers', () => {
+    expect(isCorporateSignupEmail('support@stripe.com')).toBe(false);
+    expect(isCorporateSignupEmail('ada@manifest.build')).toBe(false);
+    expect(isCorporateSignupEmail('ada@atomicmail.io')).toBe(false);
+  });
+});
+
+describe('isSignupCluster', () => {
+  const at = (iso: string, has_traffic = false) => ({ signed_up_at: iso, has_traffic });
+
+  it('flags three trafficless signups inside a month', () => {
+    expect(
+      isSignupCluster([
+        at('2026-03-01T00:00:00.000Z'),
+        at('2026-03-10T00:00:00.000Z'),
+        at('2026-03-18T00:00:00.000Z'),
+      ]),
+    ).toBe(true);
+  });
+
+  it('spares a domain below the signup threshold', () => {
+    expect(isSignupCluster([at('2026-03-01T00:00:00.000Z'), at('2026-03-02T00:00:00.000Z')])).toBe(
+      false,
+    );
+  });
+
+  it('spares a domain where anyone ever sent a request', () => {
+    expect(
+      isSignupCluster([
+        at('2026-03-01T00:00:00.000Z'),
+        at('2026-03-10T00:00:00.000Z'),
+        at('2026-03-18T00:00:00.000Z', true),
+      ]),
+    ).toBe(false);
+  });
+
+  it('spares a team that trickled in over more than a month', () => {
+    expect(
+      isSignupCluster([
+        at('2026-01-01T00:00:00.000Z'),
+        at('2026-03-10T00:00:00.000Z'),
+        at('2026-06-18T00:00:00.000Z'),
+      ]),
+    ).toBe(false);
+  });
+
+  it('judges the span regardless of row order', () => {
+    expect(
+      isSignupCluster([
+        at('2026-06-18T00:00:00.000Z'),
+        at('2026-01-01T00:00:00.000Z'),
+        at('2026-03-10T00:00:00.000Z'),
+      ]),
+    ).toBe(false);
   });
 });

--- a/packages/backend/src/crm-metrics/crm-metrics.filters.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.filters.ts
@@ -70,3 +70,134 @@ export function isExcludedEmail(email: string): boolean {
 function matchesDomain(domain: string, list: string[]): boolean {
   return list.some((entry) => domain === entry || domain.endsWith(`.${entry}`));
 }
+
+/**
+ * Consumer mail and privacy-relay providers.
+ *
+ * Separate from JUNK_DOMAINS because these addresses are perfectly real — the
+ * healed-user feed emails plenty of them. They are excluded from the *signup*
+ * feed only, where the whole premise is "a corporate domain implies a team
+ * behind it". A gmail.com signup carries no such signal.
+ *
+ * The relay entries matter more than the obvious freemail ones: duck.com,
+ * pm.me and simplelogin addresses read as custom domains to a naive
+ * `not freemail` check, and were the largest "corporate" domains in the
+ * database by signup count until they were listed here.
+ */
+const CONSUMER_DOMAINS = [
+  'gmail.com',
+  'googlemail.com',
+  'outlook.com',
+  'outlook.fr',
+  'hotmail.com',
+  'hotmail.fr',
+  'hotmail.co.uk',
+  'live.com',
+  'live.fr',
+  'msn.com',
+  'yahoo.com',
+  'yahoo.co.uk',
+  'yahoo.fr',
+  'ymail.com',
+  'aol.com',
+  'icloud.com',
+  'me.com',
+  'mac.com',
+  'proton.me',
+  'protonmail.com',
+  'pm.me',
+  'duck.com',
+  'simplelogin.com',
+  'simplelogin.io',
+  'anonaddy.com',
+  'posteo.de',
+  'gmx.com',
+  'gmx.de',
+  'gmx.net',
+  'web.de',
+  't-online.de',
+  'free.fr',
+  'orange.fr',
+  'wanadoo.fr',
+  'laposte.net',
+  'sfr.fr',
+  'comcast.net',
+  'qq.com',
+  '163.com',
+  '126.com',
+  'foxmail.com',
+  'sina.com',
+  'naver.com',
+  'daum.net',
+  'yandex.ru',
+  'yandex.com',
+  'mail.ru',
+  'rambler.ru',
+  'seznam.cz',
+  'zoho.com',
+  'fastmail.com',
+  'hey.com',
+  'example.com',
+  'test.com',
+];
+
+/** Signups on one domain inside this span, with no traffic, look scripted. */
+const CLUSTER_WINDOW_MS = 30 * 86_400_000;
+
+/** Fewer than this on a domain is a small team, not a cluster. */
+const CLUSTER_MIN_SIGNUPS = 3;
+
+/** The domain part of an address, lowercased; empty when unroutable. */
+export function domainOf(email: string): string {
+  const normalized = email.trim().toLowerCase();
+  const at = normalized.lastIndexOf('@');
+  if (at <= 0 || at === normalized.length - 1) return '';
+  return normalized.slice(at + 1);
+}
+
+/**
+ * True when the address belongs to a consumer mailbox or a privacy relay,
+ * rather than to an organisation.
+ *
+ * Subdomains count (`mail.duck.com`), matching `isExcludedEmail`.
+ */
+export function isConsumerEmail(email: string): boolean {
+  const domain = domainOf(email);
+  if (!domain) return true;
+  return matchesDomain(domain, CONSUMER_DOMAINS);
+}
+
+/**
+ * The signup feed's admission rule: a routable address, on a domain that looks
+ * like an organisation, that we are not already excluding for other reasons.
+ */
+export function isCorporateSignupEmail(email: string): boolean {
+  return !isExcludedEmail(email) && !isConsumerEmail(email);
+}
+
+/** One signup, reduced to what the cluster rule needs to judge a domain. */
+export interface ClusterCandidate {
+  signed_up_at: string;
+  has_traffic: boolean;
+}
+
+/**
+ * True when a domain's signups look automated rather than like a real team.
+ *
+ * Three or more accounts, created inside a month, none of which ever sent a
+ * request. A genuine team trickles in over quarters and at least one of them
+ * points something at the gateway; the scraped-address clusters we have seen
+ * arrive in a burst and never call the API.
+ *
+ * Any traffic at all clears the whole domain: a real user among them means the
+ * burst was a launch, not a script.
+ */
+export function isSignupCluster(signups: ClusterCandidate[]): boolean {
+  if (signups.length < CLUSTER_MIN_SIGNUPS) return false;
+  if (signups.some((signup) => signup.has_traffic)) return false;
+
+  const times = signups
+    .map((signup) => new Date(signup.signed_up_at).getTime())
+    .sort((a, b) => a - b);
+  return times[times.length - 1] - times[0] <= CLUSTER_WINDOW_MS;
+}

--- a/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
@@ -563,6 +563,20 @@ describe('CrmMetricsService', () => {
       ]);
     });
 
+    it('keeps a verified user who never created a tenant', async () => {
+      // Tenants are created lazily on first agent creation, so someone who
+      // signed up and never built anything has no tenant row. They are exactly
+      // who this feed is for, and an inner join would drop them: 1,274 verified
+      // users in production, 144 of them corporate.
+      setup({ signups: [signupRow({ last_request_at: null })] });
+
+      const [signup] = await service.getCorporateSignups(365, NOW);
+
+      expect(signup.has_traffic).toBe(false);
+      expect(signup.last_request_at).toBeNull();
+      expect(sqlFor('WITH signups AS MATERIALIZED')).toContain('LEFT JOIN tenants t');
+    });
+
     it('marks a tenant that has sent a request', async () => {
       setup({ signups: [signupRow({ last_request_at: '2026-09-01T08:00:00.000Z' })] });
 

--- a/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.service.spec.ts
@@ -9,6 +9,7 @@ interface Scripted {
   index?: unknown[];
   cohort?: unknown[];
   claims?: unknown[];
+  signups?: unknown[];
 }
 
 function cohortRow(over: Record<string, unknown> = {}) {
@@ -20,6 +21,16 @@ function cohortRow(over: Record<string, unknown> = {}) {
     healed_all: '1241',
     first_heal_at: '2026-07-30T15:17:31.000Z',
     last_heal_at: '2026-09-04T09:47:30.000Z',
+    ...over,
+  };
+}
+
+function signupRow(over: Record<string, unknown> = {}) {
+  return {
+    email: 'ada@stripe.com',
+    user_name: 'Ada Lovelace',
+    signed_up_at: '2026-08-01T10:00:00.000Z',
+    last_request_at: null,
     ...over,
   };
 }
@@ -39,6 +50,9 @@ describe('CrmMetricsService', () => {
     query = jest.fn().mockImplementation((sql: string) => {
       if (sql.includes('SET LOCAL')) return Promise.resolve([]);
       if (sql.includes('pg_index')) return Promise.resolve(scripted.index ?? []);
+      // Checked before the cohort branch: both queries join `tenants t`.
+      if (sql.includes('WITH signups AS MATERIALIZED'))
+        return Promise.resolve(scripted.signups ?? []);
       if (sql.includes('JOIN tenants t')) return Promise.resolve(scripted.cohort ?? []);
       if (sql.includes('FROM waitlist_claims')) return Promise.resolve(scripted.claims ?? []);
       throw new Error(`unexpected SQL: ${sql}`);
@@ -184,6 +198,7 @@ describe('CrmMetricsService', () => {
 
       await expect(service.getHealedCohort(7)).resolves.toHaveLength(1);
       await expect(service.getConversions(90)).resolves.toEqual([]);
+      await expect(service.getCorporateSignups(365)).resolves.toEqual([]);
 
       const cutoff = paramsFor('JOIN tenants t')[0] as string;
       expect(cutoff).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
@@ -502,6 +517,161 @@ describe('CrmMetricsService', () => {
       const first = await service.getConversions(90, NOW);
       const callsAfterFirst = query.mock.calls.length;
       const second = await service.getConversions(90, NOW);
+
+      expect(second).toBe(first);
+      expect(query.mock.calls).toHaveLength(callsAfterFirst);
+    });
+  });
+
+  describe('getCorporateSignups', () => {
+    it('refuses to run when the tenant/timestamp index is missing', async () => {
+      setup({ index: [] });
+
+      await expect(service.getCorporateSignups(365, NOW)).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+      expect(sqlFor('WITH signups AS MATERIALIZED')).toBe('');
+    });
+
+    it('checks for the index the lateral probe depends on', async () => {
+      await service.getCorporateSignups(365, NOW);
+
+      expect(paramsFor('pg_index')).toEqual(['IDX_requests_tenant_timestamp']);
+    });
+
+    it('cuts off on a UTC boundary, matching a timestamptz column', async () => {
+      await service.getCorporateSignups(30, NOW);
+
+      expect(paramsFor('WITH signups AS MATERIALIZED')).toEqual([
+        new Date(NOW.getTime() - 30 * 86_400_000).toISOString(),
+      ]);
+    });
+
+    it('maps a signup onto the payload shape', async () => {
+      setup({ signups: [signupRow()] });
+
+      expect(await service.getCorporateSignups(365, NOW)).toEqual([
+        {
+          email: 'ada@stripe.com',
+          name: 'Ada Lovelace',
+          domain: 'stripe.com',
+          signed_up_at: '2026-08-01T10:00:00.000Z',
+          last_request_at: null,
+          has_traffic: false,
+          domain_signups: 1,
+        },
+      ]);
+    });
+
+    it('marks a tenant that has sent a request', async () => {
+      setup({ signups: [signupRow({ last_request_at: '2026-09-01T08:00:00.000Z' })] });
+
+      const [signup] = await service.getCorporateSignups(365, NOW);
+
+      expect(signup.has_traffic).toBe(true);
+      expect(signup.last_request_at).toBe('2026-09-01T08:00:00.000Z');
+    });
+
+    it('normalises the address and derives the domain from it', async () => {
+      setup({ signups: [signupRow({ email: '  Ada@Stripe.COM ' })] });
+
+      const [signup] = await service.getCorporateSignups(365, NOW);
+
+      expect(signup.email).toBe('ada@stripe.com');
+      expect(signup.domain).toBe('stripe.com');
+    });
+
+    it('keeps a missing display name as null', async () => {
+      setup({ signups: [signupRow({ user_name: null })] });
+
+      expect((await service.getCorporateSignups(365, NOW))[0].name).toBeNull();
+    });
+
+    it('drops consumer and already-excluded addresses', async () => {
+      setup({
+        signups: [
+          signupRow({ email: 'ada@gmail.com' }),
+          signupRow({ email: 'support@stripe.com' }),
+          signupRow({ email: 'dev@manifest.build' }),
+          signupRow({ email: 'ada@stripe.com' }),
+        ],
+      });
+
+      expect((await service.getCorporateSignups(365, NOW)).map((s) => s.email)).toEqual([
+        'ada@stripe.com',
+      ]);
+    });
+
+    it('counts how many verified signups share a domain', async () => {
+      setup({
+        signups: [signupRow({ email: 'ada@stripe.com' }), signupRow({ email: 'grace@stripe.com' })],
+      });
+
+      const signups = await service.getCorporateSignups(365, NOW);
+
+      expect(signups).toHaveLength(2);
+      expect(signups.every((s) => s.domain_signups === 2)).toBe(true);
+    });
+
+    it('drops a scripted signup cluster wholesale', async () => {
+      setup({
+        signups: [
+          signupRow({ email: 'a@scraped.com', signed_up_at: '2026-03-01T00:00:00.000Z' }),
+          signupRow({ email: 'b@scraped.com', signed_up_at: '2026-03-08T00:00:00.000Z' }),
+          signupRow({ email: 'c@scraped.com', signed_up_at: '2026-03-15T00:00:00.000Z' }),
+          signupRow({ email: 'ada@stripe.com' }),
+        ],
+      });
+
+      expect((await service.getCorporateSignups(365, NOW)).map((s) => s.email)).toEqual([
+        'ada@stripe.com',
+      ]);
+    });
+
+    it('keeps a burst where somebody actually used the gateway', async () => {
+      setup({
+        signups: [
+          signupRow({ email: 'a@real.com', signed_up_at: '2026-03-01T00:00:00.000Z' }),
+          signupRow({ email: 'b@real.com', signed_up_at: '2026-03-08T00:00:00.000Z' }),
+          signupRow({
+            email: 'c@real.com',
+            signed_up_at: '2026-03-15T00:00:00.000Z',
+            last_request_at: '2026-04-01T00:00:00.000Z',
+          }),
+        ],
+      });
+
+      expect(await service.getCorporateSignups(365, NOW)).toHaveLength(3);
+    });
+
+    it('orders by domain size, then by newest signup', async () => {
+      setup({
+        signups: [
+          signupRow({ email: 'solo@alone.com', signed_up_at: '2026-08-20T00:00:00.000Z' }),
+          signupRow({ email: 'older@team.com', signed_up_at: '2026-01-01T00:00:00.000Z' }),
+          signupRow({ email: 'newer@team.com', signed_up_at: '2026-08-01T00:00:00.000Z' }),
+        ],
+      });
+
+      expect((await service.getCorporateSignups(365, NOW)).map((s) => s.email)).toEqual([
+        'newer@team.com',
+        'older@team.com',
+        'solo@alone.com',
+      ]);
+    });
+
+    it('returns nothing when no signup survives the filters', async () => {
+      setup({ signups: [signupRow({ email: 'ada@gmail.com' })] });
+
+      expect(await service.getCorporateSignups(365, NOW)).toEqual([]);
+    });
+
+    it('caches signups per window', async () => {
+      setup({ signups: [signupRow()] });
+
+      const first = await service.getCorporateSignups(365, NOW);
+      const callsAfterFirst = query.mock.calls.length;
+      const second = await service.getCorporateSignups(365, NOW);
 
       expect(second).toBe(first);
       expect(query.mock.calls).toHaveLength(callsAfterFirst);

--- a/packages/backend/src/crm-metrics/crm-metrics.service.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.service.ts
@@ -3,8 +3,19 @@ import { DataSource, QueryRunner } from 'typeorm';
 import { TtlCache } from '../common/utils/ttl-cache';
 import { toLocalSqlTimestamp } from '../common/utils/postgres-sql';
 import { sqlIsSuccessStatus } from '../analytics/services/query-helpers';
-import { isExcludedEmail } from './crm-metrics.filters';
-import type { CohortRow, CrmHealedUser, CrmWaitlistClaim } from './crm-metrics.types';
+import {
+  domainOf,
+  isCorporateSignupEmail,
+  isSignupCluster,
+  isExcludedEmail,
+} from './crm-metrics.filters';
+import type {
+  CohortRow,
+  CrmCorporateSignup,
+  CrmHealedUser,
+  CrmWaitlistClaim,
+  SignupRow,
+} from './crm-metrics.types';
 
 /**
  * Answers on the cheap: the requests Autofix repaired lately, grouped by the
@@ -18,6 +29,13 @@ import type { CohortRow, CrmHealedUser, CrmWaitlistClaim } from './crm-metrics.t
  */
 
 const HEALED_INDEX = 'IDX_requests_autofix_healed';
+
+/**
+ * The signup feed's whole cost model is one index probe per tenant. Without
+ * this index the lateral degrades to a sequential scan of `requests` per row,
+ * which measured 22s and 6.9 GB of reads against production.
+ */
+const TENANT_TIMESTAMP_INDEX = 'IDX_requests_tenant_timestamp';
 
 /**
  * Short on purpose. The cache exists to stop a retrying client from replaying
@@ -73,6 +91,41 @@ const COHORT_SQL = `
   HAVING count(*) FILTER (WHERE r.timestamp > $1) > 0
 `;
 
+/**
+ * Every verified signup in the window, with the timestamp of that tenant's most
+ * recent request.
+ *
+ * `LIMIT 1` on a backward index scan rather than an aggregate: it answers
+ * "have they ever used this, and when last" from the index alone, whereas
+ * `count(*)` or a filtered aggregate must visit the heap for every row.
+ *
+ * Domain rules are deliberately *not* in this SQL. They live in
+ * crm-metrics.filters.ts so one list governs every consumer and stays under
+ * test; the cost of returning all ~7k tenants and filtering in TypeScript is
+ * under 100ms, because the per-tenant probe is what dominates either way.
+ */
+const SIGNUPS_SQL = `
+  WITH signups AS MATERIALIZED (
+    SELECT lower(u.email)   AS email,
+           u.name           AS user_name,
+           u."createdAt"    AS signed_up_at,
+           t.id             AS tenant_id
+    FROM "user" u
+    JOIN tenants t ON t.owner_user_id = u.id
+    WHERE u."emailVerified" = true
+      AND u."createdAt" > $1
+  )
+  SELECT s.email, s.user_name, s.signed_up_at, a.last_request_at
+  FROM signups s
+  LEFT JOIN LATERAL (
+    SELECT r.timestamp AS last_request_at
+    FROM requests r
+    WHERE r.tenant_id = s.tenant_id
+    ORDER BY r.timestamp DESC
+    LIMIT 1
+  ) a ON true
+`;
+
 const CLAIMS_SQL = `
   SELECT email, source, claimed_at
   FROM waitlist_claims
@@ -87,6 +140,10 @@ export class CrmMetricsService {
     ttlMs: CACHE_TTL_MS,
   });
   private readonly claimsCache = new TtlCache<number, CrmWaitlistClaim[]>({
+    maxSize: 8,
+    ttlMs: CACHE_TTL_MS,
+  });
+  private readonly signupsCache = new TtlCache<number, CrmCorporateSignup[]>({
     maxSize: 8,
     ttlMs: CACHE_TTL_MS,
   });
@@ -112,6 +169,35 @@ export class CrmMetricsService {
 
     this.cohortCache.set(days, users);
     return users;
+  }
+
+  /**
+   * Verified signups on organisation domains within `days`, newest first.
+   *
+   * Consumer mailboxes, relays, role addresses and scripted signup clusters are
+   * removed here rather than in the CRM, so every consumer inherits the same
+   * rules.
+   */
+  async getCorporateSignups(days: number, now: Date = new Date()): Promise<CrmCorporateSignup[]> {
+    const cached = this.signupsCache.get(days);
+    if (cached) return cached;
+
+    // `user."createdAt"` is `timestamp WITH time zone`, unlike the naive
+    // `requests.timestamp` the cohort query compares against — so a UTC
+    // boundary is correct here and a local one would be off by the offset.
+    const cutoff = new Date(now.getTime() - days * 86_400_000).toISOString();
+    const signups = await this.withRunner(async (runner) => {
+      const ready = (await runner.query(INDEX_READY_SQL, [TENANT_TIMESTAMP_INDEX])) as unknown[];
+      if (ready.length === 0) {
+        throw new ServiceUnavailableException(
+          `${TENANT_TIMESTAMP_INDEX} is missing or invalid; refusing to run an unindexed scan`,
+        );
+      }
+      return buildSignups((await runner.query(SIGNUPS_SQL, [cutoff])) as SignupRow[]);
+    });
+
+    this.signupsCache.set(days, signups);
+    return signups;
   }
 
   /** Pivot waiting-list claims in the window: who converted, and from where. */
@@ -227,4 +313,52 @@ function buildUsers(merged: Map<string, Merged>): CrmHealedUser[] {
   }));
 
   return users.sort((a, b) => b.healed_recent - a.healed_recent);
+}
+
+/**
+ * Turns raw signup rows into the payload: drop addresses that are not
+ * organisations, drop domains whose signups look scripted, then annotate each
+ * survivor with how many people share its domain.
+ *
+ * Ordered by domain size then recency, so if the CRM ever caps a batch it takes
+ * the strongest team signals first.
+ */
+function buildSignups(rows: SignupRow[]): CrmCorporateSignup[] {
+  const byDomain = new Map<string, CrmCorporateSignup[]>();
+
+  for (const row of rows) {
+    const email = row.email.trim().toLowerCase();
+    if (!isCorporateSignupEmail(email)) continue;
+
+    const lastRequest = row.last_request_at ? new Date(row.last_request_at) : null;
+    const signup: CrmCorporateSignup = {
+      email,
+      name: row.user_name,
+      domain: domainOf(email),
+      signed_up_at: new Date(row.signed_up_at).toISOString(),
+      last_request_at: lastRequest ? lastRequest.toISOString() : null,
+      has_traffic: lastRequest !== null,
+      // Filled in below, once the domain's full membership is known.
+      domain_signups: 0,
+    };
+
+    const bucket = byDomain.get(signup.domain);
+    if (bucket) bucket.push(signup);
+    else byDomain.set(signup.domain, [signup]);
+  }
+
+  const kept: CrmCorporateSignup[] = [];
+  for (const signups of byDomain.values()) {
+    if (isSignupCluster(signups)) continue;
+    for (const signup of signups) {
+      signup.domain_signups = signups.length;
+      kept.push(signup);
+    }
+  }
+
+  return kept.sort(
+    (a, b) =>
+      b.domain_signups - a.domain_signups ||
+      Date.parse(b.signed_up_at) - Date.parse(a.signed_up_at),
+  );
 }

--- a/packages/backend/src/crm-metrics/crm-metrics.service.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.service.ts
@@ -101,8 +101,17 @@ const COHORT_SQL = `
  *
  * Domain rules are deliberately *not* in this SQL. They live in
  * crm-metrics.filters.ts so one list governs every consumer and stays under
- * test; the cost of returning all ~7k tenants and filtering in TypeScript is
- * under 100ms, because the per-tenant probe is what dominates either way.
+ * test; the cost of returning all ~8k users and filtering in TypeScript is
+ * one probe each, which measured 59-93ms warm and 999ms cold against
+ * production. That worst case still fits the 1.5s budget, but the margin is
+ * the reason this stays one probe per row and never an aggregate.
+ *
+ * The join to `tenants` must stay LEFT. Tenants are created lazily on first
+ * agent creation, so a user who signed up and never built anything has no
+ * tenant row at all — 1,274 verified users in production, 144 of them on
+ * corporate domains. An inner join drops exactly the people this feed exists
+ * to find. With no tenant the lateral matches nothing, which is the correct
+ * answer: `last_request_at` null, `has_traffic` false.
  */
 const SIGNUPS_SQL = `
   WITH signups AS MATERIALIZED (
@@ -111,7 +120,7 @@ const SIGNUPS_SQL = `
            u."createdAt"    AS signed_up_at,
            t.id             AS tenant_id
     FROM "user" u
-    JOIN tenants t ON t.owner_user_id = u.id
+    LEFT JOIN tenants t ON t.owner_user_id = u.id
     WHERE u."emailVerified" = true
       AND u."createdAt" > $1
   )

--- a/packages/backend/src/crm-metrics/crm-metrics.types.ts
+++ b/packages/backend/src/crm-metrics/crm-metrics.types.ts
@@ -31,3 +31,36 @@ export interface CohortRow {
   first_heal_at: Date | string;
   last_heal_at: Date | string;
 }
+
+/**
+ * One corporate signup: a verified user on an organisation domain.
+ *
+ * Deliberately thinner than `CrmHealedUser`. Per-tenant request aggregates
+ * (error counts, 30-day volume) cost a heap fetch per row and took 22s across
+ * this cohort in production; a single index probe for the latest request is
+ * 93ms and answers the only question the copy branches on — has this person
+ * ever actually used the gateway.
+ */
+export interface CrmCorporateSignup {
+  /** Lowercased primary address. The CRM dedupes people on this. */
+  email: string;
+  /** Display name from the auth record, or null when never set. */
+  name: string | null;
+  /** Lowercased domain part, so the CRM can group people onto a company. */
+  domain: string;
+  signed_up_at: string;
+  /** Null when this tenant has never sent a request. */
+  last_request_at: string | null;
+  /** `last_request_at !== null`, precomputed so template branching is trivial. */
+  has_traffic: boolean;
+  /** Verified signups sharing this domain — the "team behind it" signal. */
+  domain_signups: number;
+}
+
+/** Raw signup row, one per (user, tenant) pair, before filtering. */
+export interface SignupRow {
+  email: string;
+  user_name: string | null;
+  signed_up_at: Date | string;
+  last_request_at: Date | string | null;
+}

--- a/packages/backend/src/crm-metrics/internal-crm-metrics.controller.spec.ts
+++ b/packages/backend/src/crm-metrics/internal-crm-metrics.controller.spec.ts
@@ -22,11 +22,19 @@ function makeConfig(secret: string | undefined): ConfigService {
 }
 
 describe('InternalCrmMetricsController', () => {
-  let mockService: { getHealedCohort: jest.Mock; getConversions: jest.Mock };
+  let mockService: {
+    getHealedCohort: jest.Mock;
+    getConversions: jest.Mock;
+    getCorporateSignups: jest.Mock;
+  };
   let warn: jest.SpyInstance;
 
   beforeEach(() => {
-    mockService = { getHealedCohort: jest.fn(), getConversions: jest.fn() };
+    mockService = {
+      getHealedCohort: jest.fn(),
+      getConversions: jest.fn(),
+      getCorporateSignups: jest.fn(),
+    };
     warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     mockedIsSelfHosted.mockReturnValue(false);
   });
@@ -121,6 +129,15 @@ describe('InternalCrmMetricsController', () => {
       expect(mockService.getConversions).not.toHaveBeenCalled();
     });
 
+    it('guards the signups route too', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.signups('nope', IP, {})).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockService.getCorporateSignups).not.toHaveBeenCalled();
+    });
+
     it('logs the source ip of a rejected attempt', async () => {
       await expect(makeController(SECRET).cohort('nope', IP, {})).rejects.toThrow();
 
@@ -160,6 +177,36 @@ describe('InternalCrmMetricsController', () => {
     });
   });
 
+  describe('signups', () => {
+    it('defaults to the full 365 day history', async () => {
+      const signups = [{ email: 'ada@stripe.com' }];
+      mockService.getCorporateSignups.mockResolvedValue(signups);
+
+      const result = await makeController(SECRET).signups(SECRET, IP, {});
+
+      expect(result).toBe(signups);
+      expect(mockService.getCorporateSignups).toHaveBeenCalledWith(365);
+    });
+
+    it('passes an explicit window through', async () => {
+      mockService.getCorporateSignups.mockResolvedValue([]);
+
+      await makeController(SECRET).signups(SECRET, IP, { days: 30 });
+
+      expect(mockService.getCorporateSignups).toHaveBeenCalledWith(30);
+    });
+
+    it('propagates an unavailable index instead of answering with an empty list', async () => {
+      mockService.getCorporateSignups.mockRejectedValue(
+        new ServiceUnavailableException('IDX_requests_tenant_timestamp is missing or invalid'),
+      );
+
+      await expect(makeController(SECRET).signups(SECRET, IP, {})).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+    });
+  });
+
   describe('conversions', () => {
     it('defaults to a 90 day window', async () => {
       const claims = [{ email: 'a@b.com', source: 'cloud', claimed_at: 'x' }];
@@ -192,8 +239,10 @@ describe('InternalCrmMetricsController', () => {
       await expect(controller.conversions(SECRET, IP, {})).rejects.toBeInstanceOf(
         NotFoundException,
       );
+      await expect(controller.signups(SECRET, IP, {})).rejects.toBeInstanceOf(NotFoundException);
       expect(mockService.getHealedCohort).not.toHaveBeenCalled();
       expect(mockService.getConversions).not.toHaveBeenCalled();
+      expect(mockService.getCorporateSignups).not.toHaveBeenCalled();
     });
 
     it('checks the mode before the secret, so it never reveals whether one is set', async () => {

--- a/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
+++ b/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
@@ -14,7 +14,7 @@ import { timingSafeCompare } from '../common/utils/crypto.util';
 import { isSelfHosted } from '../common/utils/detect-self-hosted';
 import { CrmMetricsService } from './crm-metrics.service';
 import { CrmMetricsQueryDto } from './dto/crm-metrics-query.dto';
-import type { CrmHealedUser, CrmWaitlistClaim } from './crm-metrics.types';
+import type { CrmCorporateSignup, CrmHealedUser, CrmWaitlistClaim } from './crm-metrics.types';
 
 /**
  * Internal read API for the CRM outreach pipeline.
@@ -42,6 +42,12 @@ export class InternalCrmMetricsController {
   private static readonly MIN_SECRET_LENGTH = 32;
   private static readonly DEFAULT_COHORT_DAYS = 7;
   private static readonly DEFAULT_CLAIM_DAYS = 90;
+  /**
+   * The full history, because the signup campaign emails each person once ever
+   * and remembers who via the CRM rather than via a window. A shorter default
+   * would strand anyone a late or failed run skipped.
+   */
+  private static readonly DEFAULT_SIGNUP_DAYS = 365;
 
   private readonly logger = new Logger(InternalCrmMetricsController.name);
 
@@ -82,6 +88,27 @@ export class InternalCrmMetricsController {
     this.assertSecret(secret, ip);
     return this.service.getHealedCohort(
       query.days ?? InternalCrmMetricsController.DEFAULT_COHORT_DAYS,
+    );
+  }
+
+  /**
+   * Verified signups on organisation domains — the Autofix outreach cohort.
+   *
+   * A corporate address implies a team, and a team calling third-party APIs is
+   * the product's audience whether or not they ever routed an LLM request
+   * through the gateway. `has_traffic` is what the copy branches on.
+   */
+  @Public()
+  @Get('signups')
+  async signups(
+    @Headers('x-internal-secret') secret: string,
+    @Ip() ip: string,
+    @Query() query: CrmMetricsQueryDto,
+  ): Promise<CrmCorporateSignup[]> {
+    this.assertCloud();
+    this.assertSecret(secret, ip);
+    return this.service.getCorporateSignups(
+      query.days ?? InternalCrmMetricsController.DEFAULT_SIGNUP_DAYS,
     );
   }
 

--- a/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
+++ b/packages/backend/src/crm-metrics/internal-crm-metrics.controller.ts
@@ -43,9 +43,15 @@ export class InternalCrmMetricsController {
   private static readonly DEFAULT_COHORT_DAYS = 7;
   private static readonly DEFAULT_CLAIM_DAYS = 90;
   /**
-   * The full history, because the signup campaign emails each person once ever
-   * and remembers who via the CRM rather than via a window. A shorter default
-   * would strand anyone a late or failed run skipped.
+   * The widest window `CrmMetricsQueryDto` allows, which today is every signup
+   * ever (the first one is from February 2026).
+   *
+   * Wide on purpose: the signup campaign emails each person once ever and
+   * remembers who in the CRM rather than via a window, so a narrow default
+   * would strand anyone a late or failed run skipped. Once Manifest is more
+   * than a year old this stops being the full history, and someone who was
+   * never successfully contacted before ageing out would be missed. Raise the
+   * DTO cap then rather than assuming this number still means "everyone".
    */
   private static readonly DEFAULT_SIGNUP_DAYS = 365;
 

--- a/packages/backend/test/crm-metrics.e2e-spec.ts
+++ b/packages/backend/test/crm-metrics.e2e-spec.ts
@@ -13,6 +13,7 @@ import { AddRequestsAutofixHealedIndex1802200000000 } from '../src/database/migr
 
 const SECRET = 'e2e-crm-metrics-secret-at-least-32-chars';
 const HEALED_INDEX = 'IDX_requests_autofix_healed';
+const TENANT_TIMESTAMP_INDEX = 'IDX_requests_tenant_timestamp';
 
 const OWNER_ID = 'crm-owner-001';
 const OWNER_EMAIL = 'healed.user@example.com';
@@ -47,7 +48,8 @@ describe('Internal CRM metrics (e2e)', () => {
          id VARCHAR PRIMARY KEY,
          name VARCHAR,
          email VARCHAR,
-         "emailVerified" BOOLEAN
+         "emailVerified" BOOLEAN,
+         "createdAt" TIMESTAMPTZ
        )`,
     );
 
@@ -64,6 +66,16 @@ describe('Internal CRM metrics (e2e)', () => {
     } finally {
       await runner.release();
     }
+
+    // The signups feed refuses to run without this one, because the lateral
+    // degrades to a sequential scan of `requests` per row (22s and 6.9 GB of
+    // reads, measured). Production gets it from migration 1801000000000, which
+    // also creates the tables synchronize() has already built here — so run
+    // just the index. It is a plain two-column btree with no partial predicate
+    // to drift, unlike the healed index above.
+    await ds.query(
+      `CREATE INDEX IF NOT EXISTS "${TENANT_TIMESTAMP_INDEX}" ON "requests" ("tenant_id", "timestamp")`,
+    );
 
     const [built] = (await ds.query(`SELECT indexdef FROM pg_indexes WHERE indexname = $1`, [
       HEALED_INDEX,
@@ -88,7 +100,8 @@ describe('Internal CRM metrics (e2e)', () => {
     await ds.query('DELETE FROM waitlist_claims');
     await ds.query('DELETE FROM "user"');
     await ds.query(
-      `INSERT INTO "user" (id, name, email, "emailVerified") VALUES ($1, $2, $3, true)`,
+      `INSERT INTO "user" (id, name, email, "emailVerified", "createdAt")
+       VALUES ($1, $2, $3, true, now() - interval '10 days')`,
       [OWNER_ID, 'Healed User', OWNER_EMAIL],
     );
     await ds.query(`UPDATE tenants SET owner_user_id = $1 WHERE id = $2`, [
@@ -224,6 +237,116 @@ describe('Internal CRM metrics (e2e)', () => {
 
       expect(res.body).toHaveLength(1);
       expect(res.body[0]).toMatchObject({ email: 'converted@example.com', source: 'cloud' });
+    });
+  });
+
+  describe('signups', () => {
+    // Same cache caveat as the cohort block: distinct windows per assertion.
+    let signupWindow = 100;
+    const nextSignupWindow = () => `/signups?days=${++signupWindow}`;
+
+    /** A corporate address, so the filters in crm-metrics.filters.ts keep it. */
+    const addUser = async (
+      id: string,
+      email: string,
+      opts: { tenantId?: string; name?: string } = {},
+    ): Promise<void> => {
+      await ds.query(
+        `INSERT INTO "user" (id, name, email, "emailVerified", "createdAt")
+         VALUES ($1, $2, $3, true, now() - interval '5 days')`,
+        [id, opts.name ?? 'Ada Lovelace', email],
+      );
+      if (opts.tenantId) {
+        await ds.query(`UPDATE tenants SET owner_user_id = $1 WHERE id = $2`, [id, opts.tenantId]);
+      }
+    };
+
+    interface SignupRow {
+      email: string;
+      last_request_at: string | null;
+    }
+
+    const signupFor = (body: unknown[], email: string): SignupRow | undefined =>
+      (body as SignupRow[]).find((row) => row.email === email);
+
+    it('returns a corporate signup that never sent a request', async () => {
+      await addUser('signup-1', 'ada@acmecorp.io', { tenantId: TEST_TENANT_ID });
+
+      const res = await get(nextSignupWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(signupFor(res.body, 'ada@acmecorp.io')).toMatchObject({
+        email: 'ada@acmecorp.io',
+        name: 'Ada Lovelace',
+        domain: 'acmecorp.io',
+        last_request_at: null,
+        has_traffic: false,
+        domain_signups: 1,
+      });
+    });
+
+    it('keeps a verified user who never created a tenant', async () => {
+      // The regression this exists for. Tenants are created lazily on first
+      // agent creation, so this user has no tenant row at all — and is exactly
+      // who the campaign targets. An inner join would drop them silently.
+      await addUser('signup-orphan', 'grace@orphancorp.io');
+
+      const res = await get(nextSignupWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(signupFor(res.body, 'grace@orphancorp.io')).toMatchObject({
+        has_traffic: false,
+        last_request_at: null,
+      });
+    });
+
+    it('marks a signup whose tenant has sent a request', async () => {
+      await addUser('signup-2', 'ada@trafficcorp.io', { tenantId: TEST_TENANT_ID });
+      await ds.query(
+        `INSERT INTO requests (id, tenant_id, agent_id, agent_name, timestamp, status)
+         VALUES ($1, $2, $3, 'demo-agent', $4, 'success')`,
+        [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, localSqlTimestamp(new Date())],
+      );
+
+      const res = await get(nextSignupWindow()).set('x-internal-secret', SECRET).expect(200);
+      const signup = signupFor(res.body, 'ada@trafficcorp.io');
+
+      expect(signup).toMatchObject({ has_traffic: true });
+      expect(signup?.last_request_at).not.toBeNull();
+    });
+
+    it('counts people sharing a domain', async () => {
+      await addUser('signup-3a', 'ada@teamcorp.io');
+      await addUser('signup-3b', 'grace@teamcorp.io');
+
+      const res = await get(nextSignupWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(signupFor(res.body, 'ada@teamcorp.io')).toMatchObject({ domain_signups: 2 });
+      expect(signupFor(res.body, 'grace@teamcorp.io')).toMatchObject({ domain_signups: 2 });
+    });
+
+    it('omits consumer mailboxes and role addresses', async () => {
+      await addUser('signup-4', 'ada@gmail.com');
+      await addUser('signup-5', 'support@acmecorp.io');
+
+      const res = await get(nextSignupWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(signupFor(res.body, 'ada@gmail.com')).toBeUndefined();
+      expect(signupFor(res.body, 'support@acmecorp.io')).toBeUndefined();
+    });
+
+    it('omits unverified signups', async () => {
+      await ds.query(
+        `INSERT INTO "user" (id, name, email, "emailVerified", "createdAt")
+         VALUES ($1, 'Un Verified', $2, false, now())`,
+        ['signup-6', 'ada@unverifiedcorp.io'],
+      );
+
+      const res = await get(nextSignupWindow()).set('x-internal-secret', SECRET).expect(200);
+
+      expect(signupFor(res.body, 'ada@unverifiedcorp.io')).toBeUndefined();
+    });
+
+    it('requires the secret', async () => {
+      await get('/signups').expect(401);
     });
   });
 });


### PR DESCRIPTION
### 💭 Why
The healed-cohort feed only sees people who already hit the gateway. Most corporate signups never sent a request, so outreach cannot reach them at all today. A corporate address implies a team, and a team calling third-party APIs is the Autofix audience whether or not they ever routed an LLM request through us.

### ✨ What changed
- New `GET /api/v1/internal/crm-metrics/signups`, same secret and cloud-only gate as its siblings.
- Returns verified signups on organisation domains, with `has_traffic` so copy can branch on real usage.
- Filters out consumer mailboxes and privacy relays. `duck.com`, `pm.me` and `simplelogin` read as custom domains to a naive freemail check, and were the largest "corporate" domains in the database by signup count.
- Filters out scripted signup clusters: 3+ accounts on one domain inside a month, none with traffic.
- Each row carries `domain_signups`, so the CRM can tell a team from a lone signup.

### 🔧 For operators
Nothing to do. Same `CRM_METRICS_SECRET`, no migration, no new env var. Self-hosted is unaffected: the module is still never registered there.

### 📝 Notes
Query shape is driven by a measured constraint, not taste. Per-tenant request aggregates need a heap fetch per row and took 22s / 6.9 GB of reads across this cohort against prod. A backward index scan with `LIMIT 1` answers the only question the copy branches on, from the index alone, in 93ms for all ~7k tenants.

The route refuses to run when `IDX_requests_tenant_timestamp` is missing rather than silently degrade to that scan, matching how the healed cohort guards its own partial index.

Domain rules live in `crm-metrics.filters.ts` rather than in SQL, so one list governs every consumer and stays under test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a corporate-signups feed to the internal CRM metrics API so outreach can reach teams that signed up but never called the gateway — the healed-cohort feed only saw users who already had traffic.

- New `GET /api/v1/internal/crm-metrics/signups` returns verified signups on organisation domains, ordered by domain size then newest first.
- Each row carries `has_traffic`, `last_request_at`, and `domain_signups`; `has_traffic` comes from a backward index probe instead of a per-tenant aggregate.
- Keeps signups who never created a tenant (no agent) via a LEFT join — they are the primary audience.
- The route refuses to run when `IDX_requests_tenant_timestamp` is missing, rather than falling back to the 22-second scan.
- Filters out consumer mailboxes and privacy relays (`duck.com`, `pm.me`, `simplelogin`) and drops scripted clusters: 3+ trafficless signups on one domain inside a month.
- Domain rules live in `crm-metrics.filters.ts` under test, not in SQL.
- E2E tests exercise the query against real Postgres, covering the no-tenant LEFT join, traffic detection, domain counting, and filters.
- No operator action: same `CRM_METRICS_SECRET`, no migration, self-hosted unaffected.

<sup>Written for commit fd11371e703275d6dbf97d041f1f2f2966c4cf64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

