### PR TITLE
fix: bump Codex client_version so subscription discovers gpt-6-astra

### DIFF
--- a/.changeset/codex-client-version-gpt-6-astra.md
+++ b/.changeset/codex-client-version-gpt-6-astra.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix OpenAI subscription model discovery so newer Codex CLI models (e.g. `gpt-6-astra`) appear. OpenAI gates `gpt-6-astra` behind Codex CLI `0.153.0`+, and the `/backend-api/codex/models` endpoint silently returns the older model subset for older `client_version` values. Bump `CODEX_CLI_VERSION` from `0.128.0` to `0.154.0`.

--- a/packages/backend/src/common/constants/subscription-clients.ts
+++ b/packages/backend/src/common/constants/subscription-clients.ts
@@ -13,7 +13,7 @@
  * together when GitHub deprecates an older pair.
  */
 
-export const CODEX_CLI_VERSION = '0.128.0';
+export const CODEX_CLI_VERSION = '0.154.0';
 export const CODEX_CLI_ORIGINATOR = 'codex_cli_rs';
 export const CODEX_CLI_USER_AGENT = 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown';
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2609,7 +2609,7 @@ describe('ProviderModelFetcherService', () => {
       await service.fetch('openai', 'my-oauth-token', 'subscription');
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/codex/models?client_version=0.128.0',
+        'https://chatgpt.com/backend-api/codex/models?client_version=0.154.0',
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer my-oauth-token',

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1,4 +1,5 @@
 import { ProviderModelFetcherService, PROVIDER_CONFIGS } from './provider-model-fetcher.service';
+import { CODEX_CLI_VERSION } from '../common/constants/subscription-clients';
 
 describe('ProviderModelFetcherService', () => {
   let service: ProviderModelFetcherService;
@@ -2609,7 +2610,7 @@ describe('ProviderModelFetcherService', () => {
       await service.fetch('openai', 'my-oauth-token', 'subscription');
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/codex/models?client_version=0.154.0',
+        `https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_CLI_VERSION}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer my-oauth-token',


### PR DESCRIPTION
### ✨ What changed
- Bump `CODEX_CLI_VERSION` from `0.128.0` to `0.154.0`.
- Update the `provider-model-fetcher` test assertion.
- Add a changeset.

### 💭 Why
OpenAI gates `gpt-6-astra` behind Codex CLI `0.153.0`+, and the Codex `/backend-api/codex/models` endpoint silently returns the older model subset for older `client_version` values, so the OpenAI subscription route never discovered it. Same class of fix as #1801.

### 👤 For users
OpenAI subscription connections now list `gpt-6-astra` and the other newer models in model discovery.

### 📝 Notes
Closes #2873.

Verified against the live endpoint with a real ChatGPT token, same token for both rows:

| `client_version` | returned slugs |
| --- | --- |
| `0.128.0` (before) | `gpt-5.5`, `gpt-5.3-codex-spark`, `codex-auto-review` |
| `0.154.0` (after) | `gpt-6-astra`, `gpt-reserve`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.3-codex-spark`, `codex-auto-review` |

`npx jest provider-model-fetcher.service.spec` (160 passed) and `npx tsc --noEmit` pass. The user-agent stays synthetic, as in #1801.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Codex CLI `client_version` from `0.128.0` to `0.154.0` so OpenAI subscription model discovery lists `gpt-6-astra` and newer Codex models. The `/backend-api/codex/models` endpoint silently gates newer models behind Codex CLI `0.153.0`+, so subscription connections previously saw only the older subset. The user-agent stays synthetic. Fixes #2873.

<sup>Written for commit a08e35b8059fdb8c8db50139cbb36e6eac12f76d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

