### PR TITLE
fix: return M302 when a pinned override model is unavailable

### DIFF
--- a/.changeset/m302-unavailable-override-model.md
+++ b/.changeset/m302-unavailable-override-model.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Return `M302` ("model not available") instead of `M101` ("no providers configured") when a pinned routing override names a model its connection no longer offers and no fallback route resolves. Only applies while the override's provider connection still exists, so a genuinely unconfigured agent keeps the neutral `M101`.

--- a/packages/backend/src/routing/dto/resolve-response.ts
+++ b/packages/backend/src/routing/dto/resolve-response.ts
@@ -34,4 +34,10 @@ export interface ResolveResponse {
   header_tier_id?: string;
   header_tier_name?: string;
   header_tier_color?: string;
+  /**
+   * Model named by a pinned routing override that could not be resolved even
+   * though its provider connection exists. The proxy turns this into M302
+   * ("model not available") instead of M101 ("no providers configured").
+   */
+  override_model_unavailable?: string;
 }

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -997,6 +997,27 @@ describe('ProxyService — orchestration', () => {
       const body = await result.forward.response.text();
       expect(body).toContain('M101');
     });
+
+    it('returns M302 when a pinned override names an unavailable model', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: null,
+        fallback_routes: null,
+        confidence: 0,
+        score: 0,
+        reason: 'scored',
+        override_model_unavailable: 'gpt-6-astra',
+      });
+      const result = await svc.proxyRequest(baseOpts());
+      const body = await result.forward.response.text();
+      expect(body).toContain('M302');
+      expect(body).toContain('gpt-6-astra');
+      expect(body).not.toContain('M101');
+      expect(result.meta).toMatchObject({
+        reason: 'model_not_available',
+        manifest_error_code: 'M302',
+      });
+    });
   });
 
   describe('no credentials', () => {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -280,12 +280,10 @@ export class ProxyService {
         `No route available for agent=${agentId}: ` +
           `tier=${resolved.tier} confidence=${resolved.confidence} reason=${resolved.reason}`,
       );
-      if (resolved.explicit_model_unavailable) {
-        return this.buildModelUnavailableResult(
-          stream,
-          agentName,
-          resolved.explicit_model_unavailable,
-        );
+      const unavailableModel =
+        resolved.explicit_model_unavailable ?? resolved.override_model_unavailable;
+      if (unavailableModel) {
+        return this.buildModelUnavailableResult(stream, agentName, unavailableModel);
       }
       return this.buildNoProviderResult(stream, agentName);
     }

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -969,6 +969,28 @@ describe('ResolveService', () => {
       expect(result.override_model_unavailable).toBe('gpt-6-astra');
     });
 
+    it('keeps the neutral no-provider signal on the scored tier path', async () => {
+      mockedScore.mockReturnValue({
+        tier: 'standard',
+        confidence: 0.7,
+        score: 5,
+        reason: 'scored',
+      } as never);
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'standard',
+          override_route: null,
+          auto_assigned_route: null,
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+      providerKeyService.hasRouteCredentials.mockResolvedValue(false);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toBeNull();
+      expect(result.override_model_unavailable).toBeUndefined();
+    });
+
     it('falls back to the default tier when the scored tier is missing', async () => {
       mockedScore.mockReturnValue({
         tier: 'reasoning',

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -619,6 +619,48 @@ describe('ResolveService', () => {
       expect(providerKeyService.isRouteAvailable).not.toHaveBeenCalled();
     });
 
+    // A pinned override whose model the connection no longer offers must name
+    // itself so the proxy can return M302, not the neutral "no providers
+    // configured" M101. The flag only applies while the connection still exists.
+    it('flags the unavailable override model when its connection exists', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: false });
+      const override = route('openai', 'subscription', 'gpt-6-astra');
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: override,
+          auto_assigned_route: null,
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+      providerKeyService.hasRouteCredentials.mockImplementation(
+        async (_tenant, r: ModelRoute) => r === override,
+      );
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toBeNull();
+      expect(result.override_model_unavailable).toBe('gpt-6-astra');
+    });
+
+    it('keeps the neutral no-provider signal when the override connection is gone', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: false });
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: route('openai', 'subscription', 'gpt-6-astra'),
+          auto_assigned_route: null,
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+      providerKeyService.hasRouteCredentials.mockResolvedValue(false);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toBeNull();
+      expect(result.override_model_unavailable).toBeUndefined();
+    });
+
     // A configured fallback provider stays eligible when the auto-assigned
     // route's provider is not connected.
     it('promotes an available fallback when the auto_assigned_route is unavailable', async () => {
@@ -899,6 +941,32 @@ describe('ResolveService', () => {
       expect(result.tier).toBe('complex');
       expect(result.route).toEqual(route('anthropic', 'api_key', 'claude-opus'));
       expect(result.fallback_routes).toEqual([route('openai', 'api_key', 'gpt-4o')]);
+    });
+
+    it('flags the unavailable override model on the scored tier path', async () => {
+      mockedScore.mockReturnValue({
+        tier: 'standard',
+        confidence: 0.7,
+        score: 5,
+        reason: 'scored',
+      } as never);
+      const override = route('openai', 'subscription', 'gpt-6-astra');
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'standard',
+          override_route: override,
+          auto_assigned_route: null,
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+      providerKeyService.hasRouteCredentials.mockImplementation(
+        async (_tenant, r: ModelRoute) => r === override,
+      );
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toBeNull();
+      expect(result.override_model_unavailable).toBe('gpt-6-astra');
     });
 
     it('falls back to the default tier when the scored tier is missing', async () => {

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -1117,6 +1117,26 @@ describe('ResolveService', () => {
       expect(result.reason).toBe('heartbeat');
     });
 
+    it('keeps the neutral signal for heartbeats even with an unavailable override', async () => {
+      const override = route('openai', 'subscription', 'gpt-6-astra');
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'simple',
+          override_route: override,
+          auto_assigned_route: null,
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+      providerKeyService.hasRouteCredentials.mockImplementation(
+        async (_tenant, r: ModelRoute) => r === override,
+      );
+
+      const result = await svc.resolveForTier('agent-1', 'user-1', 'simple', 'heartbeat');
+      expect(result.route).toBeNull();
+      expect(result.override_model_unavailable).toBeUndefined();
+    });
+
     it('returns the override route when present', async () => {
       tierService.getTiers.mockResolvedValue([
         {

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -36,6 +36,13 @@ import type { SpecificityAssignment } from '../../entities/specificity-assignmen
 interface ResolvedRouteChain {
   primaryRoute: ModelRoute | null;
   fallbackRoutes: ModelRoute[] | null;
+  /**
+   * The model named by a pinned override that could not be resolved even
+   * though its own provider connection exists. Surfaces M302 at the proxy
+   * instead of the neutral M101, which misreads a missing model as missing
+   * configuration.
+   */
+  unavailableOverrideModel: string | null;
 }
 
 /**
@@ -183,6 +190,7 @@ export class ResolveService {
         confidence: result.confidence,
         score: result.score,
         reason: result.reason,
+        override_model_unavailable: routeChain.unavailableOverrideModel ?? undefined,
       };
     }
 
@@ -243,6 +251,9 @@ export class ResolveService {
       confidence: 1,
       score: 0,
       reason,
+      override_model_unavailable: effectiveRoutes.primaryRoute
+        ? undefined
+        : (routeChain.unavailableOverrideModel ?? undefined),
     };
   }
 
@@ -444,13 +455,25 @@ export class ResolveService {
       return {
         primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, override),
         fallbackRoutes,
+        unavailableOverrideModel: null,
       };
     }
+
+    // A configured override whose model the connection no longer offers still
+    // gets a fallback/auto route below. When none of those has credentials,
+    // name the override model so the proxy can return M302: M101 ("no providers
+    // are set up") misreads a model that is missing at this client version as
+    // missing configuration. Only flag it when the override's own connection
+    // exists, so a genuinely unconfigured agent keeps the neutral M101 (#2494).
+    let unavailableOverrideModel: string | null = null;
     if (override) {
       this.logger.warn(
         `Override ${override.model} unavailable for agent=${agentId} — ` +
           `falling back to configured routes`,
       );
+      if (await this.providerKeyService.hasRouteCredentials(tenantId, override, agentId)) {
+        unavailableOverrideModel = override.model;
+      }
     }
 
     // An orphaned override walks its fallbacks before the legacy auto-assigned
@@ -464,10 +487,11 @@ export class ResolveService {
         return {
           primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, candidates[i]),
           fallbackRoutes: rest.length > 0 ? rest : null,
+          unavailableOverrideModel: null,
         };
       }
     }
-    return { primaryRoute: null, fallbackRoutes: null };
+    return { primaryRoute: null, fallbackRoutes: null, unavailableOverrideModel };
   }
 
   /**

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -251,9 +251,13 @@ export class ResolveService {
       confidence: 1,
       score: 0,
       reason,
-      override_model_unavailable: effectiveRoutes.primaryRoute
-        ? undefined
-        : (routeChain.unavailableOverrideModel ?? undefined),
+      // Heartbeats are keep-alives, not routed chat. Keep their existing
+      // neutral M101 so an unavailable simple-tier override can't repaint
+      // every periodic heartbeat as a model-not-available response.
+      override_model_unavailable:
+        effectiveRoutes.primaryRoute || reason === 'heartbeat'
+          ? undefined
+          : (routeChain.unavailableOverrideModel ?? undefined),
     };
   }
 


### PR DESCRIPTION
### ✨ What changed
- Resolver now carries the model named by a pinned tier override when its connection exists but the model can't be resolved.
- Proxy returns `M302` ("model not available") for that case instead of `M101` ("no providers configured").
- Add resolver and proxy tests plus a changeset.

### 💭 Why
A tier override pinned to a model the connection no longer offers (for example an OpenAI subscription model missing from the cached list) fell through with no route. The caller saw `M101`, which reads as a setup problem even though providers were configured. `M302` names the real problem.

### 👤 For users
Requests routed through a pinned override that references an unavailable model now get `Model "X" is not available for this agent` instead of `no providers are set up yet`.

### 📝 Notes
Addresses the M101 observation in #2873.

The flag is only set while the override's own provider connection still exists, so a genuinely unconfigured agent keeps the neutral `M101` (#2494).

Scope is tier overrides. Header-tier and specificity overrides still fall through to tier routing by design; extending this to those paths is a possible follow-up.

`npx jest resolve.service.spec resolve.service.edge.spec proxy.service.spec` (165 passed) and `npx tsc --noEmit` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns `M302` ("model not available") instead of `M101` ("no providers configured") when a pinned tier override names a model its connection no longer offers and no fallback route resolves. The resolver reports the unavailable model only while the override's own provider connection still exists, so genuinely unconfigured agents and heartbeat checks keep the neutral `M101`.

**Notes**
- Applies to tier overrides only; header-tier and specificity overrides still fall through to tier routing.
- Adds `override_model_unavailable` to the resolve response so the proxy can include the model name in the `M302` message.
- Addresses the M101 observation in #2873.

<sup>Written for commit dea4271b440e9165b61b8687b583c92f8f9643ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/llm-gateway/pull/2875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

